### PR TITLE
[JBPM-5544] Text displayed in the model now support auto-wrap

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -176,6 +176,7 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
         this.fillGradientEndColor = endColor;
         if (null != getShape()) {
             final BoundingBox bb = getShape().getBoundingBox();
+            textViewDecorator.setTextBoundaries(bb);
             final double width = bb.getWidth();
             final double height = bb.getHeight();
             updateFillGradient(width,
@@ -357,14 +358,23 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
         HandlerRegistration r0 = addWiresResizeStartHandler(wiresResizeStartEvent -> {
             final ResizeEvent event = buildResizeEvent(wiresResizeStartEvent);
             resizeHandler.start(event);
+            removeChild(textViewDecorator.getView());
+            addTextAsChild();
+            textViewDecorator.setTextBoundaries(getShape().getBoundingBox());
         });
         HandlerRegistration r1 = addWiresResizeStepHandler(wiresResizeStepEvent -> {
             final ResizeEvent event = buildResizeEvent(wiresResizeStepEvent);
             resizeHandler.handle(event);
+            removeChild(textViewDecorator.getView());
+            addTextAsChild();
+            textViewDecorator.setTextBoundaries(getShape().getBoundingBox());
         });
         HandlerRegistration r2 = addWiresResizeEndHandler(wiresResizeEndEvent -> {
             final ResizeEvent event = buildResizeEvent(wiresResizeEndEvent);
             resizeHandler.end(event);
+            removeChild(textViewDecorator.getView());
+            addTextAsChild();
+            textViewDecorator.setTextBoundaries(getShape().getBoundingBox());
         });
         return new HandlerRegistration[]{r0, r1, r2};
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,6 +20,7 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.shape.wires.LayoutContainer;
+import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.shared.core.types.ColorName;
 import com.google.gwt.event.shared.HandlerRegistration;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.ViewEventHandlerManager;
@@ -176,6 +177,7 @@ public class WiresTextDecorator {
         }
         final boolean changed = !currentTextLayout.equals(layout);
         this.currentTextLayout = layout;
+        text.setWrapBoundaries(text.getWrapBoundaries(),getLayout());
         return changed;
     }
 
@@ -248,5 +250,9 @@ public class WiresTextDecorator {
     private boolean hasText() {
         final String text = this.text.getText();
         return null != text && text.trim().length() > 0;
+    }
+
+    public void setTextBoundaries(BoundingBox boundaries) {
+        text.setWrapBoundaries(boundaries,getLayout());
     }
 }


### PR DESCRIPTION
Depends on https://github.com/ahome-it/lienzo-core/pull/175 (you might need to use https://github.com/Christopher-Chianelli/lienzo-core/tree/auto-wrap-long-text, since kie-wb-common use an older version of lienzo). Added text wrap for wire shapes.