### PR TITLE
GUVNOR-3075: [Library] Perspective doesn't show files from Other section

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>uberfire-preferences-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-refactoring-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-preferences-processors</artifactId>
     </dependency>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryProjectRootPathIndexTerm.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryProjectRootPathIndexTerm.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.library.api.index;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.services.refactoring.model.index.terms.IndexTerm;
+
+@Portable
+public class LibraryProjectRootPathIndexTerm implements IndexTerm {
+
+    public static final String TERM = "libraryProjectRoot";
+
+    @Override
+    public String getTerm() {
+        return TERM;
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryValueProjectRootPathIndexTerm.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryValueProjectRootPathIndexTerm.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.library.api.index;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+@Portable
+public class LibraryValueProjectRootPathIndexTerm extends LibraryProjectRootPathIndexTerm implements ValueIndexTerm {
+
+    private String projectPath;
+    private TermSearchType searchType;
+
+    public LibraryValueProjectRootPathIndexTerm() {
+        //Errai marshalling
+    }
+
+    public LibraryValueProjectRootPathIndexTerm(final String projectPath) {
+        this(projectPath,
+             TermSearchType.NORMAL);
+    }
+
+    public LibraryValueProjectRootPathIndexTerm(final String projectPath,
+                                                final TermSearchType searchType) {
+        this.projectPath = PortablePreconditions.checkNotNull("projectPath",
+                                                              projectPath);
+        this.searchType = PortablePreconditions.checkNotNull("searchType",
+                                                             searchType);
+    }
+
+    @Override
+    public String getValue() {
+        return projectPath;
+    }
+
+    @Override
+    public TermSearchType getSearchType() {
+        return searchType;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/pom.xml
@@ -104,5 +104,24 @@
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-examples-screen-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-refactoring-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQuery.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQuery.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.workbench.common.services.refactoring.backend.server.query.standard;
+package org.kie.workbench.common.screens.impl;
 
 import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
@@ -22,12 +22,13 @@ import javax.inject.Inject;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.kie.workbench.common.screens.library.api.index.LibraryValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.FileDetailsResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.standard.AbstractFindQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueProjectRootPathIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.fields.FieldFactory;
 
 @ApplicationScoped
@@ -75,10 +76,10 @@ public class FindAllLibraryAssetsQuery
         checkInvalidAndRequiredTerms(queryTerms,
                                      NAME,
                                      new String[]{
-                                             ValueProjectRootPathIndexTerm.TERM,
+                                             LibraryValueProjectRootPathIndexTerm.TERM,
                                              null // not required
                                      },
-                                     (t) -> (t instanceof ValueProjectRootPathIndexTerm),
+                                     (t) -> (t instanceof LibraryValueProjectRootPathIndexTerm),
                                      (t) -> (t instanceof ValueFullFileNameIndexTerm)
         );
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetTypeDefinition.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetTypeDefinition.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.workbench.type.ResourceTypeDefinition;
+
+@ApplicationScoped
+public class LibraryAssetTypeDefinition
+        implements ResourceTypeDefinition {
+
+    @Override
+    public String getShortName() {
+        return "Library assets";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Library assets";
+    }
+
+    @Override
+    public String getPrefix() {
+        return "";
+    }
+
+    @Override
+    public String getSuffix() {
+        return "";
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    @Override
+    public String getSimpleWildcardPattern() {
+        return "*." + getSuffix();
+    }
+
+    @Override
+    public boolean accept(final Path path) {
+        return !path.getFileName().startsWith(".");
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryIndexer.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryIndexer.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.impl;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.model.Package;
+import org.kie.workbench.common.screens.library.api.index.LibraryProjectRootPathIndexTerm;
+import org.kie.workbench.common.services.refactoring.KPropertyImpl;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.AbstractFileIndexer;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.DefaultIndexBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.util.KObjectUtil;
+import org.kie.workbench.common.services.refactoring.model.index.terms.FullFileNameIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectNameIndexTerm;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.ext.metadata.backend.lucene.fields.FieldFactory;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.ext.metadata.model.KObjectKey;
+import org.uberfire.ext.metadata.model.KProperty;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+
+@ApplicationScoped
+public class LibraryIndexer extends AbstractFileIndexer {
+
+    private static final Logger logger = LoggerFactory.getLogger(LibraryIndexer.class);
+
+    private static final String LIBRARY_CLASSIFIER = "library";
+
+    private LibraryAssetTypeDefinition filter;
+
+    @Inject
+    public LibraryIndexer(final LibraryAssetTypeDefinition filter) {
+        this.filter = filter;
+    }
+
+    void setIOService(final IOService ioService) {
+        this.ioService = ioService;
+    }
+
+    void setProjectService(final KieProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @Override
+    public boolean supportsPath(final Path path) {
+        return filter.accept(Paths.convert(path));
+    }
+
+    @Override
+    protected DefaultIndexBuilder fillIndexBuilder(final Path path) throws Exception {
+        final KieProject project = getProject(path);
+        if (project == null) {
+            logger.error("Unable to index " + path.toUri().toString() + ": project could not be resolved.");
+            return null;
+        }
+
+        final Package pkg = getPackage(path);
+        if (pkg == null) {
+            logger.error("Unable to index " + path.toUri().toString() + ": package could not be resolved.");
+            return null;
+        }
+
+        // responsible for basic index info: project name, branch, etc
+        final DefaultIndexBuilder builder = new DefaultIndexBuilder(Paths.convert(path).getFileName(),
+                                                                    project,
+                                                                    pkg) {
+            @Override
+            public Set<KProperty<?>> build() {
+                final Set<KProperty<?>> indexElements = new HashSet<>();
+
+                indexElements.add(new KPropertyImpl<>(FullFileNameIndexTerm.TERM,
+                                                      fileName));
+                indexElements.add(new KPropertyImpl<>(FieldFactory.FILE_NAME_FIELD_SORTED,
+                                                      fileName.toLowerCase(),
+                                                      false,
+                                                      true));
+
+                if (project.getRootPath() != null) {
+                    final String projectRootUri = project.getRootPath().toURI();
+                    indexElements.add(new KPropertyImpl<>(LibraryProjectRootPathIndexTerm.TERM,
+                                                          projectRootUri));
+                }
+                if (project.getProjectName() != null) {
+                    final String projectName = project.getProjectName();
+                    indexElements.add(new KPropertyImpl<>(ProjectNameIndexTerm.TERM,
+                                                          projectName));
+                }
+
+                if (pkgName == null) {
+                    pkgName = pkg.getPackageName();
+                }
+                if (pkgName != null) {
+                    indexElements.add(new KPropertyImpl<>(PackageNameIndexTerm.TERM,
+                                                          pkgName));
+                }
+                return indexElements;
+            }
+        };
+        return builder;
+    }
+
+    @Override
+    public KObject toKObject(final Path path) {
+        KObject index = null;
+
+        try {
+            // create a builder with the default information
+            DefaultIndexBuilder builder = fillIndexBuilder(path);
+
+            Set<KProperty<?>> indexElements = null;
+            if (builder != null) {
+                // build index document
+                indexElements = builder.build();
+            } else {
+                indexElements = Collections.emptySet();
+            }
+
+            index = KObjectUtil.toKObject(path,
+                                          LIBRARY_CLASSIFIER,
+                                          indexElements);
+        } catch (Exception e) {
+            // Unexpected parsing or processing error
+            logger.error("Unable to index '" + path.toUri().toString() + "'.",
+                         e.getMessage(),
+                         e);
+        }
+
+        return index;
+    }
+
+    @Override
+    public KObjectKey toKObjectKey(final Path path) {
+        return KObjectUtil.toKObjectKey(path,
+                                        LIBRARY_CLASSIFIER);
+    }
+
+    protected KieProject getProject(final Path path) {
+        return projectService.resolveProject(Paths.convert(path));
+    }
+
+    protected Package getPackage(final Path path) {
+        return projectService.resolvePackage(Paths.convert(path));
+    }
+}
+

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
@@ -55,12 +55,11 @@ import org.kie.workbench.common.screens.library.api.LibraryInfo;
 import org.kie.workbench.common.screens.library.api.LibraryService;
 import org.kie.workbench.common.screens.library.api.OrganizationalUnitRepositoryInfo;
 import org.kie.workbench.common.screens.library.api.ProjectAssetsQuery;
+import org.kie.workbench.common.screens.library.api.index.LibraryValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.screens.library.api.preferences.LibraryInternalPreferences;
 import org.kie.workbench.common.screens.library.api.preferences.LibraryPreferences;
-import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindAllLibraryAssetsQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
 import org.kie.workbench.common.services.refactoring.service.RefactoringQueryService;
@@ -206,7 +205,7 @@ public class LibraryServiceImpl implements LibraryService {
 
         final HashSet<ValueIndexTerm> queryTerms = new HashSet<>();
 
-        queryTerms.add(new ValueProjectRootPathIndexTerm(query.getProject().getRootPath().toURI()));
+        queryTerms.add(new LibraryValueProjectRootPathIndexTerm(query.getProject().getRootPath().toURI()));
 
         if (query.hasFilter()) {
             queryTerms.add(new ValueFullFileNameIndexTerm("*" + query.getFilter() + "*",

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/BaseLibraryIndexingTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/BaseLibraryIndexingTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.impl;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import javax.enterprise.inject.Instance;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.lucene.analysis.Analyzer;
+import org.guvnor.common.services.project.model.Package;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.kie.workbench.common.screens.library.api.index.LibraryProjectRootPathIndexTerm;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.ImpactAnalysisAnalyzerWrapperFactory;
+import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQueries;
+import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
+import org.kie.workbench.common.services.refactoring.backend.server.query.RefactoringQueryServiceImpl;
+import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
+import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
+import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.io.IOServiceIndexedImpl;
+import org.uberfire.ext.metadata.io.IndexersFactory;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+
+import static org.mockito.Mockito.*;
+
+public abstract class BaseLibraryIndexingTest {
+
+    public static final String TEST_PROJECT_ROOT = "/a/mock/project/root";
+    public static final String TEST_PROJECT_NAME = "mock-project";
+    public static final String TEST_PACKAGE_NAME = "org.kie.workbench.mock.package";
+    protected static final Logger logger = LoggerFactory.getLogger(BaseLibraryIndexingTest.class);
+    protected static final List<File> tempFiles = new ArrayList<File>();
+    private static LuceneConfig config;
+    protected int seed = new Random(10L).nextInt();
+    protected boolean created = false;
+    protected Path basePath;
+    protected RefactoringQueryServiceImpl service;
+    private IOService ioService = null;
+
+    @AfterClass
+    @BeforeClass
+    public static void cleanup() {
+        for (final File tempFile : tempFiles) {
+            FileUtils.deleteQuietly(tempFile);
+        }
+        if (config != null) {
+            config.dispose();
+            config = null;
+        }
+    }
+
+    @Before
+    public void setup() throws IOException {
+        if (!created) {
+            final String repositoryName = getRepositoryName();
+            final String path = createTempDirectory().getAbsolutePath();
+            System.setProperty("org.uberfire.nio.git.dir",
+                               path);
+            System.setProperty("org.uberfire.nio.git.daemon.enabled",
+                               "false");
+            System.setProperty("org.uberfire.nio.git.ssh.enabled",
+                               "false");
+            System.setProperty("org.uberfire.sys.repo.monitor.disabled",
+                               "true");
+            System.out.println(".niogit: " + path);
+
+            final URI newRepo = URI.create("git://" + repositoryName);
+
+            try {
+                IOService ioService = ioService();
+                ioService.newFileSystem(newRepo,
+                                        new HashMap<String, Object>());
+
+                // Don't ask, but we need to write a single file first in order for indexing to work
+                basePath = getDirectoryPath().resolveSibling("someNewOtherPath");
+                ioService().write(basePath.resolve("dummy"),
+                                  "<none>");
+            } catch (final Exception e) {
+                e.printStackTrace();
+                logger.warn("Failed to initialize IOService instance: " + e.getClass().getSimpleName() + ": " + e.getMessage(),
+                            e);
+            } finally {
+                created = true;
+            }
+
+            final Instance<NamedQuery> namedQueriesProducer = mock(Instance.class);
+            when(namedQueriesProducer.iterator()).thenReturn(getQueries().iterator());
+
+            service = new RefactoringQueryServiceImpl(config,
+                                                      new NamedQueries(namedQueriesProducer));
+            service.init();
+        }
+    }
+
+    @After
+    public void dispose() {
+        ioService().dispose();
+        ioService = null;
+        created = false;
+    }
+
+    protected Set<NamedQuery> getQueries() {
+        // override me if using the RefactoringQueryServiceImpl!
+        return Collections.emptySet();
+    }
+
+    protected abstract String getRepositoryName();
+
+    private static File createTempDirectory() throws IOException {
+        final File temp = File.createTempFile("temp",
+                                              Long.toString(System.nanoTime()));
+        if (!(temp.delete())) {
+            throw new IOException("Could not delete temp file: " + temp.getAbsolutePath());
+        }
+        if (!(temp.mkdir())) {
+            throw new IOException("Could not create temp directory: " + temp.getAbsolutePath());
+        }
+        tempFiles.add(temp);
+        return temp;
+    }
+
+    private Path getDirectoryPath() {
+        final String repositoryName = getRepositoryName();
+        final Path dir = ioService().get(URI.create("git://" + repositoryName + "/_someDir" + seed));
+        ioService().deleteIfExists(dir);
+        return dir;
+    }
+
+    private Map<String, Analyzer> getAnalyzers() {
+        return new HashMap<String, Analyzer>() {{
+            put(ProjectRootPathIndexTerm.TERM,
+                new FilenameAnalyzer());
+            put(LibraryProjectRootPathIndexTerm.TERM,
+                new FilenameAnalyzer());
+        }};
+    }
+
+    protected void addTestFile(final String projectName,
+                               final String pathToFile) throws IOException {
+        final Path path = basePath.resolve(projectName + "/" + pathToFile);
+        final String text = loadText(pathToFile);
+        ioService().write(path,
+                          text);
+    }
+
+    protected String loadText(final String fileName) throws IOException {
+        InputStream fileInputStream = this.getClass().getResourceAsStream(fileName);
+        if (fileInputStream == null) {
+            File file = new File(fileName);
+            if (file.exists()) {
+                fileInputStream = new FileInputStream(file);
+            }
+        }
+        final BufferedReader br = new BufferedReader(new InputStreamReader(fileInputStream));
+        try {
+            StringBuilder sb = new StringBuilder();
+            String line = br.readLine();
+
+            while (line != null) {
+                sb.append(line);
+                sb.append(System.getProperty("line.separator"));
+                line = br.readLine();
+            }
+            return sb.toString();
+        } finally {
+            br.close();
+        }
+    }
+
+    protected IOService ioService() {
+        if (ioService == null) {
+            final Map<String, Analyzer> analyzers = getAnalyzers();
+            LuceneConfigBuilder configBuilder = new LuceneConfigBuilder()
+                    .withInMemoryMetaModelStore()
+                    .usingAnalyzers(analyzers)
+                    .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
+                    .useInMemoryDirectory()
+                    // If you want to use Luke to inspect the index,
+                    // comment ".useInMemoryDirectory(), and uncomment below..
+//                     .useNIODirectory()
+                    .useDirectoryBasedIndex();
+
+            if (config == null) {
+                config = configBuilder.build();
+            }
+
+            ioService = new IOServiceIndexedImpl(config.getIndexEngine());
+
+            final LibraryIndexer indexer = new LibraryIndexer(new LibraryAssetTypeDefinition());
+            IndexersFactory.addIndexer(indexer);
+
+            //Mock CDI injection and setup
+            indexer.setIOService(ioService);
+            indexer.setProjectService(getProjectService());
+        }
+        return ioService;
+    }
+
+    protected KieProjectService getProjectService() {
+        final KieProject mockProject = getKieProjectMock(TEST_PROJECT_ROOT,
+                                                         TEST_PROJECT_NAME);
+
+        final Package mockPackage = mock(Package.class);
+        when(mockPackage.getPackageName()).thenReturn(TEST_PACKAGE_NAME);
+
+        final KieProjectService mockProjectService = mock(KieProjectService.class);
+        when(mockProjectService.resolveProject(any(org.uberfire.backend.vfs.Path.class))).thenReturn(mockProject);
+        when(mockProjectService.resolvePackage(any(org.uberfire.backend.vfs.Path.class))).thenReturn(mockPackage);
+
+        return mockProjectService;
+    }
+
+    protected KieProject getKieProjectMock(final String testProjectRoot,
+                                           final String testProjectName) {
+        final org.uberfire.backend.vfs.Path mockRoot = mock(org.uberfire.backend.vfs.Path.class);
+        when(mockRoot.toURI()).thenReturn(testProjectRoot);
+
+        final KieProject mockProject = mock(KieProject.class);
+        when(mockProject.getRootPath()).thenReturn(mockRoot);
+        when(mockProject.getProjectName()).thenReturn(testProjectName);
+        return mockProject;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQueryTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQueryTest.java
@@ -13,25 +13,20 @@
  * limitations under the License.
 */
 
-package org.kie.workbench.common.services.refactoring.backend.server.query.findresources;
+package org.kie.workbench.common.screens.impl;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
-import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
-import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
-import org.kie.workbench.common.services.refactoring.backend.server.drl.TestDrlFileIndexer;
-import org.kie.workbench.common.services.refactoring.backend.server.drl.TestDrlFileTypeDefinition;
+import org.kie.workbench.common.screens.library.api.index.LibraryValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.DefaultResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
-import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindAllLibraryAssetsQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm.TermSearchType;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
@@ -44,7 +39,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class FindAllLibraryAssetsQueryTest
-        extends BaseIndexingTest<TestDrlFileTypeDefinition> {
+        extends BaseLibraryIndexingTest {
 
     private static final String SOME_OTHER_PROJECT_ROOT = "some/other/projectRoot";
     private static final String SOME_OTHER_PROJECT_NAME = "other-mock-project";
@@ -89,22 +84,22 @@ public class FindAllLibraryAssetsQueryTest
     public void listAllInProject() throws IOException, InterruptedException {
 
         //Add test files
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
                     "drl1.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "drl2.drl");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "drl2.ext2");
         addTestFile(SOME_OTHER_PROJECT_ROOT,
-                    "drl3.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "functions.drl");
+                    "drl3.ext3");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "functions.functions");
 
         Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
         {
             final RefactoringPageRequest request = new RefactoringPageRequest(FindAllLibraryAssetsQuery.NAME,
                                                                               new HashSet<ValueIndexTerm>() {{
-                                                                                  add(new ValueProjectRootPathIndexTerm(BaseIndexingTest.TEST_PROJECT_ROOT,
-                                                                                                                        TermSearchType.WILDCARD));
+                                                                                  add(new LibraryValueProjectRootPathIndexTerm(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                                                                                                                               TermSearchType.WILDCARD));
                                                                               }},
                                                                               0,
                                                                               10);
@@ -129,24 +124,24 @@ public class FindAllLibraryAssetsQueryTest
     public void filterFilesFromProject() throws IOException, InterruptedException {
 
         //Add test files
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "rule1.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "rule2.drl");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "rule1.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "rule2.rule");
         addTestFile(SOME_OTHER_PROJECT_ROOT,
-                    "rule3.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "functions.drl");
+                    "rule3.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "functions.functions");
 
         Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
         {
             final RefactoringPageRequest request = new RefactoringPageRequest(FindAllLibraryAssetsQuery.NAME,
                                                                               new HashSet<ValueIndexTerm>() {{
-                                                                                  add(new ValueProjectRootPathIndexTerm(BaseIndexingTest.TEST_PROJECT_ROOT,
-                                                                                                                        TermSearchType.WILDCARD));
+                                                                                  add(new LibraryValueProjectRootPathIndexTerm(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                                                                                                                               TermSearchType.WILDCARD));
                                                                                   add(new ValueFullFileNameIndexTerm("*rule*",
-                                                                                                                     ValueIndexTerm.TermSearchType.WILDCARD));
+                                                                                                                     TermSearchType.WILDCARD));
                                                                               }},
                                                                               0,
                                                                               10);
@@ -165,16 +160,6 @@ public class FindAllLibraryAssetsQueryTest
                 fail("Exception thrown: " + e.getMessage());
             }
         }
-    }
-
-    @Override
-    protected TestIndexer getIndexer() {
-        return new TestDrlFileIndexer();
-    }
-
-    @Override
-    protected TestDrlFileTypeDefinition getResourceTypeDefinition() {
-        return new TestDrlFileTypeDefinition();
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsSortedQueryTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsSortedQueryTest.java
@@ -13,24 +13,19 @@
  * limitations under the License.
 */
 
-package org.kie.workbench.common.services.refactoring.backend.server.query.findresources;
+package org.kie.workbench.common.screens.impl;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
-import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
-import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
-import org.kie.workbench.common.services.refactoring.backend.server.drl.TestDrlFileIndexer;
-import org.kie.workbench.common.services.refactoring.backend.server.drl.TestDrlFileTypeDefinition;
+import org.kie.workbench.common.screens.library.api.index.LibraryValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.DefaultResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
-import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindAllLibraryAssetsQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm.TermSearchType;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
@@ -44,7 +39,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class FindAllLibraryAssetsSortedQueryTest
-        extends BaseIndexingTest<TestDrlFileTypeDefinition> {
+        extends BaseLibraryIndexingTest {
 
     private static final String SOME_OTHER_PROJECT_ROOT = "some/other/projectRoot";
     private static final String SOME_OTHER_PROJECT_NAME = "other-mock-project";
@@ -89,19 +84,19 @@ public class FindAllLibraryAssetsSortedQueryTest
     public void listAllInProjectSorted() throws IOException, InterruptedException {
 
         //Add test files
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "rule3.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "functions.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "drl3.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "drl2.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "rule3.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "functions.functions");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "drl3.ext3");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "drl2.ext2");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
                     "drl1.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "RULE4.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "RULE4.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
                     "DRL4.drl");
 
         Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
@@ -109,8 +104,8 @@ public class FindAllLibraryAssetsSortedQueryTest
         {
             final RefactoringPageRequest request = new RefactoringPageRequest(FindAllLibraryAssetsQuery.NAME,
                                                                               new HashSet<ValueIndexTerm>() {{
-                                                                                  add(new ValueProjectRootPathIndexTerm(BaseIndexingTest.TEST_PROJECT_ROOT,
-                                                                                                                        TermSearchType.WILDCARD));
+                                                                                  add(new LibraryValueProjectRootPathIndexTerm(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                                                                                                                               TermSearchType.WILDCARD));
                                                                               }},
                                                                               0,
                                                                               10);
@@ -127,17 +122,17 @@ public class FindAllLibraryAssetsSortedQueryTest
                              response.getPageRowList().size());
                 assertEquals("drl1.drl",
                              ((Path) response.getPageRowList().get(0).getValue()).getFileName());
-                assertEquals("drl2.drl",
+                assertEquals("drl2.ext2",
                              ((Path) response.getPageRowList().get(1).getValue()).getFileName());
-                assertEquals("drl3.drl",
+                assertEquals("drl3.ext3",
                              ((Path) response.getPageRowList().get(2).getValue()).getFileName());
                 assertEquals("DRL4.drl",
                              ((Path) response.getPageRowList().get(3).getValue()).getFileName());
-                assertEquals("functions.drl",
+                assertEquals("functions.functions",
                              ((Path) response.getPageRowList().get(4).getValue()).getFileName());
-                assertEquals("rule3.drl",
+                assertEquals("rule3.rule",
                              ((Path) response.getPageRowList().get(5).getValue()).getFileName());
-                assertEquals("RULE4.drl",
+                assertEquals("RULE4.rule",
                              ((Path) response.getPageRowList().get(6).getValue()).getFileName());
             } catch (IllegalArgumentException e) {
                 fail("Exception thrown: " + e.getMessage());
@@ -149,19 +144,19 @@ public class FindAllLibraryAssetsSortedQueryTest
     public void listAllInProjectSortedPaged() throws IOException, InterruptedException {
 
         //Add test files
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "rule3.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "functions.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "drl3.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "drl2.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "rule3.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "functions.functions");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "drl3.ext3");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "drl2.ext2");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
                     "drl1.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
-                    "RULE4.drl");
-        addTestFile(BaseIndexingTest.TEST_PROJECT_ROOT,
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "RULE4.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
                     "DRL4.drl");
 
         Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
@@ -169,15 +164,15 @@ public class FindAllLibraryAssetsSortedQueryTest
         {
             final RefactoringPageRequest request1 = new RefactoringPageRequest(FindAllLibraryAssetsQuery.NAME,
                                                                                new HashSet<ValueIndexTerm>() {{
-                                                                                   add(new ValueProjectRootPathIndexTerm(BaseIndexingTest.TEST_PROJECT_ROOT,
-                                                                                                                         TermSearchType.WILDCARD));
+                                                                                   add(new LibraryValueProjectRootPathIndexTerm(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                                                                                                                                TermSearchType.WILDCARD));
                                                                                }},
                                                                                0,
                                                                                4);
             final RefactoringPageRequest request2 = new RefactoringPageRequest(FindAllLibraryAssetsQuery.NAME,
                                                                                new HashSet<ValueIndexTerm>() {{
-                                                                                   add(new ValueProjectRootPathIndexTerm(BaseIndexingTest.TEST_PROJECT_ROOT,
-                                                                                                                         TermSearchType.WILDCARD));
+                                                                                   add(new LibraryValueProjectRootPathIndexTerm(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                                                                                                                                TermSearchType.WILDCARD));
                                                                                }},
                                                                                4,
                                                                                4);
@@ -194,9 +189,9 @@ public class FindAllLibraryAssetsSortedQueryTest
                              response1.getPageRowList().size());
                 assertEquals("drl1.drl",
                              ((Path) response1.getPageRowList().get(0).getValue()).getFileName());
-                assertEquals("drl2.drl",
+                assertEquals("drl2.ext2",
                              ((Path) response1.getPageRowList().get(1).getValue()).getFileName());
-                assertEquals("drl3.drl",
+                assertEquals("drl3.ext3",
                              ((Path) response1.getPageRowList().get(2).getValue()).getFileName());
                 assertEquals("DRL4.drl",
                              ((Path) response1.getPageRowList().get(3).getValue()).getFileName());
@@ -210,26 +205,16 @@ public class FindAllLibraryAssetsSortedQueryTest
 
                 assertEquals(3,
                              response2.getPageRowList().size());
-                assertEquals("functions.drl",
+                assertEquals("functions.functions",
                              ((Path) response2.getPageRowList().get(0).getValue()).getFileName());
-                assertEquals("rule3.drl",
+                assertEquals("rule3.rule",
                              ((Path) response2.getPageRowList().get(1).getValue()).getFileName());
-                assertEquals("RULE4.drl",
+                assertEquals("RULE4.rule",
                              ((Path) response2.getPageRowList().get(2).getValue()).getFileName());
             } catch (IllegalArgumentException e) {
                 fail("Exception thrown: " + e.getMessage());
             }
         }
-    }
-
-    @Override
-    protected TestIndexer getIndexer() {
-        return new TestDrlFileIndexer();
-    }
-
-    @Override
-    protected TestDrlFileTypeDefinition getResourceTypeDefinition() {
-        return new TestDrlFileTypeDefinition();
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
@@ -50,7 +50,6 @@ import org.kie.workbench.common.screens.library.api.preferences.LibraryOrganizat
 import org.kie.workbench.common.screens.library.api.preferences.LibraryPreferences;
 import org.kie.workbench.common.screens.library.api.preferences.LibraryProjectPreferences;
 import org.kie.workbench.common.screens.library.api.preferences.LibraryRepositoryPreferences;
-import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindAllLibraryAssetsQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/DRL4.drl
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/DRL4.drl
@@ -1,10 +1,10 @@
-package org.kie.workbench.mock.package;
+package org.kie.workbench.common.screens.impl;
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -13,11 +13,3 @@ package org.kie.workbench.mock.package;
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
-import org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Bank;
-import function org.kie.workbench.mock.package.f3;
-
-rule "myrule 3"
-when
-then
-end;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/RULE4.rule
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/RULE4.rule
@@ -1,6 +1,6 @@
-package org.kie.workbench.mock.package;
+package org.kie.workbench.common.screens.impl;
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,3 @@ package org.kie.workbench.mock.package;
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
-import org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant;
-
-import function org.kie.workbench.mock.package.f1;
-import function org.kie.workbench.mock.package.f3;
-
-rule "myRule"
-ruleflow-group "myRuleFlowGroup"
-when
-  Applicant( age > f1(0) )
-then
-end;
-

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/drl1.drl
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/drl1.drl
@@ -1,6 +1,6 @@
-package org.kie.workbench.mock.package;
+package org.kie.workbench.common.screens.impl;
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,3 @@ package org.kie.workbench.mock.package;
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
-import org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant;
-
-import function org.kie.workbench.mock.package.f1;
-import function org.kie.workbench.mock.package.f3;
-
-rule "myRule"
-ruleflow-group "myRuleFlowGroup"
-when
-  Applicant( age > f1(0) )
-then
-end;
-

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/drl2.ext2
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/drl2.ext2
@@ -1,10 +1,10 @@
-package org.kie.workbench.mock.package;
+package org.kie.workbench.common.screens.impl;
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -13,11 +13,3 @@ package org.kie.workbench.mock.package;
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
-import org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Bank;
-import function org.kie.workbench.mock.package.f3;
-
-rule "myrule 2"
-when
-then
-end;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/drl3.ext3
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/drl3.ext3
@@ -1,10 +1,10 @@
-package org.kie.workbench.mock.package;
+package org.kie.workbench.common.screens.impl;
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -13,11 +13,3 @@ package org.kie.workbench.mock.package;
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
-import org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Bank;
-import function org.kie.workbench.mock.package.f3;
-
-rule "myrule 1"
-when
-then
-end;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/functions.functions
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/functions.functions
@@ -1,0 +1,15 @@
+package org.kie.workbench.common.screens.impl;
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/rule1.rule
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/rule1.rule
@@ -1,0 +1,15 @@
+package org.kie.workbench.common.screens.impl;
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/rule2.rule
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/rule2.rule
@@ -1,0 +1,15 @@
+package org.kie.workbench.common.screens.impl;
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/rule3.rule
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/org/kie/workbench/common/screens/impl/rule3.rule
@@ -1,0 +1,15 @@
+package org.kie.workbench.common.screens.impl;
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
@@ -111,6 +111,10 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-library-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-api</artifactId>
     </dependency>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
@@ -24,6 +24,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.kie.workbench.common.screens.library.api.index.LibraryProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.ImpactAnalysisAnalyzerWrapperFactory;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.LowerCaseOnlyAnalyzer;
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
@@ -46,8 +47,8 @@ public class DefaultLuceneConfigProducer {
     public void setup() {
         final Map<String, Analyzer> analyzers = getAnalyzers();
         this.config = new LuceneConfigBuilder().withInMemoryMetaModelStore()
-                .usingAnalyzers( analyzers )
-                .usingAnalyzerWrapperFactory( ImpactAnalysisAnalyzerWrapperFactory.getInstance() )
+                .usingAnalyzers(analyzers)
+                .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
                 .useDirectoryBasedIndex()
                 .useNIODirectory()
                 .build();
@@ -61,12 +62,14 @@ public class DefaultLuceneConfigProducer {
 
     Map<String, Analyzer> getAnalyzers() {
         return new HashMap<String, Analyzer>() {{
-            put( ProjectRootPathIndexTerm.TERM,
-                 new FilenameAnalyzer() );
-            put( PackageNameIndexTerm.TERM,
-                 new LowerCaseOnlyAnalyzer() );
-            put( LuceneIndex.CUSTOM_FIELD_FILENAME,
-                 new FilenameAnalyzer() );
+            put(ProjectRootPathIndexTerm.TERM,
+                new FilenameAnalyzer());
+            put(LibraryProjectRootPathIndexTerm.TERM,
+                new FilenameAnalyzer());
+            put(PackageNameIndexTerm.TERM,
+                new LowerCaseOnlyAnalyzer());
+            put(LuceneIndex.CUSTOM_FIELD_FILENAME,
+                new FilenameAnalyzer());
 
             // all of the (resource, part, shared, etc) references and resource or part terms
             // are taken care of via the ImpactAnalysisAnalyzerWrapper

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/test/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/test/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducerTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.workbench.common.screens.library.api.index.LibraryProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.LowerCaseOnlyAnalyzer;
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
@@ -42,11 +43,11 @@ public class DefaultLuceneConfigProducerTest {
     public void checkDefaultAnalyzers() {
         final Map<String, Analyzer> analyzers = producer.getAnalyzers();
 
-        assertEquals( 3,
-                      analyzers.size() );
-        assertTrue( analyzers.get( ProjectRootPathIndexTerm.TERM ) instanceof FilenameAnalyzer );
-        assertTrue( analyzers.get( PackageNameIndexTerm.TERM ) instanceof LowerCaseOnlyAnalyzer );
-        assertTrue( analyzers.get( LuceneIndex.CUSTOM_FIELD_FILENAME ) instanceof FilenameAnalyzer );
+        assertEquals(4,
+                     analyzers.size());
+        assertTrue(analyzers.get(ProjectRootPathIndexTerm.TERM) instanceof FilenameAnalyzer);
+        assertTrue(analyzers.get(LibraryProjectRootPathIndexTerm.TERM) instanceof FilenameAnalyzer);
+        assertTrue(analyzers.get(PackageNameIndexTerm.TERM) instanceof LowerCaseOnlyAnalyzer);
+        assertTrue(analyzers.get(LuceneIndex.CUSTOM_FIELD_FILENAME) instanceof FilenameAnalyzer);
     }
-
 }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/terms/IndexTerm.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/terms/IndexTerm.java
@@ -26,6 +26,8 @@ package org.kie.workbench.common.services.refactoring.model.index.terms;
  */
 public interface IndexTerm {
 
+    String REFACTORING_CLASSIFIER = "refactor-info";
+
     String getTerm();
 
 }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
@@ -175,6 +175,11 @@
       <artifactId>simple-jndi</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/indexing/DefaultIndexBuilder.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/indexing/DefaultIndexBuilder.java
@@ -23,20 +23,18 @@ import org.guvnor.common.services.project.model.Package;
 import org.guvnor.common.services.project.model.Project;
 import org.kie.workbench.common.services.refactoring.IndexElementsGenerator;
 import org.kie.workbench.common.services.refactoring.KPropertyImpl;
-import org.kie.workbench.common.services.refactoring.model.index.terms.FullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
 import org.uberfire.commons.validation.PortablePreconditions;
-import org.uberfire.ext.metadata.backend.lucene.fields.FieldFactory;
 import org.uberfire.ext.metadata.model.KProperty;
 
 public class DefaultIndexBuilder {
 
-    private final String fileName;
-    private Project project;
-    private Package pkg;
-    private String pkgName;
+    protected final String fileName;
+    protected final Project project;
+    protected final Package pkg;
+    protected String pkgName;
 
     private Set<IndexElementsGenerator> generators = new HashSet<IndexElementsGenerator>();
 
@@ -61,13 +59,6 @@ public class DefaultIndexBuilder {
         final Set<KProperty<?>> indexElements = new HashSet<>();
         generators.forEach((generator) -> addIndexElements(indexElements,
                                                            generator));
-
-        indexElements.add(new KPropertyImpl<>(FullFileNameIndexTerm.TERM,
-                                              fileName));
-        indexElements.add(new KPropertyImpl<>(FieldFactory.FILE_NAME_FIELD_SORTED,
-                                              fileName.toLowerCase(),
-                                              false,
-                                              true));
 
         if (project != null && project.getRootPath() != null) {
             final String projectRootUri = project.getRootPath().toURI();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/util/KObjectUtil.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/util/KObjectUtil.java
@@ -53,12 +53,13 @@ public class KObjectUtil {
 
     }
 
-    public static KObjectKey toKObjectKey(final Path path) {
+    public static KObjectKey toKObjectKey(final Path path,
+                                          final String classifier) {
         return new KObjectKey() {
 
             @Override
             public String getId() {
-                return sha1(getType().getName() + "|refactor-info|" + getKey());
+                return sha1(getType().getName() + "|" + classifier + "|" + getKey());
             }
 
             @Override
@@ -97,12 +98,13 @@ public class KObjectUtil {
     }
 
     public static KObject toKObject(final Path path,
+                                    final String classifier,
                                     final Set<KProperty<?>> indexElements) {
         return new KObject() {
 
             @Override
             public String getId() {
-                return sha1(getType().getName() + "|refactor-info|" + getKey());
+                return sha1(getType().getName() + "|" + classifier + "|" + getKey());
             }
 
             @Override

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/TestPropertiesFileIndexer.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/TestPropertiesFileIndexer.java
@@ -24,6 +24,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.kie.workbench.common.services.refactoring.KPropertyImpl;
 import org.kie.workbench.common.services.refactoring.backend.server.util.KObjectUtil;
+import org.kie.workbench.common.services.refactoring.model.index.terms.IndexTerm;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.ext.metadata.model.KObject;
@@ -81,11 +82,13 @@ public class TestPropertiesFileIndexer implements TestIndexer<TestPropertiesFile
                                                   properties.getProperty(propertyName)));
         }
         return KObjectUtil.toKObject(path,
+                                     IndexTerm.REFACTORING_CLASSIFIER,
                                      indexElements);
     }
 
     @Override
     public KObjectKey toKObjectKey(final Path path) {
-        return KObjectUtil.toKObjectKey(path);
+        return KObjectUtil.toKObjectKey(path,
+                                        IndexTerm.REFACTORING_CLASSIFIER);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3075

This moves "Library" specific index information into a new generic ```Indexer```. It also moves **all** the "Library" related (index/query) code from the ```refactoring-backend``` module to the ```library-backend``` module.

I've tested with ```drools-wb``` and WID's and uploaded files; and it appears OK. I've also tested with ```kie-wb``` and the auto-generated files from Designer (when exporting the PNG) appears in the Library too.