### PR TITLE
[JBPM-6069] Missing CRUD buttons in asset editors

### DIFF
--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieEditor.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieEditor.java
@@ -44,6 +44,7 @@ import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.Menus;
 
 public abstract class KieEditor
         extends BaseEditor
@@ -76,6 +77,8 @@ public abstract class KieEditor
     protected Metadata metadata;
 
     private ViewDRLSourceWidget sourceWidget;
+
+    protected Menus menus;
 
     //The default implementation delegates to the HashCode comparison in BaseEditor
     private final MayCloseHandler DEFAULT_MAY_CLOSE_HANDLER = new MayCloseHandler() {


### PR DESCRIPTION
Reverting https://github.com/kiegroup/kie-wb-common/commit/a18fe0c3a2b27a480a5d166966c432e70877bbb5#diff-7987251173d3d91720dcb2a2b380e509 .

