### PR TITLE
JBPM-5828: Case Modeller: Stages and Activities to use icons

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/WiresContainerShapeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/WiresContainerShapeView.java
@@ -57,4 +57,10 @@ public class WiresContainerShapeView<T extends WiresContainerShapeView>
     public Iterable<T> getChildren() {
         return children;
     }
+
+    @Override
+    protected void preDestroy() {
+        this.getChildren().forEach(WiresContainerShapeView::destroy);
+        super.preDestroy();
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/WiresContainerShapeViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/WiresContainerShapeViewTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.lienzo.shape.view;
+
+import com.ait.lienzo.client.core.shape.MultiPath;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.shape.HasChildren;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class WiresContainerShapeViewTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkDestructionDestroysChildren() {
+        final WiresContainerShapeView parent = makeShape();
+        final WiresContainerShapeView child1 = spy(makeShape());
+        final WiresContainerShapeView child2 = spy(makeShape());
+
+        parent.addChild(child1,
+                        HasChildren.Layout.CENTER);
+        parent.addChild(child2,
+                        HasChildren.Layout.CENTER);
+
+        parent.preDestroy();
+
+        verify(child1).preDestroy();
+        verify(child2).preDestroy();
+    }
+
+    private WiresContainerShapeView makeShape() {
+        return new WiresContainerShapeView(new ViewEventType[]{},
+                                           new MultiPath());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/pom.xml
@@ -137,6 +137,18 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.ahome-it</groupId>
+      <artifactId>lienzo-tests</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>apache-jsp</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/PictureShapeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/PictureShapeView.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.stunner.shapes.client.view;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Picture;
+import com.google.gwt.core.client.Scheduler;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ShapeViewSupportedEvents;
 
@@ -42,21 +43,27 @@ public class PictureShapeView<T extends PictureShapeView>
                             height)
                       .setStrokeAlpha(0)
                       .setFillAlpha(0));
