### PR TITLE
BZ-1164738 - EJB invocation issues thrown when working with the product

### DIFF
--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/PropertyTypeFactoryImpl.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/PropertyTypeFactoryImpl.java
@@ -13,8 +13,6 @@ import java.util.List;
 
 public class PropertyTypeFactoryImpl implements PropertyTypeFactory {
 
-    private static PropertyTypeFactory singleton = null;
-
     private static List<PropertyType> baseTypes = new ArrayList<PropertyType>();
     
     private static HashMap<String, PropertyType> baseTypesByClass = new HashMap<String, PropertyType>();
@@ -53,10 +51,8 @@ public class PropertyTypeFactoryImpl implements PropertyTypeFactory {
     }
 
     public static PropertyTypeFactory getInstance() {
-        if (singleton == null) {
-            singleton = new PropertyTypeFactoryImpl();
-        }
-        return singleton;
+
+        return HoldInstance.INSTANCE;
     }
 
     @Override
@@ -73,5 +69,9 @@ public class PropertyTypeFactoryImpl implements PropertyTypeFactory {
     public boolean isPrimitivePropertyType(String className) {
         PropertyType type = baseTypesByClass.get(className);
         return type != null && type.isPrimitive();
+    }
+
+    private static class HoldInstance {
+        private static final PropertyTypeFactoryImpl INSTANCE = new PropertyTypeFactoryImpl();
     }
 }


### PR DESCRIPTION
This in one of three commits (various repositories) to resolve EAP issue with asynchronous ejb methods:

``` plain
Invocation failed on component SimpleAsyncExecutorService for method public void 
org.uberfire.commons.async.SimpleAsyncExecutorService.execute(java.lang.Runnable): 
javax.ejb.ConcurrentAccessTimeoutException: JBAS014373: EJB 3.1 PFD2 4.8.5.5.1 concurrent access 
timeout on org.jboss.invocation.InterceptorContext$Invocation@755032d4 - could not obtain lock within 
5000MILLISECONDS
```

There are several BZ for bpms/brms and this might affect actual indexation of file systems in case it fails - usually bigger filesystem that indexation takes more than 5 seconds.

P.S.
I believe (once approved) it needs to be back ported to 0.5.x branch as well.
