### PR TITLE
JBPM-5532 & JBPM-5579: Fixing new Form popup bugs

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-client/src/main/java/org/kie/workbench/common/forms/data/modeller/client/formModel/DataObjectFormModelCreationViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-client/src/main/java/org/kie/workbench/common/forms/data/modeller/client/formModel/DataObjectFormModelCreationViewImpl.java
@@ -76,8 +76,6 @@ public class DataObjectFormModelCreationViewImpl implements DataObjectFormModelC
     @Override
     public void reset() {
         listBox.setValue( null );
-        listBox.setAcceptableValues( new ArrayList<>() );
-        listBox.reset();
         clearValidationErrors();
     }
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/formModel/JBPMFormModelCreationPresenterManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/formModel/JBPMFormModelCreationPresenterManager.java
@@ -96,7 +96,6 @@ public class JBPMFormModelCreationPresenterManager implements FormModelCreationV
     @Override
     public void reset() {
         view.reset();
-        newResourcePresenter.setResourceName( "" );
     }
 
     @Override
@@ -110,9 +109,7 @@ public class JBPMFormModelCreationPresenterManager implements FormModelCreationV
         this.model = model;
 
         if ( model != null ) {
-            newResourcePresenter.setResourceName( model.getFormName() );
-        } else {
-            newResourcePresenter.setResourceName( "" );
+            newResourcePresenter.setResourceName(model.getFormName());
         }
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/resources/org/kie/workbench/common/forms/jbpm/client/resources/i18n/Constants.properties
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/resources/org/kie/workbench/common/forms/jbpm/client/resources/i18n/Constants.properties
@@ -1,19 +1,3 @@
-#
-# Copyright 2016 Red Hat, Inc. and/or its affiliates.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 JBPMFormModelCreationPresenter.Process=Business Process
 JBPMFormModelCreationPresenter.InvalidFormModel=There's no process or task selected
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/test/java/org/kie/workbench/common/forms/jbpm/client/formModel/JBPMFormModelCreationPresenterTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/test/java/org/kie/workbench/common/forms/jbpm/client/formModel/JBPMFormModelCreationPresenterTest.java
@@ -115,8 +115,6 @@ public class JBPMFormModelCreationPresenterTest {
 
         presenter.reset();
 
-        verify( newResourcePresenter, times( 2 ) ).setResourceName( "" );
-
         boolean isValid = presenter.isValid();
 
         assertTrue( isValid );


### PR DESCRIPTION
JBPM-5579: Data objects in the data source dropdown disappear on the second select of the radio button.
JBPM-5532: Form definition name in the new item dialog gets deleted on data source select.

@wmedvede can you take a look please?