### PR TITLE
GUVNOR-3261: Wrong version pom.properties is contained in kjar

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/test/java/org/kie/workbench/common/screens/projecteditor/backend/server/ProjectScreenServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/test/java/org/kie/workbench/common/screens/projecteditor/backend/server/ProjectScreenServiceImplTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.projecteditor.model.ProjectScreenModel;
 import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
+import org.kie.workbench.common.services.backend.builder.core.LRUPomModelCache;
 import org.kie.workbench.common.services.shared.kmodule.KModuleModel;
 import org.kie.workbench.common.services.shared.kmodule.KModuleService;
 import org.kie.workbench.common.services.shared.project.KieProject;
@@ -128,617 +129,616 @@ public class ProjectScreenServiceImplTest {
     @Mock
     private CommentedOptionFactory commentedOptionFactory;
 
+    @Mock
+    private LRUPomModelCache pomModelCache;
+
     private ProjectScreenService service;
     private ProjectScreenModelLoader loader;
     private ProjectScreenModelSaver saver;
     private ProjectImports projectImports;
     private ProjectRepositories projectRepositories;
 
-    private GAV gav = new GAV( "org.test",
-                               "project-screen-test",
-                               "1.0.0" );
-    private POM pom = new POM( "test",
-                               "test",
-                               gav );
+    private GAV gav = new GAV("org.test",
+                              "project-screen-test",
+                              "1.0.0");
+    private POM pom = new POM("test",
+                              "test",
+                              gav);
 
     @BeforeClass
     public static void setupSystemProperties() {
         //These are not needed for the tests
-        System.setProperty( "org.uberfire.nio.git.daemon.enabled",
-                            "false" );
-        System.setProperty( "org.uberfire.nio.git.ssh.enabled",
-                            "false" );
-        System.setProperty( "org.uberfire.sys.repo.monitor.disabled",
-                            "true" );
+        System.setProperty("org.uberfire.nio.git.daemon.enabled",
+                           "false");
+        System.setProperty("org.uberfire.nio.git.ssh.enabled",
+                           "false");
+        System.setProperty("org.uberfire.sys.repo.monitor.disabled",
+                           "true");
     }
 
     @Before
     public void setup() {
         projectImports = new ProjectImports();
         projectRepositories = new ProjectRepositories();
-        loader = new ProjectScreenModelLoader( projectService,
-                                               pomService,
-                                               metadataService,
-                                               kModuleService,
-                                               importsService,
-                                               repositoriesService,
-                                               whiteListService ) {
+        loader = new ProjectScreenModelLoader(projectService,
+                                              pomService,
+                                              metadataService,
+                                              kModuleService,
+                                              importsService,
+                                              repositoriesService,
+                                              whiteListService) {
             @Override
-            protected boolean fileExists( final Path path ) {
+            protected boolean fileExists(final Path path) {
                 return true;
             }
         };
-        saver = new ProjectScreenModelSaver( pomService,
-                                             kModuleService,
-                                             importsService,
-                                             repositoriesService,
-                                             whiteListService,
-                                             ioService,
-                                             projectService,
-                                             repositoryResolver,
-                                             commentedOptionFactory );
-        service = new ProjectScreenServiceImpl( projectService,
-                                                loader,
-                                                saver );
+        saver = new ProjectScreenModelSaver(pomService,
+                                            kModuleService,
+                                            importsService,
+                                            repositoriesService,
+                                            whiteListService,
+                                            ioService,
+                                            projectService,
+                                            repositoryResolver,
+                                            commentedOptionFactory,
+                                            pomModelCache);
+        service = new ProjectScreenServiceImpl(projectService,
+                                               loader,
+                                               saver);
 
-        when( project.getKModuleXMLPath() ).thenReturn( pathToKieModule );
-        when( project.getImportsPath() ).thenReturn( pathToProjectImports );
-        when( project.getRepositoriesPath() ).thenReturn( pathToProjectRepositories );
-        when( project.getPom() ).thenReturn( pom );
+        when(project.getKModuleXMLPath()).thenReturn(pathToKieModule);
+        when(project.getImportsPath()).thenReturn(pathToProjectImports);
+        when(project.getRepositoriesPath()).thenReturn(pathToProjectRepositories);
+        when(project.getPom()).thenReturn(pom);
 
-        when( pathToPom.toURI() ).thenReturn( "default://project/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://project/pom.xml");
 
-        when( pomService.load( eq( pathToPom ) ) ).thenReturn( pom );
-        when( kModuleService.load( eq( pathToKieModule ) ) ).thenReturn( kmodule );
-        when( importsService.load( eq( pathToProjectImports ) ) ).thenReturn( projectImports );
-        when( repositoriesService.load( eq( pathToProjectRepositories ) ) ).thenReturn( projectRepositories );
+        when(pomService.load(eq(pathToPom))).thenReturn(pom);
+        when(kModuleService.load(eq(pathToKieModule))).thenReturn(kmodule);
+        when(importsService.load(eq(pathToProjectImports))).thenReturn(projectImports);
+        when(repositoriesService.load(eq(pathToProjectRepositories))).thenReturn(projectRepositories);
 
-        when( projectService.resolveProject( eq( pathToPom ) ) ).thenReturn( project );
+        when(projectService.resolveProject(eq(pathToPom))).thenReturn(project);
 
-        when( metadataService.getMetadata( eq( pathToPom ) ) ).thenReturn( pomMetaData );
-        when( metadataService.getMetadata( eq( pathToKieModule ) ) ).thenReturn( kmoduleMetaData );
-        when( metadataService.getMetadata( eq( pathToProjectImports ) ) ).thenReturn( projectImportsMetaData );
+        when(metadataService.getMetadata(eq(pathToPom))).thenReturn(pomMetaData);
+        when(metadataService.getMetadata(eq(pathToKieModule))).thenReturn(kmoduleMetaData);
+        when(metadataService.getMetadata(eq(pathToProjectImports))).thenReturn(projectImportsMetaData);
     }
 
     @Test
     public void testLoad() throws Exception {
-        final ProjectScreenModel model = service.load( pathToPom );
+        final ProjectScreenModel model = service.load(pathToPom);
 
-        assertEquals( pom,
-                      model.getPOM() );
-        assertEquals( pomMetaData,
-                      model.getPOMMetaData() );
-        assertEquals( pathToPom,
-                      model.getPathToPOM() );
+        assertEquals(pom,
+                     model.getPOM());
+        assertEquals(pomMetaData,
+                     model.getPOMMetaData());
+        assertEquals(pathToPom,
+                     model.getPathToPOM());
 
-        assertEquals( kmodule,
-                      model.getKModule() );
-        assertEquals( kmoduleMetaData,
-                      model.getKModuleMetaData() );
-        assertEquals( pathToKieModule,
-                      model.getPathToKModule() );
+        assertEquals(kmodule,
+                     model.getKModule());
+        assertEquals(kmoduleMetaData,
+                     model.getKModuleMetaData());
+        assertEquals(pathToKieModule,
+                     model.getPathToKModule());
 
-        assertEquals( projectImports,
-                      model.getProjectImports() );
-        assertEquals( projectImportsMetaData,
-                      model.getProjectImportsMetaData() );
-        assertEquals( pathToProjectImports,
-                      model.getPathToImports() );
+        assertEquals(projectImports,
+                     model.getProjectImports());
+        assertEquals(projectImportsMetaData,
+                     model.getProjectImportsMetaData());
+        assertEquals(pathToProjectImports,
+                     model.getPathToImports());
 
-        assertEquals( projectRepositories,
-                      model.getRepositories() );
-        assertEquals( pathToProjectRepositories,
-                      model.getPathToRepositories() );
+        assertEquals(projectRepositories,
+                     model.getRepositories());
+        assertEquals(pathToProjectRepositories,
+                     model.getPathToRepositories());
 
-        verify( pomService,
-                times( 1 ) ).load( eq( pathToPom ) );
-        verify( metadataService,
-                times( 1 ) ).getMetadata( eq( pathToPom ) );
-        verify( projectService,
-                times( 1 ) ).resolveProject( eq( pathToPom ) );
+        verify(pomService,
+               times(1)).load(eq(pathToPom));
+        verify(metadataService,
+               times(1)).getMetadata(eq(pathToPom));
+        verify(projectService,
+               times(1)).resolveProject(eq(pathToPom));
 
-        verify( kModuleService,
-                times( 1 ) ).load( eq( pathToKieModule ) );
-        verify( metadataService,
-                times( 1 ) ).getMetadata( eq( pathToKieModule ) );
+        verify(kModuleService,
+               times(1)).load(eq(pathToKieModule));
+        verify(metadataService,
+               times(1)).getMetadata(eq(pathToKieModule));
 
-        verify( importsService,
-                times( 1 ) ).load( eq( pathToProjectImports ) );
-        verify( metadataService,
-                times( 1 ) ).getMetadata( eq( pathToProjectImports ) );
+        verify(importsService,
+               times(1)).load(eq(pathToProjectImports));
+        verify(metadataService,
+               times(1)).getMetadata(eq(pathToProjectImports));
 
-        verify( repositoriesService,
-                times( 1 ) ).load( eq( pathToProjectRepositories ) );
+        verify(repositoriesService,
+               times(1)).load(eq(pathToProjectRepositories));
     }
 
     @Test
     public void testSaveNonClashingGAVChangeToGAV() {
-        when( pathToPom.toURI() ).thenReturn( "default://p0/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://p0/pom.xml");
 
         final ProjectScreenModel model = new ProjectScreenModel();
-        model.setPOM( new POM( new GAV( "groupId",
-                                        "artifactId",
-                                        "2.0.0" ) ) );
-        model.setPOMMetaData( pomMetaData );
-        model.setPathToPOM( pathToPom );
+        model.setPOM(new POM(new GAV("groupId",
+                                     "artifactId",
+                                     "2.0.0")));
+        model.setPOMMetaData(pomMetaData);
+        model.setPathToPOM(pathToPom);
 
-        model.setKModule( kmodule );
-        model.setKModuleMetaData( kmoduleMetaData );
-        model.setPathToKModule( pathToKieModule );
+        model.setKModule(kmodule);
+        model.setKModuleMetaData(kmoduleMetaData);
+        model.setPathToKModule(pathToKieModule);
 
-        model.setProjectImports( projectImports );
-        model.setProjectImportsMetaData( projectImportsMetaData );
-        model.setPathToImports( pathToProjectImports );
+        model.setProjectImports(projectImports);
+        model.setProjectImportsMetaData(projectImportsMetaData);
+        model.setPathToImports(pathToProjectImports);
 
-        model.setRepositories( projectRepositories );
-        model.setPathToRepositories( pathToProjectRepositories );
+        model.setRepositories(projectRepositories);
+        model.setPathToRepositories(pathToProjectRepositories);
 
         final String comment = "comment";
 
-        service.save( pathToPom,
-                      model,
-                      comment );
+        service.save(pathToPom,
+                     model,
+                     comment);
 
-        verify( repositoryResolver,
-                times( 1 ) ).getRepositoriesResolvingArtifact( eq( model.getPOM().getGav() ),
-                                                               eq( project ) );
+        verify(repositoryResolver,
+               times(1)).getRepositoriesResolvingArtifact(eq(model.getPOM().getGav()),
+                                                          eq(project));
 
-        verify( ioService,
-                times( 1 ) ).startBatch( any( FileSystem.class ),
-                                         any( CommentedOption.class ) );
-        verify( pomService,
-                times( 1 ) ).save( eq( pathToPom ),
-                                   eq( model.getPOM() ),
-                                   eq( pomMetaData ),
-                                   eq( comment ) );
-        verify( kModuleService,
-                times( 1 ) ).save( eq( pathToKieModule ),
-                                   eq( kmodule ),
-                                   eq( kmoduleMetaData ),
-                                   eq( comment ) );
-        verify( importsService,
-                times( 1 ) ).save( eq( pathToProjectImports ),
-                                   eq( projectImports ),
-                                   eq( projectImportsMetaData ),
-                                   eq( comment ) );
-        verify( repositoriesService,
-                times( 1 ) ).save( eq( pathToProjectRepositories ),
-                                   eq( projectRepositories ),
-                                   eq( comment ) );
-        verify( ioService,
-                times( 1 ) ).endBatch();
+        verify(ioService,
+               times(1)).startBatch(any(FileSystem.class),
+                                    any(CommentedOption.class));
+        verify(pomService,
+               times(1)).save(eq(pathToPom),
+                              eq(model.getPOM()),
+                              eq(pomMetaData),
+                              eq(comment));
+        verify(kModuleService,
+               times(1)).save(eq(pathToKieModule),
+                              eq(kmodule),
+                              eq(kmoduleMetaData),
+                              eq(comment));
+        verify(importsService,
+               times(1)).save(eq(pathToProjectImports),
+                              eq(projectImports),
+                              eq(projectImportsMetaData),
+                              eq(comment));
+        verify(repositoriesService,
+               times(1)).save(eq(pathToProjectRepositories),
+                              eq(projectRepositories),
+                              eq(comment));
+        verify(ioService,
+               times(1)).endBatch();
     }
 
     @Test
     public void testSaveNonClashingGAVNoChangeToGAV() {
-        when( pathToPom.toURI() ).thenReturn( "default://p0/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://p0/pom.xml");
 
         final ProjectScreenModel model = new ProjectScreenModel();
-        model.setPOM( pom );
-        model.setPOMMetaData( pomMetaData );
-        model.setPathToPOM( pathToPom );
+        model.setPOM(pom);
+        model.setPOMMetaData(pomMetaData);
+        model.setPathToPOM(pathToPom);
 
-        model.setKModule( kmodule );
-        model.setKModuleMetaData( kmoduleMetaData );
-        model.setPathToKModule( pathToKieModule );
+        model.setKModule(kmodule);
+        model.setKModuleMetaData(kmoduleMetaData);
+        model.setPathToKModule(pathToKieModule);
 
-        model.setProjectImports( projectImports );
-        model.setProjectImportsMetaData( projectImportsMetaData );
-        model.setPathToImports( pathToProjectImports );
+        model.setProjectImports(projectImports);
+        model.setProjectImportsMetaData(projectImportsMetaData);
+        model.setPathToImports(pathToProjectImports);
 
-        model.setRepositories( projectRepositories );
-        model.setPathToRepositories( pathToProjectRepositories );
+        model.setRepositories(projectRepositories);
+        model.setPathToRepositories(pathToProjectRepositories);
 
         final String comment = "comment";
 
-        service.save( pathToPom,
-                      model,
-                      comment );
+        service.save(pathToPom,
+                     model,
+                     comment);
 
-        verify( repositoryResolver,
-                never() ).getRepositoriesResolvingArtifact( eq( model.getPOM().getGav() ),
-                                                            eq( project ) );
+        verify(repositoryResolver,
+               never()).getRepositoriesResolvingArtifact(eq(model.getPOM().getGav()),
+                                                         eq(project));
 
-        verify( ioService,
-                times( 1 ) ).startBatch( any( FileSystem.class ),
-                                         any( CommentedOption.class ) );
-        verify( pomService,
-                times( 1 ) ).save( eq( pathToPom ),
-                                   eq( model.getPOM() ),
-                                   eq( pomMetaData ),
-                                   eq( comment ) );
-        verify( kModuleService,
-                times( 1 ) ).save( eq( pathToKieModule ),
-                                   eq( kmodule ),
-                                   eq( kmoduleMetaData ),
-                                   eq( comment ) );
-        verify( importsService,
-                times( 1 ) ).save( eq( pathToProjectImports ),
-                                   eq( projectImports ),
-                                   eq( projectImportsMetaData ),
-                                   eq( comment ) );
-        verify( repositoriesService,
-                times( 1 ) ).save( eq( pathToProjectRepositories ),
-                                   eq( projectRepositories ),
-                                   eq( comment ) );
-        verify( ioService,
-                times( 1 ) ).endBatch();
+        verify(ioService,
+               times(1)).startBatch(any(FileSystem.class),
+                                    any(CommentedOption.class));
+        verify(pomService,
+               times(1)).save(eq(pathToPom),
+                              eq(model.getPOM()),
+                              eq(pomMetaData),
+                              eq(comment));
+        verify(kModuleService,
+               times(1)).save(eq(pathToKieModule),
+                              eq(kmodule),
+                              eq(kmoduleMetaData),
+                              eq(comment));
+        verify(importsService,
+               times(1)).save(eq(pathToProjectImports),
+                              eq(projectImports),
+                              eq(projectImportsMetaData),
+                              eq(comment));
+        verify(repositoriesService,
+               times(1)).save(eq(pathToProjectRepositories),
+                              eq(projectRepositories),
+                              eq(comment));
+        verify(ioService,
+               times(1)).endBatch();
     }
 
     @Test()
     public void testSaveClashingGAVChangeToGAV() {
-        when( pathToPom.toURI() ).thenReturn( "default://p0/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://p0/pom.xml");
 
         final ProjectScreenModel model = new ProjectScreenModel();
-        model.setPOM( new POM( new GAV( "groupId",
-                                        "artifactId",
-                                        "2.0.0" ) ) );
-        model.setPOMMetaData( pomMetaData );
-        model.setPathToPOM( pathToPom );
+        model.setPOM(new POM(new GAV("groupId",
+                                     "artifactId",
+                                     "2.0.0")));
+        model.setPOMMetaData(pomMetaData);
+        model.setPathToPOM(pathToPom);
 
-        model.setKModule( kmodule );
-        model.setKModuleMetaData( kmoduleMetaData );
-        model.setPathToKModule( pathToKieModule );
+        model.setKModule(kmodule);
+        model.setKModuleMetaData(kmoduleMetaData);
+        model.setPathToKModule(pathToKieModule);
 
-        model.setProjectImports( projectImports );
-        model.setProjectImportsMetaData( projectImportsMetaData );
-        model.setPathToImports( pathToProjectImports );
+        model.setProjectImports(projectImports);
+        model.setProjectImportsMetaData(projectImportsMetaData);
+        model.setPathToImports(pathToProjectImports);
 
-        model.setRepositories( projectRepositories );
-        model.setPathToRepositories( pathToProjectRepositories );
+        model.setRepositories(projectRepositories);
+        model.setPathToRepositories(pathToProjectRepositories);
 
-        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata( "id",
-                                                                                        "url",
-                                                                                        MavenRepositorySource.LOCAL );
+        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata("id",
+                                                                                       "url",
+                                                                                       MavenRepositorySource.LOCAL);
 
-        projectRepositories.getRepositories().add( new ProjectRepositories.ProjectRepository( true,
-                                                                                              repositoryMetadata ) );
+        projectRepositories.getRepositories().add(new ProjectRepositories.ProjectRepository(true,
+                                                                                            repositoryMetadata));
 
-        when( repositoryResolver.getRepositoriesResolvingArtifact( eq( gav ),
-                                                                   eq( project ),
-                                                                   eq( repositoryMetadata ) ) ).thenReturn( new HashSet<MavenRepositoryMetadata>() {{
-            add( repositoryMetadata );
-        }} );
+        when(repositoryResolver.getRepositoriesResolvingArtifact(eq(gav),
+                                                                 eq(project),
+                                                                 eq(repositoryMetadata))).thenReturn(new HashSet<MavenRepositoryMetadata>() {{
+            add(repositoryMetadata);
+        }});
 
         final String comment = "comment";
 
         try {
-            service.save( pathToPom,
-                          model,
-                          comment );
-
-        } catch ( GAVAlreadyExistsException e ) {
+            service.save(pathToPom,
+                         model,
+                         comment);
+        } catch (GAVAlreadyExistsException e) {
             // This is expected! We catch here rather than let JUnit handle it with
             // @Test(expected = GAVAlreadyExistsException.class) so we can verify
             // that only the expected methods have been invoked.
 
-        } catch ( Exception e ) {
-            fail( e.getMessage() );
+        } catch (Exception e) {
+            fail(e.getMessage());
         }
 
-        verify( repositoryResolver,
-                times( 1 ) ).getRepositoriesResolvingArtifact( eq( model.getPOM().getGav() ),
-                                                               eq( project ),
-                                                               any( MavenRepositoryMetadata.class ) );
+        verify(repositoryResolver,
+               times(1)).getRepositoriesResolvingArtifact(eq(model.getPOM().getGav()),
+                                                          eq(project),
+                                                          any(MavenRepositoryMetadata.class));
 
-        verify( pomService,
-                times( 1 ) ).save( eq( pathToPom ),
-                                   eq( model.getPOM() ),
-                                   eq( pomMetaData ),
-                                   eq( comment ) );
-        verify( kModuleService,
-                times( 1 ) ).save( eq( pathToKieModule ),
-                                   eq( kmodule ),
-                                   eq( kmoduleMetaData ),
-                                   eq( comment ) );
-        verify( importsService,
-                times( 1 ) ).save( eq( pathToProjectImports ),
-                                   eq( projectImports ),
-                                   eq( projectImportsMetaData ),
-                                   eq( comment ) );
-        verify( repositoriesService,
-                times( 1 ) ).save( eq( pathToProjectRepositories ),
-                                   eq( projectRepositories ),
-                                   eq( comment ) );
+        verify(pomService,
+               times(1)).save(eq(pathToPom),
+                              eq(model.getPOM()),
+                              eq(pomMetaData),
+                              eq(comment));
+        verify(kModuleService,
+               times(1)).save(eq(pathToKieModule),
+                              eq(kmodule),
+                              eq(kmoduleMetaData),
+                              eq(comment));
+        verify(importsService,
+               times(1)).save(eq(pathToProjectImports),
+                              eq(projectImports),
+                              eq(projectImportsMetaData),
+                              eq(comment));
+        verify(repositoriesService,
+               times(1)).save(eq(pathToProjectRepositories),
+                              eq(projectRepositories),
+                              eq(comment));
     }
 
     @Test()
     public void testSaveClashingGAVNoChangeToGAV() {
-        when( pathToPom.toURI() ).thenReturn( "default://p0/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://p0/pom.xml");
 
         final ProjectScreenModel model = new ProjectScreenModel();
-        model.setPOM( pom );
-        model.setPOMMetaData( pomMetaData );
-        model.setPathToPOM( pathToPom );
+        model.setPOM(pom);
+        model.setPOMMetaData(pomMetaData);
+        model.setPathToPOM(pathToPom);
 
-        model.setKModule( kmodule );
-        model.setKModuleMetaData( kmoduleMetaData );
-        model.setPathToKModule( pathToKieModule );
+        model.setKModule(kmodule);
+        model.setKModuleMetaData(kmoduleMetaData);
+        model.setPathToKModule(pathToKieModule);
 
-        model.setProjectImports( projectImports );
-        model.setProjectImportsMetaData( projectImportsMetaData );
-        model.setPathToImports( pathToProjectImports );
+        model.setProjectImports(projectImports);
+        model.setProjectImportsMetaData(projectImportsMetaData);
+        model.setPathToImports(pathToProjectImports);
 
-        model.setRepositories( projectRepositories );
-        model.setPathToRepositories( pathToProjectRepositories );
+        model.setRepositories(projectRepositories);
+        model.setPathToRepositories(pathToProjectRepositories);
 
-        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata( "id",
-                                                                                        "url",
-                                                                                        MavenRepositorySource.LOCAL );
+        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata("id",
+                                                                                       "url",
+                                                                                       MavenRepositorySource.LOCAL);
 
-        projectRepositories.getRepositories().add( new ProjectRepositories.ProjectRepository( true,
-                                                                                              repositoryMetadata ) );
+        projectRepositories.getRepositories().add(new ProjectRepositories.ProjectRepository(true,
+                                                                                            repositoryMetadata));
 
-        when( repositoryResolver.getRepositoriesResolvingArtifact( eq( gav ),
-                                                                   eq( project ),
-                                                                   eq( repositoryMetadata ) ) ).thenReturn( new HashSet<MavenRepositoryMetadata>() {{
-            add( repositoryMetadata );
-        }} );
+        when(repositoryResolver.getRepositoriesResolvingArtifact(eq(gav),
+                                                                 eq(project),
+                                                                 eq(repositoryMetadata))).thenReturn(new HashSet<MavenRepositoryMetadata>() {{
+            add(repositoryMetadata);
+        }});
 
         final String comment = "comment";
 
         try {
-            service.save( pathToPom,
-                          model,
-                          comment );
-
-        } catch ( GAVAlreadyExistsException e ) {
-            fail( e.getMessage() );
+            service.save(pathToPom,
+                         model,
+                         comment);
+        } catch (GAVAlreadyExistsException e) {
+            fail(e.getMessage());
         }
 
-        verify( repositoryResolver,
-                never() ).getRepositoriesResolvingArtifact( eq( model.getPOM().getGav() ),
-                                                            eq( project ) );
+        verify(repositoryResolver,
+               never()).getRepositoriesResolvingArtifact(eq(model.getPOM().getGav()),
+                                                         eq(project));
 
-        verify( pomService,
-                times( 1 ) ).save( eq( pathToPom ),
-                                   eq( model.getPOM() ),
-                                   eq( pomMetaData ),
-                                   eq( comment ) );
-        verify( kModuleService,
-                times( 1 ) ).save( eq( pathToKieModule ),
-                                   eq( kmodule ),
-                                   eq( kmoduleMetaData ),
-                                   eq( comment ) );
-        verify( importsService,
-                times( 1 ) ).save( eq( pathToProjectImports ),
-                                   eq( projectImports ),
-                                   eq( projectImportsMetaData ),
-                                   eq( comment ) );
-        verify( repositoriesService,
-                times( 1 ) ).save( eq( pathToProjectRepositories ),
-                                   eq( projectRepositories ),
-                                   eq( comment ) );
+        verify(pomService,
+               times(1)).save(eq(pathToPom),
+                              eq(model.getPOM()),
+                              eq(pomMetaData),
+                              eq(comment));
+        verify(kModuleService,
+               times(1)).save(eq(pathToKieModule),
+                              eq(kmodule),
+                              eq(kmoduleMetaData),
+                              eq(comment));
+        verify(importsService,
+               times(1)).save(eq(pathToProjectImports),
+                              eq(projectImports),
+                              eq(projectImportsMetaData),
+                              eq(comment));
+        verify(repositoriesService,
+               times(1)).save(eq(pathToProjectRepositories),
+                              eq(projectRepositories),
+                              eq(comment));
     }
 
     @Test()
     public void testSaveClashingGAVFilteredRepositoryChangeToGAV() {
-        when( pathToPom.toURI() ).thenReturn( "default://p0/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://p0/pom.xml");
 
         final ProjectScreenModel model = new ProjectScreenModel();
-        model.setPOM( new POM( new GAV( "groupId",
-                                        "artifactId",
-                                        "2.0.0" ) ) );
-        model.setPOMMetaData( pomMetaData );
-        model.setPathToPOM( pathToPom );
+        model.setPOM(new POM(new GAV("groupId",
+                                     "artifactId",
+                                     "2.0.0")));
+        model.setPOMMetaData(pomMetaData);
+        model.setPathToPOM(pathToPom);
 
-        model.setKModule( kmodule );
-        model.setKModuleMetaData( kmoduleMetaData );
-        model.setPathToKModule( pathToKieModule );
+        model.setKModule(kmodule);
+        model.setKModuleMetaData(kmoduleMetaData);
+        model.setPathToKModule(pathToKieModule);
 
-        model.setProjectImports( projectImports );
-        model.setProjectImportsMetaData( projectImportsMetaData );
-        model.setPathToImports( pathToProjectImports );
+        model.setProjectImports(projectImports);
+        model.setProjectImportsMetaData(projectImportsMetaData);
+        model.setPathToImports(pathToProjectImports);
 
-        model.setRepositories( projectRepositories );
-        model.setPathToRepositories( pathToProjectRepositories );
+        model.setRepositories(projectRepositories);
+        model.setPathToRepositories(pathToProjectRepositories);
 
-        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata( "id",
-                                                                                        "url",
-                                                                                        MavenRepositorySource.LOCAL );
+        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata("id",
+                                                                                       "url",
+                                                                                       MavenRepositorySource.LOCAL);
 
-        projectRepositories.getRepositories().add( new ProjectRepositories.ProjectRepository( false,
-                                                                                              repositoryMetadata ) );
+        projectRepositories.getRepositories().add(new ProjectRepositories.ProjectRepository(false,
+                                                                                            repositoryMetadata));
 
-        final ArgumentCaptor<MavenRepositoryMetadata> filterCaptor = ArgumentCaptor.forClass( MavenRepositoryMetadata.class );
-        when( repositoryResolver.getRepositoriesResolvingArtifact( eq( gav ),
-                                                                   eq( project ),
-                                                                   filterCaptor.capture() ) ).thenReturn( new HashSet<MavenRepositoryMetadata>() );
+        final ArgumentCaptor<MavenRepositoryMetadata> filterCaptor = ArgumentCaptor.forClass(MavenRepositoryMetadata.class);
+        when(repositoryResolver.getRepositoriesResolvingArtifact(eq(gav),
+                                                                 eq(project),
+                                                                 filterCaptor.capture())).thenReturn(new HashSet<MavenRepositoryMetadata>());
 
         final String comment = "comment";
 
         try {
-            service.save( pathToPom,
-                          model,
-                          comment );
-
-        } catch ( GAVAlreadyExistsException e ) {
+            service.save(pathToPom,
+                         model,
+                         comment);
+        } catch (GAVAlreadyExistsException e) {
             //This should not be thrown if we're filtering out the Repository from the check
-            fail( e.getMessage() );
+            fail(e.getMessage());
         }
 
         final List<MavenRepositoryMetadata> filter = filterCaptor.getAllValues();
-        assertEquals( 0,
-                      filter.size() );
+        assertEquals(0,
+                     filter.size());
 
-        verify( repositoryResolver,
-                times( 1 ) ).getRepositoriesResolvingArtifact( eq( model.getPOM().getGav() ),
-                                                               eq( project ) );
+        verify(repositoryResolver,
+               times(1)).getRepositoriesResolvingArtifact(eq(model.getPOM().getGav()),
+                                                          eq(project));
 
-        verify( ioService,
-                times( 1 ) ).startBatch( any( FileSystem.class ),
-                                         any( CommentedOption.class ) );
-        verify( pomService,
-                times( 1 ) ).save( eq( pathToPom ),
-                                   eq( model.getPOM() ),
-                                   eq( pomMetaData ),
-                                   eq( comment ) );
-        verify( kModuleService,
-                times( 1 ) ).save( eq( pathToKieModule ),
-                                   eq( kmodule ),
-                                   eq( kmoduleMetaData ),
-                                   eq( comment ) );
-        verify( importsService,
-                times( 1 ) ).save( eq( pathToProjectImports ),
-                                   eq( projectImports ),
-                                   eq( projectImportsMetaData ),
-                                   eq( comment ) );
-        verify( repositoriesService,
-                times( 1 ) ).save( eq( pathToProjectRepositories ),
-                                   eq( projectRepositories ),
-                                   eq( comment ) );
-        verify( ioService,
-                times( 1 ) ).endBatch();
+        verify(ioService,
+               times(1)).startBatch(any(FileSystem.class),
+                                    any(CommentedOption.class));
+        verify(pomService,
+               times(1)).save(eq(pathToPom),
+                              eq(model.getPOM()),
+                              eq(pomMetaData),
+                              eq(comment));
+        verify(kModuleService,
+               times(1)).save(eq(pathToKieModule),
+                              eq(kmodule),
+                              eq(kmoduleMetaData),
+                              eq(comment));
+        verify(importsService,
+               times(1)).save(eq(pathToProjectImports),
+                              eq(projectImports),
+                              eq(projectImportsMetaData),
+                              eq(comment));
+        verify(repositoriesService,
+               times(1)).save(eq(pathToProjectRepositories),
+                              eq(projectRepositories),
+                              eq(comment));
+        verify(ioService,
+               times(1)).endBatch();
     }
 
     @Test()
     public void testSaveClashingGAVFilteredRepositoryNoChangeToGAV() {
-        when( pathToPom.toURI() ).thenReturn( "default://p0/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://p0/pom.xml");
 
         final ProjectScreenModel model = new ProjectScreenModel();
-        model.setPOM( pom );
-        model.setPOMMetaData( pomMetaData );
-        model.setPathToPOM( pathToPom );
+        model.setPOM(pom);
+        model.setPOMMetaData(pomMetaData);
+        model.setPathToPOM(pathToPom);
 
-        model.setKModule( kmodule );
-        model.setKModuleMetaData( kmoduleMetaData );
-        model.setPathToKModule( pathToKieModule );
+        model.setKModule(kmodule);
+        model.setKModuleMetaData(kmoduleMetaData);
+        model.setPathToKModule(pathToKieModule);
 
-        model.setProjectImports( projectImports );
-        model.setProjectImportsMetaData( projectImportsMetaData );
-        model.setPathToImports( pathToProjectImports );
+        model.setProjectImports(projectImports);
+        model.setProjectImportsMetaData(projectImportsMetaData);
+        model.setPathToImports(pathToProjectImports);
 
-        model.setRepositories( projectRepositories );
-        model.setPathToRepositories( pathToProjectRepositories );
+        model.setRepositories(projectRepositories);
+        model.setPathToRepositories(pathToProjectRepositories);
 
-        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata( "id",
-                                                                                        "url",
-                                                                                        MavenRepositorySource.LOCAL );
+        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata("id",
+                                                                                       "url",
+                                                                                       MavenRepositorySource.LOCAL);
 
-        projectRepositories.getRepositories().add( new ProjectRepositories.ProjectRepository( false,
-                                                                                              repositoryMetadata ) );
+        projectRepositories.getRepositories().add(new ProjectRepositories.ProjectRepository(false,
+                                                                                            repositoryMetadata));
 
-        final ArgumentCaptor<MavenRepositoryMetadata> filterCaptor = ArgumentCaptor.forClass( MavenRepositoryMetadata.class );
-        when( repositoryResolver.getRepositoriesResolvingArtifact( eq( gav ),
-                                                                   eq( project ),
-                                                                   filterCaptor.capture() ) ).thenReturn( new HashSet<MavenRepositoryMetadata>() );
+        final ArgumentCaptor<MavenRepositoryMetadata> filterCaptor = ArgumentCaptor.forClass(MavenRepositoryMetadata.class);
+        when(repositoryResolver.getRepositoriesResolvingArtifact(eq(gav),
+                                                                 eq(project),
+                                                                 filterCaptor.capture())).thenReturn(new HashSet<MavenRepositoryMetadata>());
 
         final String comment = "comment";
 
         try {
-            service.save( pathToPom,
-                          model,
-                          comment );
-
-        } catch ( GAVAlreadyExistsException e ) {
+            service.save(pathToPom,
+                         model,
+                         comment);
+        } catch (GAVAlreadyExistsException e) {
             //This should not be thrown if we're filtering out the Repository from the check
-            fail( e.getMessage() );
+            fail(e.getMessage());
         }
 
         final List<MavenRepositoryMetadata> filter = filterCaptor.getAllValues();
-        assertEquals( 0,
-                      filter.size() );
+        assertEquals(0,
+                     filter.size());
 
-        verify( repositoryResolver,
-                never() ).getRepositoriesResolvingArtifact( eq( model.getPOM().getGav() ),
-                                                            eq( project ) );
+        verify(repositoryResolver,
+               never()).getRepositoriesResolvingArtifact(eq(model.getPOM().getGav()),
+                                                         eq(project));
 
-        verify( ioService,
-                times( 1 ) ).startBatch( any( FileSystem.class ),
-                                         any( CommentedOption.class ) );
-        verify( pomService,
-                times( 1 ) ).save( eq( pathToPom ),
-                                   eq( model.getPOM() ),
-                                   eq( pomMetaData ),
-                                   eq( comment ) );
-        verify( kModuleService,
-                times( 1 ) ).save( eq( pathToKieModule ),
-                                   eq( kmodule ),
-                                   eq( kmoduleMetaData ),
-                                   eq( comment ) );
-        verify( importsService,
-                times( 1 ) ).save( eq( pathToProjectImports ),
-                                   eq( projectImports ),
-                                   eq( projectImportsMetaData ),
-                                   eq( comment ) );
-        verify( repositoriesService,
-                times( 1 ) ).save( eq( pathToProjectRepositories ),
-                                   eq( projectRepositories ),
-                                   eq( comment ) );
-        verify( ioService,
-                times( 1 ) ).endBatch();
+        verify(ioService,
+               times(1)).startBatch(any(FileSystem.class),
+                                    any(CommentedOption.class));
+        verify(pomService,
+               times(1)).save(eq(pathToPom),
+                              eq(model.getPOM()),
+                              eq(pomMetaData),
+                              eq(comment));
+        verify(kModuleService,
+               times(1)).save(eq(pathToKieModule),
+                              eq(kmodule),
+                              eq(kmoduleMetaData),
+                              eq(comment));
+        verify(importsService,
+               times(1)).save(eq(pathToProjectImports),
+                              eq(projectImports),
+                              eq(projectImportsMetaData),
+                              eq(comment));
+        verify(repositoriesService,
+               times(1)).save(eq(pathToProjectRepositories),
+                              eq(projectRepositories),
+                              eq(comment));
+        verify(ioService,
+               times(1)).endBatch();
     }
 
     @Test()
     public void testSaveClashingGAVForced() {
-        when( pathToPom.toURI() ).thenReturn( "default://p0/pom.xml" );
+        when(pathToPom.toURI()).thenReturn("default://p0/pom.xml");
 
         final ProjectScreenModel model = new ProjectScreenModel();
-        model.setPOM( pom );
-        model.setPOMMetaData( pomMetaData );
-        model.setPathToPOM( pathToPom );
+        model.setPOM(pom);
+        model.setPOMMetaData(pomMetaData);
+        model.setPathToPOM(pathToPom);
 
-        model.setKModule( kmodule );
-        model.setKModuleMetaData( kmoduleMetaData );
-        model.setPathToKModule( pathToKieModule );
+        model.setKModule(kmodule);
+        model.setKModuleMetaData(kmoduleMetaData);
+        model.setPathToKModule(pathToKieModule);
 
-        model.setProjectImports( projectImports );
-        model.setProjectImportsMetaData( projectImportsMetaData );
-        model.setPathToImports( pathToProjectImports );
+        model.setProjectImports(projectImports);
+        model.setProjectImportsMetaData(projectImportsMetaData);
+        model.setPathToImports(pathToProjectImports);
 
-        model.setRepositories( projectRepositories );
-        model.setPathToRepositories( pathToProjectRepositories );
+        model.setRepositories(projectRepositories);
+        model.setPathToRepositories(pathToProjectRepositories);
 
-        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata( "id",
-                                                                                        "url",
-                                                                                        MavenRepositorySource.LOCAL );
+        final MavenRepositoryMetadata repositoryMetadata = new MavenRepositoryMetadata("id",
+                                                                                       "url",
+                                                                                       MavenRepositorySource.LOCAL);
 
-        projectRepositories.getRepositories().add( new ProjectRepositories.ProjectRepository( true,
-                                                                                              repositoryMetadata ) );
+        projectRepositories.getRepositories().add(new ProjectRepositories.ProjectRepository(true,
+                                                                                            repositoryMetadata));
 
-        when( repositoryResolver.getRepositoriesResolvingArtifact( eq( gav ),
-                                                                   eq( project ),
-                                                                   eq( repositoryMetadata ) ) ).thenReturn( new HashSet<MavenRepositoryMetadata>() {{
-            add( repositoryMetadata );
-        }} );
+        when(repositoryResolver.getRepositoriesResolvingArtifact(eq(gav),
+                                                                 eq(project),
+                                                                 eq(repositoryMetadata))).thenReturn(new HashSet<MavenRepositoryMetadata>() {{
+            add(repositoryMetadata);
+        }});
 
         final String comment = "comment";
 
         try {
-            service.save( pathToPom,
-                          model,
-                          comment,
-                          DeploymentMode.FORCED );
-
-        } catch ( GAVAlreadyExistsException e ) {
-            fail( "Unexpected exception thrown: " + e.getMessage() );
+            service.save(pathToPom,
+                         model,
+                         comment,
+                         DeploymentMode.FORCED);
+        } catch (GAVAlreadyExistsException e) {
+            fail("Unexpected exception thrown: " + e.getMessage());
         }
 
-        verify( pomService,
-                times( 1 ) ).save( eq( pathToPom ),
-                                   eq( model.getPOM() ),
-                                   eq( pomMetaData ),
-                                   eq( comment ) );
-        verify( kModuleService,
-                times( 1 ) ).save( eq( pathToKieModule ),
-                                   eq( kmodule ),
-                                   eq( kmoduleMetaData ),
-                                   eq( comment ) );
-        verify( importsService,
-                times( 1 ) ).save( eq( pathToProjectImports ),
-                                   eq( projectImports ),
-                                   eq( projectImportsMetaData ),
-                                   eq( comment ) );
-        verify( repositoriesService,
-                times( 1 ) ).save( eq( pathToProjectRepositories ),
-                                   eq( projectRepositories ),
-                                   eq( comment ) );
+        verify(pomService,
+               times(1)).save(eq(pathToPom),
+                              eq(model.getPOM()),
+                              eq(pomMetaData),
+                              eq(comment));
+        verify(kModuleService,
+               times(1)).save(eq(pathToKieModule),
+                              eq(kmodule),
+                              eq(kmoduleMetaData),
+                              eq(comment));
+        verify(importsService,
+               times(1)).save(eq(pathToProjectImports),
+                              eq(projectImports),
+                              eq(projectImportsMetaData),
+                              eq(comment));
+        verify(repositoriesService,
+               times(1)).save(eq(pathToProjectRepositories),
+                              eq(projectRepositories),
+                              eq(comment));
     }
 
     @Test
     public void testReImport() throws Exception {
-        service.reImport( pathToPom );
+        service.reImport(pathToPom);
 
-        verify( projectService ).reImport( pathToPom );
+        verify(projectService).reImport(pathToPom);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3261

The problem was that the ```LRUPomModelCache``` may not be invalidated by a ```InvalidateDMOProjectCacheEvent``` (raised by VFS observing a change to the ```pom.xml```) until **after** the ```KieBuilder``` (used to perform the build) is instantiated and ```PomModel``` set (if found to be cached). The ```PomModel``` controls the GAV in the build.