### PR TITLE
PLANNER-784: Workbench: AbstractSolution.score can't be marshaled when using JAXB

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/DataModelCommandBuilder.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/DataModelCommandBuilder.java
@@ -171,6 +171,17 @@ public class DataModelCommandBuilder {
                 propertyType, isMultiple, notifier );
     }
 
+    public RemovePropertyCommand buildRemovePropertyCommand(final DataModelerContext context,
+                                                            final String source,
+                                                            final DataObject dataObject,
+                                                            final String propertyName) {
+        return new RemovePropertyCommand(context,
+                                         source,
+                                         dataObject,
+                                         propertyName,
+                                         notifier);
+    }
+
     public DataObjectSuperClassChangeCommand buildDataObjectSuperClassChangeCommand( final DataModelerContext context,
             final String source,
             final DataObject dataObject,

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/RemovePropertyCommand.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/RemovePropertyCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.datamodeller.client.command;
+
+import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectFieldDeletedEvent;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+public class RemovePropertyCommand extends AbstractDataModelCommand {
+
+    private String propertyName;
+
+    public RemovePropertyCommand(final DataModelerContext context,
+                                 final String source,
+                                 final DataObject dataObject,
+                                 final String propertyName,
+                                 final DataModelChangeNotifier notifier) {
+        super(context,
+              source,
+              dataObject,
+              notifier);
+        this.propertyName = PortablePreconditions.checkNotNull("propertyName",
+                                                               propertyName);
+    }
+
+    @Override
+    public void execute() {
+
+        if (dataObject != null) {
+            ObjectProperty property = dataObject.getProperty(propertyName);
+            if (property != null) {
+                dataObject.removeProperty(propertyName);
+                notifyChange(new DataObjectFieldDeletedEvent(getContext().getContextId(),
+                                                             getSource(),
+                                                             getDataObject(),
+                                                             property));
+            }
+        }
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/DomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/DomainHandler.java
@@ -18,8 +18,7 @@ package org.kie.workbench.common.screens.datamodeller.client.handlers;
 
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerValueChangeEvent;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 
 public interface DomainHandler {
 
@@ -27,8 +26,9 @@ public interface DomainHandler {
 
     int getPriority();
 
-    ResourceOptions getResourceOptions( boolean newInstance );
+    ResourceOptions getResourceOptions(boolean newInstance);
 
-    void postCommandProcessing( DataModelCommand command );
+    void postCommandProcessing(DataModelCommand command);
 
+    boolean isDomainSpecificProperty(ObjectProperty objectProperty);
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/advanceddomain/AdvancedDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/advanceddomain/AdvancedDomainHandler.java
@@ -21,8 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerValueChangeEvent;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 
 @ApplicationScoped
 public class AdvancedDomainHandler implements DomainHandler {
@@ -41,14 +40,19 @@ public class AdvancedDomainHandler implements DomainHandler {
     }
 
     @Override
-    public ResourceOptions getResourceOptions( boolean newInstance ) {
+    public ResourceOptions getResourceOptions(boolean newInstance) {
         //this domain has no special options at resource creation time.
         return null;
     }
 
     @Override
-    public void postCommandProcessing( DataModelCommand command ) {
+    public void postCommandProcessing(DataModelCommand command) {
         //no post command processing for this domain.
     }
 
+    @Override
+    public boolean isDomainSpecificProperty(ObjectProperty objectProperty) {
+        // no specific object properties defined for this domain
+        return false;
+    }
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/droolsdomain/DroolsDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/droolsdomain/DroolsDomainHandler.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 
 @ApplicationScoped
 public class DroolsDomainHandler implements DomainHandler {
@@ -39,14 +40,19 @@ public class DroolsDomainHandler implements DomainHandler {
     }
 
     @Override
-    public ResourceOptions getResourceOptions( boolean newInstance ) {
+    public ResourceOptions getResourceOptions(boolean newInstance) {
         //this domain has no special options at resource creation time.
         return null;
     }
 
     @Override
-    public void postCommandProcessing( DataModelCommand command ) {
+    public void postCommandProcessing(DataModelCommand command) {
         //no post command processing for this domain.
     }
 
+    @Override
+    public boolean isDomainSpecificProperty(ObjectProperty objectProperty) {
+        // no specific object properties defined for this domain
+        return false;
+    }
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/jpadomain/JPADomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/jpadomain/JPADomainHandler.java
@@ -58,50 +58,55 @@ public class JPADomainHandler implements DomainHandler {
     }
 
     @Override
-    public ResourceOptions getResourceOptions( boolean newInstance ) {
+    public ResourceOptions getResourceOptions(boolean newInstance) {
         //currently same instance is always returned, since file handlers are all ApplicationScoped
         return newResourceOptions.get();
     }
 
     @Override
-    public void postCommandProcessing( DataModelCommand command ) {
-        if ( command instanceof FieldTypeChangeCommand &&
-                ( isPersistable( ( (FieldTypeChangeCommand) command ).getDataObject() ) ||
-                        isRelationConfigured( ( (FieldTypeChangeCommand) command ).getField() ) ) ) {
+    public void postCommandProcessing(DataModelCommand command) {
+        if (command instanceof FieldTypeChangeCommand &&
+                (isPersistable(((FieldTypeChangeCommand) command).getDataObject()) ||
+                        isRelationConfigured(((FieldTypeChangeCommand) command).getField()))) {
 
             AdjustFieldDefaultRelationsCommand postCommand = commandBuilder.buildAdjustFieldDefaultRelationsCommand(
                     (FieldTypeChangeCommand) command,
                     getName(),
-                    ( (FieldTypeChangeCommand) command ).getField() );
+                    ((FieldTypeChangeCommand) command).getField());
             postCommand.execute();
-
-        } else if ( command instanceof AddPropertyCommand &&
-                isPersistable( ( (AddPropertyCommand) command ).getDataObject() ) ) {
+        } else if (command instanceof AddPropertyCommand &&
+                isPersistable(((AddPropertyCommand) command).getDataObject())) {
             AdjustFieldDefaultRelationsCommand postCommand = commandBuilder.buildAdjustFieldDefaultRelationsCommand(
                     (AddPropertyCommand) command,
                     getName(),
-                    ( (AddPropertyCommand) command ).getProperty() );
+                    ((AddPropertyCommand) command).getProperty());
             postCommand.execute();
         }
     }
 
-    public boolean isOptionEnabled( String option ) {
-        return ApplicationPreferences.getBooleanPref( "data-modeler-options." + option );
+    public boolean isOptionEnabled(String option) {
+        return ApplicationPreferences.getBooleanPref("data-modeler-options." + option);
     }
 
     public boolean isDataObjectAuditEnabled() {
-        return isOptionEnabled( JPADomainHandler.ENABLE_DATA_OBJECT_AUDIT );
+        return isOptionEnabled(JPADomainHandler.ENABLE_DATA_OBJECT_AUDIT);
     }
 
-    private boolean isPersistable( DataObject dataObject ) {
-        return dataObject.getAnnotation( JPADomainAnnotations.JAVAX_PERSISTENCE_ENTITY_ANNOTATION ) != null;
+    private boolean isPersistable(DataObject dataObject) {
+        return dataObject.getAnnotation(JPADomainAnnotations.JAVAX_PERSISTENCE_ENTITY_ANNOTATION) != null;
     }
 
-    private boolean isRelationConfigured( ObjectProperty objectProperty ) {
-        return objectProperty.getAnnotation( JPADomainAnnotations.JAVAX_PERSISTENCE_MANY_TO_ONE ) != null ||
-                objectProperty.getAnnotation( JPADomainAnnotations.JAVAX_PERSISTENCE_MANY_TO_MANY ) != null ||
-                objectProperty.getAnnotation( JPADomainAnnotations.JAVAX_PERSISTENCE_ONE_TO_ONE ) != null ||
-                objectProperty.getAnnotation( JPADomainAnnotations.JAVAX_PERSISTENCE_ONE_TO_MANY ) != null ||
-                objectProperty.getAnnotation( JPADomainAnnotations.JAVAX_PERSISTENCE_ELEMENT_COLLECTION ) != null;
+    private boolean isRelationConfigured(ObjectProperty objectProperty) {
+        return objectProperty.getAnnotation(JPADomainAnnotations.JAVAX_PERSISTENCE_MANY_TO_ONE) != null ||
+                objectProperty.getAnnotation(JPADomainAnnotations.JAVAX_PERSISTENCE_MANY_TO_MANY) != null ||
+                objectProperty.getAnnotation(JPADomainAnnotations.JAVAX_PERSISTENCE_ONE_TO_ONE) != null ||
+                objectProperty.getAnnotation(JPADomainAnnotations.JAVAX_PERSISTENCE_ONE_TO_MANY) != null ||
+                objectProperty.getAnnotation(JPADomainAnnotations.JAVAX_PERSISTENCE_ELEMENT_COLLECTION) != null;
+    }
+
+    @Override
+    public boolean isDomainSpecificProperty(ObjectProperty objectProperty) {
+        // no specific object properties defined for this domain
+        return false;
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/maindomain/MainDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/maindomain/MainDomainHandler.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 
 @ApplicationScoped
 public class MainDomainHandler implements DomainHandler {
@@ -39,14 +40,19 @@ public class MainDomainHandler implements DomainHandler {
     }
 
     @Override
-    public ResourceOptions getResourceOptions( boolean newInstance ) {
+    public ResourceOptions getResourceOptions(boolean newInstance) {
         //this domain has no special options at resource creation time.
         return null;
     }
 
     @Override
-    public void postCommandProcessing( DataModelCommand command ) {
+    public void postCommandProcessing(DataModelCommand command) {
         //no post command processing for this domain.
     }
 
+    @Override
+    public boolean isDomainSpecificProperty(ObjectProperty objectProperty) {
+        // no specific object properties defined for this domain
+        return false;
+    }
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowser.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowser.java
@@ -243,7 +243,7 @@ public class DataObjectBrowser
         }
     }
 
-    private void setDataObject( DataObject dataObject ) {
+    void setDataObject( DataObject dataObject ) {
         this.dataObject = dataObject;
         setObjectSelectorLabel( dataObject );
 
@@ -519,6 +519,13 @@ public class DataObjectBrowser
     }
 
     private void onDataObjectFieldCreated( @Observes DataObjectFieldCreatedEvent event ) {
+        if ( event.isFromContext( context != null ? context.getContextId() : null ) &&
+                !DataModelerEvent.DATA_OBJECT_BROWSER.equals( event.getSource() ) ) {
+            setDataObject( dataObject );
+        }
+    }
+
+    void onDataObjectFieldDeleted( @Observes DataObjectFieldDeletedEvent event ) {
         if ( event.isFromContext( context != null ? context.getContextId() : null ) &&
                 !DataModelerEvent.DATA_OBJECT_BROWSER.equals( event.getSource() ) ) {
             setDataObject( dataObject );

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/command/RemovePropertyCommandTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/command/RemovePropertyCommandTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.datamodeller.client.command;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectFieldDeletedEvent;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemovePropertyCommandTest {
+
+    @Test
+    public void execute() {
+        DataObject dataObject = new DataObjectImpl("org.test",
+                                                   "TestDataObject");
+        dataObject.addProperty(new ObjectPropertyImpl("testProperty",
+                                                      Integer.class.getName(),
+                                                      false));
+        DataModelChangeNotifier notifier = mock(DataModelChangeNotifier.class);
+        RemovePropertyCommand command = new RemovePropertyCommand(new DataModelerContext(),
+                                                                  "source",
+                                                                  dataObject,
+                                                                  "testProperty",
+                                                                  notifier);
+
+        command.execute();
+
+        assertNull(dataObject.getProperty("testProperty"));
+        verify(notifier,
+               times(1)).notifyChange(any(DataObjectFieldDeletedEvent.class));
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowserTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowserTest.java
@@ -28,10 +28,12 @@ import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
 import org.kie.workbench.common.screens.datamodeller.client.context.DataModelerWorkbenchContextChangeEvent;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.DomainEditorBaseTest;
 import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectFieldDeletedEvent;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
 import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 import org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.client.mvp.PlaceManager;
@@ -222,4 +224,23 @@ public class DataObjectBrowserTest
         assertEquals( 3, dataObject.getProperties().size() );
     }
 
+    @Test
+    public void onDataObjectFieldDeleted() {
+        DataObjectBrowser dataObjectBrowser = spy(createBrowser());
+        DataModelerContext context = createContext();
+        context.setContextId("contextId");
+        dataObjectBrowser.setContext( context );
+
+        DataObject dataObject = mock(DataObject.class);
+        dataObjectBrowser.setDataObject(dataObject);
+
+        DataObjectFieldDeletedEvent event = new DataObjectFieldDeletedEvent();
+        event.setContextId("contextId");
+
+        Mockito.reset(dataObjectBrowser);
+
+        dataObjectBrowser.onDataObjectFieldDeleted(event);
+
+        verify(dataObjectBrowser, times(1)).setDataObject(dataObject);
+    }
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowserViewImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowserViewImplTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.datamodeller.client.widgets.editor;
+
+import java.util.Arrays;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DataObjectBrowserViewImplTest {
+
+    @Test
+    public void isRemoveButtonEnabled() {
+        DataObjectBrowserViewImpl view = new DataObjectBrowserViewImpl();
+
+        ObjectProperty objectProperty = mock(ObjectProperty.class);
+
+        DomainHandler matchingHandler = mock(DomainHandler.class);
+        when(matchingHandler.isDomainSpecificProperty(objectProperty)).thenReturn(true);
+
+        DomainHandler nonMatchingHandler = mock(DomainHandler.class);
+        when(nonMatchingHandler.isDomainSpecificProperty(objectProperty)).thenReturn(false);
+
+        view.setDomainHandlers(Arrays.asList(matchingHandler,
+                                             nonMatchingHandler));
+
+        assertFalse(view.isRemoveButtonEnabled(objectProperty));
+
+        view.setDomainHandlers(Arrays.asList(matchingHandler));
+
+        assertFalse(view.isRemoveButtonEnabled(objectProperty));
+
+        view.setDomainHandlers(Arrays.asList(nonMatchingHandler));
+
+        assertTrue(view.isRemoveButtonEnabled(objectProperty));
+    }
+}


### PR DESCRIPTION
- Ignore getter/setter creation for generated attributes (generators need to add those manually)
- Add data object field remove command
- Object editor - Disable remove button for generated fields

@wmedvede As this impacts the data modeler, could you please take a look? Thanks. I haven't formatted all the code yet, so that the changes are visible at first glance.

Part of:
- https://github.com/kiegroup/kie-wb-common/pull/869
- https://github.com/kiegroup/optaplanner-wb/pull/158
- https://github.com/kiegroup/kie-wb-playground/pull/23