### PR TITLE
[Stunner] List of diagrams is not rendered correctly when first loading previews

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/diagrams/DiagramNavigatorItemImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/diagrams/DiagramNavigatorItemImpl.java
@@ -67,8 +67,14 @@ public class DiagramNavigatorItemImpl implements IsWidget,
                      final Command callback) {
         this.callback = callback;
         this.name = diagramRepresentation.getName();
-        view.setUUID(name)
-                .setItemTitle(diagramRepresentation.getTitle());
+        view.setUUID(name);
+        view.setItemTitle(diagramRepresentation.getTitle());
+
+        //Set size before Uri/data as we cannot scale until the image is loaded and it's real size known
+        view.setItemPxSize(widthInPx,
+                           heightInPx);
+
+        //Set Uri/data. Image's LoadHandler will set size requested above after image is loaded from Uri/data
         final String thumbData = diagramRepresentation.getThumbImageData();
         if (isEmpty(thumbData)) {
             final String defSetId = diagramRepresentation.getDefinitionSetId();
@@ -77,8 +83,6 @@ public class DiagramNavigatorItemImpl implements IsWidget,
         } else {
             view.setThumbData(thumbData);
         }
-        view.setItemPxSize(widthInPx,
-                           heightInPx);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/item/NavigatorThumbnailItemView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/item/NavigatorThumbnailItemView.java
@@ -127,19 +127,23 @@ public class NavigatorThumbnailItemView
     @Override
     public NavigatorThumbnailItemView setItemPxSize(final int width,
                                                     final int height) {
-        final int imgWidth = thumbImage.getWidth();
-        final int imgHeight = thumbImage.getHeight();
-        final float wfactor = imgWidth > width ? imgWidth / width : 1;
-        final float hfactor = imgHeight > height ? imgHeight / height : 1;
-        final float factor = wfactor >= hfactor ? wfactor : hfactor;
-        if (factor > 1) {
-            final int w = (int) Math.ceil(imgWidth / factor);
-            final int h = (int) Math.ceil(imgHeight / factor);
+        thumbImage.addLoadHandler((e) -> {
+            final int imgWidth = thumbImage.getWidth();
+            final int imgHeight = thumbImage.getHeight();
+            final float wfactor = imgWidth > width ? imgWidth / width : 1;
+            final float hfactor = imgHeight > height ? imgHeight / height : 1;
+            final float factor = wfactor >= hfactor ? wfactor : hfactor;
+            int w = width;
+            int h = height;
+            if (factor > 1) {
+                w = (int) Math.ceil(imgWidth / factor);
+                h = (int) Math.ceil(imgHeight / factor);
+            }
             thumbImage.setPixelSize(w,
                                     h);
-        }
-        body.setPixelSize(width,
-                          height);
+            body.setPixelSize(width,
+                              height);
+        });
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/diagrams/DiagramNavigatorItemImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/diagrams/DiagramNavigatorItemImplTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.explorer.navigator.diagrams;
+
+import com.google.gwt.safehtml.shared.SafeUri;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.explorer.navigator.NavigatorItem;
+import org.kie.workbench.common.stunner.client.widgets.explorer.navigator.NavigatorItemView;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.lookup.diagram.DiagramRepresentation;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DiagramNavigatorItemImplTest {
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private NavigatorItemView<NavigatorItem> view;
+
+    private DiagramNavigatorItemImpl diagramNavigatorItem;
+
+    @Before
+    public void setup() {
+        this.diagramNavigatorItem = new DiagramNavigatorItemImpl(shapeManager,
+                                                                 view);
+    }
+
+    @Test
+    public void checkSizeIsSetBeforeUriWhenShowing() {
+        final InOrder inOrder = inOrder(view,
+                                        view);
+
+        final SafeUri uri = mock(SafeUri.class);
+        final DiagramRepresentation diagramRepresentation = mock(DiagramRepresentation.class);
+        when(diagramRepresentation.getDefinitionSetId()).thenReturn("defId");
+        when(shapeManager.getThumbnail(eq("defId"))).thenReturn(uri);
+
+        when(diagramRepresentation.getThumbImageData()).thenReturn(null);
+
+        diagramNavigatorItem.show(diagramRepresentation,
+                                  100,
+                                  200,
+                                  () -> {
+                                  });
+
+        inOrder.verify(view).setItemPxSize(eq(100),
+                                           eq(200));
+        inOrder.verify(view).setThumbUri(eq(uri));
+    }
+
+    @Test
+    public void checkSizeIsSetBeforeDataWhenShowing() {
+        final InOrder inOrder = inOrder(view,
+                                        view);
+
+        final DiagramRepresentation diagramRepresentation = mock(DiagramRepresentation.class);
+        when(diagramRepresentation.getThumbImageData()).thenReturn("thumbData");
+
+        diagramNavigatorItem.show(diagramRepresentation,
+                                  100,
+                                  200,
+                                  () -> {
+                                  });
+
+        inOrder.verify(view).setItemPxSize(eq(100),
+                                           eq(200));
+        inOrder.verify(view).setThumbData(eq("thumbData"));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/item/NavigatorThumbnailItemViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/item/NavigatorThumbnailItemViewTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.explorer.navigator.item;
+
+import com.google.gwt.event.dom.client.LoadEvent;
+import com.google.gwt.event.dom.client.LoadHandler;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.Image;
+import org.gwtbootstrap3.client.ui.PanelBody;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.explorer.navigator.NavigatorItem;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NavigatorThumbnailItemViewTest {
+
+    @GwtMock
+    private Image thumbImage;
+
+    @GwtMock
+    private PanelBody body;
+
+    @Mock
+    private NavigatorItem presenter;
+
+    private NavigatorThumbnailItemView navigatorThumbnailItemView;
+
+    @Before
+    public void setup() {
+        this.navigatorThumbnailItemView = new NavigatorThumbnailItemView();
+        this.navigatorThumbnailItemView.init(presenter);
+    }
+
+    @Test
+    public void checkSetSizeAttachesLoadHandler() {
+        navigatorThumbnailItemView.setItemPxSize(100,
+                                                 200);
+
+        final ArgumentCaptor<LoadHandler> loadHandlerArgumentCaptor = ArgumentCaptor.forClass(LoadHandler.class);
+        when(thumbImage.getWidth()).thenReturn(100);
+        when(thumbImage.getHeight()).thenReturn(200);
+
+        verify(thumbImage).addLoadHandler(loadHandlerArgumentCaptor.capture());
+
+        final LoadHandler loadHandler = loadHandlerArgumentCaptor.getValue();
+        assertNotNull(loadHandler);
+
+        loadHandler.onLoad(mock(LoadEvent.class));
+
+        verify(body).setPixelSize(eq(100),
+                                  eq(200));
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3247

The problem was that the size was set before the browser had loaded the image and hence; on the "first view" the preview was not re-sized. However when it had loaded the ```Image``` in the ```DOM``` held the full size image. 