### PR TITLE
[6.5.x] RHBPMS-4564: Cloning managed repo as unmanaged causes menu on project editor displays different options for user using same roles in BxMS 6

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterRefreshTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterRefreshTest.java
@@ -47,7 +47,7 @@ public class ProjectScreenPresenterRefreshTest
         ApplicationPreferences.setUp( new HashMap<String, String>() );
 
         mockBuildOptions();
-
+        mockRepositoryService();
 
         final ProjectScreenModel model = new ProjectScreenModel();
         model.setPOMMetaData( new Metadata() );

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTestBase.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTestBase.java
@@ -20,7 +20,9 @@ import java.util.Collection;
 import java.util.Collections;
 
 import com.google.gwtmockito.GwtMock;
+import org.guvnor.asset.management.model.RepositoryStructureModel;
 import org.guvnor.asset.management.service.AssetManagementService;
+import org.guvnor.asset.management.service.RepositoryStructureService;
 import org.guvnor.common.services.project.builder.model.BuildResults;
 import org.guvnor.common.services.project.builder.service.BuildService;
 import org.guvnor.common.services.project.client.repositories.ConflictingRepositoriesPopup;
@@ -99,9 +101,15 @@ public abstract class ProjectScreenPresenterTestBase {
     @Mock
     protected Repository repository;
     @Mock
+    protected RepositoryStructureModel repositoryStructureModel;
+    @Mock
     protected Path pomPath;
+    @Mock
+    protected RepositoryStructureService repositoryStructureService;
 
     protected ObservablePath observablePathToPomXML;
+    
+    protected ProjectScreenPresenter spiedPresenter;
 
     protected void mockBuildOptions() {
         when( view.getBuildOptionsButton() ).thenReturn( buildOptions );
@@ -173,7 +181,8 @@ public abstract class ProjectScreenPresenterTestBase {
                                                 new CallerMock<ValidationService>( mock( ValidationService.class ) ),
                                                 lockManagerInstanceProvider,
                                                 mock( EventSourceMock.class ),
-                                                conflictingRepositoriesPopup ) {
+                                                conflictingRepositoriesPopup,
+                                                new CallerMock<RepositoryStructureService>( repositoryStructureService ) ) {
 
             @Override
             protected void setupPathToPomXML() {
@@ -207,5 +216,11 @@ public abstract class ProjectScreenPresenterTestBase {
             }
         };
 
+        spiedPresenter = spy( presenter );
+    }
+
+    protected void mockRepositoryService() {
+        when( repositoryStructureModel.isManaged() ).thenReturn( true );
+        when( repositoryStructureService.load( any(Repository.class) ) ).thenReturn( repositoryStructureModel );
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4564

Before (or [see the video](https://drive.google.com/a/redhat.com/file/d/0B4qIOCgZfb2eeG4zN0c3Y19vN2s/view?usp=sharing)):
![before](https://cloud.githubusercontent.com/assets/1079279/25667623/6d99aa5e-2ffa-11e7-89e0-698e12863960.gif)

After:
![after](https://cloud.githubusercontent.com/assets/1079279/25667630/6feee3be-2ffa-11e7-9cc9-539321668ce1.gif)
