### PR TITLE
increase coverage in kie-wb-common-forms-adf-engine-api

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/test/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/TextAreaFieldInitializerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/test/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/TextAreaFieldInitializerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.FormGenerationContext;
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.I18nHelper;
+import org.kie.workbench.common.forms.adf.service.definitions.elements.FieldElement;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TextAreaFieldInitializerTest {
+
+    private static final String ROWS_PARAM = "rows";
+    private static final String ROWS = "10";
+    private static final String PLACEHOLDER_PARAM = "placeHolder";
+    private static final String PLACEHOLDER = "placeholder";
+
+    private HasPlaceHolderFieldInitializer placeholderInitializer;
+    private HasRowsFieldInitializer rowsInitializer;
+
+    private TextAreaFieldDefinition field;
+
+    @Mock
+    private FieldElement fieldElement;
+
+    @Mock
+    private FormGenerationContext context;
+
+    @Mock
+    private I18nHelper i18nHelper;
+
+
+    private Map<String, String> fieldElementParams = new HashMap<>();
+
+    @Before
+    public void setUp() throws Exception {
+        placeholderInitializer = new HasPlaceHolderFieldInitializer();
+        rowsInitializer = new HasRowsFieldInitializer();
+        field = spy(new TextAreaFieldDefinition());
+        when(fieldElement.getParams()).thenReturn(fieldElementParams);
+        when(context.getI18nHelper()).thenReturn(i18nHelper);
+        when(i18nHelper.getTranslation(PLACEHOLDER)).thenReturn(PLACEHOLDER);
+    }
+
+    @Test
+    public void testInitializeWithParams() throws Exception {
+        fieldElementParams.put(PLACEHOLDER_PARAM, PLACEHOLDER);
+        fieldElementParams.put(ROWS_PARAM, ROWS);
+
+        placeholderInitializer.initialize(field, fieldElement, context);
+        rowsInitializer.initialize(field, fieldElement, context);
+
+        verify(field).setPlaceHolder(any());
+        verify(field).setRows(any());
+
+        assertEquals(PLACEHOLDER, field.getPlaceHolder());
+        assertEquals(Integer.valueOf(ROWS), field.getRows());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/test/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/selectors/SelectorFieldInitilizerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/test/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/selectors/SelectorFieldInitilizerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.selectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.adf.definitions.annotations.field.selector.SelectorDataProvider;
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.FormGenerationContext;
+import org.kie.workbench.common.forms.adf.service.definitions.elements.FieldElement;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorFieldBaseDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.StringListBoxFieldDefinition;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SelectorFieldInitilizerTest {
+
+    private static final String DATA_PROVIDER = SelectorDataProvider.class.getName();
+
+    private SelectorFieldInitilizer initializer;
+
+    private SelectorFieldBaseDefinition field;
+
+    @Mock
+    private FieldElement fieldElement;
+
+    @Mock
+    private FormGenerationContext context;
+
+    private Map<String, String> fieldElementParams = new HashMap<>();
+
+    @Before
+    public void init() {
+        initializer = new SelectorFieldInitilizer();
+        field = spy(new StringListBoxFieldDefinition());
+        when(fieldElement.getParams()).thenReturn(fieldElementParams);
+    }
+
+    @Test
+    public void testInitialize() {
+        fieldElementParams.put(DATA_PROVIDER, DATA_PROVIDER);
+        initializer.initialize(field, fieldElement, context);
+
+        verify(field).setDataProvider(any());
+        assertEquals(DATA_PROVIDER, field.getDataProvider());
+    }
+
+
+}


### PR DESCRIPTION
TextAreaFieldInitializerTest increases coverage of HasPlaceholderInitializer and HasRowsFieldInitializer classes. SelectorFieldInitilizerTest increases coverage of SelectorFieldInitilizer class.