### PR TITLE
Stunner showcase - Added missing dashbuilder dependencies.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -995,6 +995,23 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Dashbuilder. -->
+
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-json</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-navigation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-dataset-api</artifactId>
+    </dependency>
+
     <!-- UberFire Apps -->
 
     <dependency>


### PR DESCRIPTION
Hey @manstis @hasys ,

The stunner's showcase was not starting due to some missing class dependencies to Dashbuilder, here is a fix for it.

Thanks!!
