### PR TITLE
[7.0.x] GUVNOR-3089 : Workbench: Asset list is not complete after importing a project

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreen.java
@@ -291,7 +291,7 @@ public class ProjectScreen {
                                                    return false;
                                                }
                                            },
-                                           1000);
+                                           2000);
     }
 
     public void onFilterChange() {


### PR DESCRIPTION
(cherry picked from commit ac2baf838210b76c4d297206df6f34df1b288c82)

Related to #890 

And another fix that should still go in.
