### PR TITLE
GUVNOR-2968: [Library] Remove margin above Messages panel

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryView.less
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryView.less
@@ -342,4 +342,10 @@
     .fixed-header + .page-content-kie {
         padding-top: 4em;
     }
+
+    .page-content-kie:after {
+        content: " ";
+        display: table;
+        clear: both;
+    }
 }


### PR DESCRIPTION
The fix to [GUVNOR-2968](https://issues.jboss.org/browse/GUVNOR-2968) depends on [this PR](https://github.com/uberfire/uberfire/pull/653) too, but both PRs can be merged independently.