### PR TITLE
[7.0.x] GUVNOR-3083: Library: Indexer should not index folders

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetTypeDefinition.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetTypeDefinition.java
@@ -17,7 +17,9 @@ package org.kie.workbench.common.screens.impl;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.java.nio.file.Files;
 import org.uberfire.workbench.type.ResourceTypeDefinition;
 
 @ApplicationScoped
@@ -56,6 +58,10 @@ public class LibraryAssetTypeDefinition
 
     @Override
     public boolean accept(final Path path) {
-        return !path.getFileName().startsWith(".");
+        return !(isFolder(path) || path.getFileName().startsWith("."));
+    }
+
+    boolean isFolder(final Path path) {
+        return Files.isDirectory(Paths.convert(path));
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryAssetTypeDefinitionTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryAssetTypeDefinitionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.impl;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.uberfire.backend.vfs.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class LibraryAssetTypeDefinitionTest {
+
+    private String fileName;
+
+    private boolean isFolder;
+
+    private boolean isAccepted;
+
+    private LibraryAssetTypeDefinition definition;
+
+    @Before
+    public void setup() {
+        this.definition = new LibraryAssetTypeDefinition() {
+            @Override
+            boolean isFolder(final Path path) {
+                return isFolder;
+            }
+        };
+    }
+
+    public LibraryAssetTypeDefinitionTest(final String fileName,
+                                          final boolean isFolder,
+                                          final boolean isAccepted) {
+        this.fileName = fileName;
+        this.isFolder = isFolder;
+        this.isAccepted = isAccepted;
+    }
+
+    @Parameterized.Parameters(name = "{index}: file={0}, isFolder={1}, isAccepted={2}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[][]{
+                        {"file.drl", false, true},
+                        {".file.drl", false, false},
+                        {"folder", true, false},
+                        {".folder", true, false}
+                }
+        );
+    }
+
+    @Test
+    public void checkAccept() {
+        final Path path = mock(Path.class);
+        when(path.getFileName()).thenReturn(fileName);
+        assertEquals(isAccepted,
+                     definition.accept(path));
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3083

This is the corollary of https://github.com/kiegroup/kie-wb-common/pull/883 for 7.0.x

(cherry picked from commit 41fe528630fe7bd876c27489044e725cd6e7dbea)