### PR TITLE
JBPM-6035: Show added constants only for current row in DataIOEditor

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
@@ -306,7 +306,9 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
     @Override
     public void setProcessVariables(final ListBoxValues processVarListBoxValues) {
         processVarComboBox.setCurrentTextValue("");
-        processVarComboBox.setListBoxValues(processVarListBoxValues);
+        ListBoxValues copyProcessVarListBoxValues = new ListBoxValues(processVarListBoxValues,
+                                                                      false);
+        processVarComboBox.setListBoxValues(copyProcessVarListBoxValues);
         String con = getConstant();
         // processVar set here because the ListBoxValues must already have been set
         if (con != null && !con.isEmpty()) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
@@ -68,6 +68,21 @@ public class ListBoxValues {
         this.maxDisplayLength = DEFAULT_MAX_DISPLAY_LENGTH;
     }
 
+    public ListBoxValues(final ListBoxValues copy,
+                         final boolean copyCustomValues) {
+        this.customPrompt = copy.customPrompt;
+        this.editPrefix = copy.editPrefix;
+        this.valueTester = copy.valueTester;
+        this.maxDisplayLength = copy.maxDisplayLength;
+        this.addValues(copy.acceptableValuesWithoutCustomValues);
+        if (copyCustomValues) {
+            for (String copyCustomValue : copy.customValues) {
+                this.addCustomValue(copyCustomValue,
+                                    null);
+            }
+        }
+    }
+
     public String getEditPrefix() {
         return editPrefix;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
@@ -312,7 +312,9 @@ public class AssignmentListItemWidgetTest {
         widget.setConstant(sConstant);
         widget.setProcessVariables(processVarListBoxValues);
         verify(processVarComboBox,
-               times(2)).setListBoxValues(processVarListBoxValues);
+               times(1)).setListBoxValues(processVarListBoxValues);
+        verify(processVarComboBox,
+               times(2)).setListBoxValues(any(ListBoxValues.class));
         verify(processVarComboBox).addCustomValueToListBoxValues(sConstant,
                                                                  "");
         verify(processVar).setValue(sConstant);
@@ -335,7 +337,9 @@ public class AssignmentListItemWidgetTest {
         widget.setConstant(sConstant);
         widget.setProcessVariables(processVarListBoxValues);
         verify(processVarComboBox,
-               times(2)).setListBoxValues(processVarListBoxValues);
+               times(1)).setListBoxValues(processVarListBoxValues);
+        verify(processVarComboBox,
+               times(2)).setListBoxValues(any(ListBoxValues.class));
         verify(processVarComboBox).addCustomValueToListBoxValues(sConstant,
                                                                  "");
         verify(processVar).setValue("\"abcdeabcde...\"");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
@@ -323,4 +323,38 @@ public class ListBoxValuesTest {
         Assert.assertEquals(displayValue,
                             value);
     }
+
+    @Test
+    public void testCopyConstructor() {
+        List<String> processVarStartValues = Arrays.asList(
+                "** Variable Definitions **",
+                "employee",
+                "reason",
+                "performance"
+        );
+        ListBoxValues listBoxValues = new ListBoxValues("Constant ...",
+                                                        "Edit ",
+                                                        null);
+        listBoxValues.addValues(processVarStartValues);
+        listBoxValues.addCustomValue("\"abc\"",
+                                     "");
+        listBoxValues.addCustomValue("\"def\"",
+                                     "");
+
+        // Copy custom values as well as non-custom
+        ListBoxValues copy1 = new ListBoxValues(listBoxValues,
+                                                true);
+        Assert.assertTrue(copy1.getAcceptableValuesWithCustomValues().size() == 8);
+        Assert.assertTrue(copy1.getAcceptableValuesWithoutCustomValues().size() == 4);
+        Assert.assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"abc\""));
+        Assert.assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"def\""));
+
+        // Don't copy custom values as well as non-custom
+        ListBoxValues copy2 = new ListBoxValues(listBoxValues,
+                                                false);
+        Assert.assertTrue(copy2.getAcceptableValuesWithCustomValues().size() == 6);
+        Assert.assertTrue(copy2.getAcceptableValuesWithoutCustomValues().size() == 4);
+        Assert.assertFalse(copy2.getAcceptableValuesWithCustomValues().contains("\"abc\""));
+        Assert.assertFalse(copy2.getAcceptableValuesWithCustomValues().contains("\"def\""));
+    }
 }


### PR DESCRIPTION
This Jira and PR were created because the same problem was recently fixed in Designer.
@romartin  , @hasys  Will you review please. Today is my last day, so if it needs changes will one of you make the necessary changes. (Hopefully none will be needed!). Thanks.