### PR TITLE
JBPM-6088 - Not possible to run Simulation of process with Send Task

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/indexing/BpmnProcessDataEventListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/indexing/BpmnProcessDataEventListener.java
@@ -141,7 +141,8 @@ public class BpmnProcessDataEventListener
             signals = (Set<String>) data;
         } else if ("Messages".equals(name)) {
             Map<String, Message> builderMessagesMap = (Map<String, Message>) data;
-            messages = builderMessagesMap.keySet();
+            //JDK-6750650 - cant serialize the keySet itself - so copy is needed
+            messages = new HashSet(builderMessagesMap.keySet());
         }
     }
 


### PR DESCRIPTION
@manstis i would really like your opinion on how to write a meaningful test for this small change if there is one. 

The actual test is in jbpm-designer https://github.com/kiegroup/jbpm-designer/pull/617 but when designer runs in workbench (with stunner) BpmnProcessDataEventListener also gets serialized and afaik stunner does not yet support send task to write a test against)