### PR TITLE
GUVNOR-3220: [DMN Editor] FlowActionsToolboxControlProvider always uses a 'default' connector

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/AbstractToolboxControlProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/AbstractToolboxControlProvider.java
@@ -22,8 +22,8 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 
 public abstract class AbstractToolboxControlProvider implements ToolboxControlProvider<AbstractCanvasHandler, Element> {
 
-    protected final static int DEFAULT_ICON_SIZE = 12;
-    protected final static int DEFAULT_PADDING = 10;
+    public final static int DEFAULT_ICON_SIZE = 12;
+    public final static int DEFAULT_PADDING = 10;
 
     protected ToolboxFactory toolboxFactory;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/FlowActionsToolboxControlProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/FlowActionsToolboxControlProvider.java
@@ -45,7 +45,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 /**
  * A toolbox control provider implementation that provides buttons to create new elements
  * and update the graph structure.
- * <p>
+ * <p/>
  * It provides buttons for:
  * - Creating a new connection from the source element.
  * It looks for the default connector type and creates a button for it.
@@ -145,6 +145,7 @@ public class FlowActionsToolboxControlProvider extends AbstractToolboxControlPro
                 if (null != allowedMorphDefaultDefinitionIds && !allowedMorphDefaultDefinitionIds.isEmpty()) {
                     for (final String allowedDefId : allowedMorphDefaultDefinitionIds) {
                         final NewNodeCommand newNodeCommand = defaultToolboxCommandFactory.newNodeCommand();
+                        newNodeCommand.setEdgeIdentifier(defaultConnectorId);
                         newNodeCommand.setDefinitionIdentifier(allowedDefId);
                         commands.add(newNodeCommand);
                     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/command/builder/NewNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/command/builder/NewNodeCommand.java
@@ -67,6 +67,7 @@ public class NewNodeCommand<I> extends AbstractElementBuilderCommand<I> {
     private final DefinitionUtils definitionUtils;
     private final CanvasLayoutUtils canvasLayoutUtils;
 
+    private String edgeId;
     private String definitionId;
     private Magnet sourceMagnet;
     private Magnet targetMagnet;
@@ -112,18 +113,17 @@ public class NewNodeCommand<I> extends AbstractElementBuilderCommand<I> {
         getGlyphTooltip().setPrefix("Click to create a ");
     }
 
+    public void setEdgeIdentifier(final String edgeId) {
+        this.edgeId = edgeId;
+    }
+
     public void setDefinitionIdentifier(final String definitionId) {
         this.definitionId = definitionId;
     }
 
-    private String getEdgeIdentifier(final Context<AbstractCanvasHandler> context) {
-        final String defSetId = context.getCanvasHandler().getDiagram().getMetadata().getDefinitionSetId();
-        return definitionUtils.getDefaultConnectorId(defSetId);
-    }
-
     @Override
     protected String getDefinitionIdentifier(final Context<AbstractCanvasHandler> context) {
-        return getEdgeIdentifier(context);
+        return this.edgeId;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/FlowActionsToolboxControlProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/FlowActionsToolboxControlProviderTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.command.ToolboxCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.command.ToolboxCommandFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.command.builder.NewConnectorCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.command.builder.NewNodeCommand;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.ToolboxFactory;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.builder.ToolboxBuilder;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.builder.ToolboxButtonGridBuilder;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.lookup.util.CommonLookups;
+import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionSetRegistry;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FlowActionsToolboxControlProviderTest {
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private ToolboxFactory toolboxFactory;
+
+    @Mock
+    private ToolboxButtonGridBuilder toolboxButtonGridBuilder;
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private FactoryManager factoryManager;
+
+    @Mock
+    private ToolboxCommandFactory defaultToolboxCommandFactory;
+
+    @Mock
+    private CommonLookups commonLookups;
+
+    @Mock
+    private TypeDefinitionSetRegistry typeDefinitionSetRegistry;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private DefinitionSetAdapter definitionSetAdapter;
+
+    @Mock
+    private DefinitionAdapter definitionAdapter;
+
+    private AbstractToolboxControlProvider provider;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
+        when(toolboxFactory.toolboxGridBuilder()).thenReturn(toolboxButtonGridBuilder);
+        when(toolboxButtonGridBuilder.setRows(anyInt())).thenReturn(toolboxButtonGridBuilder);
+        when(toolboxButtonGridBuilder.setColumns(anyInt())).thenReturn(toolboxButtonGridBuilder);
+        when(toolboxButtonGridBuilder.setIconSize(anyInt())).thenReturn(toolboxButtonGridBuilder);
+        when(toolboxButtonGridBuilder.setPadding(anyInt())).thenReturn(toolboxButtonGridBuilder);
+        when(definitionManager.definitionSets()).thenReturn(typeDefinitionSetRegistry);
+        when(typeDefinitionSetRegistry.getDefinitionSetByType(eq(MockDefinitionSet.class))).thenReturn(new MockDefinitionSet());
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.forDefinitionSet()).thenReturn(definitionSetAdapter);
+        when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
+        when(definitionSetAdapter.getDefinitions(any(MockDefinitionSet.class))).thenReturn(new HashSet<String>() {{
+            add(MockNode.class.getName());
+            add(MockConnector.class.getName());
+        }});
+        when(definitionAdapter.getId(anyObject())).thenAnswer((o) -> o.getArguments()[0].getClass().getName());
+
+        this.provider = new FlowActionsToolboxControlProvider(toolboxFactory,
+                                                              definitionUtils,
+                                                              defaultToolboxCommandFactory,
+                                                              commonLookups);
+    }
+
+    @Test
+    public void checkGridHasExpectedConfiguration() {
+        final AbstractCanvasHandler context = mock(AbstractCanvasHandler.class);
+        final Element item = mock(Element.class);
+
+        provider.getGrid(context,
+                         item);
+
+        verify(toolboxButtonGridBuilder).setRows(5);
+        verify(toolboxButtonGridBuilder).setColumns(2);
+        verify(toolboxButtonGridBuilder).setIconSize(AbstractToolboxControlProvider.DEFAULT_ICON_SIZE);
+        verify(toolboxButtonGridBuilder).setPadding(AbstractToolboxControlProvider.DEFAULT_PADDING);
+        verify(toolboxButtonGridBuilder).build();
+    }
+
+    @Test
+    public void checkGetOnIsNorthEast() {
+        assertEquals(ToolboxBuilder.Direction.NORTH_EAST,
+                     provider.getOn());
+    }
+
+    @Test
+    public void checkGetTowardsIsSouthEast() {
+        assertEquals(ToolboxBuilder.Direction.SOUTH_EAST,
+                     provider.getTowards());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkGetCommandsForAvailableConnectors() {
+        final AbstractCanvasHandler context = mock(AbstractCanvasHandler.class);
+        setupDiagramMetaData(context);
+
+        final Node node = mock(Node.class);
+        final NewConnectorCommand newConnectorCommand = mock(NewConnectorCommand.class);
+
+        when(commonLookups.getAllowedConnectors(eq(MockDefinitionSet.class.getName()),
+                                                eq(node),
+                                                anyInt(),
+                                                anyInt())).thenReturn(Collections.singleton(MockConnector.class.getName()));
+        when(defaultToolboxCommandFactory.newConnectorCommand()).thenReturn(newConnectorCommand);
+
+        final List<ToolboxCommand<AbstractCanvasHandler, ?>> commands = provider.getCommands(context,
+                                                                                             node);
+
+        assertEquals(1,
+                     commands.size());
+        assertTrue(commands.contains(newConnectorCommand));
+        verify(newConnectorCommand).setEdgeIdentifier(eq(MockConnector.class.getName()));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkGetCommandsForAvailableConnectorAndFlowNode() {
+        final AbstractCanvasHandler context = mock(AbstractCanvasHandler.class);
+        setupDiagramMetaData(context);
+
+        final Node node = mock(Node.class);
+        final NewConnectorCommand newConnectorCommand = mock(NewConnectorCommand.class);
+        when(commonLookups.getAllowedConnectors(eq(MockDefinitionSet.class.getName()),
+                                                eq(node),
+                                                anyInt(),
+                                                anyInt())).thenReturn(Collections.singleton(MockConnector.class.getName()));
+        when(defaultToolboxCommandFactory.newConnectorCommand()).thenReturn(newConnectorCommand);
+
+        when(definitionUtils.getDefaultConnectorId(eq(MockDefinitionSet.class.getName()))).thenReturn(MockConnector.class.getName());
+
+        final NewNodeCommand newNodeCommand = mock(NewNodeCommand.class);
+        when(commonLookups.getAllowedMorphDefaultDefinitions(eq(MockDefinitionSet.class.getName()),
+                                                             any(Graph.class),
+                                                             eq(node),
+                                                             eq(MockConnector.class.getName()),
+                                                             anyInt(),
+                                                             anyInt())).thenReturn(Collections.singleton(MockNode.class.getName()));
+        when(defaultToolboxCommandFactory.newNodeCommand()).thenReturn(newNodeCommand);
+
+        final List<ToolboxCommand<AbstractCanvasHandler, ?>> commands = provider.getCommands(context,
+                                                                                             node);
+
+        assertEquals(2,
+                     commands.size());
+        assertTrue(commands.contains(newConnectorCommand));
+        verify(newConnectorCommand).setEdgeIdentifier(eq(MockConnector.class.getName()));
+        assertTrue(commands.contains(newNodeCommand));
+        verify(newNodeCommand).setEdgeIdentifier(eq(MockConnector.class.getName()));
+        verify(newNodeCommand).setDefinitionIdentifier(eq(MockNode.class.getName()));
+    }
+
+    private void setupDiagramMetaData(final AbstractCanvasHandler context) {
+        final Diagram diagram = mock(Diagram.class);
+        final Metadata metadata = mock(Metadata.class);
+        when(context.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getDefinitionSetId()).thenReturn(MockDefinitionSet.class.getName());
+    }
+
+    private static class MockDefinitionSet {
+
+    }
+
+    private static class MockNode {
+
+    }
+
+    private static class MockConnector {
+
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/util/CommonLookups.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/util/CommonLookups.java
@@ -60,7 +60,7 @@ import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull
 /**
  * An utils class that provides common used look-ups and other logic for querying the domain model and the rules model,
  * that is used along the application.
- * <p>
+ * <p/>
  * // TODO: Some kind of cache to avoid frequently used lookups? Consider performance and memory, this class
  * is shared on both server and client sides.
  */
@@ -151,7 +151,7 @@ public class CommonLookups {
      * the given edge (connector) identifier.
      * This method only returns the definition identifiers that are considered the default types for its morph type,
      * it does NOT return all the identifiers for all the allowed target definitions.
-     * <p>
+     * <p/>
      * TODO: Handle several result pages.
      */
     public <T> Set<String> getAllowedMorphDefaultDefinitions(final String defSetId,
@@ -193,7 +193,7 @@ public class CommonLookups {
     /**
      * Returns the allowed definition identifiers that can be used as target node for the given source node and
      * the given edge (connector) identifier.
-     * <p>
+     * <p/>
      * TODO: Handle several result pages.
      */
     @SuppressWarnings("unchecked")
@@ -203,6 +203,8 @@ public class CommonLookups {
                                                        final String edgeId,
                                                        final int page,
                                                        final int pageSize) {
+        final Set<Object> result = new LinkedHashSet<>();
+
         if (null != defSetId && null != graph && null != sourceNode && null != edgeId) {
             final T definition = sourceNode.getContent().getDefinition();
             final RuleSet ruleSet = getRuleSet(defSetId);
@@ -248,7 +250,6 @@ public class CommonLookups {
                                                                                                allowedConnectionRoles);
                         final int inConnectorsCount = countIncomingEdges(sourceNode,
                                                                          edgeId);
-                        final Set<Object> result = new LinkedHashSet<>();
                         allowedDefinitions
                                 .stream()
                                 .forEach(defId -> {
@@ -301,12 +302,12 @@ public class CommonLookups {
                 }
             }
         }
-        return null;
+        return result;
     }
 
     /**
      * Returns all the Definition Set's definition identifiers that contains the given labels.
-     * <p>
+     * <p/>
      * TODO: Handle several result pages.
      */
     private Set<String> getDefinitions(final String defSetId,
@@ -362,7 +363,7 @@ public class CommonLookups {
     /**
      * Returns the allowed ROLES that satisfy connection rules for a given source
      * definition ( domain model object, not a node ).and the given edge (connector) identifier.
-     * <p>
+     * <p/>
      * TODO: Handle several result pages.
      */
     private <T> Set<String> getConnectionRulesAllowedTargets(final String defSetId,
@@ -377,12 +378,15 @@ public class CommonLookups {
                                                        pageSize);
         if (null != rules && !rules.isEmpty()) {
             final Set<String> result = new LinkedHashSet<>();
+            final Set<String> sourceDefLabels = getDefinitionLabels(sourceDefinition);
             for (final Rule rule : rules) {
                 final CanConnect cr = (CanConnect) rule;
                 final List<CanConnect.PermittedConnection> connections = cr.getPermittedConnections();
                 if (null != connections && !connections.isEmpty()) {
                     for (final CanConnect.PermittedConnection connection : connections) {
-                        result.add(connection.getEndRole());
+                        if (sourceDefLabels != null && sourceDefLabels.contains(connection.getStartRole())) {
+                            result.add(connection.getEndRole());
+                        }
                     }
                 }
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/util/CommonLookupsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/util/CommonLookupsTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.lookup.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetRuleAdapter;
+import org.kie.workbench.common.stunner.core.factory.graph.EdgeFactory;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.lookup.definition.DefinitionLookupManager;
+import org.kie.workbench.common.stunner.core.lookup.definition.DefinitionLookupManagerImpl;
+import org.kie.workbench.common.stunner.core.lookup.rule.RuleLookupManager;
+import org.kie.workbench.common.stunner.core.lookup.rule.RuleLookupManagerImpl;
+import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
+import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
+import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionRegistry;
+import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionSetRegistry;
+import org.kie.workbench.common.stunner.core.rule.EmptyRuleSet;
+import org.kie.workbench.common.stunner.core.rule.Rule;
+import org.kie.workbench.common.stunner.core.rule.RuleManager;
+import org.kie.workbench.common.stunner.core.rule.RuleSet;
+import org.kie.workbench.common.stunner.core.rule.RuleSetImpl;
+import org.kie.workbench.common.stunner.core.rule.impl.CanConnect;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommonLookupsTest {
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private TypeDefinitionSetRegistry typeDefinitionSetRegistry;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private DefinitionAdapter definitionAdapter;
+
+    @Mock
+    private DefinitionSetAdapter definitionSetAdapter;
+
+    @Mock
+    private DefinitionSetRuleAdapter definitionSetRuleAdapter;
+
+    @Mock
+    private RuleManager ruleManager;
+
+    @Mock
+    private FactoryManager factoryManager;
+
+    @Mock
+    private RegistryFactory registryFactory;
+
+    @Mock
+    private TypeDefinitionRegistry typeDefinitionRegistry;
+
+    @Mock
+    private DefinitionAdapter mockDefinitionAdaptor;
+
+    @Mock
+    private DefinitionAdapter mockConnectionAdaptor;
+
+    @Mock
+    private Graph graph;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private MockNodeContent nodeContent;
+
+    private RuleSet ruleSet;
+
+    private RuleLookupManager ruleLookupManager;
+
+    private DefinitionLookupManager definitionLookupManager;
+
+    private CommonLookups lookups;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        when(registryFactory.newDefinitionRegistry()).thenReturn(typeDefinitionRegistry);
+        when(typeDefinitionRegistry.getDefinitionById(eq(MockDefinition.class.getName()))).thenReturn(new MockDefinition());
+        when(typeDefinitionRegistry.getDefinitionById(eq(MockConnector.class.getName()))).thenReturn(new MockConnector());
+
+        this.ruleSet = new EmptyRuleSet();
+        this.ruleLookupManager = new RuleLookupManagerImpl(definitionManager);
+        this.definitionLookupManager = new DefinitionLookupManagerImpl(definitionManager,
+                                                                       factoryManager,
+                                                                       registryFactory);
+        this.lookups = new CommonLookups(definitionUtils,
+                                         ruleManager,
+                                         definitionLookupManager,
+                                         ruleLookupManager,
+                                         factoryManager);
+
+        when(node.getContent()).thenReturn(nodeContent);
+        when(nodeContent.getDefinition()).thenReturn(new MockDefinition());
+        when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
+        when(definitionManager.definitionSets()).thenReturn(typeDefinitionSetRegistry);
+        when(typeDefinitionSetRegistry.getDefinitionSetById(eq(MockDefinitionSet.class.getName()))).thenReturn(new MockDefinitionSet());
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.registry()).thenReturn(adapterRegistry);
+        when(adapterRegistry.getDefinitionSetRuleAdapter(eq(MockDefinitionSet.class))).thenReturn(definitionSetRuleAdapter);
+        when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
+        when(adapterManager.forRules()).thenReturn(definitionSetRuleAdapter);
+        when(adapterManager.forDefinitionSet()).thenReturn(definitionSetAdapter);
+        when(definitionSetAdapter.getDefinitions(any(MockDefinitionSet.class))).thenReturn(new HashSet<String>() {{
+            add(MockDefinition.class.getName());
+            add(MockConnector.class.getName());
+        }});
+
+        when(adapterRegistry.getDefinitionAdapter(eq(MockDefinition.class))).thenReturn(mockDefinitionAdaptor);
+        when(adapterRegistry.getDefinitionAdapter(eq(MockConnector.class))).thenReturn(mockConnectionAdaptor);
+        when(mockDefinitionAdaptor.getLabels(any(MockDefinition.class))).thenReturn(Collections.singleton("definition-role"));
+        when(mockConnectionAdaptor.getLabels(any(MockConnector.class))).thenReturn(Collections.singleton("connector-role"));
+        when(mockDefinitionAdaptor.getGraphFactoryType(any(MockDefinition.class))).thenReturn(NodeFactory.class);
+        when(mockConnectionAdaptor.getGraphFactoryType(any(MockConnector.class))).thenReturn(EdgeFactory.class);
+
+        when(graph.nodes()).thenReturn(Collections.emptyList());
+
+        when(factoryManager.newDefinition(eq(MockDefinition.class.getName()))).thenReturn(new MockDefinition());
+        when(factoryManager.newDefinition(eq(MockConnector.class.getName()))).thenReturn(new MockConnector());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkAllowedTargetDefinitionsWithPermittedConnectionRules() {
+        this.ruleSet = new RuleSetImpl("connection-rules",
+                                       new ArrayList<Rule>() {{
+                                           add(new CanConnect(MockConnector.class.getName(),
+                                                              MockConnector.class.getName(),
+                                                              new ArrayList<CanConnect.PermittedConnection>() {{
+                                                                  add(new CanConnect.PermittedConnection("definition-role",
+                                                                                                         "definition-role"));
+                                                              }}));
+                                       }});
+
+        when(definitionAdapter.getLabels(any(MockDefinition.class))).thenReturn(Collections.singleton("definition-role"));
+        when(definitionSetRuleAdapter.getRuleSet(any(MockDefinitionSet.class))).thenReturn(ruleSet);
+
+        final Set<Object> targetDefinitions = lookups.getAllowedTargetDefinitions(MockDefinitionSet.class.getName(),
+                                                                                  graph,
+                                                                                  node,
+                                                                                  MockConnector.class.getName(),
+                                                                                  0,
+                                                                                  10);
+        assertEquals(1,
+                     targetDefinitions.size());
+        assertTrue(targetDefinitions.iterator().next() instanceof MockDefinition);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkAllowedTargetDefinitionsWithNotPermittedStartConnectionRules() {
+        this.ruleSet = new RuleSetImpl("connection-rules",
+                                       new ArrayList<Rule>() {{
+                                           add(new CanConnect(MockConnector.class.getName(),
+                                                              MockConnector.class.getName(),
+                                                              new ArrayList<CanConnect.PermittedConnection>() {{
+                                                                  add(new CanConnect.PermittedConnection("not-permitted",
+                                                                                                         "definition-role"));
+                                                              }}));
+                                       }});
+
+        when(definitionAdapter.getLabels(any(MockDefinition.class))).thenReturn(Collections.singleton("definition-role"));
+        when(definitionSetRuleAdapter.getRuleSet(any(MockDefinitionSet.class))).thenReturn(ruleSet);
+
+        final Set<Object> targetDefinitions = lookups.getAllowedTargetDefinitions(MockDefinitionSet.class.getName(),
+                                                                                  graph,
+                                                                                  node,
+                                                                                  MockConnector.class.getName(),
+                                                                                  0,
+                                                                                  10);
+        assertTrue(targetDefinitions.isEmpty());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkAllowedTargetDefinitionsWithNotPermittedEndConnectionRules() {
+        this.ruleSet = new RuleSetImpl("connection-rules",
+                                       new ArrayList<Rule>() {{
+                                           add(new CanConnect(MockConnector.class.getName(),
+                                                              MockConnector.class.getName(),
+                                                              new ArrayList<CanConnect.PermittedConnection>() {{
+                                                                  add(new CanConnect.PermittedConnection("definition-role",
+                                                                                                         "not-permitted"));
+                                                              }}));
+                                       }});
+
+        when(definitionAdapter.getLabels(any(MockDefinition.class))).thenReturn(Collections.singleton("definition-role"));
+        when(definitionSetRuleAdapter.getRuleSet(any(MockDefinitionSet.class))).thenReturn(ruleSet);
+
+        final Set<Object> targetDefinitions = lookups.getAllowedTargetDefinitions(MockDefinitionSet.class.getName(),
+                                                                                  graph,
+                                                                                  node,
+                                                                                  MockConnector.class.getName(),
+                                                                                  0,
+                                                                                  10);
+        assertTrue(targetDefinitions.isEmpty());
+    }
+
+    private static class MockDefinitionSet {
+
+    }
+
+    private static class MockDefinition {
+
+    }
+
+    private static class MockNodeContent implements Definition<MockDefinition> {
+
+        private MockDefinition definition;
+
+        @Override
+        public MockDefinition getDefinition() {
+            return definition;
+        }
+
+        @Override
+        public void setDefinition(final MockDefinition definition) {
+            this.definition = definition;
+        }
+    }
+
+    private static class MockConnector {
+
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3220

@romartin This moves the fix for always using "default connector" in ```AddNodeCommand``` to ```master``` which also includes the fix to ```CommonLookups``` that did not check if an "allowed connection" (to a target node) originated from the "source node". 

It _might_ interfere with https://github.com/kiegroup/kie-wb-common/pull/948 as we;'ve both dabbled with ```AddNodeCommand```.