### PR TITLE
[DO NOT MERGE] GUVNOR-3082: Asset Search: The ability to search by meta-data has disappeared

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
@@ -143,4 +143,6 @@ public class LibraryConstants {
     @TranslationKey(defaultValue = "No more files. Please, press previous.")
     public static final String NoMoreFilesPleasePressPrevious = "NoMoreFilesPleasePressPrevious";
 
+    @TranslationKey(defaultValue = "Asset search")
+    public static final String AssetSearch = "AssetSearch";
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
@@ -83,6 +83,7 @@ public class LibraryPlaces {
     public static final String PROJECT_EXPLORER = "org.kie.guvnor.explorer";
     public static final String MESSAGES = "org.kie.workbench.common.screens.messageconsole.MessageConsole";
     public static final String REPOSITORY_STRUCTURE_SCREEN = "repositoryStructureScreen";
+    public static final String ASSET_SEARCH = "FindForm";
 
     public static final List<String> LIBRARY_PLACES = Collections.unmodifiableList(new ArrayList<String>(7) {{
         add(NEW_PROJECT_SCREEN);

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/Library.properties
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/Library.properties
@@ -102,3 +102,4 @@ Description=Description
 PerPage=per page
 IndexingHasNotFinished=Indexing has not finished
 PleaseWaitWhileTheProjectContentIsBeingIndexed=Please wait while the project content is being indexed
+AssetSearch=Asset search

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
@@ -15,18 +15,28 @@
  */
 package org.kie.workbench.common.screens.library.client.perspective;
 
-import javax.enterprise.event.Event;
-
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.library.api.search.FilterUpdateEvent;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
 import org.kie.workbench.common.widgets.client.search.ContextualSearch;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.workbench.model.PanelDefinition;
+import org.uberfire.workbench.model.PartDefinition;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.MenuItemCommand;
+import org.uberfire.workbench.model.menu.Menus;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(GwtMockitoTestRunner.class)
@@ -41,13 +51,28 @@ public class LibraryPerspectiveTest {
     @Mock
     private EventSourceMock<FilterUpdateEvent> filterUpdateEvent;
 
+    @Mock
+    private TranslationService translationService;
+
+    @Mock
+    private PlaceManager placeManager;
+
+    @Captor
+    private ArgumentCaptor<PartDefinition> partDefinitionArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<PanelDefinition> panelDefinitionArgumentCaptor;
+
     private LibraryPerspective perspective;
 
     @Before
     public void setup() {
         perspective = new LibraryPerspective(libraryPlaces,
                                              contextualSearch,
-                                             filterUpdateEvent);
+                                             filterUpdateEvent,
+                                             translationService,
+                                             placeManager);
+        doAnswer((InvocationOnMock invocation) -> invocation.getArguments()[0]).when(translationService).getTranslation(any(String.class));
     }
 
     @Test
@@ -63,5 +88,32 @@ public class LibraryPerspectiveTest {
 
         verify(contextualSearch).setPerspectiveSearchBehavior(eq(LibraryPlaces.LIBRARY_PERSPECTIVE),
                                                               any());
+    }
+
+    @Test
+    public void libraryMenus() {
+        final PerspectiveDefinition perspectiveDefinition = perspective.buildPerspective();
+        final Menus menus = perspective.buildMenuBar();
+        assertNotNull(menus);
+        assertEquals(1,
+                     menus.getItems().size());
+
+        final MenuItem menuItem = menus.getItems().get(0);
+        assertNotNull(menuItem);
+        assertTrue(menuItem instanceof MenuItemCommand);
+
+        final MenuItemCommand command = (MenuItemCommand) menuItem;
+        command.getCommand().execute();
+
+        verify(placeManager,
+               times(1)).goTo(partDefinitionArgumentCaptor.capture(),
+                              panelDefinitionArgumentCaptor.capture());
+
+        final PartDefinition partDefinition = partDefinitionArgumentCaptor.getValue();
+        final PanelDefinition panelDefinition = panelDefinitionArgumentCaptor.getValue();
+        assertEquals(LibraryPlaces.ASSET_SEARCH,
+                     partDefinition.getPlace().getIdentifier());
+        assertEquals(perspectiveDefinition.getRoot(),
+                     panelDefinition);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3082

@paulovmr The feature used to be available on the [Authoring Perspectives](https://github.com/kiegroup/kie-wb-distributions/blob/master/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/DroolsAuthoringPerspective.java#L110). IDK if this is the correct place to add it back; but it makes sense to me (unless UX had different ideas?!)