### PR TITLE
GUVNOR-3066: GUVNOR-3043: Workbench reloading on User interactions

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/EmptyProjectView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/EmptyProjectView.html
@@ -22,9 +22,9 @@
         <div class="col-md-8 col-lg-9">
             <div class="main-content-kie">
                 <div class="toolbar-pf">
-                    <form data-field="assets-toolbar" class="toolbar-pf-actions">
+                    <div data-field="assets-toolbar" class="toolbar-pf-actions">
                         <div class="toolbar-data-title-kie" data-i18n-key="Assets"></div>
-                    </form>
+                    </div>
                 </div>
                 <div class="blank-slate-pf">
                     <h1 data-i18n-key="Title"></h1>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/EmptyProjectView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/EmptyProjectView.java
@@ -21,7 +21,6 @@ import javax.inject.Inject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import org.jboss.errai.common.client.dom.Anchor;
 import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.common.client.dom.Form;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
@@ -56,7 +55,7 @@ public class EmptyProjectView implements EmptyProjectScreen.View,
 
     @Inject
     @DataField("assets-toolbar")
-    Form assetsToolbar;
+    Div assetsToolbar;
 
     @Inject
     @DataField("details-container")

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryView.html
@@ -19,7 +19,7 @@
         <div data-field="main-container" class="col-md-12 col-lg-12">
             <div class="main-content-kie">
                 <div class="toolbar-pf">
-                    <form class="toolbar-pf-actions">
+                    <div class="toolbar-pf-actions">
                         <div class="toolbar-data-title-kie" data-i18n-key="Projects"></div>
 
                         <div class="form-group toolbar-pf-filter">
@@ -49,7 +49,7 @@
                                 </div>
                             </span>
                         </div>
-                    </form>
+                    </div>
                 </div>
 
                 <div class="list-group list-view-pf list-view-pf-view" id="project-list">

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/NewProjectView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/NewProjectView.html
@@ -19,9 +19,9 @@
         <div class="col-md-12 col-lg-12">
             <div class="main-content-kie">
                 <div class="toolbar-pf">
-                    <form data-field="toolbar" class="toolbar-pf-actions">
+                    <div data-field="toolbar" class="toolbar-pf-actions">
                         <div class="toolbar-data-title-kie" data-i18n-key="NewProject"></div>
-                    </form>
+                    </div>
                 </div>
                 <div class="blank-slate-pf form-horizontal">
                     <div class="form-group">

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.html
@@ -22,7 +22,7 @@
         <div class="col-md-8 col-lg-9">
             <div class="main-content-kie">
                 <div class="toolbar-pf">
-                    <form data-field="assets-toolbar" class="toolbar-pf-actions">
+                    <div data-field="assets-toolbar" class="toolbar-pf-actions">
                         <div class="toolbar-data-title-kie" data-i18n-key="Assets"></div>
                         <div class="form-group toolbar-pf-filter">
                             <label class="sr-only" for="filter-text" data-i18n-key="Name"></label>
@@ -40,7 +40,7 @@
                             </div>
                         </div>
 
-                    </form>
+                    </div>
                 </div>
 
                 <div class="list-group list-view-pf list-view-pf-view" id="asset-list">
@@ -48,7 +48,7 @@
                 <div id="indexing-info" visible="false" class="blank-slate-pf">
                 </div>
                 <div>
-                    <form class="content-view-pf-pagination table-view-pf-pagination clearfix" id="pagination1">
+                    <div class="content-view-pf-pagination table-view-pf-pagination clearfix" id="pagination1">
                         <div class="form-group">
                             <select id="howManyOnOnePage" class="form-control pagination-pf-pagesize" style="width: 64px;">
                                 <option value="15">15</option>
@@ -79,7 +79,7 @@
                                 </li>
                             </ul>
                         </div>
-                    </form>
+                    </div>
                 </div>
 
             </div>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectView.java
@@ -24,7 +24,6 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.common.client.dom.Button;
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.common.client.dom.Form;
 import org.jboss.errai.common.client.dom.Input;
 import org.jboss.errai.common.client.dom.Select;
 import org.jboss.errai.common.client.dom.Span;
@@ -51,7 +50,7 @@ public class ProjectView
     Div projectToolbar;
     @Inject
     @DataField("assets-toolbar")
-    Form assetsToolbar;
+    Div assetsToolbar;
     @Inject
     @DataField("details-container")
     Div detailsContainer;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/organizationalunit/OrganizationalUnitsView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/organizationalunit/OrganizationalUnitsView.html
@@ -17,7 +17,7 @@
 <div class="library container-fluid">
     <div class="row page-content-kie">
         <div class="toolbar-pf">
-            <form class="toolbar-pf-actions">
+            <div class="toolbar-pf-actions">
                 <div class="toolbar-data-title-kie" data-field="title"></div>
                 <div class="form-group toolbar-pf-filter">
                     <label class="sr-only" for="filter-name" data-i18n-key="Name"></label>
@@ -37,7 +37,7 @@
                 <div class="btn-group">
                     <button type="button" class="btn btn-primary" data-field="create-organizational-unit"></button>
                 </div>
-            </form>
+            </div>
         </div>
         <div class="container-fluid container-cards-pf">
             <div class="row row-cards-pf" data-field="cards-container">

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceViewImpl.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceViewImpl.html
@@ -1,5 +1,5 @@
 <div>
-    <form>
+    <div>
         <fieldset>
             <div class="form-group" data-field="fileNameGroup">
                 <label class="control-label" data-field="fileTypeLabel" for="fileName"></label>
@@ -11,10 +11,11 @@
                 <label data-i18n-key="packageName"></label>
                 <div data-field="packageListBox"></div>
                 <div class="help-block" data-field="packageHelpInline">
+                </div>
             </div>
             <div class="form-group" data-field="handlerExtensionsGroup">
                 <div data-field="handlerExtensions"></div>
             </div>
         </fieldset>
-    </form>
+    </div>
 </div>


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3043 and https://issues.jboss.org/browse/GUVNOR-3066

Use of ```<button>``` inside ```<form>``` elements leads to the form being resubmitted when either the ```<enter>``` key is pressed or the User clicks the ```<button>``` element. This is expected behaviour (and correctly implemented by Chrome).

See:
http://stackoverflow.com/questions/23420795/why-would-a-button-click-event-cause-site-to-reload-in-a-bootstrap-form
http://stackoverflow.com/questions/17406320/enter-key-reloads-chrome-browser