### PR TITLE
GUVNOR-3114: [Library] Proj.exp initialization causes random project to be loaded when returning to library from other perspectives

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspective.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspective.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.widgets.client.search.SearchBehavior;
 import org.uberfire.client.annotations.Perspective;
 import org.uberfire.client.annotations.WorkbenchPerspective;
 import org.uberfire.client.workbench.panels.impl.MultiListWorkbenchPanelPresenter;
+import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.Command;
@@ -93,6 +94,11 @@ public class LibraryPerspective {
             callback = () -> libraryPlaces.goToLibrary();
         }
         libraryPlaces.refresh(callback);
+    }
+
+    @OnClose
+    public void onClose() {
+        libraryPlaces.hideDocks();
     }
 
     public PanelDefinition getRootPanel() {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.workbench.common.screens.library.client.perspective;
 
-import javax.enterprise.event.Event;
-
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,5 +61,12 @@ public class LibraryPerspectiveTest {
 
         verify(contextualSearch).setPerspectiveSearchBehavior(eq(LibraryPlaces.LIBRARY_PERSPECTIVE),
                                                               any());
+    }
+
+    @Test
+    public void libraryHidesDocksOnCloseTest() {
+        perspective.onClose();
+
+        verify(libraryPlaces).hideDocks();
     }
 }


### PR DESCRIPTION
Hi @jhrcek, if you could check if the issue is gone, please. Thanks!