### PR TITLE
JBPM-5457: Start and Stop container buttons change states even though they fail

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
@@ -287,20 +287,18 @@ public class ContainerPresenter {
     }
 
     public void stopContainer() {
-        specManagementService.call( new RemoteCallback<Void>() {
-            @Override
-            public void callback( final Void response ) {
-                updateStatus( KieContainerStatus.STOPPED );
-            }
-        }, new ErrorCallback<Object>() {
-            @Override
-            public boolean error( final Object o,
-                                  final Throwable throwable ) {
-                notification.fire( new NotificationEvent( view.getStopContainerErrorMessage(), NotificationEvent.NotificationType.ERROR ) );
-                updateStatus( KieContainerStatus.STARTED );
-                return false;
-            }
-        } ).stopContainer( containerSpec );
+        final RemoteCallback<Object> onSuccess = response -> refresh();
+        final ErrorCallback<Object> errorCallback = (o, throwable) -> {
+            notification.fire(new NotificationEvent(view.getStopContainerErrorMessage(),
+                                                    NotificationEvent.NotificationType.ERROR));
+
+            refresh();
+
+            return false;
+        };
+
+        specManagementService.call(onSuccess,
+                                   errorCallback).stopContainer(containerSpec);
     }
 
     public void startContainer() {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
@@ -121,14 +121,15 @@ public class ContainerPresenterTest {
 
     @Before
     public void init() {
-        runtimeManagementServiceCaller = new CallerMock<RuntimeManagementService>( runtimeManagementService );
-        specManagementServiceCaller = new CallerMock<SpecManagementService>( specManagementService );
-        doNothing().when( serverTemplateSelectedEvent ).fire( any( ServerTemplateSelected.class ) );
-        doNothing().when( notification ).fire( any( NotificationEvent.class ) );
-        when( containerStatusEmptyPresenter.getView() ).thenReturn( containerStatusEmptyPresenterView );
-        when( containerRemoteStatusPresenter.getView() ).thenReturn( containerRemoteStatusPresenterView );
-        presenter = spy( new ContainerPresenter(
-                logger, view,
+        runtimeManagementServiceCaller = new CallerMock<RuntimeManagementService>(runtimeManagementService);
+        specManagementServiceCaller = new CallerMock<SpecManagementService>(specManagementService);
+        doNothing().when(serverTemplateSelectedEvent).fire(any(ServerTemplateSelected.class));
+        doNothing().when(notification).fire(any(NotificationEvent.class));
+        when(containerStatusEmptyPresenter.getView()).thenReturn(containerStatusEmptyPresenterView);
+        when(containerRemoteStatusPresenter.getView()).thenReturn(containerRemoteStatusPresenterView);
+        presenter = spy(new ContainerPresenter(
+                logger,
+                view,
                 containerRemoteStatusPresenter,
                 containerStatusEmptyPresenter,
                 containerProcessConfigPresenter,
@@ -136,193 +137,257 @@ public class ContainerPresenterTest {
                 runtimeManagementServiceCaller,
                 specManagementServiceCaller,
                 serverTemplateSelectedEvent,
-                notification ) );
+                notification));
 
-        releaseId = new ReleaseId( "org.kie", "container", "1.0.0" );
-        serverTemplateKey = new ServerTemplateKey( "serverTemplateKeyId", "serverTemplateKeyName" );
-        containerSpec = new ContainerSpec( "containerId", "containerName", serverTemplateKey, releaseId, KieContainerStatus.STOPPED, new HashMap<Capability, ContainerConfig>() );
-        containerSpec.addConfig( Capability.PROCESS, new ProcessConfig() );
-        containerSpec.addConfig( Capability.RULE, new RuleConfig() );
+        releaseId = new ReleaseId("org.kie",
+                                  "container",
+                                  "1.0.0");
+        serverTemplateKey = new ServerTemplateKey("serverTemplateKeyId",
+                                                  "serverTemplateKeyName");
+        containerSpec = new ContainerSpec("containerId",
+                                          "containerName",
+                                          serverTemplateKey,
+                                          releaseId,
+                                          KieContainerStatus.STOPPED,
+                                          new HashMap<Capability, ContainerConfig>());
+        containerSpec.addConfig(Capability.PROCESS,
+                                new ProcessConfig());
+        containerSpec.addConfig(Capability.RULE,
+                                new RuleConfig());
         containers = new ArrayList<Container>();
-        containerSpecData = new ContainerSpecData( containerSpec, containers );
+        containerSpecData = new ContainerSpecData(containerSpec,
+                                                  containers);
     }
 
     @Test
     public void testInit() {
         presenter.init();
 
-        verify( view ).init( presenter );
-        assertEquals( view, presenter.getView() );
-        verify( view ).setStatus( containerRemoteStatusPresenter.getView() );
-        verify( view ).setRulesConfig( containerRulesConfigPresenter.getView() );
-        verify( view ).setProcessConfig( containerProcessConfigPresenter.getView() );
+        verify(view).init(presenter);
+        assertEquals(view,
+                     presenter.getView());
+        verify(view).setStatus(containerRemoteStatusPresenter.getView());
+        verify(view).setRulesConfig(containerRulesConfigPresenter.getView());
+        verify(view).setProcessConfig(containerProcessConfigPresenter.getView());
     }
 
     @Test
     public void testStartContainer() {
-        presenter.loadContainers( containerSpecData );
+        presenter.loadContainers(containerSpecData);
 
         presenter.startContainer();
 
-        verify( view ).setContainerStartState( State.ENABLED );
-        verify( view ).setContainerStopState( State.DISABLED );
-        verify( view ).disableRemoveButton();
+        verify(view).setContainerStartState(State.ENABLED);
+        verify(view).setContainerStopState(State.DISABLED);
+        verify(view).disableRemoveButton();
 
         final String errorMessage = "ERROR";
-        when( view.getStartContainerErrorMessage() ).thenReturn( errorMessage );
-        doThrow( new RuntimeException() ).when( specManagementService ).startContainer( containerSpecData.getContainerSpec() );
+        when(view.getStartContainerErrorMessage()).thenReturn(errorMessage);
+        doThrow(new RuntimeException()).when(specManagementService).startContainer(containerSpecData.getContainerSpec());
         presenter.startContainer();
-        verify( notification ).fire( new NotificationEvent( errorMessage, NotificationEvent.NotificationType.ERROR ) );
+        verify(notification).fire(new NotificationEvent(errorMessage,
+                                                        NotificationEvent.NotificationType.ERROR));
 
-        verify( view, times( 2 ) ).setContainerStartState( State.DISABLED );
-        verify( view, times( 2 ) ).setContainerStopState( State.ENABLED );
-        verify( view, times( 2 ) ).enableRemoveButton();
+        verify(view,
+               times(2)).setContainerStartState(State.DISABLED);
+        verify(view,
+               times(2)).setContainerStopState(State.ENABLED);
+        verify(view,
+               times(2)).enableRemoveButton();
     }
 
     @Test
-    public void testStopContainer() {
-        presenter.loadContainers( containerSpecData );
+    public void testStopContainerWhenStopContainerIsSuccessfully() {
+        doNothing().when(presenter).refresh();
+
+        presenter.loadContainers(containerSpecData);
 
         presenter.stopContainer();
 
-        verify( view, times( 2 ) ).setContainerStartState( State.DISABLED );
-        verify( view, times( 2 ) ).setContainerStopState( State.ENABLED );
-        verify( view, times( 2 ) ).enableRemoveButton();
+        verify(presenter).refresh();
+    }
 
+    @Test
+    public void testStopContainerWhenStopContainerIsNotSuccessfully() {
         final String errorMessage = "ERROR";
-        when( view.getStopContainerErrorMessage() ).thenReturn( errorMessage );
-        doThrow( new RuntimeException() ).when( specManagementService ).stopContainer( containerSpecData.getContainerSpec() );
-        presenter.stopContainer();
-        verify( notification ).fire( new NotificationEvent( errorMessage, NotificationEvent.NotificationType.ERROR ) );
 
-        verify( view ).setContainerStartState( State.ENABLED );
-        verify( view ).setContainerStopState( State.DISABLED );
-        verify( view ).disableRemoveButton();
+        doReturn(errorMessage).when(view).getStopContainerErrorMessage();
+        doThrow(new RuntimeException()).when(specManagementService).stopContainer(containerSpecData.getContainerSpec());
+        doNothing().when(presenter).refresh();
+
+        presenter.loadContainers(containerSpecData);
+
+        presenter.stopContainer();
+
+        verify(presenter).refresh();
+        verify(notification).fire(new NotificationEvent(errorMessage,
+                                                        NotificationEvent.NotificationType.ERROR));
     }
 
     @Test
     public void testLoadContainersEmpty() {
-        presenter.loadContainers( containerSpecData );
+        presenter.loadContainers(containerSpecData);
 
-        verifyLoad( true, 1 );
+        verifyLoad(true,
+                   1);
     }
 
     @Test
     public void testRefresh() {
-        when( runtimeManagementService.getContainersByContainerSpec(
+        when(runtimeManagementService.getContainersByContainerSpec(
                 serverTemplateKey.getId(),
-                containerSpec.getId() ) ).thenReturn( containerSpecData );
+                containerSpec.getId())).thenReturn(containerSpecData);
 
-        presenter.loadContainers( containerSpecData );
+        presenter.loadContainers(containerSpecData);
         presenter.refresh();
 
-        verifyLoad( true, 2 );
+        verifyLoad(true,
+                   2);
     }
 
     @Test
     public void testLoadContainers() {
-        final Container container = new Container( "containerSpecId", "containerName", new ServerInstanceKey(), Collections.<Message>emptyList(), null, null );
-        containerSpecData.getContainers().add( container );
-        presenter.loadContainers( containerSpecData );
+        final Container container = new Container("containerSpecId",
+                                                  "containerName",
+                                                  new ServerInstanceKey(),
+                                                  Collections.<Message>emptyList(),
+                                                  null,
+                                                  null);
+        containerSpecData.getContainers().add(container);
+        presenter.loadContainers(containerSpecData);
 
-        verifyLoad( true, 1 );
+        verifyLoad(true,
+                   1);
     }
 
     @Test
     public void testLoadContainersNonStoped() {
-        final Container container = new Container( "containerSpecId", "containerName", new ServerInstanceKey(), Collections.<Message>emptyList(), null, null );
-        container.setStatus( KieContainerStatus.STARTED );
-        containerSpecData.getContainers().add( container );
-        presenter.loadContainers( containerSpecData );
+        final Container container = new Container("containerSpecId",
+                                                  "containerName",
+                                                  new ServerInstanceKey(),
+                                                  Collections.<Message>emptyList(),
+                                                  null,
+                                                  null);
+        container.setStatus(KieContainerStatus.STARTED);
+        containerSpecData.getContainers().add(container);
+        presenter.loadContainers(containerSpecData);
 
-        verifyLoad( false, 1 );
+        verifyLoad(false,
+                   1);
     }
 
-    private void verifyLoad( boolean empty,
-                             int times ) {
-        verify( containerStatusEmptyPresenter, times( times ) ).setup( containerSpec );
-        verify( containerRemoteStatusPresenter, times( times ) ).setup( containerSpec, containers );
-        verify( view, times( times ) ).clear();
+    private void verifyLoad(boolean empty,
+                            int times) {
+        verify(containerStatusEmptyPresenter,
+               times(times)).setup(containerSpec);
+        verify(containerRemoteStatusPresenter,
+               times(times)).setup(containerSpec,
+                                   containers);
+        verify(view,
+               times(times)).clear();
 
-        if ( empty ) {
-            verify( view, times( times ) ).setStatus( containerStatusEmptyPresenterView );
-            verify( view, never() ).setStatus( containerRemoteStatusPresenterView );
+        if (empty) {
+            verify(view,
+                   times(times)).setStatus(containerStatusEmptyPresenterView);
+            verify(view,
+                   never()).setStatus(containerRemoteStatusPresenterView);
         } else {
-            verify( view, times( times ) ).setStatus( containerRemoteStatusPresenterView );
-            verify( view, never() ).setStatus( containerStatusEmptyPresenterView );
+            verify(view,
+                   times(times)).setStatus(containerRemoteStatusPresenterView);
+            verify(view,
+                   never()).setStatus(containerStatusEmptyPresenterView);
         }
 
-        verify( view, times( times ) ).setContainerName( containerSpec.getContainerName() );
-        verify( view, times( times ) ).setGroupIp( containerSpec.getReleasedId().getGroupId() );
-        verify( view, times( times ) ).setArtifactId( containerSpec.getReleasedId().getArtifactId() );
-        verify( containerRulesConfigPresenter, times( times ) ).setVersion( releaseId.getVersion() );
-        verify( containerProcessConfigPresenter, times( times ) ).disable();
+        verify(view,
+               times(times)).setContainerName(containerSpec.getContainerName());
+        verify(view,
+               times(times)).setGroupIp(containerSpec.getReleasedId().getGroupId());
+        verify(view,
+               times(times)).setArtifactId(containerSpec.getReleasedId().getArtifactId());
+        verify(containerRulesConfigPresenter,
+               times(times)).setVersion(releaseId.getVersion());
+        verify(containerProcessConfigPresenter,
+               times(times)).disable();
 
-        verify( view, times( times ) ).setContainerStartState( State.DISABLED );
-        verify( view, times( times ) ).setContainerStopState( State.ENABLED );
+        verify(view,
+               times(times)).setContainerStartState(State.DISABLED);
+        verify(view,
+               times(times)).setContainerStopState(State.ENABLED);
 
-        verify( containerProcessConfigPresenter, times( times ) ).setup( containerSpec, (ProcessConfig) containerSpec.getConfigs().get( Capability.PROCESS ) );
-        verify( containerRulesConfigPresenter, times( times ) ).setup( containerSpec, (RuleConfig) containerSpec.getConfigs().get( Capability.RULE ) );
+        verify(containerProcessConfigPresenter,
+               times(times)).setup(containerSpec,
+                                   (ProcessConfig) containerSpec.getConfigs().get(Capability.PROCESS));
+        verify(containerRulesConfigPresenter,
+               times(times)).setup(containerSpec,
+                                   (RuleConfig) containerSpec.getConfigs().get(Capability.RULE));
     }
 
     @Test
     public void testLoad() {
-        when( runtimeManagementService.getContainersByContainerSpec(
+        when(runtimeManagementService.getContainersByContainerSpec(
                 serverTemplateKey.getId(),
-                containerSpec.getId() ) ).thenReturn( containerSpecData );
+                containerSpec.getId())).thenReturn(containerSpecData);
 
-        presenter.load( new ContainerSpecSelected( containerSpec ) );
+        presenter.load(new ContainerSpecSelected(containerSpec));
 
-        verifyLoad( true, 1 );
+        verifyLoad(true,
+                   1);
     }
 
     @Test
     public void testOnRefresh() {
-        when( runtimeManagementService.getContainersByContainerSpec(
+        when(runtimeManagementService.getContainersByContainerSpec(
                 serverTemplateKey.getId(),
-                containerSpec.getId() ) ).thenReturn( containerSpecData );
+                containerSpec.getId())).thenReturn(containerSpecData);
 
-        presenter.onRefresh( new RefreshRemoteServers( containerSpec ) );
+        presenter.onRefresh(new RefreshRemoteServers(containerSpec));
 
-        verifyLoad( true, 1 );
+        verifyLoad(true,
+                   1);
     }
 
     @Test
     public void testRemoveContainer() {
-        doAnswer( new Answer() {
+        doAnswer(new Answer() {
             @Override
-            public Object answer( InvocationOnMock invocation ) throws Throwable {
-                final Command command = (Command) invocation.getArguments()[ 0 ];
-                if ( command != null ) {
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                final Command command = (Command) invocation.getArguments()[0];
+                if (command != null) {
                     command.execute();
                 }
                 return null;
             }
-        } ).when( view ).confirmRemove( any( Command.class ) );
+        }).when(view).confirmRemove(any(Command.class));
         final String successMessage = "SUCCESS";
-        when( view.getRemoveContainerSuccessMessage() ).thenReturn( successMessage );
+        when(view.getRemoveContainerSuccessMessage()).thenReturn(successMessage);
 
-        presenter.loadContainers( containerSpecData );
+        presenter.loadContainers(containerSpecData);
         presenter.removeContainer();
 
-        verify( specManagementService ).deleteContainerSpec( serverTemplateKey.getId(), containerSpec.getId() );
+        verify(specManagementService).deleteContainerSpec(serverTemplateKey.getId(),
+                                                          containerSpec.getId());
 
-        final ArgumentCaptor<NotificationEvent> notificationCaptor = ArgumentCaptor.forClass( NotificationEvent.class );
-        verify( notification ).fire( notificationCaptor.capture() );
+        final ArgumentCaptor<NotificationEvent> notificationCaptor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(notification).fire(notificationCaptor.capture());
         final NotificationEvent event = notificationCaptor.getValue();
-        assertEquals( NotificationEvent.NotificationType.SUCCESS, event.getType() );
-        assertEquals( successMessage, event.getNotification() );
+        assertEquals(NotificationEvent.NotificationType.SUCCESS,
+                     event.getType());
+        assertEquals(successMessage,
+                     event.getNotification());
 
-        final ArgumentCaptor<ServerTemplateSelected> serverTemplateSelectedCaptor = ArgumentCaptor.forClass( ServerTemplateSelected.class );
-        verify( serverTemplateSelectedEvent ).fire( serverTemplateSelectedCaptor.capture() );
-        assertEquals( serverTemplateKey.getId(), serverTemplateSelectedCaptor.getValue().getServerTemplateKey().getId() );
+        final ArgumentCaptor<ServerTemplateSelected> serverTemplateSelectedCaptor = ArgumentCaptor.forClass(ServerTemplateSelected.class);
+        verify(serverTemplateSelectedEvent).fire(serverTemplateSelectedCaptor.capture());
+        assertEquals(serverTemplateKey.getId(),
+                     serverTemplateSelectedCaptor.getValue().getServerTemplateKey().getId());
 
         final String errorMessage = "ERROR";
-        when( view.getRemoveContainerErrorMessage() ).thenReturn( errorMessage );
-        doThrow( new RuntimeException() ).when( specManagementService ).deleteContainerSpec( serverTemplateKey.getId(), containerSpec.getId() );
+        when(view.getRemoveContainerErrorMessage()).thenReturn(errorMessage);
+        doThrow(new RuntimeException()).when(specManagementService).deleteContainerSpec(serverTemplateKey.getId(),
+                                                                                        containerSpec.getId());
         presenter.removeContainer();
-        verify( notification ).fire( new NotificationEvent( errorMessage, NotificationEvent.NotificationType.ERROR ) );
-        verify( serverTemplateSelectedEvent, times( 2 ) ).fire( new ServerTemplateSelected( containerSpec.getServerTemplateKey() ) );
+        verify(notification).fire(new NotificationEvent(errorMessage,
+                                                        NotificationEvent.NotificationType.ERROR));
+        verify(serverTemplateSelectedEvent,
+               times(2)).fire(new ServerTemplateSelected(containerSpec.getServerTemplateKey()));
     }
-
 }


### PR DESCRIPTION
This PR solves the issue [JBPM-5457](https://issues.jboss.org/browse/JBPM-5457) and the [RHBRMS-2874](https://issues.jboss.org/browse/RHBRMS-2874).

----

Part of an ensemble:
- https://github.com/kiegroup/droolsjbpm-integration/pull/1057
- https://github.com/kiegroup/kie-wb-common/pull/987

----

- https://issues.jboss.org/browse/JBPM-5457

Before:
![before](https://user-images.githubusercontent.com/1079279/28383662-55140f12-6c98-11e7-85b6-22c772bf1143.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/28383667-57f46452-6c98-11e7-9aa1-157300227b7a.gif)

----

- https://issues.jboss.org/browse/RHBRMS-2874

Before:
![before](https://user-images.githubusercontent.com/1079279/28387701-8471e32a-6ca6-11e7-937a-3ba00775d117.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/28387704-869e26ae-6ca6-11e7-9e94-8697ebabfbb0.gif)
(my gif has a super low FPS rate, but when you’re using the screen, the containers are shown)