### PR TITLE
JBPM-5546: Right click on shape shouldn't to bring up the browser right click functionality

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManager.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -265,7 +265,7 @@ public class ViewEventHandlerManager {
 
     protected HandlerRegistration[] registerClickHandler(final ViewHandler<ViewEvent> eventHandler) {
         return new HandlerRegistration[]{
-                node.addNodeMouseClickHandler(nodeMouseClickEvent -> {
+                node.addNodeMouseDownHandler(nodeMouseClickEvent -> {
                     if (ViewEventHandlerManager.this.isEnabled()) {
                         restoreClickHandler();
                         final int x = nodeMouseClickEvent.getX();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/canvas/AbstractCanvasViewer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/canvas/AbstractCanvasViewer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,13 @@ package org.kie.workbench.common.stunner.client.widgets.presenters.canvas;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.event.dom.client.ContextMenuHandler;
+import com.google.gwt.event.dom.client.MouseEvent;
+import com.google.gwt.user.client.ui.Widget;
 import org.kie.workbench.common.stunner.client.lienzo.util.LienzoUtils;
 import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.views.WidgetWrapperView;
@@ -36,6 +43,24 @@ public abstract class AbstractCanvasViewer<T, H extends AbstractCanvasHandler, V
     private final WidgetWrapperView view;
 
     public AbstractCanvasViewer(final WidgetWrapperView view) {
+        view.asWidget().addDomHandler(new ContextMenuHandler() {
+
+            @Override public void onContextMenu(ContextMenuEvent event) {
+                event.preventDefault();
+                /*NativeEvent e = event.getNativeEvent();
+                NativeEvent clickEvent = Document.get().createMouseDownEvent(0,
+                        e.getScreenX(),
+                        e.getScreenY(),
+                        e.getClientX(),
+                        e.getClientY(),
+                        e.getCtrlKey(),
+                        e.getAltKey(),
+                        e.getShiftKey(),
+                        e.getMetaKey(),
+                        e.getButton());
+                MouseEvent.fireNativeEvent(clickEvent, view.asWidget());*/
+            }
+        }, ContextMenuEvent.getType());
         this.view = view;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/AbstractSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/AbstractSelectionControl.java
@@ -69,7 +69,7 @@ public abstract class AbstractSelectionControl<H extends AbstractCanvasHandler> 
 
             @Override
             public void handle(final MouseClickEvent event) {
-                if (event.isButtonLeft()) {
+                if (event.isButtonLeft() || event.isButtonRight()) {
                     handleLayerClick(!event.isShiftKeyDown());
                 }
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/SelectionControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/SelectionControlImpl.java
@@ -58,7 +58,7 @@ public final class SelectionControlImpl<H extends AbstractCanvasHandler> extends
                 final MouseClickHandler clickHandler = new MouseClickHandler() {
                     @Override
                     public void handle(final MouseClickEvent event) {
-                        if (event.isButtonLeft()) {
+                        if (event.isButtonLeft() || event.isButtonRight()) {
                             SelectionControlImpl.super.select(element,
                                                               !event.isShiftKeyDown());
                         }


### PR DESCRIPTION
@romartin I am posting this pull request here even though it not complete so I can get feedback ASAP. Currently, the workbench cannot detect right clicks: it tracks only MouseClick events, which are only fired from the left mouse button. To fix this, I changed the node.registerMouseClickListener to node.registerMouseDownListener. Currently it builds and I didn't notice anything breaking. However, one of the tests check if registerMouseClickListener is called. Should I update the test? Register both MouseClick and MouseDown listeners, or create a new ViewEvent type?