### PR TITLE
GUVNOR-3058: Asset list search / paging issues

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.html
@@ -50,7 +50,7 @@
                 <div>
                     <form class="content-view-pf-pagination table-view-pf-pagination clearfix" id="pagination1">
                         <div class="form-group">
-                            <select id="howManyOnOnePage" class="form-control pagination-pf-pagesize" style="width: 45px;">
+                            <select id="howManyOnOnePage" class="form-control pagination-pf-pagesize" style="width: 64px;">
                                 <option value="15">15</option>
                                 <option value="25">25</option>
                                 <option value="50">50</option>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.java
@@ -223,6 +223,11 @@ public class ProjectView
     }
 
     @Override
+    public void setPageNumber(int pageNumber) {
+        this.pageNumber.setValue(Integer.toString(pageNumber));
+    }
+
+    @Override
     public Integer getStep() {
         return Integer.valueOf(howManyOnOnePage.getValue());
     }
@@ -231,11 +236,6 @@ public class ProjectView
     public void range(int from,
                       int to) {
         fromToRange.setInnerHTML(from + " - " + to);
-    }
-
-    @Override
-    public void setPageNumber(int pageNumber) {
-        this.pageNumber.setValue(Integer.toString(pageNumber));
     }
 
     @Override
@@ -280,11 +280,9 @@ public class ProjectView
         presenter.onToPrevious();
     }
 
-    @SinkNative(Event.ONKEYDOWN)
+    @SinkNative(Event.ONKEYUP)
     @EventHandler("filter-text")
     public void onFilterTextChange(Event e) {
-        if (e.getKeyCode() == KeyCodes.KEY_ENTER) {
-            presenter.onUpdateAssets();
-        }
+        presenter.onUpdateAssets();
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenButtonDisableEnableTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenButtonDisableEnableTest.java
@@ -16,12 +16,14 @@
 
 package org.kie.workbench.common.screens.library.client.screens;
 
+import com.google.gwt.user.client.Timer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.library.api.AssetInfo;
 import org.kie.workbench.common.screens.library.api.ProjectAssetsQuery;
 import org.kie.workbench.common.screens.library.client.events.ProjectDetailEvent;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.CallerMock;
 
@@ -30,6 +32,9 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectScreenButtonDisableEnableTest
         extends ProjectScreenTestBase {
+
+    @Mock
+    private Timer timer;
 
     @Before
     public void setup() {
@@ -45,10 +50,20 @@ public class ProjectScreenButtonDisableEnableTest
             protected void reload() {
                 onUpdateAssets();
             }
+
+            @Override
+            protected Timer createTimer() {
+                return timer;
+            }
         });
 
         doReturn("createdTime").when(projectScreen).getCreatedTime(any(AssetInfo.class));
         doReturn("lastModifiedTime").when(projectScreen).getLastModifiedTime(any(AssetInfo.class));
+
+        doAnswer(a -> {
+            projectScreen.loadProjectInfo();
+            return null;
+        }).when(timer).schedule(anyInt());
 
         mockClientResourceType();
         mockAssets();

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenReloadTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenReloadTest.java
@@ -16,25 +16,18 @@
 
 package org.kie.workbench.common.screens.library.client.screens;
 
-import java.util.Date;
-
-import org.guvnor.common.services.project.model.Project;
-import org.guvnor.structure.organizationalunit.OrganizationalUnit;
-import org.guvnor.structure.repositories.Repository;
+import com.google.gwt.user.client.Timer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.explorer.model.FolderItem;
 import org.kie.workbench.common.screens.explorer.model.FolderItemType;
 import org.kie.workbench.common.screens.library.api.AssetInfo;
 import org.kie.workbench.common.screens.library.api.ProjectAssetsQuery;
-import org.kie.workbench.common.screens.library.api.ProjectInfo;
 import org.kie.workbench.common.screens.library.client.events.ProjectDetailEvent;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-import org.uberfire.backend.vfs.Path;
-import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.mocks.CallerMock;
 
 import static org.junit.Assert.*;
@@ -43,6 +36,9 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectScreenReloadTest
         extends ProjectScreenTestBase {
+
+    @Mock
+    private Timer timer;
 
     private int numberOfCalls;
 
@@ -73,7 +69,17 @@ public class ProjectScreenReloadTest
 
                 onUpdateAssets();
             }
+
+            @Override
+            protected Timer createTimer() {
+                return timer;
+            }
         };
+
+        doAnswer(a -> {
+            projectScreen.loadProjectInfo();
+            return null;
+        }).when(timer).schedule(anyInt());
 
         mockClientResourceType();
         when(libraryService.getProjectAssets(any(ProjectAssetsQuery.class))).thenAnswer(new Answer<Object>() {
@@ -197,7 +203,4 @@ public class ProjectScreenReloadTest
         assertEquals(4,
                      numberOfCalls);
     }
-
-
-
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.screens.library.client.screens;
 
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.kie.workbench.common.screens.library.api.search.FilterUpdateEvent;
 import org.kie.workbench.common.screens.library.client.events.AssetDetailEvent;
 import org.kie.workbench.common.screens.library.client.events.ProjectDetailEvent;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.workbench.events.PlaceGainFocusEvent;
@@ -41,6 +43,9 @@ import static org.mockito.Mockito.*;
 public class ProjectScreenTest
         extends ProjectScreenTestBase {
 
+    @Mock
+    private Timer timer;
+
     @Before
     public void setup() {
 
@@ -55,10 +60,20 @@ public class ProjectScreenTest
             protected void reload() {
                 onUpdateAssets();
             }
+
+            @Override
+            protected Timer createTimer() {
+                return timer;
+            }
         });
 
         doReturn("createdTime").when(projectScreen).getCreatedTime(any(AssetInfo.class));
         doReturn("lastModifiedTime").when(projectScreen).getLastModifiedTime(any(AssetInfo.class));
+
+        doAnswer(a -> {
+            projectScreen.loadProjectInfo();
+            return null;
+        }).when(timer).schedule(anyInt());
 
         mockClientResourceType();
         mockAssets();

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenTestBase.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenTestBase.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.screens.library.client.screens;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import javax.enterprise.event.Event;
 
 import org.guvnor.common.services.project.model.Project;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
@@ -39,6 +38,7 @@ import org.mockito.Mock;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.mocks.EventSourceMock;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -61,7 +61,7 @@ public class ProjectScreenTestBase {
     protected Classifier assetClassifier;
 
     @Mock
-    protected Event<AssetDetailEvent> assetDetailEvent;
+    protected EventSourceMock<AssetDetailEvent> assetDetailEvent;
 
     @Mock
     protected BusyIndicatorView busyIndicatorView;


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3058

This fixes use of "key down" to activate filtering of the Project asset list; consistent with the other "filters".

I added a couple of tricks to prevent the server being flooded with requests for assets as the User types:

1. Only make the server call after a timer (250ms) has elapsed to cater for a User typing quickly
2. Only invoke the server call after any "in progress" calls have completed; thus as a User is typing and the timer expires triggering a server call successive changes to the filter do not invoke new server calls until the first completes. 

This also fixes the width of the "page size" selector.