### PR TITLE
RHBPMS-4375 - Container is not started when being created

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.java
@@ -114,6 +114,9 @@ public class Constants {
     public static final String NewContainerFormView_NewContainerWizardSaveError = "NewContainerFormView.NewContainerWizardSaveError";
 
     @TranslationKey(defaultValue = "")
+    public static final String NewContainerFormView_StartContainerText = "NewContainerFormView.StartContainerText";
+
+    @TranslationKey(defaultValue = "")
     public static final String NewContainerFormView_TitleText = "NewContainerFormView.TitleText";
 
     @TranslationKey(defaultValue = "")

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormPresenter.java
@@ -66,6 +66,8 @@ public class NewContainerFormPresenter implements WizardPage {
 
         void setContainerName( final String containerName );
 
+        void setStartContainer( boolean startContainer );
+
         String getContainerName();
 
         String getContainerAlias();
@@ -75,6 +77,8 @@ public class NewContainerFormPresenter implements WizardPage {
         String getArtifactId();
 
         String getVersion();
+
+        boolean isStartContainer();
 
         void errorOnContainerName();
 
@@ -334,7 +338,7 @@ public class NewContainerFormPresenter implements WizardPage {
                                   view.getContainerAlias(),
                                   new ServerTemplateKey( serverTemplateId, null ),
                                   new ReleaseId( view.getGroupId(), view.getArtifactId(), view.getVersion() ),
-                                  KieContainerStatus.STOPPED,
+                                  view.isStartContainer() ? KieContainerStatus.STARTED : KieContainerStatus.STOPPED,
                                   configs );
     }
 

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormView.html
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormView.html
@@ -25,6 +25,8 @@
                         <label class="control-label" data-i18n-key="Version"></label>
                         <input type="text" class="form-control" data-field="new-version">
                     </div>
+                    <div class="checkbox" data-field="new-start-container">
+                    </div>
                 </fieldset>
             </form>
         </div>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormView.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormView.java
@@ -25,6 +25,7 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Composite;
+import org.gwtbootstrap3.client.ui.CheckBox;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -87,6 +88,10 @@ public class NewContainerFormView extends Composite
     TextBox version;
 
     @Inject
+    @DataField("new-start-container")
+    CheckBox startContainer;
+
+    @Inject
     @DataField("content-area")
     Div content;
 
@@ -147,6 +152,7 @@ public class NewContainerFormView extends Composite
                 fireChangeHandlers();
             }
         } );
+        startContainer.setText(getStartContainerCheckBoxText());
     }
 
     private void fireChangeHandlers() {
@@ -172,6 +178,7 @@ public class NewContainerFormView extends Composite
         groupId.setText( "" );
         artifactId.setText( "" );
         version.setText( "" );
+        startContainer.setValue( false );
 
         noErrors();
     }
@@ -228,6 +235,16 @@ public class NewContainerFormView extends Composite
     @Override
     public void setContainerName( final String value ) {
         containerName.setText( value );
+    }
+
+    @Override
+    public boolean isStartContainer() {
+        return startContainer.getValue();
+    }
+
+    @Override
+    public void setStartContainer(boolean startContainer) {
+        this.startContainer.setValue( startContainer );
     }
 
     @Override
@@ -304,5 +321,9 @@ public class NewContainerFormView extends Composite
 
     private String getTitleText() {
         return translationService.format( Constants.NewContainerFormView_TitleText );
+    }
+
+    private String getStartContainerCheckBoxText() {
+        return translationService.format( Constants.NewContainerFormView_StartContainerText );
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/resources/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.properties
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/resources/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.properties
@@ -77,6 +77,7 @@ NewContainerFormView.NewContainerWizardSaveSuccess=New Container created.
 NewContainerFormView.NewContainerWizardTitle=New Container
 NewContainerFormView.TitleText=Container
 NewContainerFormView.Version=Version
+NewContainerFormView.StartContainerText=Start Container?
 NewTemplateView.Capabilities=Capabilities:
 NewTemplateView.InvalidErrorMessage=Invalid name.
 NewTemplateView.Name=Name:

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormPresenterTest.java
@@ -270,4 +270,27 @@ public class NewContainerFormPresenterTest {
 
         verify( view ).setContainerName( path );
     }
+
+    @Test
+    public void testNewContainerStarted() {
+        final String path = "org:kie:1.0";
+        final GAV gav = new GAV( path );
+        when( m2RepoService.loadGAVFromJar( path ) ).thenReturn( gav );
+        when( view.getContainerName() ).thenReturn( "containerName" );
+        when( view.getContainerAlias() ).thenReturn( "containerAlias" );
+        when( view.getGroupId() ).thenReturn( gav.getGroupId() );
+        when( view.getArtifactId() ).thenReturn( gav.getArtifactId() );
+        when( view.getVersion() ).thenReturn( gav.getVersion() );
+        when( view.isStartContainer() ).thenReturn( true );
+
+        presenter.asWidget();
+
+
+        final ContainerSpec containerSpec = presenter.buildContainerSpec( "templateId", Collections.<Capability, ContainerConfig>emptyMap() );
+
+        assertEquals( new ReleaseId( gav.getGroupId(), gav.getArtifactId(), gav.getVersion() ), containerSpec.getReleasedId() );
+        assertEquals( KieContainerStatus.STARTED, containerSpec.getStatus() );
+        assertEquals( "containerAlias", containerSpec.getContainerName() );
+        assertEquals( "containerName", containerSpec.getId() );
+    }
 }


### PR DESCRIPTION
depends on https://github.com/kiegroup/droolsjbpm-integration/pull/948

this PR introduces new checkbox on the new container wizard to allow directly start the container when created
<img width="1807" alt="screen shot 2017-05-09 at 19 42 19" src="https://cloud.githubusercontent.com/assets/904474/25864573/3b2a4b0a-34f0-11e7-8ec3-b4025da94696.png">