-        new Picture(uri,
-                    picture1 -> {
-                        this.picture = picture1;
-                        scalePicture(picture1,
-                                     width,
-                                     height);
-                        addChild(picture1);
-                        refresh();
-                    });
+        this.picture = new Picture(uri,
+                                   picture -> {
+                                       scalePicture(picture,
+                                                    width,
+                                                    height);
+                                       addChild(picture);
+                                       refresh();
+                                   });
         super.setResizable(false);
     }
 
     @Override
     protected void preDestroy() {
         super.preDestroy();
-        picture.removeFromParent();
+        PictureUtils.tryDestroy(getPicture(),
+                                (p) -> Scheduler.get().scheduleFixedDelay(() -> !PictureUtils.retryDestroy(p),
+                                                                          200));
+    }
+
+    //package-protected method to support overriding Picture in Unit Tests
+    Picture getPicture() {
+        return this.picture;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/PictureUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/PictureUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.shapes.client.view;
+
+import java.util.function.Consumer;
+
+import com.ait.lienzo.client.core.shape.Picture;
+
+public class PictureUtils {
+
+    public static void tryDestroy(final Picture picture,
+                                  final Consumer<Picture> retryCallback) {
+        // Destroy the <img..> related to the Glyph added to the DOM root by Picture's use of ImageLoader.
+        // If the image has not completed loading attempts to remove from the DOM result in an error; therefore
+        // schedule successive attempts until success.
+        if (!retryDestroy(picture)) {
+            retryCallback.accept(picture);
+        }
+    }
+
+    public static boolean retryDestroy(final Picture picture) {
+        if (picture != null && picture.isLoaded()) {
+            picture.removeFromParent();
+            picture.getImageProxy().getImage().removeFromParent();
+            return true;
+        }
+        return false;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/glyph/PictureGlyph.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/glyph/PictureGlyph.java
@@ -21,6 +21,7 @@ import com.ait.lienzo.client.core.shape.Rectangle;
 import com.ait.lienzo.shared.core.types.ColorName;
 import com.google.gwt.core.client.Scheduler;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.glyph.AbstractLienzoShapeGlyph;
+import org.kie.workbench.common.stunner.shapes.client.view.PictureUtils;
 
 import static org.kie.workbench.common.stunner.client.lienzo.util.LienzoShapeUtils.scalePicture;
 
@@ -41,22 +42,14 @@ public final class PictureGlyph extends AbstractLienzoShapeGlyph {
 
     @Override
     public void destroy() {
-        // Destroy the <img..> related to the Glyph added to the DOM root by Picture's use of ImageLoader.
-        // If the image has not completed loading attempts to remove from the DOM result in an error; therefore
-        // schedule successive attempts until success.
-        if (!doDestroy()) {
-            Scheduler.get().scheduleFixedDelay(() -> !doDestroy(),
-                                               200);
-        }
+        PictureUtils.tryDestroy(getPicture(),
+                                (p) -> Scheduler.get().scheduleFixedDelay(() -> !PictureUtils.retryDestroy(p),
+                                                                          200));
     }
 
-    private boolean doDestroy() {
-        if (picture != null && picture.isLoaded()) {
-            picture.getImageProxy().getImage().removeFromParent();
-            picture = null;
-            return true;
-        }
-        return false;
+    //package-protected method to support overriding Picture in Unit Tests
+    Picture getPicture() {
+        return this.picture;
     }
 
     private void build(final String uri,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/test/java/org/kie/workbench/common/stunner/shapes/client/view/PictureShapeViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/test/java/org/kie/workbench/common/stunner/shapes/client/view/PictureShapeViewTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.shapes.client.view;
+
+import com.ait.lienzo.client.core.image.ImageProxy;
+import com.ait.lienzo.client.core.shape.Picture;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.ImageElement;
+import com.google.gwtmockito.WithClassesToStub;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+@WithClassesToStub({com.google.gwt.dom.client.ImageElement.class})
+@RunWith(LienzoMockitoTestRunner.class)
+public class PictureShapeViewTest {
+
+    @Mock
+    private Picture picture;
+
+    @Mock
+    private ImageProxy imageProxy;
+
+    @Mock
+    private ImageElement imageElement;
+
+    private PictureShapeView view;
+
+    @Before
+    public void setup() {
+        view = spy(new PictureShapeView("http://url",
+                                        10,
+                                        10));
+        //Fake image loading...
+        when(picture.isLoaded()).thenReturn(true);
+        when(picture.getImageProxy()).thenReturn(imageProxy);
+        when(imageProxy.getImage()).thenReturn(imageElement);
+        when(view.getPicture()).thenReturn(picture);
+    }
+
+    @Test
+    public void checkPreDestructionRemovesResourcesFromDOM() {
+        view.preDestroy();
+
+        verify(picture).removeFromParent();
+        verify(imageElement).removeFromParent();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/test/java/org/kie/workbench/common/stunner/shapes/client/view/PictureUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/test/java/org/kie/workbench/common/stunner/shapes/client/view/PictureUtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.shapes.client.view;
+
+import com.ait.lienzo.client.core.image.ImageProxy;
+import com.ait.lienzo.client.core.shape.Picture;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.ImageElement;
+import com.google.gwtmockito.WithClassesToStub;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+@WithClassesToStub({ImageElement.class})
+@RunWith(LienzoMockitoTestRunner.class)
+public class PictureUtilsTest {
+
+    @Mock
+    private Picture picture;
+
+    @Mock
+    private ImageProxy imageProxy;
+
+    @Mock
+    private ImageElement imageElement;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        //Fake image loading...
+        when(picture.getImageProxy()).thenReturn(imageProxy);
+        when(imageProxy.getImage()).thenReturn(imageElement);
+    }
+
+    @Test
+    public void checkDestructionRemovesResourcesFromDOMWhenPictureIsLoaded() {
+        when(picture.isLoaded()).thenReturn(true);
+
+        PictureUtils.tryDestroy(picture,
+                                PictureUtils::retryDestroy);
+
+        verify(picture).removeFromParent();
+        verify(imageElement).removeFromParent();
+    }
+
+    @Test
+    public void checkDestructionRemovesResourcesFromDOMWhenPictureLoadedIsDelayed() {
+        when(picture.isLoaded()).thenReturn(false);
+
+        PictureUtils.tryDestroy(picture,
+                                (p) -> {
+                                    when(picture.isLoaded()).thenReturn(true);
+                                    PictureUtils.retryDestroy(p);
+                                });
+
+        verify(picture).removeFromParent();
+        verify(imageElement).removeFromParent();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/test/java/org/kie/workbench/common/stunner/shapes/client/view/glyph/PictureGlyphTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/test/java/org/kie/workbench/common/stunner/shapes/client/view/glyph/PictureGlyphTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.shapes.client.view.glyph;
+
+import com.ait.lienzo.client.core.image.ImageProxy;
+import com.ait.lienzo.client.core.shape.Picture;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.ImageElement;
+import com.google.gwtmockito.WithClassesToStub;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+@WithClassesToStub({ImageElement.class})
+@RunWith(LienzoMockitoTestRunner.class)
+public class PictureGlyphTest {
+
+    @Mock
+    private Picture picture;
+
+    @Mock
+    private ImageProxy imageProxy;
+
+    @Mock
+    private ImageElement imageElement;
+
+    private PictureGlyph glyph;
+
+    @Before
+    public void setup() {
+        glyph = spy(new PictureGlyph("http://url",
+                                     10,
+                                     10));
+        //Fake image loading...
+        when(picture.isLoaded()).thenReturn(true);
+        when(picture.getImageProxy()).thenReturn(imageProxy);
+        when(imageProxy.getImage()).thenReturn(imageElement);
+        when(glyph.getPicture()).thenReturn(picture);
+    }
+
+    @Test
+    public void checkDestructionRemovesResourcesFromDOM() {
+        glyph.destroy();
+
+        verify(picture).removeFromParent();
+        verify(imageElement).removeFromParent();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
@@ -315,6 +315,7 @@ public class BS3PaletteWidgetImpl extends AbstractPalette<DefinitionSetPalette>
     protected void doDestroy() {
         categoryWidgetInstance.destroyAll();
         iconRendererInstance.destroyAll();
+        viewFactory.destroy();
         view.destroy();
         this.itemDropCallback = null;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteGlyphViewFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteGlyphViewFactory.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.client.widgets.palette.factory;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.validation.client.impl.Group;
 import org.kie.workbench.common.stunner.client.lienzo.util.LienzoPanelUtils;
@@ -32,6 +35,8 @@ class BS3PaletteGlyphViewFactory implements BS3PaletteViewFactory {
 
     private final ShapeManager shapeManager;
 
+    private final Set<Glyph<Group>> glyphs = new HashSet<>();
+
     BS3PaletteGlyphViewFactory(final ShapeManager shapeManager) {
         this.shapeManager = shapeManager;
     }
@@ -47,6 +52,7 @@ class BS3PaletteGlyphViewFactory implements BS3PaletteViewFactory {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public PaletteIconSettings getDefinitionIconSettings(String defSetId,
                                                          String itemId) {
         IsWidget panel = getDefinitionView(defSetId,
@@ -54,6 +60,12 @@ class BS3PaletteGlyphViewFactory implements BS3PaletteViewFactory {
 
         return new PaletteIconSettings(LienzoPanelIconRenderer.class,
                                        new IconResource<>(panel));
+    }
+
+    @Override
+    public void destroy() {
+        glyphs.forEach(Glyph::destroy);
+        glyphs.clear();
     }
 
     protected IsWidget getDefinitionView(final String defSetId,
@@ -72,8 +84,10 @@ class BS3PaletteGlyphViewFactory implements BS3PaletteViewFactory {
                                   final String id,
                                   final int width,
                                   final int height) {
-        return shapeManager.getDefaultShapeSet(defSetId).getShapeFactory().glyph(id,
-                                                                                 width,
-                                                                                 height);
+        final Glyph<Group> glyph = shapeManager.getDefaultShapeSet(defSetId).getShapeFactory().glyph(id,
+                                                                                                     width,
+                                                                                                     height);
+        glyphs.add(glyph);
+        return glyph;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteViewFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteViewFactory.java
@@ -26,4 +26,10 @@ public interface BS3PaletteViewFactory {
     boolean accepts(final String defSetId);
 
     PaletteIconSettings getCategoryIconSettings(final String categoryId);
+
+    /**
+     * Destroys resources that may need releasing when the factory is destroyed
+     */
+    default void destroy() {
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BindableBS3PaletteGlyphViewFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BindableBS3PaletteGlyphViewFactory.java
@@ -24,7 +24,17 @@ public abstract class BindableBS3PaletteGlyphViewFactory extends BindableBS3Pale
     private final BS3PaletteGlyphViewFactory glyphViewFactory;
 
     public BindableBS3PaletteGlyphViewFactory(final ShapeManager shapeManager) {
-        this.glyphViewFactory = new BS3PaletteGlyphViewFactory(shapeManager);
+        this.glyphViewFactory = getBS3PaletteGlyphViewFactory(shapeManager);
+    }
+
+    //package-protected method to support overriding factory in Unit Tests
+    BS3PaletteGlyphViewFactory getBS3PaletteGlyphViewFactory(final ShapeManager shapeManager) {
+        return new BS3PaletteGlyphViewFactory(shapeManager);
+    }
+
+    @Override
+    public void destroy() {
+        glyphViewFactory.destroy();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionPresenter.java
@@ -182,7 +182,6 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
         if (null != getToolbar()) {
             getToolbar().clear();
         }
-        sessionManager.destroy();
         getDisplayer().clear();
         diagram = null;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionViewer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionViewer.java
@@ -77,7 +77,6 @@ public abstract class AbstractSessionViewer<S extends AbstractClientSession, H e
     public void clear() {
         if (null != getDiagramViewer()) {
             getDiagramViewer().clear();
-            session = null;
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/tooltip/DefinitionGlyphTooltipImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/tooltip/DefinitionGlyphTooltipImpl.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.client.widgets.tooltip;
 
+import java.util.Optional;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -40,6 +42,8 @@ public class DefinitionGlyphTooltipImpl
     private String prefix;
     private String suffix;
 
+    private Optional<Glyph> glyph = Optional.empty();
+
     protected DefinitionGlyphTooltipImpl() {
         this(null,
              null,
@@ -56,6 +60,11 @@ public class DefinitionGlyphTooltipImpl
         this.definitionManager = definitionManager;
         this.factoryManager = factoryManager;
         this.shapeManager = shapeManager;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        glyph.ifPresent(Glyph::destroy);
     }
 
     @Override
@@ -97,10 +106,10 @@ public class DefinitionGlyphTooltipImpl
         final String title = getTitle(definitionId);
         if (null != title) {
             final ShapeFactory<?, ?, ?> factory = shapeManager.getDefaultShapeSet(defSetId).getShapeFactory();
-            final Glyph glyph = factory.glyph(definitionId,
-                                              width,
-                                              height);
-            this.show(glyph,
+            this.glyph = Optional.of(factory.glyph(definitionId,
+                                                   width,
+                                                   height));
+            this.show(glyph.get(),
                       getTitleToShow(title),
                       x,
                       y,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImplTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.palette;
+
+import com.ait.lienzo.client.core.shape.Group;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.palette.categories.DefinitionPaletteCategoryWidget;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteViewFactory;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.icons.IconRenderer;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.glyph.ShapeGlyphDragHandler;
+import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BS3PaletteWidgetImplTest {
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private ClientFactoryService clientFactoryServices;
+
+    @Mock
+    private BS3PaletteWidgetView view;
+
+    @Mock
+    private ShapeGlyphDragHandler<Group> shapeGlyphDragHandler;
+
+    @Mock
+    private ManagedInstance<DefinitionPaletteCategoryWidget> categoryWidgetInstance;
+
+    @Mock
+    private ManagedInstance<IconRenderer> iconRendererInstance;
+
+    @Mock
+    private BS3PaletteViewFactory viewFactory;
+
+    private BS3PaletteWidgetImpl palette;
+
+    @Before
+    public void setup() {
+        this.palette = new BS3PaletteWidgetImpl(shapeManager,
+                                                clientFactoryServices,
+                                                view,
+                                                shapeGlyphDragHandler,
+                                                categoryWidgetInstance,
+                                                iconRendererInstance);
+        this.palette.init();
+        this.palette.setViewFactory(viewFactory);
+    }
+
+    @Test
+    public void checkDestructionReleasesResources() {
+        palette.doDestroy();
+
+        verify(categoryWidgetInstance).destroyAll();
+        verify(iconRendererInstance).destroyAll();
+        verify(viewFactory).destroy();
+        verify(view).destroy();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteGlyphViewFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteGlyphViewFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.palette.factory;
+
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.Node;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.ShapeSet;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.client.shape.view.glyph.Glyph;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class BS3PaletteGlyphViewFactoryTest {
+
+    private static final String DEFINITION_SET_ID = "defSetId";
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private ShapeSet shapeSet;
+
+    @Mock
+    private ShapeFactory shapeFactory;
+
+    private BS3PaletteGlyphViewFactory factory;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.factory = new BS3PaletteGlyphViewFactory(shapeManager);
+
+        when(shapeManager.getDefaultShapeSet(eq(DEFINITION_SET_ID))).thenReturn(shapeSet);
+        when(shapeSet.getShapeFactory()).thenReturn(shapeFactory);
+    }
+
+    @Test
+    public void checkGlyphsAreDestroyed() {
+        final Glyph glyph1 = makeGlyph("id1");
+        final Glyph glyph2 = makeGlyph("id2");
+
+        factory.getDefinitionIconSettings(DEFINITION_SET_ID,
+                                          "id1");
+        factory.getDefinitionIconSettings(DEFINITION_SET_ID,
+                                          "id2");
+
+        factory.destroy();
+
+        verify(glyph1).destroy();
+        verify(glyph2).destroy();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Glyph makeGlyph(final String id) {
+        final Glyph glyph = mock(Glyph.class);
+        final Group group = mock(Group.class);
+        when(glyph.getGroup()).thenReturn(group);
+        when(group.asNode()).thenReturn(mock(Node.class));
+        when(shapeFactory.glyph(eq(id),
+                                anyDouble(),
+                                anyDouble())).thenReturn(glyph);
+        return glyph;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BindableBS3PaletteGlyphViewFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BindableBS3PaletteGlyphViewFactoryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.palette.factory;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.icons.IconRenderer;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.icons.IconResource;
+import org.kie.workbench.common.stunner.core.client.ShapeSet;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class BindableBS3PaletteGlyphViewFactoryTest {
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private ShapeSet shapeSet;
+
+    @Mock
+    private ShapeFactory shapeFactory;
+
+    @Mock
+    private BS3PaletteGlyphViewFactory glyphViewFactory;
+
+    private BindableBS3PaletteGlyphViewFactory factory;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.factory = new BindableBS3PaletteGlyphViewFactory(shapeManager) {
+
+            @Override
+            BS3PaletteGlyphViewFactory getBS3PaletteGlyphViewFactory(final ShapeManager shapeManager) {
+                return glyphViewFactory;
+            }
+
+            @Override
+            protected Class<?> getDefinitionSetType() {
+                //Dummy value
+                return DefinitionSet.class;
+            }
+
+            @Override
+            protected Class<? extends IconRenderer> getPaletteIconRendererType() {
+                //Dummy value
+                return IconRenderer.class;
+            }
+
+            @Override
+            protected Map<String, IconResource> getCategoryIconResources() {
+                //Dummy value
+                return Collections.emptyMap();
+            }
+
+            @Override
+            protected Map<String, IconResource> getDefinitionIconResources() {
+                //Dummy value
+                return Collections.emptyMap();
+            }
+        };
+    }
+
+    @Test
+    public void checkGlyphViewFactoryIsDestroyed() {
+        factory.destroy();
+
+        verify(glyphViewFactory).destroy();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorTest.java
@@ -128,7 +128,6 @@ public class SessionEditorTest extends AbstractCanvasHandlerViewerTest {
         tested.open(session,
                     callback);
         tested.clear();
-        assertNull(tested.getInstance());
         verify(canvasHandler,
                times(1)).clear();
         verify(view,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionViewerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionViewerTest.java
@@ -98,7 +98,6 @@ public class SessionViewerTest extends AbstractCanvasHandlerViewerTest {
         tested.open(session,
                     callback);
         tested.clear();
-        assertNull(tested.getInstance());
         verify(canvasHandler,
                times(1)).clear();
         verify(view,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/tooltip/DefinitionGlyphTooltipImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/tooltip/DefinitionGlyphTooltipImplTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.tooltip;
+
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.Node;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.client.ShapeSet;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.glyph.GlyphTooltip;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.client.shape.view.glyph.Glyph;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefinitionGlyphTooltipImplTest {
+
+    private static final String DEFINITION_SET_ID = "defSetId";
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private FactoryManager factoryManager;
+
+    @Mock
+    private GlyphTooltipImpl.View view;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private DefinitionAdapter definitionAdapter;
+
+    @Mock
+    private ShapeSet shapeSet;
+
+    @Mock
+    private ShapeFactory shapeFactory;
+
+    private DefinitionGlyphTooltipImpl tooltip;
+
+    @Before
+    public void setup() {
+        tooltip = new DefinitionGlyphTooltipImpl(definitionManager,
+                                                 shapeManager,
+                                                 factoryManager,
+                                                 view);
+    }
+
+    @Test
+    public void checkTooltipGlyphsAreDestroyed() {
+        final Glyph glyph = makeGlyph("id1");
+
+        tooltip.destroy();
+
+        verify(glyph).destroy();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Glyph makeGlyph(final String id) {
+        final Glyph glyph = mock(Glyph.class);
+        final Group group = mock(Group.class);
+        final Object definition = mock(Object.class);
+        when(glyph.getGroup()).thenReturn(group);
+        when(group.asNode()).thenReturn(mock(Node.class));
+        when(factoryManager.newDefinition(eq(id))).thenReturn(definition);
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
+        when(definitionAdapter.getTitle(eq(definition))).thenReturn(id);
+
+        when(shapeManager.getDefaultShapeSet(eq(DEFINITION_SET_ID))).thenReturn(shapeSet);
+        when(shapeSet.getShapeFactory()).thenReturn(shapeFactory);
+        when(shapeFactory.glyph(eq(id),
+                                anyDouble(),
+                                anyDouble())).thenReturn(glyph);
+
+        tooltip.showGlyph(DEFINITION_SET_ID,
+                          id,
+                          0,
+                          0,
+                          0,
+                          0,
+                          GlyphTooltip.Direction.NORTH);
+
+        return glyph;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -467,6 +467,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
     private void destroySession() {
         unbindCommands();
         presenter.clear();
+        presenter.destroy();
     }
 
     private void updateTitle(final String title) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/AbstractCaseManagementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/AbstractCaseManagementShape.java
@@ -22,11 +22,11 @@ import java.util.Optional;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
-import org.kie.workbench.common.stunner.client.lienzo.shape.view.ext.WiresShapeViewExt;
+import org.kie.workbench.common.stunner.client.lienzo.shape.view.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 
-public abstract class AbstractCaseManagementShape<T extends WiresShapeViewExt> extends WiresShapeViewExt<T> implements HasSize<T> {
+public abstract class AbstractCaseManagementShape<T extends WiresContainerShapeView> extends WiresContainerShapeView<T> implements HasSize<T> {
 
     private final double minWidth;
     private final double minHeight;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementDelegateShapeFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementDelegateShapeFactoryTest.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.stunner.cm.client.shape.factory;
 
 import java.util.function.Consumer;
 
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.IContainer;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,6 +69,7 @@ import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
 import org.kie.workbench.common.stunner.core.definition.shape.GlyphDef;
 import org.kie.workbench.common.stunner.shapes.client.factory.BasicShapesFactoryImpl;
+import org.kie.workbench.common.stunner.shapes.client.view.PictureShapeView;
 import org.kie.workbench.common.stunner.shapes.client.view.ShapeViewFactory;
 import org.kie.workbench.common.stunner.shapes.factory.BasicShapesFactory;
 import org.mockito.Mock;
@@ -98,6 +101,10 @@ public class CaseManagementDelegateShapeFactoryTest {
 
     @Mock
     private ShapeViewFactory shapeViewFactory;
+
+    @Mock
+    private PictureShapeView pictureShapeView;
+    private IContainer pictureShapeViewContainer = new Group();
 
     @Mock
     private CaseManagementCanvasHandler canvasHandler;
@@ -143,6 +150,7 @@ public class CaseManagementDelegateShapeFactoryTest {
                                                                                  definitionManager,
                                                                                  glyphBuilderFactory);
         final CaseManagementShapesFactory caseManagementShapesFactory = new CaseManagementShapesFactoryImpl(factoryManager,
+                                                                                                            shapeViewFactory,
                                                                                                             definitionManager,
                                                                                                             glyphBuilderFactory);
         this.factory = new CaseManagementDelegateShapeFactory(definitionManager,
@@ -150,6 +158,10 @@ public class CaseManagementDelegateShapeFactoryTest {
                                                               caseManagementShapesFactory);
         this.factory.init();
 
+        when(shapeViewFactory.picture(anyObject(),
+                                      anyDouble(),
+                                      anyDouble())).thenReturn(pictureShapeView);
+        when(pictureShapeView.getContainer()).thenReturn(pictureShapeViewContainer);
         when(definitionManager.adapters()).thenReturn(adapterManager);
         when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
         when(glyphBuilderFactory.getBuilder(any(GlyphDef.class))).thenReturn(glyphBuilder);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/MockCaseManagementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/MockCaseManagementShape.java
@@ -17,13 +17,13 @@
 package org.kie.workbench.common.stunner.cm.client.wires;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import org.kie.workbench.common.stunner.client.lienzo.shape.view.ext.WiresShapeViewExt;
+import org.kie.workbench.common.stunner.client.lienzo.shape.view.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 
 /**
  * Mock implementation of AbstractCaseManagementShape for Unit Tests
  */
-public class MockCaseManagementShape extends AbstractCaseManagementShape<WiresShapeViewExt> {
+public class MockCaseManagementShape extends AbstractCaseManagementShape<WiresContainerShapeView> {
 
     public MockCaseManagementShape() {
         super(new ViewEventType[]{},
@@ -38,8 +38,8 @@ public class MockCaseManagementShape extends AbstractCaseManagementShape<WiresSh
     }
 
     @Override
-    public WiresShapeViewExt setSize(double width,
-                                     double height) {
+    public WiresContainerShapeView setSize(double width,
+                                           double height) {
         return this;
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-5828

Whilst adding icons I noticed some DOM leaks regarding glyphs (used for the icons) and fixed those too.

The leaks fixes probably relate to https://issues.jboss.org/browse/JBPM-5462