### PR TITLE
GUVNOR-3107: [Library] Indexer: Duplicates results of searches

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryFileNameIndexTerm.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryFileNameIndexTerm.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.library.api.index;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.services.refactoring.model.index.terms.IndexTerm;
+
+@Portable
+public class LibraryFileNameIndexTerm implements IndexTerm {
+
+    public static final String TERM = "libraryFileName";
+
+    @Override
+    public String getTerm() {
+        return TERM;
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryValueFileNameIndexTerm.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/index/LibraryValueFileNameIndexTerm.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.library.api.index;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+@Portable
+public class LibraryValueFileNameIndexTerm extends LibraryFileNameIndexTerm implements ValueIndexTerm {
+
+    private String fileName;
+    private TermSearchType searchType;
+
+    public LibraryValueFileNameIndexTerm() {
+        //Errai marshalling
+    }
+
+    public LibraryValueFileNameIndexTerm(final String fileName) {
+        this(fileName,
+             TermSearchType.NORMAL);
+    }
+
+    public LibraryValueFileNameIndexTerm(final String fileName,
+                                         final TermSearchType searchType) {
+        this.fileName = PortablePreconditions.checkNotNull("fileName",
+                                                           fileName);
+        this.searchType = PortablePreconditions.checkNotNull("searchType",
+                                                             searchType);
+    }
+
+    @Override
+    public String getValue() {
+        return fileName;
+    }
+
+    @Override
+    public TermSearchType getSearchType() {
+        return searchType;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQuery.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQuery.java
@@ -22,12 +22,12 @@ import javax.inject.Inject;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.kie.workbench.common.screens.library.api.index.LibraryValueFileNameIndexTerm;
 import org.kie.workbench.common.screens.library.api.index.LibraryValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.FileDetailsResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.AbstractFindQuery;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.fields.FieldFactory;
 
@@ -80,7 +80,7 @@ public class FindAllLibraryAssetsQuery
                                              null // not required
                                      },
                                      (t) -> (t instanceof LibraryValueProjectRootPathIndexTerm),
-                                     (t) -> (t instanceof ValueFullFileNameIndexTerm)
+                                     (t) -> (t instanceof LibraryValueFileNameIndexTerm)
         );
 
         checkTermsSize(2,

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryIndexer.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryIndexer.java
@@ -22,12 +22,12 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.guvnor.common.services.project.model.Package;
+import org.kie.workbench.common.screens.library.api.index.LibraryFileNameIndexTerm;
 import org.kie.workbench.common.screens.library.api.index.LibraryProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.KPropertyImpl;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.AbstractFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.DefaultIndexBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.util.KObjectUtil;
-import org.kie.workbench.common.services.refactoring.model.index.terms.FullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectNameIndexTerm;
 import org.kie.workbench.common.services.shared.project.KieProject;
@@ -91,7 +91,7 @@ public class LibraryIndexer extends AbstractFileIndexer {
             public Set<KProperty<?>> build() {
                 final Set<KProperty<?>> indexElements = new HashSet<>();
 
-                indexElements.add(new KPropertyImpl<>(FullFileNameIndexTerm.TERM,
+                indexElements.add(new KPropertyImpl<>(LibraryFileNameIndexTerm.TERM,
                                                       fileName));
                 indexElements.add(new KPropertyImpl<>(FieldFactory.FILE_NAME_FIELD_SORTED,
                                                       fileName.toLowerCase(),

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
@@ -55,10 +55,10 @@ import org.kie.workbench.common.screens.library.api.LibraryInfo;
 import org.kie.workbench.common.screens.library.api.LibraryService;
 import org.kie.workbench.common.screens.library.api.OrganizationalUnitRepositoryInfo;
 import org.kie.workbench.common.screens.library.api.ProjectAssetsQuery;
+import org.kie.workbench.common.screens.library.api.index.LibraryValueFileNameIndexTerm;
 import org.kie.workbench.common.screens.library.api.index.LibraryValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.screens.library.api.preferences.LibraryInternalPreferences;
 import org.kie.workbench.common.screens.library.api.preferences.LibraryPreferences;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
@@ -209,8 +209,8 @@ public class LibraryServiceImpl implements LibraryService {
         queryTerms.add(new LibraryValueProjectRootPathIndexTerm(query.getProject().getRootPath().toURI()));
 
         if (query.hasFilter()) {
-            queryTerms.add(new ValueFullFileNameIndexTerm("*" + query.getFilter() + "*",
-                                                          ValueIndexTerm.TermSearchType.WILDCARD));
+            queryTerms.add(new LibraryValueFileNameIndexTerm("*" + query.getFilter() + "*",
+                                                             ValueIndexTerm.TermSearchType.WILDCARD));
         }
 
         final PageResponse<RefactoringPageRow> findRulesByProjectQuery = refactoringQueryService.query(new RefactoringPageRequest(FindAllLibraryAssetsQuery.NAME,

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQueryTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsQueryTest.java
@@ -20,11 +20,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
+import org.kie.workbench.common.screens.library.api.index.LibraryValueFileNameIndexTerm;
 import org.kie.workbench.common.screens.library.api.index.LibraryValueProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.DefaultResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFullFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm.TermSearchType;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
@@ -140,8 +140,8 @@ public class FindAllLibraryAssetsQueryTest
                                                                               new HashSet<ValueIndexTerm>() {{
                                                                                   add(new LibraryValueProjectRootPathIndexTerm(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
                                                                                                                                TermSearchType.WILDCARD));
-                                                                                  add(new ValueFullFileNameIndexTerm("*rule*",
-                                                                                                                     TermSearchType.WILDCARD));
+                                                                                  add(new LibraryValueFileNameIndexTerm("*rule*",
+                                                                                                                        TermSearchType.WILDCARD));
                                                                               }},
                                                                               0,
                                                                               10);

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/ListAssetsTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/ListAssetsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.impl;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.lucene.search.Query;
+import org.junit.Test;
+import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
+import org.kie.workbench.common.services.refactoring.backend.server.query.response.DefaultResponseBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.standard.AbstractFindQuery;
+import org.kie.workbench.common.services.refactoring.model.index.terms.FullFileNameIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFullFileNameIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
+import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
+import org.uberfire.paging.PageResponse;
+
+import static org.junit.Assert.*;
+
+public class ListAssetsTest
+        extends BaseLibraryIndexingTest {
+
+    @Override
+    protected Set<NamedQuery> getQueries() {
+        return new HashSet<NamedQuery>() {{
+            add(new TestFindFilesQuery());
+        }};
+    }
+
+    @Test
+    public void listFilesShouldNotHaveDuplicatesFromLibraryIndexer() throws IOException, InterruptedException {
+
+        //Add test files
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "rule1.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "rule2.rule");
+        addTestFile(BaseLibraryIndexingTest.TEST_PROJECT_ROOT,
+                    "rule3.rule");
+
+        Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+
+        {
+            final RefactoringPageRequest request = new RefactoringPageRequest(TestFindFilesQuery.NAME,
+                                                                              new HashSet<ValueIndexTerm>() {{
+                                                                                  add(new ValueFullFileNameIndexTerm("*.rule",
+                                                                                                                     ValueIndexTerm.TermSearchType.WILDCARD));
+                                                                              }},
+                                                                              0,
+                                                                              10);
+
+            try {
+                final PageResponse<RefactoringPageRow> response = service.query(request);
+                assertNotNull(response);
+
+                for (RefactoringPageRow refactoringPageRow : response.getPageRowList()) {
+                    System.out.println(refactoringPageRow.getValue());
+                }
+
+                assertEquals(3,
+                             response.getPageRowList().size());
+            } catch (IllegalArgumentException e) {
+                fail("Exception thrown: " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    protected String getRepositoryName() {
+        return this.getClass().getSimpleName();
+    }
+
+    /**
+     * This Query searches for "filename" index entries
+     */
+    private class TestFindFilesQuery extends AbstractFindQuery implements NamedQuery {
+
+        public static final String NAME = "TestFindFilesQuery";
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public void validateTerms(final Set<ValueIndexTerm> queryTerms) throws IllegalArgumentException {
+            checkInvalidAndRequiredTerms(queryTerms,
+                                         NAME,
+                                         new String[]{
+                                                 FullFileNameIndexTerm.TERM,
+                                                 null // not required
+                                         },
+                                         (t) -> (t instanceof ValueFullFileNameIndexTerm));
+        }
+
+        @Override
+        public Query toQuery(final Set<ValueIndexTerm> terms) {
+            return buildFromMultipleTerms(terms);
+        }
+
+        @Override
+        public ResponseBuilder getResponseBuilder() {
+            return new DefaultResponseBuilder(ioService());
+        }
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
@@ -24,6 +24,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.kie.workbench.common.screens.library.api.index.LibraryFileNameIndexTerm;
 import org.kie.workbench.common.screens.library.api.index.LibraryProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.ImpactAnalysisAnalyzerWrapperFactory;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.LowerCaseOnlyAnalyzer;
@@ -62,9 +63,11 @@ public class DefaultLuceneConfigProducer {
 
     Map<String, Analyzer> getAnalyzers() {
         return new HashMap<String, Analyzer>() {{
-            put(ProjectRootPathIndexTerm.TERM,
+            put(LibraryFileNameIndexTerm.TERM,
                 new FilenameAnalyzer());
             put(LibraryProjectRootPathIndexTerm.TERM,
+                new FilenameAnalyzer());
+            put(ProjectRootPathIndexTerm.TERM,
                 new FilenameAnalyzer());
             put(PackageNameIndexTerm.TERM,
                 new LowerCaseOnlyAnalyzer());

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/test/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/test/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducerTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.workbench.common.screens.library.api.index.LibraryFileNameIndexTerm;
 import org.kie.workbench.common.screens.library.api.index.LibraryProjectRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.LowerCaseOnlyAnalyzer;
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
@@ -43,10 +44,11 @@ public class DefaultLuceneConfigProducerTest {
     public void checkDefaultAnalyzers() {
         final Map<String, Analyzer> analyzers = producer.getAnalyzers();
 
-        assertEquals(4,
+        assertEquals(5,
                      analyzers.size());
-        assertTrue(analyzers.get(ProjectRootPathIndexTerm.TERM) instanceof FilenameAnalyzer);
+        assertTrue(analyzers.get(LibraryFileNameIndexTerm.TERM) instanceof FilenameAnalyzer);
         assertTrue(analyzers.get(LibraryProjectRootPathIndexTerm.TERM) instanceof FilenameAnalyzer);
+        assertTrue(analyzers.get(ProjectRootPathIndexTerm.TERM) instanceof FilenameAnalyzer);
         assertTrue(analyzers.get(PackageNameIndexTerm.TERM) instanceof LowerCaseOnlyAnalyzer);
         assertTrue(analyzers.get(LuceneIndex.CUSTOM_FIELD_FILENAME) instanceof FilenameAnalyzer);
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3107

You won't be able to test this "live" without merging https://github.com/kiegroup/kie-wb-common/pull/881 locally (as there's no way to perform a "meta-data" search in the Workbench at the moment... however I found this issue when furthering my work for GUVNOR-3082 and thought better to fix now than - forget - later).