### PR TITLE
JBPM-6006 & JBPM-6076: Fixings for connectors when removing nodes.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommand.java
@@ -70,19 +70,13 @@ public class DeleteNodeCommand extends AbstractCanvasGraphCommand {
     private class CanvasDeleteProcessor implements SafeDeleteNodeCommand.SafeDeleteNodeCommandCallback {
 
         @Override
-        public void deleteIncomingConnection(final Edge<? extends View<?>, Node> edge) {
-            deleteConnector(edge);
+        public void deleteCandidateConnector(final Edge<? extends View<?>, Node> connector) {
+            doDeleteConnector(connector);
         }
 
         @Override
-        public void deleteOutgoingConnection(final Edge<? extends View<?>, Node> edge) {
-            deleteConnector(edge);
-        }
-
-        @Override
-        public void deleteEdge(final Edge<? extends View<?>, Node> candidate) {
-            log("DeleteCanvasConnectorCommand [candidate=" + candidate.getUUID() + "]");
-            getCommand().addCommand(new DeleteCanvasConnectorCommand(candidate));
+        public void deleteConnector(final Edge<? extends View<?>, Node> connector) {
+            doDeleteConnector(connector);
         }
 
         @Override
@@ -107,14 +101,23 @@ public class DeleteNodeCommand extends AbstractCanvasGraphCommand {
         }
 
         @Override
+        public void deleteCandidateNode(final Node<?, Edge> node) {
+            doDeleteNode(node);
+        }
+
+        @Override
         public void deleteNode(final Node<?, Edge> node) {
+            doDeleteNode(node);
+        }
+
+        private void doDeleteNode(final Node<?, Edge> node) {
             log("DeleteCanvasNodeCommand [node=" + node.getUUID() + "]");
             getCommand().addCommand(new DeleteCanvasNodeCommand(node));
         }
 
-        private void deleteConnector(final Edge<? extends View<?>, Node> connector) {
-            log("SetCanvasConnectionCommand [connector=" + connector.getUUID() + "]");
-            getCommand().addCommand(new SetCanvasConnectionCommand(connector));
+        private void doDeleteConnector(final Edge<? extends View<?>, Node> connector) {
+            log("DeleteCanvasConnectorCommand [connector=" + connector.getUUID() + "]");
+            getCommand().addCommand(new DeleteCanvasConnectorCommand(connector));
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommandTest.java
@@ -90,16 +90,16 @@ public class DeleteNodeCommandTest {
         assertTrue(3 == compositeCommand.size());
         final List<Command<AbstractCanvasHandler, CanvasViolation>> commands = compositeCommand.getCommands();
         assertNotNull(commands);
-        final SetCanvasConnectionCommand c1 = (SetCanvasConnectionCommand) commands.get(0);
-        assertNotNull(c1);
-        assertEquals(graphHolder.edge1,
-                     c1.getEdge());
-        final RemoveCanvasChildCommand c2 = (RemoveCanvasChildCommand) commands.get(1);
+        final RemoveCanvasChildCommand c2 = (RemoveCanvasChildCommand) commands.get(0);
         assertNotNull(c2);
         assertEquals(graphHolder.parentNode,
                      c2.getParent());
         assertEquals(graphHolder.startNode,
                      c2.getChild());
+        final DeleteCanvasConnectorCommand delete1 = (DeleteCanvasConnectorCommand) commands.get(1);
+        assertNotNull(delete1);
+        assertEquals(graphHolder.edge1,
+                     delete1.getCandidate());
         final DeleteCanvasNodeCommand c3 = (DeleteCanvasNodeCommand) commands.get(2);
         assertNotNull(c3);
         assertEquals(graphHolder.startNode,
@@ -125,32 +125,24 @@ public class DeleteNodeCommandTest {
         final AbstractCompositeCommand<AbstractCanvasHandler, CanvasViolation> compositeCommand =
                 (AbstractCompositeCommand<AbstractCanvasHandler, CanvasViolation>) tested.getCommand();
         assertNotNull(compositeCommand);
-        assertTrue(6 == compositeCommand.size());
+        assertTrue(4 == compositeCommand.size());
         final List<Command<AbstractCanvasHandler, CanvasViolation>> commands = compositeCommand.getCommands();
         assertNotNull(commands);
-        final SetCanvasConnectionCommand c1 = (SetCanvasConnectionCommand) commands.get(0);
-        assertNotNull(c1);
-        assertEquals(graphHolder.edge2,
-                     c1.getEdge());
-        final SetCanvasConnectionCommand c2 = (SetCanvasConnectionCommand) commands.get(1);
-        assertNotNull(c2);
-        assertEquals(graphHolder.edge1,
-                     c2.getEdge());
-        final RemoveCanvasChildCommand c3 = (RemoveCanvasChildCommand) commands.get(2);
+        final RemoveCanvasChildCommand c3 = (RemoveCanvasChildCommand) commands.get(0);
         assertNotNull(c3);
         assertEquals(graphHolder.parentNode,
                      c3.getParent());
         assertEquals(graphHolder.intermNode,
                      c3.getChild());
-        final DeleteCanvasConnectorCommand c4 = (DeleteCanvasConnectorCommand) commands.get(3);
-        assertNotNull(c4);
+        final DeleteCanvasConnectorCommand delete2 = (DeleteCanvasConnectorCommand) commands.get(1);
+        assertNotNull(delete2);
         assertEquals(graphHolder.edge2,
-                     c4.getCandidate());
-        final SetCanvasConnectionCommand c5 = (SetCanvasConnectionCommand) commands.get(4);
+                     delete2.getCandidate());
+        final SetCanvasConnectionCommand c5 = (SetCanvasConnectionCommand) commands.get(2);
         assertNotNull(c5);
         assertEquals(graphHolder.edge1,
                      c5.getEdge());
-        final DeleteCanvasNodeCommand c6 = (DeleteCanvasNodeCommand) commands.get(5);
+        final DeleteCanvasNodeCommand c6 = (DeleteCanvasNodeCommand) commands.get(3);
         assertNotNull(c6);
         assertEquals(graphHolder.intermNode,
                      c6.getCandidate());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommandTest.java
@@ -57,17 +57,16 @@ public class SafeDeleteNodeCommandTest {
         final List<Command<GraphCommandExecutionContext, RuleViolation>> commands = tested.getCommands();
         assertNotNull(commands);
         assertTrue(3 == commands.size());
-        final SetConnectionSourceNodeCommand setConnectionSource = (SetConnectionSourceNodeCommand) commands.get(0);
-        assertNotNull(setConnectionSource);
-        assertEquals(graphHolder.edge1,
-                     setConnectionSource.getEdge());
-        assertNull(setConnectionSource.getSourceNode());
-        final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(1);
+        final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(0);
         assertNotNull(removeChild);
         assertEquals(graphHolder.parentNode,
                      removeChild.getParent());
         assertEquals(graphHolder.startNode,
                      removeChild.getCandidate());
+        final DeleteConnectorCommand delete1 = (DeleteConnectorCommand) commands.get(1);
+        assertNotNull(delete1);
+        assertEquals(graphHolder.edge1,
+                     delete1.getEdge());
         final DeregisterNodeCommand deleteNode = (DeregisterNodeCommand) commands.get(2);
         assertNotNull(deleteNode);
         assertEquals(graphHolder.startNode,
@@ -84,17 +83,17 @@ public class SafeDeleteNodeCommandTest {
         final List<Command<GraphCommandExecutionContext, RuleViolation>> commands = tested.getCommands();
         assertNotNull(commands);
         assertTrue(3 == commands.size());
-        final SetConnectionTargetNodeCommand setConnectionTarget = (SetConnectionTargetNodeCommand) commands.get(0);
-        assertNotNull(setConnectionTarget);
-        assertEquals(graphHolder.edge2,
-                     setConnectionTarget.getEdge());
-        assertNull(setConnectionTarget.getTargetNode());
-        final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(1);
+        final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(0);
         assertNotNull(removeChild);
         assertEquals(graphHolder.parentNode,
                      removeChild.getParent());
         assertEquals(graphHolder.endNode,
                      removeChild.getCandidate());
+        final DeleteConnectorCommand delete2 = (DeleteConnectorCommand) commands.get(1);
+        assertNotNull(delete2);
+        assertEquals(graphHolder.edge2,
+                     delete2.getEdge());
+
         final DeregisterNodeCommand deleteNode = (DeregisterNodeCommand) commands.get(2);
         assertNotNull(deleteNode);
         assertEquals(graphHolder.endNode,
@@ -111,32 +110,18 @@ public class SafeDeleteNodeCommandTest {
         final CommandResult<RuleViolation> result = tested.allow(graphTestHandler.graphCommandExecutionContext);
         final List<Command<GraphCommandExecutionContext, RuleViolation>> commands = tested.getCommands();
         assertNotNull(commands);
-        assertTrue(6 == commands.size());
-        final SetConnectionSourceNodeCommand setConnectionSource = (SetConnectionSourceNodeCommand) commands.get(0);
-        assertNotNull(setConnectionSource);
-        assertEquals(graphHolder.edge2,
-                     setConnectionSource.getEdge());
-        assertNull(setConnectionSource.getSourceNode());
-        assertEquals(graphHolder.endNode,
-                     setConnectionSource.getTargetNode());
-        final SetConnectionTargetNodeCommand setConnectionTarget = (SetConnectionTargetNodeCommand) commands.get(1);
-        assertNotNull(setConnectionTarget);
-        assertEquals(graphHolder.edge1,
-                     setConnectionTarget.getEdge());
-        assertNull(setConnectionTarget.getTargetNode());
-        assertEquals(graphHolder.startNode,
-                     setConnectionTarget.getSourceNode());
-        final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(2);
+        assertTrue(4 == commands.size());
+        final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(0);
         assertNotNull(removeChild);
         assertEquals(graphHolder.parentNode,
                      removeChild.getParent());
         assertEquals(graphHolder.intermNode,
                      removeChild.getCandidate());
-        final DeleteConnectorCommand deleteConnector2 = (DeleteConnectorCommand) commands.get(3);
-        assertNotNull(deleteConnector2);
+        final DeleteConnectorCommand delete2 = (DeleteConnectorCommand) commands.get(1);
+        assertNotNull(delete2);
         assertEquals(graphHolder.edge2,
-                     deleteConnector2.getEdge());
-        final SetConnectionTargetNodeCommand setConnectionNewTarget = (SetConnectionTargetNodeCommand) commands.get(4);
+                     delete2.getEdge());
+        final SetConnectionTargetNodeCommand setConnectionNewTarget = (SetConnectionTargetNodeCommand) commands.get(2);
         assertNotNull(setConnectionNewTarget);
         assertEquals(graphHolder.edge1,
                      setConnectionNewTarget.getEdge());
@@ -144,7 +129,7 @@ public class SafeDeleteNodeCommandTest {
                      setConnectionNewTarget.getSourceNode());
         assertEquals(graphHolder.endNode,
                      setConnectionNewTarget.getTargetNode());
-        final DeregisterNodeCommand deleteNode = (DeregisterNodeCommand) commands.get(5);
+        final DeregisterNodeCommand deleteNode = (DeregisterNodeCommand) commands.get(3);
         assertNotNull(deleteNode);
         assertEquals(graphHolder.intermNode,
                      deleteNode.getNode());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/SafeDeleteNodeProcessorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/SafeDeleteNodeProcessorTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
-import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessorImpl;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessorImpl;
@@ -55,9 +54,13 @@ public class SafeDeleteNodeProcessorTest {
                                                   graphHolder.graph,
                                                   graphHolder.startNode);
         tested.run(callback);
-        verifyDeleteStartNode();
         verify(callback,
-               never()).deleteIncomingConnection(any(Edge.class));
+               times(1)).deleteCandidateConnector(eq(graphHolder.edge1));
+        verify(callback,
+               times(1)).removeChild(eq(graphHolder.parentNode),
+                                     eq(graphHolder.startNode));
+        verify(callback,
+               times(1)).deleteCandidateNode(eq(graphHolder.startNode));
         verify(callback,
                never()).removeDock(any(Node.class),
                                    any(Node.class));
@@ -70,7 +73,15 @@ public class SafeDeleteNodeProcessorTest {
                                                   graphHolder.graph,
                                                   graphHolder.intermNode);
         tested.run(callback);
-        verifyDeleteIntermediateNode();
+        verify(callback,
+               times(1)).deleteCandidateConnector(eq(graphHolder.edge1));
+        verify(callback,
+               times(1)).deleteCandidateConnector(eq(graphHolder.edge2));
+        verify(callback,
+               times(1)).removeChild(eq(graphHolder.parentNode),
+                                     eq(graphHolder.intermNode));
+        verify(callback,
+               times(1)).deleteCandidateNode(eq(graphHolder.intermNode));
         verify(callback,
                never()).removeDock(any(Node.class),
                                    any(Node.class));
@@ -83,9 +94,13 @@ public class SafeDeleteNodeProcessorTest {
                                                   graphHolder.graph,
                                                   graphHolder.endNode);
         tested.run(callback);
-        verifyDeleteEndNode();
         verify(callback,
-               never()).deleteOutgoingConnection(any(Edge.class));
+               times(1)).deleteCandidateConnector(eq(graphHolder.edge2));
+        verify(callback,
+               times(1)).removeChild(eq(graphHolder.parentNode),
+                                     eq(graphHolder.endNode));
+        verify(callback,
+               times(1)).deleteCandidateNode(eq(graphHolder.endNode));
         verify(callback,
                never()).removeDock(any(Node.class),
                                    any(Node.class));
@@ -98,50 +113,30 @@ public class SafeDeleteNodeProcessorTest {
                                                   graphHolder.graph,
                                                   graphHolder.parentNode);
         tested.run(callback);
-        verifyDeleteEndNode();
-        verifyDeleteIntermediateNode();
-        verifyDeleteStartNode();
-        verifyDeleteParentNode();
-    }
-
-    @SuppressWarnings("unchecked")
-    private void verifyDeleteStartNode() {
         verify(callback,
-               times(1)).deleteOutgoingConnection(eq(graphHolder.edge1));
-        verify(callback,
-               times(1)).removeChild(eq(graphHolder.parentNode),
-                                     eq(graphHolder.startNode));
-        verify(callback,
-               times(1)).deleteNode(eq(graphHolder.startNode));
-    }
-
-    @SuppressWarnings("unchecked")
-    private void verifyDeleteIntermediateNode() {
-        verify(callback,
-               times(1)).deleteIncomingConnection(eq(graphHolder.edge1));
-        verify(callback,
-               times(1)).deleteOutgoingConnection(eq(graphHolder.edge2));
-        verify(callback,
-               times(1)).removeChild(eq(graphHolder.parentNode),
-                                     eq(graphHolder.intermNode));
-        verify(callback,
-               times(1)).deleteNode(eq(graphHolder.intermNode));
-    }
-
-    @SuppressWarnings("unchecked")
-    private void verifyDeleteEndNode() {
-        verify(callback,
-               times(1)).deleteIncomingConnection(eq(graphHolder.edge2));
+               times(1)).deleteConnector(eq(graphHolder.edge2));
         verify(callback,
                times(1)).removeChild(eq(graphHolder.parentNode),
                                      eq(graphHolder.endNode));
         verify(callback,
                times(1)).deleteNode(eq(graphHolder.endNode));
-    }
-
-    @SuppressWarnings("unchecked")
-    private void verifyDeleteParentNode() {
         verify(callback,
-               times(1)).deleteNode(eq(graphHolder.parentNode));
+               times(1)).deleteConnector(eq(graphHolder.edge1));
+        verify(callback,
+               times(1)).deleteConnector(eq(graphHolder.edge2));
+        verify(callback,
+               times(1)).removeChild(eq(graphHolder.parentNode),
+                                     eq(graphHolder.intermNode));
+        verify(callback,
+               times(1)).deleteNode(eq(graphHolder.intermNode));
+        verify(callback,
+               times(1)).deleteConnector(eq(graphHolder.edge1));
+        verify(callback,
+               times(1)).removeChild(eq(graphHolder.parentNode),
+                                     eq(graphHolder.startNode));
+        verify(callback,
+               times(1)).deleteNode(eq(graphHolder.startNode));
+        verify(callback,
+               times(1)).deleteCandidateNode(eq(graphHolder.parentNode));
     }
 }


### PR DESCRIPTION
Hey @manstis @hasys 

This commit fixes these two bugs: [JBPM-6006](https://issues.jboss.org/browse/JBPM-6006) and [JBPM-6076](https://issues.jboss.org/browse/JBPM-6076). 

It basically removes the connectors (in some cases) instead of setting empty source/target connections. 

Thanks!