### PR TITLE
JBPM-5790: Case Modeller: Change containment rules for Diagram and Stages

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/java/org/kie/workbench/common/stunner/bpmn/project/factory/impl/BPMNProjectDiagramFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/java/org/kie/workbench/common/stunner/bpmn/project/factory/impl/BPMNProjectDiagramFactory.java
@@ -19,6 +19,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.util.BPMNUtils;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.factory.impl.BindableDiagramFactory;
@@ -67,33 +68,38 @@ public class BPMNProjectDiagramFactory
     protected void updateDiagramProperties(final String name,
                                            final Graph<DefinitionSet, ?> graph,
                                            final ProjectMetadata metadata) {
+        final DiagramSet diagramSet = getDiagramSet(graph);
+        final String id = diagramSet.getId().getValue();
+        final String projectName = null != metadata.getProjectName() ? metadata.getProjectName() + "." : "";
+        if (null == id || id.isEmpty()) {
+            diagramSet.getId().setValue(projectName + name);
+        }
+        final String p = diagramSet.getPackageProperty().getValue();
+        if (null == p || p.isEmpty()) {
+            String metadataPackage = metadata.getProjectPackage();
+            if (metadataPackage == null || metadataPackage.isEmpty()) {
+                diagramSet.getPackageProperty().setValue(diagramSet.getPackageProperty().DEFAULT_PACKAGE);
+            } else {
+                diagramSet.getPackageProperty().setValue(metadata.getProjectPackage());
+            }
+        }
+        final String diagramName = diagramSet.getName().getValue();
+        if (null == diagramName || diagramName.isEmpty()) {
+            diagramSet.getName().setValue(name);
+        }
+    }
+
+    protected DiagramSet getDiagramSet(final Graph<DefinitionSet, ?> graph) {
         final Node<Definition<BPMNDiagram>, ?> diagramNode = getFirstDiagramNode(graph);
         if (null == diagramNode) {
             throw new IllegalStateException("A BPMN Diagram is expected to be present on BPMN Diagram graphs.");
         }
         final BPMNDiagram diagram = diagramNode.getContent().getDefinition();
-        final String id = diagram.getDiagramSet().getId().getValue();
-        final String projectName = null != metadata.getProjectName() ? metadata.getProjectName() + "." : "";
-        if (null == id || id.isEmpty()) {
-            diagram.getDiagramSet().getId().setValue(projectName + name);
-        }
-        final String p = diagram.getDiagramSet().getPackageProperty().getValue();
-        if (null == p || p.isEmpty()) {
-            String metadataPackage = metadata.getProjectPackage();
-            if (metadataPackage == null || metadataPackage.isEmpty()) {
-                diagram.getDiagramSet().getPackageProperty().setValue(diagram.getDiagramSet().getPackageProperty().DEFAULT_PACKAGE);
-            } else {
-                diagram.getDiagramSet().getPackageProperty().setValue(metadata.getProjectPackage());
-            }
-        }
-        final String diagramName = diagram.getDiagramSet().getName().getValue();
-        if (null == diagramName || diagramName.isEmpty()) {
-            diagram.getDiagramSet().getName().setValue(name);
-        }
+        return diagram.getDiagramSet();
     }
 
     @SuppressWarnings("unchecked")
