### PR TITLE
JBPM-5802: fixing styling to make icons don't appear cropped on the palette

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/icons/svg/SVGIconRendererViewImpl.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/icons/svg/SVGIconRendererViewImpl.css
@@ -5,7 +5,9 @@
 
 .bs3-icon-svg-position {
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    top:0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/icons/svg/SVGIconRendererViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/icons/svg/SVGIconRendererViewImpl.java
@@ -86,6 +86,9 @@ public class SVGIconRendererViewImpl implements SVGIconRendererView,
                                                   size + "px");
                 svgElement.getStyle().setProperty("height",
                                                   size + "px");
+                svgElement.getStyle().setProperty("position", "absolute");
+                svgElement.getStyle().setProperty("top", "0px");
+                svgElement.getStyle().setProperty("left", "0px");
             }
         }
     }


### PR DESCRIPTION
Fixes a CSS issue that makes some SVG look bad on the palette.

@romartin can you take a look?