### PR TITLE
[7.0.x] GUVNOR-3030: Resizing Project Explorer Dock throws NPE

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocks.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocks.java
@@ -228,10 +228,15 @@ public class AuthoringWorkbenchDocks {
     }
 
     public void projectExplorerExpandedEvent(@Observes final UberfireDocksInteractionEvent uberfireDocksInteractionEvent) {
-        if (uberfireDocksInteractionEvent.getTargetDock().equals(projectExplorerDock)) {
-            if (uberfireDocksInteractionEvent.getType().equals(UberfireDocksInteractionEvent.InteractionType.SELECTED)) {
+        final UberfireDock targetDock = uberfireDocksInteractionEvent.getTargetDock();
+        if (targetDock == null) {
+            return;
+        }
+        if (targetDock.equals(projectExplorerDock)) {
+            final UberfireDocksInteractionEvent.InteractionType interactionType = uberfireDocksInteractionEvent.getType();
+            if (interactionType.equals(UberfireDocksInteractionEvent.InteractionType.SELECTED)) {
                 setProjectExplorerExpandedPreference(true);
-            } else if (uberfireDocksInteractionEvent.getType().equals(UberfireDocksInteractionEvent.InteractionType.DESELECTED)) {
+            } else if (interactionType.equals(UberfireDocksInteractionEvent.InteractionType.DESELECTED)) {
                 setProjectExplorerExpandedPreference(false);
             }
         }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocksTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocksTest.java
@@ -336,9 +336,26 @@ public class AuthoringWorkbenchDocksTest {
                never()).setProjectExplorerExpandedPreference(anyBoolean());
     }
 
+    @Test
+    public void projectExplorerExpandedEvent_WithNullTargetDock() {
+        final UberfireDocksInteractionEvent uberfireDocksInteractionEvent = createUberfireDocksInteractionEvent(UberfireDockPosition.WEST,
+                                                                                                                UberfireDocksInteractionEvent.InteractionType.RESIZED);
+
+        authoringDocks.projectExplorerExpandedEvent(uberfireDocksInteractionEvent);
+
+        verify(authoringDocks,
+               never()).setProjectExplorerExpandedPreference(anyBoolean());
+    }
+
     private UberfireDocksInteractionEvent createUberfireDocksInteractionEvent(final UberfireDock uberfireDock,
                                                                               final UberfireDocksInteractionEvent.InteractionType interactionType) {
         return new UberfireDocksInteractionEvent(uberfireDock,
+                                                 interactionType);
+    }
+
+    private UberfireDocksInteractionEvent createUberfireDocksInteractionEvent(final UberfireDockPosition position,
+                                                                              final UberfireDocksInteractionEvent.InteractionType interactionType) {
+        return new UberfireDocksInteractionEvent(position,
                                                  interactionType);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3030

This is the corollary of https://github.com/kiegroup/kie-wb-common/pull/798 for 7.0.x

(cherry picked from commit c5cb87153a4ba08a0b33e4d2f34868b4d6e7eda8)