### PR TITLE
GUVNOR-3038: [Library] Import examples not working

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
@@ -186,14 +186,14 @@ public class ExamplesServiceImpl implements ExamplesService {
                                              @Override
                                              public java.nio.file.FileVisitResult visitFile(java.nio.file.Path file,
                                                                                             java.nio.file.attribute.BasicFileAttributes attrs) throws java.io.IOException {
-                                                 java.nio.file.Files.delete(file);
+                                                 file.toFile().delete();
                                                  return java.nio.file.FileVisitResult.CONTINUE;
                                              }
 
                                              @Override
                                              public java.nio.file.FileVisitResult postVisitDirectory(java.nio.file.Path dir,
                                                                                                      java.io.IOException exc) throws java.io.IOException {
-                                                 java.nio.file.Files.delete(dir);
+                                                 dir.toFile().delete();
                                                  return java.nio.file.FileVisitResult.CONTINUE;
                                              }
                                          });


### PR DESCRIPTION
Replace Files.delete by File.delete to avoid AccesDeniedExceptions if directory is marked as read-only (windows-related).