-    protected Node<Definition<BPMNDiagram>, ?> getFirstDiagramNode(final Graph graph) {
+    private Node<Definition<BPMNDiagram>, ?> getFirstDiagramNode(final Graph graph) {
         return BPMNUtils.getFirstDiagramNode(graph);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/BPMNDiagram.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/BPMNDiagram.java
@@ -15,18 +15,30 @@
  */
 package org.kie.workbench.common.stunner.cm.definition;
 
+import java.util.HashSet;
+import java.util.Set;
+import javax.validation.Valid;
+
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDefinition;
+import org.kie.workbench.common.stunner.bpmn.definition.Categories;
 import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dimensions.RectangleDimensionsSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.definition.annotation.Description;
+import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Title;
 import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
@@ -39,24 +51,47 @@ import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
         startElement = "diagramSet",
         policy = FieldPolicy.ONLY_MARKED
 )
+// This is a clone of org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram with different containment rules.
+// Unfortunately extending the foregoing and providing a new @CanContain annotation leads to problems with identifying
+// Factories for Definitions; as CM's BindableDefinitionAdapterProxy is then generated with support for the super-class.
+// This then leads the unmarshalling of model Elements to Definitions to use the wrong Factory and hence fail.
+public class BPMNDiagram implements BPMNDefinition {
 
-public class BPMNDiagram extends org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram {
+    @Category
+    public static final transient String category = Categories.LANES;
 
-    public BPMNDiagram() {
-        super();
-    }
+    @Title
+    public static final transient String title = "BPMN Diagram";
 
-    public BPMNDiagram(final @MapsTo("diagramSet") DiagramSet diagramSet,
-                       final @MapsTo("processData") ProcessData processData,
-                       final @MapsTo("backgroundSet") BackgroundSet backgroundSet,
-                       final @MapsTo("fontSet") FontSet fontSet,
-                       final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet) {
-        super(diagramSet,
-              processData,
-              backgroundSet,
-              fontSet,
-              dimensionsSet);
-    }
+    @Description
+    public static final transient String description = "BPMN Diagram";
+
+    @PropertySet
+    @FormField
+    @Valid
+    private DiagramSet diagramSet;
+
+    @PropertySet
+    @FormField(
+            afterElement = "diagramSet"
+    )
+    @Valid
+    protected ProcessData processData;
+
+    @PropertySet
+    private BackgroundSet backgroundSet;
+
+    @PropertySet
+    private FontSet fontSet;
+
+    @PropertySet
+    protected RectangleDimensionsSet dimensionsSet;
+
+    @Labels
+    private final Set<String> labels = new HashSet<String>() {{
+        add("canContainArtifacts");
+        add("diagram");
+    }};
 
     @NonPortable
     public static class BPMNDiagramBuilder implements Builder<BPMNDiagram> {
@@ -78,5 +113,77 @@ public class BPMNDiagram extends org.kie.workbench.common.stunner.bpmn.definitio
                                    new RectangleDimensionsSet(WIDTH,
                                                               HEIGHT));
         }
+    }
+
+    public BPMNDiagram() {
+    }
+
+    public BPMNDiagram(final @MapsTo("diagramSet") DiagramSet diagramSet,
+                       final @MapsTo("processData") ProcessData processData,
+                       final @MapsTo("backgroundSet") BackgroundSet backgroundSet,
+                       final @MapsTo("fontSet") FontSet fontSet,
+                       final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet) {
+        this.diagramSet = diagramSet;
+        this.processData = processData;
+        this.backgroundSet = backgroundSet;
+        this.fontSet = fontSet;
+        this.dimensionsSet = dimensionsSet;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Set<String> getLabels() {
+        return labels;
+    }
+
+    public DiagramSet getDiagramSet() {
+        return diagramSet;
+    }
+
+    public RectangleDimensionsSet getDimensionsSet() {
+        return dimensionsSet;
+    }
+
+    public void setDimensionsSet(final RectangleDimensionsSet dimensionsSet) {
+        this.dimensionsSet = dimensionsSet;
+    }
+
+    public ProcessData getProcessData() {
+        return processData;
+    }
+
+    public BackgroundSet getBackgroundSet() {
+        return backgroundSet;
+    }
+
+    public FontSet getFontSet() {
+        return fontSet;
+    }
+
+    public void setDiagramSet(final DiagramSet diagramSet) {
+        this.diagramSet = diagramSet;
+    }
+
+    public void setProcessData(final ProcessData processData) {
+        this.processData = processData;
+    }
+
+    public void setBackgroundSet(final BackgroundSet backgroundSet) {
+        this.backgroundSet = backgroundSet;
+    }
+
+    public void setFontSet(final FontSet fontSet) {
+        this.fontSet = fontSet;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/util/CaseManagementUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/util/CaseManagementUtils.java
@@ -31,7 +31,7 @@ public class CaseManagementUtils {
      * @param graph The graph structure.
      */
     @SuppressWarnings("unchecked")
-    public static Node<Definition<org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram>, ?> getFirstDiagramNode(final Graph<?, Node> graph) {
+    public static Node<Definition<BPMNDiagram>, ?> getFirstDiagramNode(final Graph<?, Node> graph) {
         return GraphUtils.getFirstNode(graph,
                                        BPMNDiagram.class);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-backend/src/main/java/org/kie/workbench/common/stunner/cm/backend/CaseManagementDiagramMarshaller.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-backend/src/main/java/org/kie/workbench/common/stunner/cm/backend/CaseManagementDiagramMarshaller.java
@@ -20,7 +20,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.backend.service.XMLEncoderDiagramMetadataMarshaller;
-import org.kie.workbench.common.stunner.bpmn.backend.BPMNDiagramMarshaller;
+import org.kie.workbench.common.stunner.bpmn.backend.BaseDiagramMarshaller;
 import org.kie.workbench.common.stunner.bpmn.backend.marshall.json.builder.GraphObjectBuilderFactory;
 import org.kie.workbench.common.stunner.bpmn.backend.marshall.json.oryx.OryxManager;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDefinition;
@@ -41,7 +41,7 @@ import org.kie.workbench.common.stunner.core.rule.RuleManager;
 
 @Dependent
 @CaseManagementEditor
-public class CaseManagementDiagramMarshaller extends BPMNDiagramMarshaller {
+public class CaseManagementDiagramMarshaller extends BaseDiagramMarshaller<BPMNDiagram> {
 
     @Inject
     public CaseManagementDiagramMarshaller(final XMLEncoderDiagramMetadataMarshaller diagramMetadataMarshaller,
@@ -77,8 +77,20 @@ public class CaseManagementDiagramMarshaller extends BPMNDiagramMarshaller {
     }
 
     @Override
+    public String getTitle(final Graph graph) {
+        final Node<Definition<BPMNDiagram>, ?> diagramNode = getFirstDiagramNode(graph);
+        final BPMNDiagram diagramBean = null != diagramNode ? (BPMNDiagram) ((Definition) diagramNode.getContent()).getDefinition() : null;
+        return getTitle(diagramBean);
+    }
+
+    private String getTitle(final BPMNDiagram diagram) {
+        final String title = diagram.getDiagramSet().getName().getValue();
+        return title != null && title.trim().length() > 0 ? title : "-- Untitled BPMN2 diagram --";
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
-    public Node<Definition<org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram>, ?> getFirstDiagramNode(final Graph graph) {
+    public Node<Definition<BPMNDiagram>, ?> getFirstDiagramNode(final Graph graph) {
         return CaseManagementUtils.getFirstDiagramNode(graph);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-api/src/main/java/org/kie/workbench/common/stunner/cm/project/factory/CaseManagementProjectDiagramFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-api/src/main/java/org/kie/workbench/common/stunner/cm/project/factory/CaseManagementProjectDiagramFactory.java
@@ -18,12 +18,15 @@ package org.kie.workbench.common.stunner.cm.project.factory;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.project.factory.impl.BPMNProjectDiagramFactory;
 import org.kie.workbench.common.stunner.cm.CaseManagementDefinitionSet;
+import org.kie.workbench.common.stunner.cm.definition.BPMNDiagram;
 import org.kie.workbench.common.stunner.cm.util.CaseManagementUtils;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
 
 @ApplicationScoped
 public class CaseManagementProjectDiagramFactory
@@ -35,8 +38,17 @@ public class CaseManagementProjectDiagramFactory
     }
 
     @Override
+    protected DiagramSet getDiagramSet(final Graph<DefinitionSet, ?> graph) {
+        final Node<Definition<BPMNDiagram>, ?> diagramNode = getFirstDiagramNode(graph);
+        if (null == diagramNode) {
+            throw new IllegalStateException("A BPMN Diagram is expected to be present on BPMN Diagram graphs.");
+        }
+        final BPMNDiagram diagram = diagramNode.getContent().getDefinition();
+        return diagram.getDiagramSet();
+    }
+
     @SuppressWarnings("unchecked")
-    protected Node<Definition<org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram>, ?> getFirstDiagramNode(final Graph graph) {
+    private Node<Definition<BPMNDiagram>, ?> getFirstDiagramNode(final Graph graph) {
         return CaseManagementUtils.getFirstDiagramNode(graph);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-5790

Following https://github.com/kiegroup/kie-wb-common/pull/737 @hasys reports it is no longer possible to open BPMN diagrams into Stunner/BPMN editor. I replicated the issue using the same steps as @hasys (although could not replicate using InteliJ). The problem was traced to CM's ```BPMNDiagram``` extending BPMN's ```BPMNDiagram```.