### PR TITLE
Add missing dependency to fix failing tests

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-client/pom.xml
@@ -37,7 +37,7 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
-   <dependency>
+    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
       <scope>provided</scope>
@@ -112,6 +112,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
See https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kie-wb-common-pullrequests/1034/#showFailuresLink (while it's alive).

This PR fixes missing test dependencies.