### PR TITLE
JBPM-5560: Support for BPMN2 Embedded Subprocess.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/AnimationShapeStateHelper.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/AnimationShapeStateHelper.java
@@ -38,7 +38,7 @@ public class AnimationShapeStateHelper<V extends ShapeView, S extends Shape<V>> 
     protected void applyActiveState(final String color) {
         runAnimation(color,
                      getActiveStrokeWidth(),
-                     ACTIVE_STROKE_ALPHA);
+                     getActiveStrokeAlpha());
     }
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/morph/MorphDefinitionImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/morph/MorphDefinitionImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.definition.morph;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class MorphDefinitionImpl implements MorphDefinition {
+
+    private final String definitionId;
+    private final String base;
+    private final String defaultDefinitionId;
+    private final List<String> targets;
+    private final MorphPolicy policy;
+
+    public MorphDefinitionImpl(final @MapsTo("definitionId") String definitionId,
+                               final @MapsTo("base") String base,
+                               final @MapsTo("defaultDefinitionId") String defaultDefinitionId,
+                               final @MapsTo("targets") List<String> targets,
+                               final @MapsTo("policy") MorphPolicy policy) {
+        this.definitionId = definitionId;
+        this.base = base;
+        this.defaultDefinitionId = defaultDefinitionId;
+        this.targets = targets;
+        this.policy = policy;
+    }
+
+    @Override
+    public boolean accepts(final String definitionId) {
+        return this.definitionId.equals(definitionId);
+    }
+
+    @Override
+    public String getBase() {
+        return base;
+    }
+
+    @Override
+    public String getDefault() {
+        return defaultDefinitionId;
+    }
+
+    @Override
+    public Iterable<String> getTargets(final String definitionId) {
+        if (this.definitionId.equals(definitionId)) {
+            return targets;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public MorphPolicy getPolicy() {
+        return policy;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/RuleExtension.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/RuleExtension.java
@@ -37,7 +37,7 @@ import org.kie.workbench.common.stunner.core.rule.Rule;
  * @See {@link org.kie.workbench.common.stunner.core.rule.annotation.RuleExtension}
  */
 @Portable
-public final class RuleExtension implements Rule {
+public class RuleExtension implements Rule {
 
     private final String name;
     private final String id;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/definition/morph/MorphDefinitionImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/definition/morph/MorphDefinitionImplTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.definition.morph;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MorphDefinitionImplTest {
+
+    private static final String DEFINITION_ID = "def1";
+    private static final String BASE = "base1";
+    private static final String DEF_DEFINITION_ID = "default1";
+    private static final List<String> TARGETS = Arrays.asList("target1",
+                                                              "target2");
+    private static final MorphPolicy POLICY = MorphPolicy.ALL;
+
+    private MorphDefinitionImpl tested;
+
+    @Before
+    public void setup() {
+        this.tested = new MorphDefinitionImpl(DEFINITION_ID,
+                                              BASE,
+                                              DEF_DEFINITION_ID,
+                                              TARGETS,
+                                              POLICY);
+    }
+
+    @Test
+    public void testAccepts() {
+        assertTrue(tested.accepts(DEFINITION_ID));
+        assertFalse(tested.accepts("def2"));
+    }
+
+    @Test
+    public void testGetters() {
+        assertEquals(BASE,
+                     tested.getBase());
+        assertEquals(DEF_DEFINITION_ID,
+                     tested.getDefault());
+        assertEquals(TARGETS,
+                     tested.getTargets(DEFINITION_ID));
+        assertFalse(tested.getTargets("def2").iterator().hasNext());
+        assertEquals(POLICY,
+                     tested.getPolicy());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeImpl.java
@@ -71,7 +71,6 @@ public class ShapeImpl<V extends ShapeView>
     @Override
     public void applyState(final ShapeState shapeState) {
         shapeStateHelper
-                .save(ShapeState.NONE::equals)
                 .applyState(shapeState);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeStateHelper.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeStateHelper.java
@@ -24,8 +24,8 @@ import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 
 public class ShapeStateHelper<V extends ShapeView, S extends Shape<V>> {
 
-    public static final double ACTIVE_STROKE_WIDTH = 1d;
-    public static final double ACTIVE_STROKE_ALPHA = 1d;
+    static final double ACTIVE_STROKE_WIDTH_PCT = 1d;
+    static final double ACTIVE_STROKE_ALPHA = 1d;
 
     /*
         The following instance members:
@@ -68,6 +68,7 @@ public class ShapeStateHelper<V extends ShapeView, S extends Shape<V>> {
     public ShapeStateHelper save(final Predicate<ShapeState> stateFilter) {
         if (stateFilter.test(this.state)) {
             this.strokeWidth = getShapeView().getStrokeWidth();
+            this.activeStrokeWidth = strokeWidth + (strokeWidth * ACTIVE_STROKE_WIDTH_PCT);
             this.strokeAlpha = getShapeView().getStrokeAlpha();
             this.strokeColor = getShapeView().getStrokeColor();
         }
@@ -99,7 +100,7 @@ public class ShapeStateHelper<V extends ShapeView, S extends Shape<V>> {
     protected void applyActiveState(final String color) {
         getShapeView().setStrokeColor(color);
         getShapeView().setStrokeWidth(getActiveStrokeWidth());
-        getShapeView().setStrokeAlpha(ACTIVE_STROKE_ALPHA);
+        getShapeView().setStrokeAlpha(getActiveStrokeAlpha());
     }
 
     protected void applyNoneState(final String color,
@@ -112,18 +113,21 @@ public class ShapeStateHelper<V extends ShapeView, S extends Shape<V>> {
 
     protected void init() {
         this.state = ShapeState.NONE;
-        this.activeStrokeWidth = ACTIVE_STROKE_WIDTH;
+        this.activeStrokeWidth = 1;
         this.strokeWidth = 1;
         this.strokeAlpha = 1;
     }
 
-    protected double getActiveStrokeWidth() {
-        //return activeStrokeWidth;
-        return strokeWidth + (strokeWidth * activeStrokeWidth);
-    }
-
     protected S getShape() {
         return shape;
+    }
+
+    protected double getActiveStrokeWidth() {
+        return activeStrokeWidth;
+    }
+
+    protected static double getActiveStrokeAlpha() {
+        return ACTIVE_STROKE_ALPHA;
     }
 
     private void applySelectedState() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/ConnectorShapeTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/ConnectorShapeTest.java
@@ -59,7 +59,6 @@ public class ConnectorShapeTest {
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         shapeView = spy(new ConnectorViewStub());
-        when(shapeStateHelper.save(any(Predicate.class))).thenReturn(shapeStateHelper);
         this.tested = new ConnectorShape(shapeDef,
                                          shapeView,
                                          shapeStateHelper);
@@ -70,7 +69,7 @@ public class ConnectorShapeTest {
     public void testApplyState() {
         tested.applyState(ShapeState.NONE);
         verify(shapeStateHelper,
-               times(1)).save(any(Predicate.class));
+               never()).save(any(Predicate.class));
         verify(shapeStateHelper,
                times(1)).applyState(eq(ShapeState.NONE));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeImplTest.java
@@ -42,7 +42,6 @@ public class ShapeImplTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
-        when(shapeStateHelper.save(any(Predicate.class))).thenReturn(shapeStateHelper);
         this.view = spy(new ShapeViewExtStub());
         this.tested = new ShapeImpl<ShapeView>(view,
                                                shapeStateHelper);
@@ -70,7 +69,7 @@ public class ShapeImplTest {
     public void testApplyState() {
         tested.applyState(ShapeState.NONE);
         verify(shapeStateHelper,
-               times(1)).save(any(Predicate.class));
+               never()).save(any(Predicate.class));
         verify(shapeStateHelper,
                times(1)).applyState(eq(ShapeState.NONE));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeStateHelperTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeStateHelperTest.java
@@ -85,7 +85,7 @@ public class ShapeStateHelperTest {
         verify(shapeView,
                times(1)).setStrokeColor(eq(state.getColor()));
         verify(shapeView,
-               times(1)).setStrokeWidth(eq(STROKE_WIDTH_0 + (ShapeStateHelper.ACTIVE_STROKE_WIDTH * STROKE_WIDTH_0)));
+               times(1)).setStrokeWidth(eq(STROKE_WIDTH_0 + (ShapeStateHelper.ACTIVE_STROKE_WIDTH_PCT * STROKE_WIDTH_0)));
         verify(shapeView,
                times(1)).setStrokeAlpha(eq(ShapeStateHelper.ACTIVE_STROKE_ALPHA));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcher.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcher.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+/**
+ * A predicate that checks if two nodes are using sharing the same parent
+ * for a given type of Definition. It also filters a given node and
+ * used the given parent as a candidate for it, instead of
+ * processing the graph structure.
+ */
+public class FilteredParentsTypeMatcher
+        implements BiPredicate<Node<? extends View<?>, ? extends Edge>, Node<? extends View<?>, ? extends Edge>> {
+
+    private final ParentsTypeMatchPredicate parentsTypeMatchPredicate;
+    private final Optional<Element<? extends Definition<?>>> candidateParent;
+    private final Optional<Node<? extends Definition<?>, ? extends Edge>> candidateNode;
+
+    public FilteredParentsTypeMatcher(final DefinitionManager definitionManager,
+                                      final Element<? extends Definition<?>> candidateParent,
+                                      final Node<? extends Definition<?>, ? extends Edge> candidateNode) {
+        this.candidateParent = Optional.ofNullable(candidateParent);
+        this.candidateNode = Optional.ofNullable(candidateNode);
+        this.parentsTypeMatchPredicate =
+                new ParentsTypeMatchPredicate(new FilteredParentByDefinitionIdProvider(definitionManager),
+                                              new FilteredHasParentPredicate());
+    }
+
+    public FilteredParentsTypeMatcher forParentType(final Class<?> parentType) {
+        this.parentsTypeMatchPredicate.forParentType(parentType);
+        return this;
+    }
+
+    @Override
+    public boolean test(final Node<? extends View<?>, ? extends Edge> node,
+                        final Node<? extends View<?>, ? extends Edge> node2) {
+        return parentsTypeMatchPredicate.test(node,
+                                              node2);
+    }
+
+    private class FilteredHasParentPredicate implements BiPredicate<Node<?, ? extends Edge>, Element<?>> {
+
+        private final GraphUtils.HasParentPredicate hasParentPredicate;
+
+        private FilteredHasParentPredicate() {
+            this.hasParentPredicate = new GraphUtils.HasParentPredicate();
+        }
+
+        @Override
+        public boolean test(final Node<?, ? extends Edge> node,
+                            final Element<?> parent) {
+            return isCandidate.test(node) ?
+                    candidateParent
+                            .filter(parent::equals)
+                            .isPresent() :
+                    hasParentPredicate.test(node,
+                                            parent);
+        }
+    }
+
+    private class FilteredParentByDefinitionIdProvider
+            implements BiFunction<Node<? extends View<?>, ? extends Edge>, Class<?>, Optional<Element<?>>> {
+
+        private final ParentsTypeMatcher.ParentByDefinitionIdProvider provider;
+
+        private FilteredParentByDefinitionIdProvider(final DefinitionManager definitionManager) {
+            this.provider = new ParentsTypeMatcher.ParentByDefinitionIdProvider(definitionManager);
+        }
+
+        @Override
+        public Optional<Element<?>> apply(final Node<? extends View<?>, ? extends Edge> node,
+                                          final Class<?> parentType) {
+                return getParent(node, parentType);
+        }
+
+        private Optional<Element<?>> getParent(final Node<? extends View<?>, ? extends Edge> node,
+                                               final Class<?> parentType) {
+            return isCandidate.test(node) ?
+                    getCandidateParentInstance(parentType) :
+                    provider.apply(node, parentType);
+        }
+
+        @SuppressWarnings("unchecked")
+        private Optional<Element<?>> getCandidateParentInstance(final Class<?> parentType) {
+            return candidateParent.isPresent() ?
+                    (ParentsTypeMatcher.ParentByDefinitionIdProvider.getDefinitionIdByTpe(parentType)
+                            .equals(getCandidateParentId().get()) ?
+                            Optional.of(candidateParent.get()) :
+                            getParent((Node<? extends View<?>, ? extends Edge>) candidateParent.get(),
+                                      parentType)) :
+                    Optional.empty();
+        }
+
+        private Optional<String> getCandidateParentId() {
+            return candidateParent.isPresent() ?
+                    Optional.ofNullable(provider.definitionManager.adapters()
+                                                .forDefinition()
+                                                .getId(candidateParent.get().getContent().getDefinition())) :
+                    Optional.empty();
+        }
+    }
+
+    private Predicate<Node<?, ? extends Edge>> isCandidate = new Predicate<Node<?, ? extends Edge>>() {
+        @Override
+        public boolean test(final Node<?, ? extends Edge> node) {
+            return candidateNode
+                    .filter(node::equals)
+                    .isPresent();
+        }
+    };
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
+
+/**
+ * A predicate that checks if two nodes are using sharing the same parent
+ * for a given type of Definition.
+ */
+class ParentsTypeMatchPredicate implements BiPredicate<Node<? extends View<?>, ? extends Edge>, Node<? extends View<?>, ? extends Edge>> {
+
+    private final BiFunction<Node<? extends View<?>, ? extends Edge>, Class<?>, Optional<Element<?>>> parentProvider;
+    private final BiPredicate<Node<?, ? extends Edge>, Element<?>> hasParentPredicate;
+    private Class<?> parentType;
+
+    ParentsTypeMatchPredicate(final BiFunction<Node<? extends View<?>, ? extends Edge>, Class<?>, Optional<Element<?>>> parentProvider,
+                              final BiPredicate<Node<?, ? extends Edge>, Element<?>> hasParentPredicate) {
+        this.parentProvider = parentProvider;
+        this.hasParentPredicate = hasParentPredicate;
+    }
+
+    public ParentsTypeMatchPredicate forParentType(final Class<?> parentType) {
+        this.parentType = parentType;
+        return this;
+    }
+
+    /**
+     * Tests if both nodes have same parent instance, for the given type.
+     *
+     * @param nodeA A node
+     * @param nodeB A node
+     * @return It returns <code>true</code> in case both nodes exist and both are
+     * child of the same parent instance for the given type, or in case bot nodes
+     * exist and both are not child of any parent instance of the given type.
+     */
+    @Override
+    public boolean test(final Node<? extends View<?>, ? extends Edge> nodeA,
+                        final Node<? extends View<?>, ? extends Edge> nodeB) {
+        checkNotNull("parentType",
+                     parentType);
+        checkNotNull("nodeA",
+                     nodeA);
+        checkNotNull("nodeB",
+                     nodeB);
+        final Optional<Element<?>> parentInstance = getParentInstance(nodeA,
+                                                                      parentType);
+        return parentInstance.isPresent() ?
+                hasParent(nodeB,
+                          parentInstance.get()) :
+                !getParentInstance(nodeB,
+                                   parentType)
+                        .isPresent();
+    }
+
+    private Optional<Element<?>> getParentInstance(final Node<? extends View<?>, ? extends Edge> node,
+                                                   final Class<?> aClass) {
+        return parentProvider.apply(node,
+                                    aClass);
+    }
+
+    private boolean hasParent(final Node<?, ? extends Edge> node,
+                              final Element<?> parent) {
+        return hasParentPredicate.test(node,
+                                       parent);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcher.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcher.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+/**
+ * A predicate that checks if two nodes are using sharing the same parent
+ * for a given type of Definition.
+ */
+public class ParentsTypeMatcher
+        implements BiPredicate<Node<? extends View<?>, ? extends Edge>, Node<? extends View<?>, ? extends Edge>> {
+
+    private final ParentsTypeMatchPredicate parentsTypeMatch;
+
+    public ParentsTypeMatcher(final DefinitionManager definitionManager) {
+        this.parentsTypeMatch = new ParentsTypeMatchPredicate(new ParentByDefinitionIdProvider(definitionManager),
+                                                              new GraphUtils.HasParentPredicate());
+    }
+
+    public ParentsTypeMatcher forParentType(final Class<?> parentType) {
+        this.parentsTypeMatch.forParentType(parentType);
+        return this;
+    }
+
+    @Override
+    public boolean test(final Node<? extends View<?>, ? extends Edge> node,
+                        final Node<? extends View<?>, ? extends Edge> node2) {
+        return parentsTypeMatch.test(node,
+                                     node2);
+    }
+
+
+    static class ParentByDefinitionIdProvider
+            implements BiFunction<Node<? extends View<?>, ? extends Edge>, Class<?>, Optional<Element<?>>> {
+
+        final DefinitionManager definitionManager;
+
+        ParentByDefinitionIdProvider(final DefinitionManager definitionManager) {
+            this.definitionManager = definitionManager;
+        }
+
+        @Override
+        public Optional<Element<?>> apply(final Node<? extends View<?>, ? extends Edge> node,
+                                          final Class<?> parentType) {
+            return null != node ?
+                    GraphUtils.getParentByDefinitionId(definitionManager,
+                                                       node,
+                                                       getDefinitionIdByTpe(parentType)) :
+                    Optional.empty();
+        }
+
+        static String getDefinitionIdByTpe(final Class<?> type) {
+            return BindableAdapterUtils.getDefinitionId(type);
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/AbstractParentsMatchHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/AbstractParentsMatchHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.rule.ext.impl;
+
+import java.util.Optional;
+
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.rule.RuleEvaluationContext;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtensionHandler;
+import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
+import org.kie.workbench.common.stunner.core.rule.violations.RuleViolationImpl;
+
+public abstract class AbstractParentsMatchHandler<T extends AbstractParentsMatchHandler, C extends RuleEvaluationContext>
+        extends RuleExtensionHandler<T, C> {
+
+    public static Class<?> getParentType(final RuleExtension rule) {
+        final Class<?>[] typeArguments = rule.getTypeArguments();
+        return null != typeArguments ? typeArguments[0] : null;
+    }
+
+    protected String getViolationMessage(final RuleExtension rule) {
+        final String[] arguments = rule.getArguments();
+        if (null != arguments && arguments.length > 0) {
+            return arguments[0];
+        }
+        return "Violation produced by {" + getClass().getName() + "]";
+    }
+
+    protected void addViolation(final String uuid,
+                                final RuleExtension rule,
+                                final DefaultRuleViolations result) {
+        final RuleViolationImpl violation = new RuleViolationImpl(getViolationMessage(rule));
+        violation.setUUID(uuid);
+        result.addViolation(violation);
+    }
+
+    protected static Optional<String> getId(final DefinitionManager definitionManager,
+                                            final Edge edge) {
+        final Object content = edge.getContent();
+        if (content instanceof Definition) {
+            final Definition holder = (Definition) content;
+            return Optional.of(definitionManager.adapters().forDefinition().getId(holder.getDefinition()));
+        }
+        return Optional.empty();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.rule.ext.impl;
+
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessor;
+import org.kie.workbench.common.stunner.core.graph.util.ParentsTypeMatcher;
+import org.kie.workbench.common.stunner.core.rule.RuleViolations;
+import org.kie.workbench.common.stunner.core.rule.context.GraphConnectionContext;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
+import org.kie.workbench.common.stunner.core.rule.handler.impl.GraphEvaluationHandlerUtils;
+import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
+
+/**
+ * A rule handler that checks if both source and target nodes for a given connector
+ * have the same parent instance for a given type.
+ * <p>
+ * This handler applies for graph connection contexts.
+ * <p>
+ * The RuleExtension instance used by this handler needs the following arguments:
+ * - RuleExtension#getTypeArguments()[0] - The parent type
+ * - RuleExtension#getArguments()[0] - The rule violation's message
+ * <p>
+ * Example:
+ * <code>
+ * @RuleExtension( handler = ConnectorParentsMatchConnectionHandler.class,
+ * typeArguments = {TheParentType.class}
+ * arguments = {"My violation's message"}
+ * )
+ * public class MyConnectorBean {
+ * }
+ * </code>
+ */
+@ApplicationScoped
+public class ConnectorParentsMatchConnectionHandler
+        extends AbstractParentsMatchHandler<ConnectorParentsMatchConnectionHandler, GraphConnectionContext> {
+
+    private static Logger LOGGER = Logger.getLogger(ConnectorParentsMatchConnectionHandler.class.getName());
+
+    private final DefinitionManager definitionManager;
+    private final GraphEvaluationHandlerUtils evalUtils;
+
+    protected ConnectorParentsMatchConnectionHandler() {
+        this(null);
+    }
+
+    @Inject
+    public ConnectorParentsMatchConnectionHandler(final DefinitionManager definitionManager) {
+        this.definitionManager = definitionManager;
+        this.evalUtils = new GraphEvaluationHandlerUtils(definitionManager);
+    }
+
+    @Override
+    public Class<ConnectorParentsMatchConnectionHandler> getExtensionType() {
+        return ConnectorParentsMatchConnectionHandler.class;
+    }
+
+    @Override
+    public Class<GraphConnectionContext> getContextType() {
+        return GraphConnectionContext.class;
+    }
+
+    @Override
+    public boolean accepts(final RuleExtension rule,
+                           final GraphConnectionContext context) {
+        return acceptsConnection(rule,
+                                 context);
+    }
+
+    @Override
+    public RuleViolations evaluate(final RuleExtension rule,
+                                   final GraphConnectionContext context) {
+        return evaluateConnection(rule,
+                                  context);
+    }
+
+    private boolean acceptsConnection(final RuleExtension rule,
+                                      final GraphConnectionContext context) {
+        final Edge<? extends View<?>, ? extends Node> connector = context.getConnector();
+        return evalUtils.getElementDefinitionId(connector).equals(rule.getId());
+    }
+
+    private RuleViolations evaluateConnection(final RuleExtension rule,
+                                              final GraphConnectionContext context) {
+        LOGGER.log(Level.INFO,
+                   "Evaluating rule handler [" + getClass().getName() + "]...");
+        final Optional<Node<? extends View<?>, ? extends Edge>> sourceNode = context.getSource();
+        final Optional<Node<? extends View<?>, ? extends Edge>> targetNode = context.getTarget();
+        final Class<?>[] typeArguments = rule.getTypeArguments();
+        final Class<?> parentType = null != typeArguments ? typeArguments[0] : null;
+        final DefaultRuleViolations result = new DefaultRuleViolations();
+        boolean isValid = true;
+        if (sourceNode.isPresent() && targetNode.isPresent()) {
+            isValid = new ParentsTypeMatcher(definitionManager)
+                    .forParentType(parentType)
+                    .test(sourceNode.get(),
+                          targetNode.get());
+        }
+        if (!isValid) {
+            addViolation(context.getConnector().getUUID(),
+                         rule,
+                         result);
+        }
+        return result;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandler.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.rule.ext.impl;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.AbstractTreeTraverseCallback;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessor;
+import org.kie.workbench.common.stunner.core.graph.util.FilteredParentsTypeMatcher;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.rule.RuleViolations;
+import org.kie.workbench.common.stunner.core.rule.context.NodeContainmentContext;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
+import org.kie.workbench.common.stunner.core.rule.handler.impl.GraphEvaluationHandlerUtils;
+import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
+
+/**
+ * A rule handler that checks if both source and target nodes for a given connector
+ * have the same parent instance for a given type.
+ * <p>
+ * This handler applies for graph containment contexts.
+ * <p>
+ * The RuleExtension instance used by this handler needs the following arguments:
+ * - RuleExtension#getTypeArguments()[0] - The parent type
+ * - RuleExtension#getArguments()[0] - The rule violation's message
+ * <p>
+ * Example:
+ * <code>
+ * @RuleExtension( handler = ConnectorParentsMatchConnectionHandler.class,
+ * typeArguments = {TheParentType.class}
+ * arguments = {"My violation's message"}
+ * )
+ * public class MyConnectorBean {
+ * }
+ * </code>
+ */
+@ApplicationScoped
+public class ConnectorParentsMatchContainmentHandler
+        extends AbstractParentsMatchHandler<ConnectorParentsMatchContainmentHandler, NodeContainmentContext> {
+
+    private static Logger LOGGER = Logger.getLogger(ConnectorParentsMatchContainmentHandler.class.getName());
+
+    private final DefinitionManager definitionManager;
+    private final TreeWalkTraverseProcessor treeWalkTraverseProcessor;
+    private final GraphEvaluationHandlerUtils evalUtils;
+
+    protected ConnectorParentsMatchContainmentHandler() {
+        this(null,
+             null);
+    }
+
+    @Inject
+    public ConnectorParentsMatchContainmentHandler(final DefinitionManager definitionManager,
+                                                   final TreeWalkTraverseProcessor treeWalkTraverseProcessor) {
+        this.definitionManager = definitionManager;
+        this.treeWalkTraverseProcessor = treeWalkTraverseProcessor;
+        this.evalUtils = new GraphEvaluationHandlerUtils(definitionManager);
+    }
+
+    @Override
+    public Class<ConnectorParentsMatchContainmentHandler> getExtensionType() {
+        return ConnectorParentsMatchContainmentHandler.class;
+    }
+
+    @Override
+    public Class<NodeContainmentContext> getContextType() {
+        return NodeContainmentContext.class;
+    }
+
+    @Override
+    public boolean accepts(final RuleExtension rule,
+                           final NodeContainmentContext context) {
+        return acceptsContainment(rule,
+                                  context);
+    }
+
+    @Override
+    public RuleViolations evaluate(final RuleExtension rule,
+                                   final NodeContainmentContext context) {
+        return evaluateContainment(rule,
+                                   context);
+    }
+
+    private boolean acceptsContainment(final RuleExtension rule,
+                                       final NodeContainmentContext context) {
+        final Class<?> parentType = getParentType(rule);
+        final String expectedParentId = BindableAdapterUtils.getDefinitionId(parentType);
+        final Element<? extends Definition<?>> parent = context.getParent();
+        final Node<? extends Definition<?>, ? extends Edge> candidate = context.getCandidate();
+        final String parentId = evalUtils.getElementDefinitionId(parent);
+        return parentId.equals(expectedParentId) || hasOldParentType(candidate,
+                                                                     expectedParentId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private RuleViolations evaluateContainment(final RuleExtension rule,
+                                               final NodeContainmentContext context) {
+        final String connectorId = rule.getId();
+        final Graph<?, ? extends Node> graph = context.getGraph();
+        final Element<? extends Definition<?>> parent = context.getParent();
+        final Node<? extends Definition<?>, ? extends Edge> candidate = context.getCandidate();
+        final Class<?> parentType = getParentType(rule);
+        final DefaultRuleViolations result = new DefaultRuleViolations();
+        // Walk throw the graph and evaluate connector source and target nodes parent match.
+        treeWalkTraverseProcessor
+                .traverse(graph,
+                          candidate,
+                          new AbstractTreeTraverseCallback<Graph, Node, Edge>() {
+
+                              private final FilteredParentsTypeMatcher matcher =
+                                      new FilteredParentsTypeMatcher(definitionManager,
+                                                                     parent,
+                                                                     candidate)
+                                              .forParentType(parentType);
+
+                              @Override
+                              public boolean startNodeTraversal(final Node node) {
+                                  // Process incoming edges into the node as well.
+                                  final List<? extends Edge> inEdges = node.getInEdges();
+                                  if (null != inEdges) {
+                                      inEdges.stream().forEach(this::process);
+                                  }
+                                  return true;
+                              }
+
+                              @Override
+                              public boolean startEdgeTraversal(final Edge edge) {
+                                  return process(edge);
+                              }
+
+                              private boolean process(final Edge edge) {
+                                  final Optional<String> eId = getId(definitionManager,
+                                                                     edge);
+                                  if (eId.isPresent() && connectorId.equals(eId.get())) {
+                                      final Node sourceNode = edge.getSourceNode();
+                                      final Node targetNode = edge.getTargetNode();
+                                      boolean valid = true;
+                                      if (null != sourceNode && null != targetNode) {
+                                          valid = matcher
+                                                  .test(sourceNode,
+                                                        targetNode);
+                                      }
+                                      if (!valid) {
+                                          addViolation(edge.getUUID(),
+                                                       rule,
+                                                       result);
+                                      }
+                                  }
+                                  return true;
+                              }
+                          });
+        return result;
+    }
+
+    private boolean hasOldParentType(final Node<? extends Definition<?>, ? extends Edge> candidate,
+                                     final String pId) {
+        return GraphUtils.getParentByDefinitionId(definitionManager,
+                                                  candidate,
+                                                  pId).isPresent();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.rule.ext.impl;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.rule.RuleEvaluationContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolations;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtensionHandler;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtensionMultiHandler;
+
+/**
+ * A rule handler that checks if both source and target nodes for a given connector
+ * have the same parent instance for a certain type.
+ * <p>
+ * This handler applies for both Graph connection and containment evaluation contexts.
+ * - For a connection context - evaluates parent instance match for both source / target nodes
+ * - For a containment context - evaluates parent instance match for both source / target nodes
+ * for all candidate connectors and connectors on its children, if any.
+ * <p>
+ * The RuleExtension instance used by this handler needs the following arguments:
+ * - RuleExtension#getTypeArguments()[0] - The parent type
+ * - RuleExtension#getArguments()[0] - The rule violation's message
+ * <p>
+ * Example:
+ * <code>
+ * @RuleExtension( handler = ConnectorParentsMatchHandler.class,
+ * typeArguments = {TheParentType.class}
+ * arguments = {"My violation's message"}
+ * )
+ * public class MyConnectorBean {
+ * }
+ * </code>
+ */
+@ApplicationScoped
+public class ConnectorParentsMatchHandler
+        extends RuleExtensionHandler<ConnectorParentsMatchHandler, RuleEvaluationContext> {
+
+    private final ConnectorParentsMatchConnectionHandler connectionHandler;
+    private final ConnectorParentsMatchContainmentHandler containmentHandler;
+    private final RuleExtensionMultiHandler multiHandler;
+
+    protected ConnectorParentsMatchHandler() {
+        this(null,
+             null,
+             null);
+    }
+
+    @Inject
+    public ConnectorParentsMatchHandler(final ConnectorParentsMatchConnectionHandler connectionHandler,
+                                        final ConnectorParentsMatchContainmentHandler containmentHandler,
+                                        final RuleExtensionMultiHandler multiHandler) {
+        this.connectionHandler = connectionHandler;
+        this.containmentHandler = containmentHandler;
+        this.multiHandler = multiHandler;
+    }
+
+    @PostConstruct
+    public void init() {
+        multiHandler.addHandler(connectionHandler);
+        multiHandler.addHandler(containmentHandler);
+    }
+
+    @Override
+    public Class<ConnectorParentsMatchHandler> getExtensionType() {
+        return ConnectorParentsMatchHandler.class;
+    }
+
+    @Override
+    public Class<RuleEvaluationContext> getContextType() {
+        return RuleEvaluationContext.class;
+    }
+
+    @Override
+    public boolean accepts(final RuleExtension rule,
+                           final RuleEvaluationContext context) {
+        checkParentTypeExists(rule);
+        return multiHandler.accepts(rule,
+                                    context);
+    }
+
+    @Override
+    public RuleViolations evaluate(final RuleExtension rule,
+                                   final RuleEvaluationContext context) {
+        checkParentTypeExists(rule);
+        return multiHandler.evaluate(rule,
+                                     context);
+    }
+
+    private void checkParentTypeExists(final RuleExtension rule) {
+        final Class<?> parentType = AbstractParentsMatchHandler.getParentType(rule);
+        if (null == parentType) {
+            throw new IllegalArgumentException("No parent type specified in @RuleExtension " +
+                                                       "for handler [" + this.getClass().getName() + "]");
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/AbstractGraphDefinitionTypesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/AbstractGraphDefinitionTypesTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core;
+
+import java.util.Optional;
+
+import org.kie.workbench.common.stunner.core.graph.Node;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class AbstractGraphDefinitionTypesTest {
+
+    public static final String DEF_ROOT_ID = RootDefinition.class.getName();
+    public static final String DEF_PARENT_ID = ParentDefinition.class.getName();
+    public static final String DEF_A_ID = DefinitionA.class.getName();
+    public static final String DEF_B_ID = DefinitionB.class.getName();
+    public static final String DEF_C_ID = DefinitionC.class.getName();
+    public static final String ROOT_UUID = "root-uuid";
+    public static final String PARENT_UUID = "parent-uuid";
+    public static final String A_UUID = "a-uuid";
+    public static final String B_UUID = "b-uuid";
+    public static final String C_UUID = "c-uuid";
+
+    protected class RootDefinition {
+
+    }
+
+    protected class ParentDefinition {
+
+    }
+
+    protected class DefinitionA {
+
+    }
+
+    protected class DefinitionB {
+
+    }
+
+    protected class DefinitionC {
+
+    }
+
+    protected TestingGraphMockHandler graphHandler;
+
+    protected RootDefinition rootDefinition;
+    protected ParentDefinition parentDefinition;
+    protected DefinitionA definitionA;
+    protected DefinitionB definitionB;
+    protected DefinitionC definitionC;
+    protected Node rootNode;
+    protected Node parentNode;
+    protected Node nodeA;
+    protected Node nodeB;
+    protected Node nodeC;
+
+    protected void setup() throws Exception {
+        this.graphHandler = new TestingGraphMockHandler();
+        this.rootDefinition = new RootDefinition();
+        this.parentDefinition = new ParentDefinition();
+        this.definitionA = new DefinitionA();
+        this.definitionB = new DefinitionB();
+        this.definitionC = new DefinitionC();
+        when(graphHandler.definitionAdapter.getId(eq(rootDefinition))).thenReturn(DEF_ROOT_ID);
+        when(graphHandler.definitionAdapter.getId(eq(parentDefinition))).thenReturn(DEF_PARENT_ID);
+        when(graphHandler.definitionAdapter.getId(eq(definitionA))).thenReturn(DEF_A_ID);
+        when(graphHandler.definitionAdapter.getId(eq(definitionB))).thenReturn(DEF_B_ID);
+        when(graphHandler.definitionAdapter.getId(eq(definitionC))).thenReturn(DEF_C_ID);
+        this.rootNode = newViewNode(ROOT_UUID,
+                                    rootDefinition,
+                                    0,
+                                    0,
+                                    10000,
+                                    10000);
+        this.parentNode = newViewNode(PARENT_UUID,
+                                      parentDefinition,
+                                      0,
+                                      0,
+                                      1000,
+                                      1000);
+        this.nodeA = newViewNode(A_UUID,
+                                 definitionA,
+                                 0,
+                                 0,
+                                 10,
+                                 10);
+        this.nodeB = newViewNode(B_UUID,
+                                 definitionB,
+                                 20,
+                                 20,
+                                 10,
+                                 10);
+        this.nodeC = newViewNode(C_UUID,
+                                 definitionC,
+                                 40,
+                                 40,
+                                 10,
+                                 10);
+        graphHandler
+                .setChild(rootNode,
+                          parentNode)
+                .setChild(rootNode,
+                          nodeC)
+                .setChild(parentNode,
+                          nodeA)
+                .setChild(parentNode,
+                          nodeB);
+    }
+
+    protected Node newViewNode(String uuid,
+                               Object def,
+                               final double x,
+                               final double y,
+                               final double w,
+                               final double h) {
+        return graphHandler.newViewNode(uuid,
+                                        Optional.of(def),
+                                        x,
+                                        y,
+                                        w,
+                                        h);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.AbstractGraphDefinitionTypesTest;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void testMissingNodeA() {
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(nodeA,
+                                  null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void testMissingNodeB() {
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(null,
+                                  nodeB));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void testMissingNodes() {
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(null,
+                                  null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithParents() {
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(nodeA,
+                                  nodeB));
+        assertTrue(newPredicate(DefinitionA.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(DefinitionB.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(RootDefinition.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(DefinitionC.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(ParentDefinition.class)
+                           .test(nodeA,
+                                 nodeC));
+        assertTrue(newPredicate(RootDefinition.class)
+                           .test(nodeA,
+                                 nodeC));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithNoParent() {
+        graphHandler.removeChild(parentNode,
+                                 nodeB);
+        assertFalse(newPredicate(RootDefinition.class)
+                            .test(nodeA,
+                                  nodeB));
+        assertTrue(newPredicate(ParentDefinition.class)
+                           .test(nodeA,
+                                 nodeB));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithNoParents() {
+        graphHandler
+                .removeChild(parentNode,
+                             nodeB)
+                .removeChild(parentNode,
+                             nodeC);
+        assertTrue(newPredicate(DefinitionC.class)
+                           .test(nodeB,
+                                 nodeC));
+    }
+
+    @SuppressWarnings("unchecked")
+    private FilteredParentsTypeMatcher newPredicate(final Class<?> parentType) {
+        return new FilteredParentsTypeMatcher(graphHandler.definitionManager,
+                                              rootNode,
+                                              nodeA)
+                .forParentType(parentType);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.AbstractGraphDefinitionTypesTest;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    private ParentsTypeMatcher newPredicate(final Class<?> parentType) {
+        return new ParentsTypeMatcher(graphHandler.definitionManager)
+                .forParentType(parentType);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void testMissingNodeA() {
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(nodeA,
+                                  null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void testMissingNodeB() {
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(null,
+                                  nodeB));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void testMissingNodes() {
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(null,
+                                  null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithParents() {
+        assertTrue(newPredicate(ParentDefinition.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(DefinitionA.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(DefinitionB.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(RootDefinition.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertTrue(newPredicate(DefinitionC.class)
+                           .test(nodeA,
+                                 nodeB));
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(nodeA,
+                                  nodeC));
+        assertTrue(newPredicate(RootDefinition.class)
+                           .test(nodeA,
+                                 nodeC));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithNoParents() {
+        graphHandler
+                .removeChild(parentNode,
+                             nodeA)
+                .removeChild(parentNode,
+                             nodeB);
+        assertTrue(newPredicate(RootDefinition.class)
+                           .test(nodeA,
+                                 nodeB));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithNoParent() {
+        graphHandler
+                .removeChild(parentNode,
+                             nodeA);
+        assertTrue(newPredicate(DefinitionC.class)
+                           .test(nodeA,
+                                 nodeC));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.rule.ext.impl;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.AbstractGraphDefinitionTypesTest;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.rule.RuleViolations;
+import org.kie.workbench.common.stunner.core.rule.context.GraphConnectionContext;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectorParentsMatchConnectionHandlerTest extends AbstractGraphDefinitionTypesTest {
+
+    public static final String DEF_EDGE_ID = "EdgeDef1";
+    public static final String EDGE_UUID = "edge1";
+
+    @Mock
+    private RuleExtension ruleExtension;
+
+    @Mock
+    private GraphConnectionContext connectionContext;
+
+    @Mock
+    private Object connectorDef;
+
+    private ConnectorParentsMatchConnectionHandler tested;
+    private Edge connector;
+    private Graph graph;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        super.setup();
+        this.graph = graphHandler.graph;
+        this.connector = graphHandler.newEdge(EDGE_UUID,
+                                              Optional.of(connectorDef));
+        when(graphHandler.definitionAdapter.getId(eq(connectorDef))).thenReturn(DEF_EDGE_ID);
+        when(connectionContext.getGraph()).thenReturn(graph);
+        when(connectionContext.getConnector()).thenReturn(connector);
+        when(ruleExtension.getId()).thenReturn(DEF_EDGE_ID);
+        when(ruleExtension.getArguments()).thenReturn(new String[]{"violation1"});
+        tested = new ConnectorParentsMatchConnectionHandler(graphHandler.definitionManager);
+    }
+
+    @Test
+    public void testTypes() {
+        assertEquals(ConnectorParentsMatchConnectionHandler.class,
+                     tested.getExtensionType());
+        assertEquals(GraphConnectionContext.class,
+                     tested.getContextType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAccepts() {
+        when(connectionContext.getSource()).thenReturn(Optional.of(nodeA));
+        when(connectionContext.getTarget()).thenReturn(Optional.of(nodeB));
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
+        assertTrue(tested.accepts(ruleExtension,
+                                  connectionContext));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testNotAccepts() {
+        when(connectionContext.getSource()).thenReturn(Optional.of(nodeA));
+        when(connectionContext.getTarget()).thenReturn(Optional.of(nodeB));
+        when(ruleExtension.getId()).thenReturn("anyOtherId");
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
+        assertFalse(tested.accepts(ruleExtension,
+                                  connectionContext));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testFailEvaluateParentDefinition() {
+        when(connectionContext.getSource()).thenReturn(Optional.of(nodeA));
+        when(connectionContext.getTarget()).thenReturn(Optional.of(nodeC));
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
+        final RuleViolations violations = tested.evaluate(ruleExtension,
+                                                          connectionContext);
+        assertNotNull(violations);
+        assertTrue(violations.violations(Violation.Type.ERROR).iterator().hasNext());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEvaluateParentDefinition() {
+        assertEvalSuccess(Optional.of(nodeA),
+                          Optional.of(nodeB));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEvaluateMissingSource() {
+        assertEvalSuccess(Optional.empty(),
+                          Optional.of(nodeB));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEvaluateMissingTarget() {
+        assertEvalSuccess(Optional.of(nodeA),
+                          Optional.empty());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEvaluateMissingNodes() {
+        assertEvalSuccess(Optional.empty(),
+                          Optional.empty());
+    }
+
+    private void assertEvalSuccess(final Optional<Node<? extends View<?>, ? extends Edge>> source,
+                                   final Optional<Node<? extends View<?>, ? extends Edge>> target) {
+        when(connectionContext.getSource()).thenReturn(source);
+        when(connectionContext.getTarget()).thenReturn(target);
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
+        final RuleViolations violations = tested.evaluate(ruleExtension,
+                                                          connectionContext);
+        assertNotNull(violations);
+        assertFalse(violations.violations(Violation.Type.ERROR).iterator().hasNext());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandlerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.rule.ext.impl;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.AbstractGraphDefinitionTypesTest;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessorImpl;
+import org.kie.workbench.common.stunner.core.rule.RuleViolations;
+import org.kie.workbench.common.stunner.core.rule.context.NodeContainmentContext;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectorParentsMatchContainmentHandlerTest extends AbstractGraphDefinitionTypesTest {
+
+    public static final String DEF_EDGE_ID = "EdgeDef1";
+    public static final String EDGE_UUID = "edge1";
+
+    @Mock
+    private RuleExtension ruleExtension;
+
+    @Mock
+    private NodeContainmentContext containmentContext;
+
+    @Mock
+    private Object connectorDef;
+
+    private ConnectorParentsMatchContainmentHandler tested;
+    private Edge connector;
+    private Graph graph;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        super.setup();
+        this.graph = graphHandler.graph;
+        when(graphHandler.definitionAdapter.getId(eq(connectorDef))).thenReturn(DEF_EDGE_ID);
+        this.connector = graphHandler.newEdge(EDGE_UUID,
+                                              Optional.of(connectorDef));
+        when(containmentContext.getGraph()).thenReturn(graph);
+        when(ruleExtension.getId()).thenReturn(DEF_EDGE_ID);
+        when(ruleExtension.getArguments()).thenReturn(new String[]{"violation1"});
+        tested = new ConnectorParentsMatchContainmentHandler(graphHandler.definitionManager,
+                                                            new TreeWalkTraverseProcessorImpl());
+    }
+
+    @Test
+    public void testTypes() {
+        assertEquals(ConnectorParentsMatchContainmentHandler.class,
+                     tested.getExtensionType());
+        assertEquals(NodeContainmentContext.class,
+                     tested.getContextType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAccepts() {
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
+        when(containmentContext.getCandidate()).thenReturn(nodeA);
+        when(containmentContext.getParent()).thenReturn(parentNode);
+        assertTrue(tested.accepts(ruleExtension,
+                                  containmentContext));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testNotAccepts() {
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{DefinitionC.class});
+        when(containmentContext.getCandidate()).thenReturn(nodeA);
+        when(containmentContext.getParent()).thenReturn(parentNode);
+        assertFalse(tested.accepts(ruleExtension,
+                                  containmentContext));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEvaluateParentSuccess() {
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
+        when(containmentContext.getCandidate()).thenReturn(nodeA);
+        when(containmentContext.getParent()).thenReturn(parentNode);
+        graphHandler.addEdge(connector,
+                             nodeA)
+                .connectTo(connector, nodeB);
+        final RuleViolations violations = tested.evaluate(ruleExtension,
+                                         containmentContext);
+        assertNotNull(violations);
+        assertFalse(violations.violations(Violation.Type.ERROR).iterator().hasNext());
+
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEvaluateParentFailed() {
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
+        when(containmentContext.getCandidate()).thenReturn(nodeA);
+        when(containmentContext.getParent()).thenReturn(parentNode);
+        graphHandler.addEdge(connector,
+                             nodeA)
+                .connectTo(connector, nodeC);
+        final RuleViolations violations = tested.evaluate(ruleExtension,
+                                                          containmentContext);
+        assertNotNull(violations);
+        assertTrue(violations.violations(Violation.Type.ERROR).iterator().hasNext());
+
+    }
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchHandlerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.rule.ext.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.rule.RuleEvaluationContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolations;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
+import org.kie.workbench.common.stunner.core.rule.ext.RuleExtensionMultiHandler;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectorParentsMatchHandlerTest {
+
+    @Mock
+    private ConnectorParentsMatchConnectionHandler connectionHandler;
+
+    @Mock
+    private ConnectorParentsMatchContainmentHandler containmentHandler;
+
+    @Mock
+    private RuleExtensionMultiHandler multiHandler;
+
+    @Mock
+    private RuleViolations ruleViolations;
+
+    private ConnectorParentsMatchHandler tested;
+
+    @Before
+    public void setup() throws Exception {
+        when(multiHandler.accepts(any(RuleExtension.class),
+                                  any(RuleEvaluationContext.class))).thenReturn(true);
+        when(multiHandler.evaluate(any(RuleExtension.class),
+                                   any(RuleEvaluationContext.class))).thenReturn(ruleViolations);
+        this.tested = new ConnectorParentsMatchHandler(connectionHandler,
+                                                       containmentHandler,
+                                                       multiHandler);
+    }
+
+    @Test
+    public void testInit() {
+        tested.init();
+        verify(multiHandler,
+               times(1)).addHandler(eq(connectionHandler));
+        verify(multiHandler,
+               times(1)).addHandler(eq(containmentHandler));
+    }
+
+    @Test
+    public void testTypes() {
+        assertEquals(ConnectorParentsMatchHandler.class,
+                     tested.getExtensionType());
+        assertEquals(RuleEvaluationContext.class,
+                     tested.getContextType());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAcceptNoParentType() {
+        final RuleExtension ruleExtension = mock(RuleExtension.class);
+        when(ruleExtension.getArguments()).thenReturn(new String[]{});
+        final RuleEvaluationContext context = mock(RuleEvaluationContext.class);
+        tested.accepts(ruleExtension,
+                       context);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEvaluateNoParentType() {
+        final RuleExtension ruleExtension = mock(RuleExtension.class);
+        when(ruleExtension.getArguments()).thenReturn(new String[]{});
+        final RuleEvaluationContext context = mock(RuleEvaluationContext.class);
+        tested.evaluate(ruleExtension,
+                        context);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAccept() {
+        final RuleExtension ruleExtension = mock(RuleExtension.class);
+        when(ruleExtension.getArguments()).thenReturn(new String[]{"parentType"});
+        final RuleEvaluationContext context = mock(RuleEvaluationContext.class);
+        assertTrue(tested.accepts(ruleExtension,
+                                  context));
+        verify(multiHandler,
+               times(1)).accepts(eq(ruleExtension),
+                                 eq(context));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEvaluate() {
+        final RuleExtension ruleExtension = mock(RuleExtension.class);
+        when(ruleExtension.getArguments()).thenReturn(new String[]{"parentType"});
+        final RuleEvaluationContext context = mock(RuleEvaluationContext.class);
+        assertEquals(ruleViolations,
+                     tested.evaluate(ruleExtension,
+                                     context));
+        verify(multiHandler,
+               times(1)).evaluate(eq(ruleExtension),
+                                  eq(context));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/BPMNDefinitionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/BPMNDefinitionSet.java
@@ -22,6 +22,7 @@ import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveDatabasedGateway;
@@ -65,6 +66,7 @@ import org.kie.workbench.common.stunner.core.rule.annotation.Occurrences;
                 ParallelGateway.class,
                 ExclusiveDatabasedGateway.class,
                 ReusableSubprocess.class,
+                EmbeddedSubprocess.class,
                 SequenceFlow.class
         },
         builder = BPMNDefinitionSet.BPMNDefinitionSetBuilder.class

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition;
+
+import javax.validation.Valid;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.NonPortable;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
+import org.kie.workbench.common.forms.adf.definitions.annotations.field.selector.SelectorDataProvider;
+import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
+import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOModel;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.SimulationSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.IsAsync;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnEntryAction;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnExitAction;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.ScriptLanguage;
+import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.definition.annotation.Description;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Title;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
+import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
+
+@Portable
+@Bindable
+@Definition(graphFactory = NodeFactory.class, builder = EmbeddedSubprocess.EmbeddedSubprocessBuilder.class)
+@CanContain(roles = {"all"})
+@FormDefinition(
+        startElement = "general",
+        policy = FieldPolicy.ONLY_MARKED
+)
+public class EmbeddedSubprocess extends BaseSubprocess implements DataIOModel {
+
+    @Title
+    public static final transient String title = "Embedded Sub-Process";
+
+    @Description
+    public static final transient String description = "An embedded sub-process.";
+
+    @NonPortable
+    public static class EmbeddedSubprocessBuilder extends BaseSubprocessBuilder<EmbeddedSubprocess> {
+
+        @Override
+        public EmbeddedSubprocess build() {
+            return new EmbeddedSubprocess(
+                    new BPMNGeneralSet("Subprocess"),
+                    new BackgroundSet("#FFFFFF",
+                                      BORDER_COLOR,
+                                      BORDER_SIZE),
+                    new FontSet(),
+                    new RectangleDimensionsSet(450d,
+                                               250d),
+                    new SimulationSet(),
+                    new OnEntryAction(""),
+                    new OnExitAction(""),
+                    new ScriptLanguage(""),
+                    new IsAsync(),
+                    new ProcessData());
+        }
+    }
+
+    @Property
+    @FormField(
+            type = TextAreaFieldType.class,
+            afterElement = "general",
+            settings = {@FieldParam(name = "rows", value = "5")}
+    )
+    @Valid
+    private OnEntryAction onEntryAction;
+
+    @Property
+    @FormField(
+            type = TextAreaFieldType.class,
+            afterElement = "onEntryAction",
+            settings = {@FieldParam(name = "rows", value = "5")}
+    )
+    @Valid
+    private OnExitAction onExitAction;
+
+    @Property
+    @FormField(
+            type = ListBoxFieldType.class,
+            afterElement = "onExitAction"
+    )
+    @SelectorDataProvider(
+            type = SelectorDataProvider.ProviderType.REMOTE,
+            className = "org.kie.workbench.common.stunner.bpmn.backend.dataproviders.ScriptLanguageFormProvider")
+    @Valid
+    protected ScriptLanguage scriptLanguage;
+
+    @Property
+    @FormField(
+            afterElement = "scriptLanguage"
+    )
+    @Valid
+    private IsAsync isAsync;
+
+    @PropertySet
+    @FormField(
+            afterElement = "isAsync"
+    )
+    @Valid
+    private ProcessData processData;
+
+    public EmbeddedSubprocess() {
+        super();
+    }
+
+    public EmbeddedSubprocess(final @MapsTo("general") BPMNGeneralSet general,
+                              final @MapsTo("backgroundSet") BackgroundSet backgroundSet,
+                              final @MapsTo("fontSet") FontSet fontSet,
+                              final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet,
+                              final @MapsTo("simulationSet") SimulationSet simulationSet,
+                              final @MapsTo("onEntryAction") OnEntryAction onEntryAction,
+                              final @MapsTo("onExitAction") OnExitAction onExitAction,
+                              final @MapsTo("scriptLanguage") ScriptLanguage scriptLanguage,
+                              final @MapsTo("isAsync") IsAsync isAsync,
+                              final @MapsTo("processData") ProcessData processData) {
+        super(general,
+              backgroundSet,
+              fontSet,
+              dimensionsSet,
+              simulationSet);
+        this.onEntryAction = onEntryAction;
+        this.onExitAction = onExitAction;
+        this.scriptLanguage = scriptLanguage;
+        this.isAsync = isAsync;
+        this.processData = processData;
+    }
+
+    @Override
+    public boolean hasInputVars() {
+        return true;
+    }
+
+    @Override
+    public boolean isSingleInputVar() {
+        return false;
+    }
+
+    @Override
+    public boolean hasOutputVars() {
+        return true;
+    }
+
+    @Override
+    public boolean isSingleOutputVar() {
+        return false;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public ProcessData getProcessData() {
+        return processData;
+    }
+
+    public void setProcessData(final ProcessData processData) {
+        this.processData = processData;
+    }
+
+    public OnEntryAction getOnEntryAction() {
+        return onEntryAction;
+    }
+
+    public void setOnEntryAction(final OnEntryAction onEntryAction) {
+        this.onEntryAction = onEntryAction;
+    }
+
+    public OnExitAction getOnExitAction() {
+        return onExitAction;
+    }
+
+    public void setOnExitAction(final OnExitAction onExitAction) {
+        this.onExitAction = onExitAction;
+    }
+
+    public ScriptLanguage getScriptLanguage() {
+        return scriptLanguage;
+    }
+
+    public void setScriptLanguage(final ScriptLanguage scriptLanguage) {
+        this.scriptLanguage = scriptLanguage;
+    }
+
+    public IsAsync getIsAsync() {
+        return isAsync;
+    }
+
+    public void setIsAsync(final IsAsync isAsync) {
+        this.isAsync = isAsync;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
@@ -35,6 +35,8 @@ import org.kie.workbench.common.stunner.core.definition.annotation.definition.Ti
 import org.kie.workbench.common.stunner.core.factory.graph.EdgeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanConnect;
 import org.kie.workbench.common.stunner.core.rule.annotation.EdgeOccurrences;
+import org.kie.workbench.common.stunner.core.rule.annotation.RuleExtension;
+import org.kie.workbench.common.stunner.core.rule.ext.impl.ConnectorParentsMatchHandler;
 
 @Portable
 @Bindable
@@ -55,6 +57,12 @@ import org.kie.workbench.common.stunner.core.rule.annotation.EdgeOccurrences;
 @EdgeOccurrences(role = "messageflow_start", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
 // A single outgoing sequence flows for event types that can be docked (boundary) such as Intermediate Timer Event
 @EdgeOccurrences(role = "IntermediateEventOnActivityBoundary", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
+// Sequence flows cannot exceed bounds when any of the nodes are in an embedded subprocess context.
+@RuleExtension(handler = ConnectorParentsMatchHandler.class,
+        typeArguments = {EmbeddedSubprocess.class},
+        arguments = {"Sequence flow connectors cannot exceed the embbedded subprocess' bounds. " +
+                "Both source and target nodes must be in same parent process."})
+
 @FormDefinition(
         startElement = "general",
         policy = FieldPolicy.ONLY_MARKED

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/oryx/BaseOryxIdMappings.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/oryx/BaseOryxIdMappings.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveDatabasedGateway;
@@ -154,6 +155,8 @@ public abstract class BaseOryxIdMappings implements OryxIdMappings {
                 "timecycle");
             put(TimeCycleLanguage.class,
                 "timecyclelanguage");
+            put(EmbeddedSubprocess.class,
+                "Subprocess");
             put(AdHoc.class,
                 "adhocprocess");
             put(ProcessInstanceDescription.class,
@@ -280,6 +283,12 @@ public abstract class BaseOryxIdMappings implements OryxIdMappings {
                 reusableSubprocessPropertiesMap);
             reusableSubprocessPropertiesMap.put(AssignmentsInfo.class,
                                                 "assignmentsinfo");
+
+            Map<Class<?>, String> embeddedSubprocessPropertiesMap = new HashMap<Class<?>, String>();
+            put(EmbeddedSubprocess.class,
+                embeddedSubprocessPropertiesMap);
+            embeddedSubprocessPropertiesMap.put(ProcessVariables.class,
+                                                "vardefs");
 
             Map<Class<?>, String> exclusiveDatabasedGatewayPropertiesMap = new HashMap<Class<?>, String>();
             put(ExclusiveDatabasedGateway.class,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDiagramMarshallerTest.java
@@ -49,6 +49,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.marshall.json.oryx.property
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveDatabasedGateway;
@@ -125,7 +126,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
-// TODO: Use Archillian to avoid all that CDI mockings.
 @RunWith(MockitoJUnitRunner.class)
 public class BPMNDiagramMarshallerTest {
 
@@ -147,6 +147,7 @@ public class BPMNDiagramMarshallerTest {
     private static final String BPMN_PROCESSPROPERTIES = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/processProperties.bpmn";
     private static final String BPMN_BUSINESSRULETASKRULEFLOWGROUP = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/businessRuleTask.bpmn";
     private static final String BPMN_REUSABLE_SUBPROCESS = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/reusableSubprocessCalledElement.bpmn";
+    private static final String BPMN_EMBEDDED_SUBPROCESS = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/embeddedSubprocess.bpmn";
     private static final String BPMN_SCRIPTTASK = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/scriptTask.bpmn";
     private static final String BPMN_USERTASKASSIGNEES = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/userTaskAssignees.bpmn";
     private static final String BPMN_USERTASKPROPERTIES = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/userTaskProperties.bpmn";
@@ -1287,7 +1288,6 @@ public class BPMNDiagramMarshallerTest {
                      0.1d);
     }
 
-
     private ViewConnector getInEdgeViewConnector(Node node) {
         List<Edge> edges = node.getInEdges();
         if (edges != null) {
@@ -1325,6 +1325,24 @@ public class BPMNDiagramMarshallerTest {
             }
         }
         return null;
+    }
+
+    @Test
+    public void testUnmarshallEmbeddedSubprocess() throws Exception {
+        Diagram<Graph, Metadata> diagram = unmarshall(BPMN_EMBEDDED_SUBPROCESS);
+        EmbeddedSubprocess subprocess = null;
+        Iterator<Element> it = nodesIterator(diagram);
+        while (it.hasNext()) {
+            Element element = it.next();
+            if (element.getContent() instanceof View) {
+                Object oDefinition = ((View) element.getContent()).getDefinition();
+                if (oDefinition instanceof EmbeddedSubprocess) {
+                    subprocess = (EmbeddedSubprocess) oDefinition;
+                    break;
+                }
+            }
+        }
+        assertNotNull(subprocess);
     }
 
     @Test
@@ -1557,6 +1575,20 @@ public class BPMNDiagramMarshallerTest {
                                                            " ");
         assertTrue(flatResult.contains("<drools:metaData name=\"elementname\"> <drools:metaValue><![CDATA[my subprocess]]></drools:metaValue> </drools:metaData>"));
         assertTrue(flatResult.contains("<drools:metaData name=\"customAsync\"> <drools:metaValue><![CDATA[true]]></drools:metaValue>"));
+    }
+
+    @Test
+    public void testMarshallEmbeddedSubprocess() throws Exception {
+        Diagram<Graph, Metadata> diagram = unmarshall(BPMN_EMBEDDED_SUBPROCESS);
+        assertDiagram(diagram,
+                      10);
+        String result = tested.marshall(diagram);
+        assertDiagram(result,
+                      1,
+                      9,
+                      7);
+
+        assertTrue(result.contains("<bpmn2:subProcess id=\"_C3EBE7F1-8E57-4BB1-B380-40BB02E9464E\" "));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/embeddedSubprocess.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/embeddedSubprocess.bpmn
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_ui6_UPntEeaHFsZ1K-7IeQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="evaluation.embp" drools:version="1.0" name="embp" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="start1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[start1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_1316B054-BB96-4821-9F38-06883A419AA2</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:endEvent id="_B47C0075-40FF-49B8-A674-768D35F06CAA" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="end1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[end1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0A8AB905-E2B7-43E8-B569-62DD77CE3A0C</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:subProcess id="_C3EBE7F1-8E57-4BB1-B380-40BB02E9464E" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="subp1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[subp1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_A8277B08-6B75-4EA5-B116-1EB2C0A9BF11</bpmn2:incoming>
+      <bpmn2:outgoing>_BF44C91F-24E6-42F5-89CE-0CEC227B2E2F</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_ui7mYPntEeaHFsZ1K-7IeQ">
+        <bpmn2:inputSet id="_ui7mYfntEeaHFsZ1K-7IeQ"/>
+        <bpmn2:outputSet id="_ui7mYvntEeaHFsZ1K-7IeQ"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:task id="_9E3DA485-DD2C-44D2-922E-D76928E6AC1A" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="subtask1">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[subtask1]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>_AB3DD628-3C24-450C-BDE6-55A492DBA62C</bpmn2:incoming>
+        <bpmn2:outgoing>_A234CBE2-004D-49A4-A6EA-7E035A233025</bpmn2:outgoing>
+      </bpmn2:task>
+      <bpmn2:task id="_9F17C436-EEF9-438C-A43D-7C848CB0E9A6" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="subtask2">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[subtask2]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>_A234CBE2-004D-49A4-A6EA-7E035A233025</bpmn2:incoming>
+        <bpmn2:outgoing>_D47418F0-1D1D-41E1-89FA-B4426774C0A1</bpmn2:outgoing>
+      </bpmn2:task>
+      <bpmn2:startEvent id="_A055C1EC-8286-4880-82B5-BB98FF985C1D" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="substart1">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[substart1]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:outgoing>_AB3DD628-3C24-450C-BDE6-55A492DBA62C</bpmn2:outgoing>
+      </bpmn2:startEvent>
+      <bpmn2:endEvent id="_FF050977-4D13-47F1-8B9B-D68FDE208666" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="subend1">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[subend1]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>_D47418F0-1D1D-41E1-89FA-B4426774C0A1</bpmn2:incoming>
+      </bpmn2:endEvent>
+      <bpmn2:sequenceFlow id="_A234CBE2-004D-49A4-A6EA-7E035A233025" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9E3DA485-DD2C-44D2-922E-D76928E6AC1A" targetRef="_9F17C436-EEF9-438C-A43D-7C848CB0E9A6"/>
+      <bpmn2:sequenceFlow id="_AB3DD628-3C24-450C-BDE6-55A492DBA62C" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A055C1EC-8286-4880-82B5-BB98FF985C1D" targetRef="_9E3DA485-DD2C-44D2-922E-D76928E6AC1A"/>
+      <bpmn2:sequenceFlow id="_D47418F0-1D1D-41E1-89FA-B4426774C0A1" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9F17C436-EEF9-438C-A43D-7C848CB0E9A6" targetRef="_FF050977-4D13-47F1-8B9B-D68FDE208666"/>
+    </bpmn2:subProcess>
+    <bpmn2:task id="_F3BF55E1-6061-4FC2-A293-4B8A5B593FB6" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Task1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_1316B054-BB96-4821-9F38-06883A419AA2</bpmn2:incoming>
+      <bpmn2:outgoing>_A8277B08-6B75-4EA5-B116-1EB2C0A9BF11</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="_1316B054-BB96-4821-9F38-06883A419AA2" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_F3BF55E1-6061-4FC2-A293-4B8A5B593FB6"/>
+    <bpmn2:sequenceFlow id="_A8277B08-6B75-4EA5-B116-1EB2C0A9BF11" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F3BF55E1-6061-4FC2-A293-4B8A5B593FB6" targetRef="_C3EBE7F1-8E57-4BB1-B380-40BB02E9464E"/>
+    <bpmn2:task id="_C7186AB4-A90E-4653-9191-8F45734DDE9B" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="task2">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[task2]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_BF44C91F-24E6-42F5-89CE-0CEC227B2E2F</bpmn2:incoming>
+      <bpmn2:outgoing>_0A8AB905-E2B7-43E8-B569-62DD77CE3A0C</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="_BF44C91F-24E6-42F5-89CE-0CEC227B2E2F" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_C3EBE7F1-8E57-4BB1-B380-40BB02E9464E" targetRef="_C7186AB4-A90E-4653-9191-8F45734DDE9B"/>
+    <bpmn2:sequenceFlow id="_0A8AB905-E2B7-43E8-B569-62DD77CE3A0C" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_C7186AB4-A90E-4653-9191-8F45734DDE9B" targetRef="_B47C0075-40FF-49B8-A674-768D35F06CAA"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_ui7mY_ntEeaHFsZ1K-7IeQ">
+    <bpmndi:BPMNPlane id="_ui7mZPntEeaHFsZ1K-7IeQ" bpmnElement="evaluation.embp">
+      <bpmndi:BPMNShape id="_ui7mZfntEeaHFsZ1K-7IeQ" bpmnElement="_C3EBE7F1-8E57-4BB1-B380-40BB02E9464E">
+        <dc:Bounds height="176.0" width="591.0" x="375.0" y="72.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7mZvntEeaHFsZ1K-7IeQ" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="60.0" y="142.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7mZ_ntEeaHFsZ1K-7IeQ" bpmnElement="_B47C0075-40FF-49B8-A674-768D35F06CAA">
+        <dc:Bounds height="28.0" width="28.0" x="1305.0" y="146.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7maPntEeaHFsZ1K-7IeQ" bpmnElement="_9E3DA485-DD2C-44D2-922E-D76928E6AC1A">
+        <dc:Bounds height="80.0" width="100.0" x="510.0" y="117.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7mafntEeaHFsZ1K-7IeQ" bpmnElement="_9F17C436-EEF9-438C-A43D-7C848CB0E9A6">
+        <dc:Bounds height="80.0" width="100.0" x="720.0" y="117.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7mavntEeaHFsZ1K-7IeQ" bpmnElement="_A055C1EC-8286-4880-82B5-BB98FF985C1D">
+        <dc:Bounds height="30.0" width="30.0" x="402.0" y="142.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7ma_ntEeaHFsZ1K-7IeQ" bpmnElement="_FF050977-4D13-47F1-8B9B-D68FDE208666">
+        <dc:Bounds height="28.0" width="28.0" x="885.0" y="143.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7mbPntEeaHFsZ1K-7IeQ" bpmnElement="_F3BF55E1-6061-4FC2-A293-4B8A5B593FB6">
+        <dc:Bounds height="80.0" width="100.0" x="210.0" y="120.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_ui7mbfntEeaHFsZ1K-7IeQ" bpmnElement="_C7186AB4-A90E-4653-9191-8F45734DDE9B">
+        <dc:Bounds height="80.0" width="100.0" x="1065.0" y="120.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_ui7mbvntEeaHFsZ1K-7IeQ" bpmnElement="_A234CBE2-004D-49A4-A6EA-7E035A233025" sourceElement="_ui7maPntEeaHFsZ1K-7IeQ" targetElement="_ui7mafntEeaHFsZ1K-7IeQ">
+        <di:waypoint xsi:type="dc:Point" x="610.0" y="157.0"/>
+        <di:waypoint xsi:type="dc:Point" x="720.0" y="157.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ui7mb_ntEeaHFsZ1K-7IeQ" bpmnElement="_AB3DD628-3C24-450C-BDE6-55A492DBA62C" sourceElement="_ui7mavntEeaHFsZ1K-7IeQ" targetElement="_ui7maPntEeaHFsZ1K-7IeQ">
+        <di:waypoint xsi:type="dc:Point" x="432.0" y="157.0"/>
+        <di:waypoint xsi:type="dc:Point" x="510.0" y="157.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ui7mcPntEeaHFsZ1K-7IeQ" bpmnElement="_D47418F0-1D1D-41E1-89FA-B4426774C0A1" sourceElement="_ui7mafntEeaHFsZ1K-7IeQ" targetElement="_ui7ma_ntEeaHFsZ1K-7IeQ">
+        <di:waypoint xsi:type="dc:Point" x="820.0" y="157.0"/>
+        <di:waypoint xsi:type="dc:Point" x="885.0" y="157.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ui7mcfntEeaHFsZ1K-7IeQ" bpmnElement="_1316B054-BB96-4821-9F38-06883A419AA2" sourceElement="_ui7mZvntEeaHFsZ1K-7IeQ" targetElement="_ui7mbPntEeaHFsZ1K-7IeQ">
+        <di:waypoint xsi:type="dc:Point" x="75.0" y="157.0"/>
+        <di:waypoint xsi:type="dc:Point" x="260.0" y="160.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ui7mcvntEeaHFsZ1K-7IeQ" bpmnElement="_A8277B08-6B75-4EA5-B116-1EB2C0A9BF11" sourceElement="_ui7mbPntEeaHFsZ1K-7IeQ" targetElement="_ui7mZfntEeaHFsZ1K-7IeQ">
+        <di:waypoint xsi:type="dc:Point" x="260.0" y="160.0"/>
+        <di:waypoint xsi:type="dc:Point" x="670.5" y="160.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ui7mc_ntEeaHFsZ1K-7IeQ" bpmnElement="_BF44C91F-24E6-42F5-89CE-0CEC227B2E2F" sourceElement="_ui7mZfntEeaHFsZ1K-7IeQ" targetElement="_ui7mbfntEeaHFsZ1K-7IeQ">
+        <di:waypoint xsi:type="dc:Point" x="670.5" y="160.0"/>
+        <di:waypoint xsi:type="dc:Point" x="1115.0" y="160.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ui7mdPntEeaHFsZ1K-7IeQ" bpmnElement="_0A8AB905-E2B7-43E8-B569-62DD77CE3A0C" sourceElement="_ui7mbfntEeaHFsZ1K-7IeQ" targetElement="_ui7mZ_ntEeaHFsZ1K-7IeQ">
+        <di:waypoint xsi:type="dc:Point" x="1115.0" y="160.0"/>
+        <di:waypoint xsi:type="dc:Point" x="1319.0" y="160.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_ui7mdfntEeaHFsZ1K-7IeQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_C3EBE7F1-8E57-4BB1-B380-40BB02E9464E" id="_ui7mdvntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_1316B054-BB96-4821-9F38-06883A419AA2" id="_ui8NcPntEeaHFsZ1K-7IeQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A234CBE2-004D-49A4-A6EA-7E035A233025" id="_ui8NcfntEeaHFsZ1K-7IeQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AB3DD628-3C24-450C-BDE6-55A492DBA62C" id="_ui8NcvntEeaHFsZ1K-7IeQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A055C1EC-8286-4880-82B5-BB98FF985C1D" id="_ui8Nc_ntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B47C0075-40FF-49B8-A674-768D35F06CAA" id="_ui8NdPntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_ui8NdfntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0A8AB905-E2B7-43E8-B569-62DD77CE3A0C" id="_ui8NdvntEeaHFsZ1K-7IeQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_BF44C91F-24E6-42F5-89CE-0CEC227B2E2F" id="_ui8Nd_ntEeaHFsZ1K-7IeQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9E3DA485-DD2C-44D2-922E-D76928E6AC1A" id="_ui8NePntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_C7186AB4-A90E-4653-9191-8F45734DDE9B" id="_ui8NefntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_D47418F0-1D1D-41E1-89FA-B4426774C0A1" id="_ui8NevntEeaHFsZ1K-7IeQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A8277B08-6B75-4EA5-B116-1EB2C0A9BF11" id="_ui8Ne_ntEeaHFsZ1K-7IeQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FF050977-4D13-47F1-8B9B-D68FDE208666" id="_ui8NfPntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9F17C436-EEF9-438C-A43D-7C848CB0E9A6" id="_ui8NffntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_F3BF55E1-6061-4FC2-A293-4B8A5B593FB6" id="_ui8NfvntEeaHFsZ1K-7IeQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_ui6_UPntEeaHFsZ1K-7IeQ</bpmn2:source>
+    <bpmn2:target>_ui6_UPntEeaHFsZ1K-7IeQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/EmbeddedSubprocessShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/EmbeddedSubprocessShapeDef.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.shape.def;
+
+import org.kie.workbench.common.stunner.bpmn.client.resources.BPMNSVGViewFactory;
+import org.kie.workbench.common.stunner.bpmn.client.shape.BPMNPictures;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.definition.shape.AbstractShapeDef;
+import org.kie.workbench.common.stunner.core.definition.shape.GlyphDef;
+import org.kie.workbench.common.stunner.shapes.def.picture.PictureGlyphDef;
+import org.kie.workbench.common.stunner.svg.client.shape.def.SVGMutableShapeDef;
+import org.kie.workbench.common.stunner.svg.client.shape.view.SVGShapeView;
+
+public class EmbeddedSubprocessShapeDef
+        extends AbstractShapeDef<EmbeddedSubprocess>
+        implements SVGMutableShapeDef<EmbeddedSubprocess, BPMNSVGViewFactory> {
+
+    @Override
+    public double getAlpha(final EmbeddedSubprocess element) {
+        return 1d;
+    }
+
+    @Override
+    public String getBackgroundColor(final EmbeddedSubprocess element) {
+        return element.getBackgroundSet().getBgColor().getValue();
+    }
+
+    @Override
+    public double getBackgroundAlpha(final EmbeddedSubprocess element) {
+        return 0.7d;
+    }
+
+    @Override
+    public String getBorderColor(final EmbeddedSubprocess element) {
+        return element.getBackgroundSet().getBorderColor().getValue();
+    }
+
+    @Override
+    public double getBorderSize(final EmbeddedSubprocess element) {
+        return element.getBackgroundSet().getBorderSize().getValue();
+    }
+
+    @Override
+    public double getBorderAlpha(final EmbeddedSubprocess element) {
+        return 1;
+    }
+
+    @Override
+    public String getFontFamily(final EmbeddedSubprocess element) {
+        return element.getFontSet().getFontFamily().getValue();
+    }
+
+    @Override
+    public String getFontColor(final EmbeddedSubprocess element) {
+        return element.getFontSet().getFontColor().getValue();
+    }
+
+    @Override
+    public String getFontBorderColor(final EmbeddedSubprocess element) {
+        return element.getFontSet().getFontBorderColor().getValue();
+    }
+
+    @Override
+    public double getFontSize(final EmbeddedSubprocess element) {
+        return element.getFontSet().getFontSize().getValue();
+    }
+
+    @Override
+    public double getFontBorderSize(final EmbeddedSubprocess element) {
+        return element.getFontSet().getFontBorderSize().getValue();
+    }
+
+    @Override
+    public HasTitle.Position getFontPosition(final EmbeddedSubprocess element) {
+        return HasTitle.Position.BOTTOM;
+    }
+
+    @Override
+    public double getFontRotation(final EmbeddedSubprocess element) {
+        return 0;
+    }
+
+    @Override
+    public double getWidth(final EmbeddedSubprocess element) {
+        return element.getDimensionsSet().getWidth().getValue();
+    }
+
+    @Override
+    public double getHeight(final EmbeddedSubprocess element) {
+        return element.getDimensionsSet().getHeight().getValue();
+    }
+
+    @Override
+    public boolean isSVGViewVisible(final String viewName,
+                                    final EmbeddedSubprocess element) {
+        return false;
+    }
+
+    @Override
+    public SVGShapeView<?> newViewInstance(final BPMNSVGViewFactory factory,
+                                           final EmbeddedSubprocess lane) {
+        return factory.subprocessEmbedded(getWidth(lane),
+                                          getHeight(lane),
+                                          true);
+    }
+
+    @Override
+    public Class<BPMNSVGViewFactory> getViewFactoryType() {
+        return BPMNSVGViewFactory.class;
+    }
+
+    @Override
+    public GlyphDef<EmbeddedSubprocess> getGlyphDef() {
+        return GLYPH_DEF;
+    }
+
+    private static final PictureGlyphDef<EmbeddedSubprocess, BPMNPictures> GLYPH_DEF = new PictureGlyphDef<EmbeddedSubprocess, BPMNPictures>() {
+        @Override
+        public BPMNPictures getSource(final Class<?> type) {
+            return BPMNPictures.SUB_PROCESS_EMBEDDED;
+        }
+
+        @Override
+        public String getGlyphDescription(final EmbeddedSubprocess element) {
+            return element.getDescription();
+        }
+    };
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/factory/BPMNSVGShapeFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/factory/BPMNSVGShapeFactory.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.BPMNDiagramShapeDef;
+import org.kie.workbench.common.stunner.bpmn.client.shape.def.EmbeddedSubprocessShapeDef;
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.EndEventShapeDef;
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.GatewayShapeDef;
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.IntermediateTimerEventShapeDef;
@@ -31,6 +32,7 @@ import org.kie.workbench.common.stunner.bpmn.client.shape.def.StartEventShapeDef
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.TaskShapeDef;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveDatabasedGateway;
@@ -113,6 +115,8 @@ public class BPMNSVGShapeFactory
                                     new LaneShapeDef());
         svgShapeFactory.addShapeDef(ReusableSubprocess.class,
                                     new ReusableSubprocessShapeDef());
+        svgShapeFactory.addShapeDef(EmbeddedSubprocess.class,
+                                    new EmbeddedSubprocessShapeDef());
         svgShapeFactory.addShapeDef(NoneTask.class,
                                     new TaskShapeDef());
         svgShapeFactory.addShapeDef(EndNoneEvent.class,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/widgets/palette/bs3/factory/BpmnBS3PaletteViewFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/widgets/palette/bs3/factory/BpmnBS3PaletteViewFactory.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
 import org.kie.workbench.common.stunner.bpmn.client.resources.BPMNImageResources;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
 import org.kie.workbench.common.stunner.bpmn.definition.Categories;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveDatabasedGateway;
@@ -48,6 +49,7 @@ import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 @ApplicationScoped
 public class BpmnBS3PaletteViewFactory extends BindableBS3PaletteGlyphViewFactory {
 
+    @SuppressWarnings("unchecked")
     private final static Map<String, IconResource> CATEGORY_RERNDERERS_SETTINGS = new HashMap<String, IconResource>() {{
         put(Categories.ACTIVITIES,
             new IconResource(BPMNImageResources.INSTANCE.categoryActivity()));
@@ -61,6 +63,7 @@ public class BpmnBS3PaletteViewFactory extends BindableBS3PaletteGlyphViewFactor
             new IconResource(BPMNImageResources.INSTANCE.categorySequence()));
     }};
 
+    @SuppressWarnings("unchecked")
     private final static Map<String, IconResource> DEFINITION_RERNDERERS_SETTINGS = new HashMap<String, IconResource>() {{
         put(NoneTask.class.getName(),
             new IconResource(BPMNImageResources.INSTANCE.taskUser()));
@@ -92,6 +95,8 @@ public class BpmnBS3PaletteViewFactory extends BindableBS3PaletteGlyphViewFactor
             new IconResource(BPMNImageResources.INSTANCE.sequenceFlow()));
         put(ReusableSubprocess.class.getName(),
             new IconResource(BPMNImageResources.INSTANCE.subProcessReusable()));
+        put(EmbeddedSubprocess.class.getName(),
+            new IconResource(BPMNImageResources.INSTANCE.subProcessEmbedded()));
     }};
 
     protected BpmnBS3PaletteViewFactory() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/lane/lane.svg
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/lane/lane.svg
@@ -16,7 +16,7 @@
   -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      x="0px" y="0px" width="448px" height="448px" viewBox="0 0 448 448">
-  <rect x="0px" y="0px" width="448px" height="448px" rx="10" ry="10" style="fill:none; stroke: black; stroke-width: 5;"/>
+  <rect x="0px" y="0px" width="448px" height="448px" rx="0" ry="0" style="fill:none; stroke: black; stroke-width: 5;"/>
   <g id="icon" style="opacity:1">
     <use xlink:href="lane_icon.svg#Layer_1"/>
   </g>


### PR DESCRIPTION
Hey @manstis @hasys ,

This commit adds the support for the `BPMN2 Embedded Subprocess`. 

It's basically about:
- Adding the bean, properties and the shape
- Adding custom rules for it (it only accepts containment for nodes that do not have sequence flows associated or the source/target nodes for the sequence flows, if any, are on same parent as the candidate).
- Add the marshalling support
- Some other concrete fixes for bugs found while trying this..

See the JIRA ticket [here](https://issues.jboss.org/browse/JBPM-5650).

Thanks in advance for you help!!! :)