### PR TITLE
GUVNOR-3290: [DMN Editor] Palette: Show top-level items for each node type

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -153,6 +153,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-commons</artifactId>
     </dependency>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactory.java
@@ -15,74 +15,35 @@
  */
 package org.kie.workbench.common.dmn.client.components.palette.factory;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Categories;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
-import org.kie.workbench.common.stunner.core.client.components.palette.factory.BindableDefSetPaletteDefinitionFactory;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
+import org.kie.workbench.common.stunner.core.client.components.palette.factory.BindablePaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPaletteBuilder;
 
 @Dependent
-public class DMNPaletteDefinitionFactory extends BindableDefSetPaletteDefinitionFactory {
-
-    private static final Map<String, String> CAT_TITLES = new HashMap<String, String>() {{
-        put(Categories.NODES,
-            "Nodes");
-        put(Categories.CONNECTORS,
-            "Connectors");
-    }};
-
-    private static final Map<String, Class<?>> CAT_DEF_IDS = new HashMap<String, Class<?>>() {{
-//        put(Categories.NODES,
-//            StartNoneEvent.class);
-//        put(Categories.CONNECTORS,
-//            SequenceFlow.class);
-    }};
+public class DMNPaletteDefinitionFactory extends BindablePaletteDefinitionFactory<DefinitionsPaletteBuilder, DefinitionsPalette, BS3PaletteWidget<DefinitionsPalette>> {
 
     @Inject
     public DMNPaletteDefinitionFactory(final ShapeManager shapeManager,
-                                       final DefinitionSetPaletteBuilder paletteBuilder) {
+                                       final DefinitionsPaletteBuilder paletteBuilder,
+                                       final BS3PaletteWidget<DefinitionsPalette> palette) {
         super(shapeManager,
-              paletteBuilder);
+              paletteBuilder,
+              palette);
+        this.paletteBuilder.excludeCategory(Categories.DIAGRAM);
+        this.paletteBuilder.excludeCategory(Categories.CONNECTORS);
+        this.paletteBuilder.excludeCategory(Categories.MISCELLANEOUS);
     }
 
     @Override
-    protected void configureBuilder() {
-        super.configureBuilder();
-
-        excludeCategory(Categories.DIAGRAM);
-        excludeCategory(Categories.CONNECTORS);
-    }
-
-    @Override
-    protected String getCategoryTitle(final String id) {
-        return CAT_TITLES.get(id);
-    }
-
-    @Override
-    protected Class<?> getCategoryTargetDefinitionId(final String id) {
-        return CAT_DEF_IDS.get(id);
-    }
-
-    @Override
-    protected String getCategoryDescription(final String id) {
-        return CAT_TITLES.get(id);
-    }
-
-    @Override
-    protected String getMorphGroupTitle(final String morphBaseId,
-                                        final Object definition) {
-        return null;
-    }
-
-    @Override
-    protected String getMorphGroupDescription(final String morphBaseId,
-                                              final Object definition) {
-        return null;
+    protected DefinitionsPaletteBuilder newBuilder() {
+        return paletteBuilder;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidget.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.components.palette.widget;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.IsElement;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteItem;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+
+@Dependent
+public class DMNPaletteItemWidget implements DMNPaletteItemWidgetView.Presenter,
+                                             IsElement {
+
+    public static final double ICON_WIDTH = 32;
+    public static final double ICON_HEIGHT = 32;
+
+    private final DMNPaletteItemWidgetView view;
+
+    private DefinitionPaletteItem item;
+    private Palette.ItemMouseDownCallback itemMouseDownCallback;
+
+    @Inject
+    public DMNPaletteItemWidget(final DMNPaletteItemWidgetView view) {
+        this.view = view;
+    }
+
+    @PostConstruct
+    public void init() {
+        view.init(this);
+    }
+
+    public void initialize(final DefinitionPaletteItem item,
+                           final ShapeFactory<?, ?> shapeFactory,
+                           final Palette.ItemMouseDownCallback itemMouseDownCallback) {
+        this.item = item;
+        this.itemMouseDownCallback = itemMouseDownCallback;
+
+        final Glyph glyph = shapeFactory.getGlyph(item.getDefinitionId());
+        view.render(glyph,
+                    ICON_WIDTH,
+                    ICON_HEIGHT);
+    }
+
+    @Override
+    public DefinitionPaletteItem getItem() {
+        return item;
+    }
+
+    @Override
+    public void onMouseDown(final int clientX,
+                            final int clientY,
+                            final int x,
+                            final int y) {
+        if (itemMouseDownCallback != null) {
+            itemMouseDownCallback.onItemMouseDown(item.getId(),
+                                                  clientX,
+                                                  clientY,
+                                                  x,
+                                                  y);
+        }
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return view.getElement();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetView.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.components.palette.widget;
+
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteItem;
+import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+import org.uberfire.client.mvp.UberElement;
+
+public interface DMNPaletteItemWidgetView extends UberElement<DMNPaletteItemWidgetView.Presenter> {
+
+    void render(Glyph glyph,
+                double width,
+                double height);
+
+    interface Presenter {
+
+        DefinitionPaletteItem getItem();
+
+        void onMouseDown(int clientX,
+                         int clientY,
+                         int x,
+                         int y);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetViewImpl.css
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetViewImpl.css
@@ -1,0 +1,3 @@
+.bs3-palette-item-icon-spacer {
+    margin: auto;
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetViewImpl.html
@@ -1,0 +1,5 @@
+<li class="list-group-item">
+    <p data-field="itemAnchor">
+        <span data-field="icon" class="bs3-palette-item-icon-spacer"></span>
+    </p>
+</li>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetViewImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.components.palette.widget;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.MouseDownEvent;
+import org.jboss.errai.common.client.dom.Paragraph;
+import org.jboss.errai.common.client.dom.Span;
+import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.stunner.client.widgets.components.glyph.DOMGlyphRenderers;
+import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+
+@Templated
+@Dependent
+public class DMNPaletteItemWidgetViewImpl implements DMNPaletteItemWidgetView,
+                                                     IsElement {
+
+    @Inject
+    @DataField
+    private Paragraph itemAnchor;
+
+    @Inject
+    @DataField
+    private Span icon;
+
+    @Inject
+    private DOMGlyphRenderers domGlyphRenderers;
+
+    private Presenter presenter;
+
+    @Override
+    public void init(final Presenter presenter) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void render(final Glyph glyph,
+                       final double width,
+                       final double height) {
+        final org.jboss.errai.common.client.api.IsElement glyphElement = domGlyphRenderers.render(glyph,
+                                                                                                  width,
+                                                                                                  height);
+        icon.appendChild(glyphElement.getElement());
+        icon.setTitle(presenter.getItem().getTitle());
+    }
+
+    @EventHandler("itemAnchor")
+    public void onMouseDown(final MouseDownEvent mouseDownEvent) {
+        presenter.onMouseDown(mouseDownEvent.getClientX(),
+                              mouseDownEvent.getClientY(),
+                              mouseDownEvent.getX(),
+                              mouseDownEvent.getY());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidget.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.components.palette.widget;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.IsElement;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteViewFactory;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.AbstractPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+
+@Dependent
+public class DMNPaletteWidget extends AbstractPalette<DefinitionsPalette>
+        implements BS3PaletteWidget<DefinitionsPalette>,
+                   IsElement {
+
+    public static final String BG_COLOR = "#D3D3D3";
+
+    private static final int GLYPH_ICON_SIZE = 30;
+
+    protected final ClientFactoryService clientFactoryServices;
+    protected ItemDropCallback itemDropCallback;
+    protected ItemDragStartCallback itemDragStartCallback;
+    protected ItemDragUpdateCallback itemDragUpdateCallback;
+
+    private ManagedInstance<DMNPaletteItemWidget> paletteItemWidgets;
+
+    private BS3PaletteViewFactory viewFactory;
+
+    private DMNPaletteWidgetView view;
+
+    @Inject
+    public DMNPaletteWidget(final ShapeManager shapeManager,
+                            final ClientFactoryService clientFactoryServices,
+                            final DMNPaletteWidgetView view,
+                            final ManagedInstance<DMNPaletteItemWidget> paletteItemWidgets) {
+        super(shapeManager);
+        this.clientFactoryServices = clientFactoryServices;
+        this.view = view;
+        this.paletteItemWidgets = paletteItemWidgets;
+    }
+
+    @PostConstruct
+    public void init() {
+        view.init(this);
+        view.setBackgroundColor(BG_COLOR);
+        view.showEmptyView(true);
+    }
+
+    @Override
+    public BS3PaletteWidget<DefinitionsPalette> onItemDrop(final ItemDropCallback callback) {
+        this.itemDropCallback = callback;
+        return this;
+    }
+
+    @Override
+    public BS3PaletteWidget<DefinitionsPalette> onItemDragStart(final ItemDragStartCallback callback) {
+        this.itemDragStartCallback = callback;
+        return this;
+    }
+
+    @Override
+    public BS3PaletteWidget<DefinitionsPalette> onItemDragUpdate(final ItemDragUpdateCallback callback) {
+        this.itemDragUpdateCallback = callback;
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onDragStart(final String definitionId,
+                            final double x,
+                            final double y) {
+        if (null != itemDragStartCallback) {
+            final Object definition = clientFactoryServices.getClientFactoryManager().newDefinition(definitionId);
+            final ShapeFactory<?, ? extends Shape> factory = getShapeFactory();
+            itemDragStartCallback.onDragStartItem(definition,
+                                                  factory,
+                                                  x,
+                                                  y);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onDragProxyMove(final String definitionId,
+                                final double x,
+                                final double y) {
+        if (null != itemDragUpdateCallback) {
+            final Object definition = clientFactoryServices.getClientFactoryManager().newDefinition(definitionId);
+            final ShapeFactory<?, ? extends Shape> factory = getShapeFactory();
+            itemDragUpdateCallback.onDragUpdateItem(definition,
+                                                    factory,
+                                                    x,
+                                                    y);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onDragProxyComplete(final String definitionId,
+                                    final double x,
+                                    final double y) {
+        if (null != itemDropCallback) {
+            final Object definition = clientFactoryServices.getClientFactoryManager().newDefinition(definitionId);
+            final ShapeFactory<?, ? extends Shape> factory = getShapeFactory();
+            itemDropCallback.onDropItem(definition,
+                                        factory,
+                                        x,
+                                        y);
+        }
+    }
+
+    @Override
+    public BS3PaletteWidget setViewFactory(final BS3PaletteViewFactory viewFactory) {
+        this.viewFactory = viewFactory;
+        return this;
+    }
+
+    @Override
+    public Glyph getShapeGlyph(final String definitionId) {
+        return getShapeFactory().getGlyph(definitionId);
+    }
+
+    @Override
+    protected String getPaletteItemId(final int index) {
+        return paletteDefinition.getItems().get(index).getId();
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return view.getElement();
+    }
+
+    protected ShapeFactory getShapeFactory() {
+        return shapeManager.getDefaultShapeSet(paletteDefinition.getDefinitionSetId()).getShapeFactory();
+    }
+
+    @Override
+    protected void beforeBind() {
+        view.clear();
+        view.showEmptyView(false);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected AbstractPalette<DefinitionsPalette> bind() {
+        final DefinitionsPalette palette = paletteDefinition;
+        if (null != palette) {
+            palette.getItems().forEach(pi -> {
+                final DMNPaletteItemWidget paletteItemWidget = paletteItemWidgets.get();
+                paletteItemWidget.initialize(pi,
+                                             getShapeFactory(),
+                                             (id, mouseX, mouseY, itemX, itemY) -> {
+                                                 view.showDragProxy(id,
+                                                                    mouseX,
+                                                                    mouseY,
+                                                                    GLYPH_ICON_SIZE,
+                                                                    GLYPH_ICON_SIZE);
+                                                 return true;
+                                             });
+
+                view.add(paletteItemWidget);
+            });
+        }
+        return this;
+    }
+
+    @Override
+    public void unbind() {
+        if (null != paletteDefinition) {
+            view.clear();
+            view.showEmptyView(true);
+            this.paletteDefinition = null;
+        }
+    }
+
+    @PreDestroy
+    @Override
+    protected void doDestroy() {
+        paletteItemWidgets.destroyAll();
+        viewFactory.destroy();
+        view.destroy();
+        this.itemDropCallback = null;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetView.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.components.palette.widget;
+
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.uberfire.client.mvp.UberElement;
+
+public interface DMNPaletteWidgetView extends UberElement<BS3PaletteWidget<DefinitionsPalette>> {
+
+    void showDragProxy(final String itemId,
+                       final double x,
+                       final double y,
+                       final double width,
+                       final double height);
+
+    void setBackgroundColor(final String backgroundColor);
+
+    void showEmptyView(final boolean showEmptyView);
+
+    void add(final DMNPaletteItemWidget widget);
+
+    void clear();
+
+    void destroy();
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.css
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.css
@@ -1,0 +1,252 @@
+.kie-palette {
+    background: #fff;
+    border-collapse: collapse;
+    overflow: visible;
+    width: calc(48px);
+    position: absolute;
+    z-index: 1;
+}
+
+.kie-palette .list-group {
+    margin-bottom: 0;
+}
+
+.kie-palette .list-group {
+    position: relative;
+    border-top: none;
+}
+
+.kie-palette .list-group-item {
+    background-color: #ededed;
+    border-color: #bbb;
+    float: none;
+    outline: 0;
+    padding: 0;
+    position: unset;
+}
+
+.kie-palette .list-group-item:last-child {
+    border-bottom: 1px solid #bbb;
+}
+
+.kie-palette .list-group-item:last-child:hover > p:after {
+    height: calc(101%);
+}
+
+.kie-palette .list-group-item > p {
+    color: #030303;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 400;
+    height: calc(54px);
+    padding: 0;
+    text-decoration: none;
+    white-space: nowrap;
+    width: calc(48px);
+    margin: 0;
+}
+
+@supports (display: flex) {
+    .kie-palette .list-group-item > p {
+        display: flex;
+    }
+}
+
+.kie-palette .list-group-item p > div {
+    width: 100%;
+    margin: auto;
+}
+
+.kie-palette .list-group-item > p .fa,
+.kie-palette .list-group-item > p .glyphicon,
+.kie-palette .list-group-item > p .pficon {
+    color: #393f44;
+    font-size: calc(21px);
+    margin: auto;
+    min-width: calc(27.999996px);
+    text-align: center;
+}
+
+.kie-palette .list-group-item:hover {
+    background-color: #fff;
+
+}
+
+.kie-palette .list-group-item:hover > .kie-palette-flyout {
+
+    height: auto;
+    width: auto;
+    min-width: 12em;
+    border-left-color: #fff;
+    display: block;
+}
+
+.kie-palette .list-group-item:hover > p {
+    background-color: inherit;
+}
+
+.kie-palette .list-group-item:hover p[data-field=categoryIcon] div svg {
+    fill: #39a5dc;
+}
+
+.kie-palette .list-group-item:hover > p .fa,
+.kie-palette .list-group-item:hover > p .glyphicon,
+.kie-palette .list-group-item:hover > p .pficon {
+    color: #39a5dc;
+}
+
+.kie-palette .list-group-item:hover > p:before {
+    background: #39a5dc;
+    content: " ";
+    height: 100%;
+    left: 0;
+    top: 0;
+    width: 5px;
+    float: left;
+}
+
+.kie-palette .list-group-item:hover > p:after {
+    background: #fff;
+    content: " ";
+    height: 100%;
+    margin-right: -1px;
+    top: 0;
+    width: 1px;
+    z-index: 10000;
+}
+
+.kie-palette .list-group-item .list-group-item-value {
+    display: block;
+    line-height: 2em;
+    max-width: 10em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+@supports (display: flex) {
+    .kie-palette .list-group-item .list-group-item-value {
+        flex: 1;
+        max-width: none;
+        padding-right: 1em;
+    }
+}
+
+.kie-list-group-item-value-more {
+    color: #0088ce;
+}
+
+.kie-palette-flyout-header {
+    color: #030303;
+    font-size: calc(15.999996px);
+    font-weight: 700;
+    margin-top: calc(12px);
+    margin-bottom: calc(12px);
+    padding-left: calc(18px);
+}
+
+.kie-palette-flyout {
+    background-color: #fff;
+    border-color: #bbb;
+    border-left: 1px solid #bbb;
+    border-right: 1px solid #bbb;
+    border-bottom: 1px solid #bbb;
+    -webkit-box-shadow: 2px 2px 2px rgba(3, 3, 3, 0.08);
+    box-shadow: 2px 2px 2px rgba(3, 3, 3, 0.08);
+    display: none;
+    left: calc(48px);
+    max-height: 100vh;
+    min-height: 100%;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    position: absolute;
+    top: 0;
+    z-index: 500;
+
+}
+
+.kie-palette-flyout h5 {
+    color: #72767b;
+    cursor: default;
+    font-size: 12px;
+    padding-left: calc(18px);
+    text-transform: uppercase;
+}
+
+.kie-palette-flyout .list-group {
+    margin-left: 1em;
+    margin-right: 1em;
+
+}
+
+.kie-palette-flyout .list-group:not\(:last-of-type\) {
+    border-bottom: 1px solid #bbb;
+}
+
+.kie-palette-flyout .list-group-item {
+    background-color: #fff;
+    float: none;
+    border-color: #fff;
+    padding-left: calc(18px);
+    margin-bottom: 0;
+    margin-left: -1em;
+    margin-right: -1em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+div.kie-palette-flyout > li:only-of-type {
+    padding-left: calc(30px);
+}
+
+.kie-palette-flyout .list-group-item > p {
+    font-size: 12px;
+    font-weight: 400;
+    height: auto;
+    padding: 0;
+    width: auto;
+}
+
+.kie-palette-flyout .list-group-item > p .fa,
+.kie-palette-flyout .list-group-item > p .glyph-icon-renderer-svg-content,
+.kie-palette-flyout .list-group-item > p .glyph-lienzo-icon-renderer-content,
+.kie-palette-flyout .list-group-item > p .glyphicon,
+.kie-palette-flyout .list-group-item > p .pficon {
+    font-size: calc(13.999992px);
+    padding-right: 1em;
+}
+
+.kie-palette .glyph-icon-svg-position {
+    position: absolute;
+}
+
+.kie-palette-flyout .list-group-item:first-child {
+    border-top: 1px solid #fff;
+}
+
+.kie-palette-flyout .list-group-item:last-child {
+    border-bottom: 1px solid transparent;
+}
+
+.kie-palette-flyout .list-group-item:hover {
+    background-color: #def3ff;
+    border-color: #39a5dc;
+}
+
+.kie-palette-flyout .list-group-item:hover:first-child {
+    border-top: 1px solid #39a5dc;
+}
+
+.kie-palette-flyout .list-group-item:hover > p {
+    color: #030303;
+    font-weight: 400;
+}
+
+.kie-palette-flyout .list-group-item:hover > p:before {
+    width: 0;
+}
+
+.kie-palette-flyout .list-group-item:hover > p .fa,
+.kie-palette-flyout .list-group-item:hover > p .glyphicon,
+.kie-palette-flyout .list-group-item:hover > p .pficon {
+    color: #39a5dc;
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.html
@@ -1,0 +1,6 @@
+<div>
+    <div class="kie-palette" data-field="kie-palette">
+        <ul class="list-group">
+        </ul>
+    </div>
+</div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.client.widgets.palette;
+package org.kie.workbench.common.dmn.client.components.palette.widget;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -25,19 +25,20 @@ import org.jboss.errai.common.client.dom.UnorderedList;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.kie.workbench.common.stunner.client.widgets.palette.categories.DefinitionPaletteCategoryWidget;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.core.client.components.glyph.ShapeGlyphDragHandler;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.uberfire.commons.validation.PortablePreconditions;
 
 @Templated
 @Dependent
-public class BS3PaletteWidgetViewImpl implements BS3PaletteWidgetView,
+public class DMNPaletteWidgetViewImpl implements DMNPaletteWidgetView,
                                                  IsElement {
 
     private ShapeGlyphDragHandler shapeGlyphDragHandler;
 
-    private BS3PaletteWidget presenter;
+    private BS3PaletteWidget<DefinitionsPalette> presenter;
 
     @Inject
     @DataField("kie-palette")
@@ -47,22 +48,26 @@ public class BS3PaletteWidgetViewImpl implements BS3PaletteWidgetView,
     @DataField("list-group")
     private UnorderedList ul;
 
-    @Override
-    public void init(BS3PaletteWidget presenter) {
-        this.presenter = presenter;
+    public DMNPaletteWidgetViewImpl() {
+        //CDI proxy
     }
 
-    @Override
-    public void setShapeGlyphDragHandler(ShapeGlyphDragHandler shapeGlyphDragHandler) {
+    @Inject
+    public DMNPaletteWidgetViewImpl(final ShapeGlyphDragHandler shapeGlyphDragHandler) {
         this.shapeGlyphDragHandler = shapeGlyphDragHandler;
     }
 
     @Override
-    public void showDragProxy(String itemId,
-                              double x,
-                              double y,
-                              double witdth,
-                              double height) {
+    public void init(final BS3PaletteWidget<DefinitionsPalette> presenter) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void showDragProxy(final String itemId,
+                              final double x,
+                              final double y,
+                              final double width,
+                              final double height) {
         final Glyph glyph = presenter.getShapeGlyph(itemId);
         presenter.onDragStart(itemId,
                               x,
@@ -71,7 +76,7 @@ public class BS3PaletteWidgetViewImpl implements BS3PaletteWidgetView,
         shapeGlyphDragHandler.show(glyph,
                                    x,
                                    y,
-                                   witdth,
+                                   width,
                                    height,
                                    new ShapeGlyphDragHandler.Callback() {
 
@@ -94,7 +99,7 @@ public class BS3PaletteWidgetViewImpl implements BS3PaletteWidgetView,
     }
 
     @Override
-    public void add(DefinitionPaletteCategoryWidget widget) {
+    public void add(final DMNPaletteItemWidget widget) {
         PortablePreconditions.checkNotNull("widget",
                                            widget);
         ul.appendChild(widget.getElement());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.components.palette.factory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Categories;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPaletteBuilder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNPaletteDefinitionFactoryTest {
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private DefinitionsPaletteBuilder paletteBuilder;
+
+    @Mock
+    private BS3PaletteWidget<DefinitionsPalette> palette;
+
+    private DMNPaletteDefinitionFactory factory;
+
+    @Before
+    public void setup() {
+        this.factory = new DMNPaletteDefinitionFactory(shapeManager,
+                                                       paletteBuilder,
+                                                       palette);
+    }
+
+    @Test
+    public void checkCategoryExclusions() {
+        verify(paletteBuilder).excludeCategory(Categories.DIAGRAM);
+        verify(paletteBuilder).excludeCategory(Categories.CONNECTORS);
+        verify(paletteBuilder).excludeCategory(Categories.MISCELLANEOUS);
+    }
+
+    @Test
+    public void checkPaletteBuilderReuse() {
+        assertEquals(paletteBuilder,
+                     factory.newBuilder());
+    }
+
+    @Test
+    public void assertDefinitionSetType() {
+        assertEquals(DMNDefinitionSet.class,
+                     factory.getDefinitionSetType());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteItemWidgetTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.components.palette.widget;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteItem;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNPaletteItemWidgetTest {
+
+    private static final String ITEM_ID = "itemId";
+
+    private static final String DEFINITION_ID = "definitionId";
+
+    @Mock
+    private DMNPaletteItemWidgetView view;
+
+    @Mock
+    private DefinitionPaletteItem item;
+
+    @Mock
+    private ShapeFactory shapeFactory;
+
+    @Mock
+    private Palette.ItemMouseDownCallback itemMouseDownCallback;
+
+    @Mock
+    private Glyph glyph;
+
+    private DMNPaletteItemWidget widget;
+
+    @Before
+    public void setup() {
+        this.widget = new DMNPaletteItemWidget(view);
+        when(item.getId()).thenReturn(ITEM_ID);
+        when(item.getDefinitionId()).thenReturn(DEFINITION_ID);
+        when(shapeFactory.getGlyph(eq(DEFINITION_ID))).thenReturn(glyph);
+    }
+
+    @Test
+    public void checkViewHasPresenterInjected() {
+        widget.init();
+        verify(view).init(eq(widget));
+    }
+
+    @Test
+    public void checkInitialiseRendersGlyph() {
+        widget.initialize(item,
+                          shapeFactory,
+                          itemMouseDownCallback);
+        verify(view).render(eq(glyph),
+                            eq(DMNPaletteItemWidget.ICON_WIDTH),
+                            eq(DMNPaletteItemWidget.ICON_HEIGHT));
+    }
+
+    @Test
+    public void checkOnMouseDownNotInvokedIfCallbackIsSet() {
+        widget.initialize(item,
+                          shapeFactory,
+                          itemMouseDownCallback);
+        widget.onMouseDown(5,
+                           10,
+                           15,
+                           20);
+        verify(itemMouseDownCallback).onItemMouseDown(eq(ITEM_ID),
+                                                      eq(5.0),
+                                                      eq(10.0),
+                                                      eq(15.0),
+                                                      eq(20.0));
+    }
+
+    @Test
+    public void checkOnMouseDownNotInvokedIfCallbackIsNotSet() {
+        widget.onMouseDown(5,
+                           10,
+                           15,
+                           20);
+        verify(itemMouseDownCallback,
+               never()).onItemMouseDown(anyString(),
+                                        anyInt(),
+                                        anyInt(),
+                                        anyInt(),
+                                        anyInt());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.components.palette.widget;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteViewFactory;
+import org.kie.workbench.common.stunner.core.client.ShapeSet;
+import org.kie.workbench.common.stunner.core.client.api.ClientFactoryManager;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteItem;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNPaletteWidgetTest {
+
+    private static final String DEFINITION_SET_ID = "definitionSetId";
+
+    private static final String DEFINITION_ID = "definitionId";
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private ClientFactoryService clientFactoryServices;
+
+    @Mock
+    private DMNPaletteWidgetView view;
+
+    @Mock
+    private ManagedInstance<DMNPaletteItemWidget> paletteItemWidgets;
+
+    @Mock
+    private ClientFactoryManager clientFactoryManager;
+
+    @Mock
+    private DefinitionsPalette palette;
+
+    @Mock
+    private ShapeSet shapeSet;
+
+    @Mock
+    private ShapeFactory shapeFactory;
+
+    @Mock
+    private Glyph glyph;
+
+    @Mock
+    private PaletteWidget.ItemDragStartCallback itemDragStartCallback;
+
+    @Mock
+    private PaletteWidget.ItemDragUpdateCallback itemDragUpdateCallback;
+
+    @Mock
+    private PaletteWidget.ItemDropCallback itemDropCallback;
+
+    private Object definition = new Object();
+
+    private DMNPaletteWidget widget;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.widget = new DMNPaletteWidget(shapeManager,
+                                           clientFactoryServices,
+                                           view,
+                                           paletteItemWidgets);
+        when(clientFactoryServices.getClientFactoryManager()).thenReturn(clientFactoryManager);
+        when(clientFactoryManager.newDefinition(eq(DEFINITION_ID))).thenReturn(definition);
+        when(palette.getDefinitionSetId()).thenReturn(DEFINITION_SET_ID);
+        when(shapeManager.getDefaultShapeSet(eq(DEFINITION_SET_ID))).thenReturn(shapeSet);
+        when(shapeSet.getShapeFactory()).thenReturn(shapeFactory);
+        when(shapeFactory.getGlyph(eq(DEFINITION_ID))).thenReturn(glyph);
+    }
+
+    @Test
+    public void checkViewHasPresenterInjected() {
+        widget.init();
+        verify(view).init(eq(widget));
+        verify(view).setBackgroundColor(eq(DMNPaletteWidget.BG_COLOR));
+        verify(view).showEmptyView(eq(true));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkOnDragStartWhenCallbackIsSet() {
+        widget.onItemDragStart(itemDragStartCallback);
+
+        widget.bind(palette);
+
+        widget.onDragStart(DEFINITION_ID,
+                           10.0,
+                           20.0);
+
+        verify(clientFactoryServices).getClientFactoryManager();
+        verify(clientFactoryManager).newDefinition(eq(DEFINITION_ID));
+
+        verify(itemDragStartCallback).onDragStartItem(eq(definition),
+                                                      eq(shapeFactory),
+                                                      eq(10.0),
+                                                      eq(20.0));
+    }
+
+    @Test
+    public void checkOnDragStartWhenCallbackIsNotSet() {
+        widget.onDragStart(DEFINITION_ID,
+                           10.0,
+                           20.0);
+
+        verify(clientFactoryServices,
+               never()).getClientFactoryManager();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkOnDragProxyMoveWhenCallbackIsSet() {
+        widget.onItemDragUpdate(itemDragUpdateCallback);
+
+        widget.bind(palette);
+
+        widget.onDragProxyMove(DEFINITION_ID,
+                               10.0,
+                               20.0);
+
+        verify(clientFactoryServices).getClientFactoryManager();
+        verify(clientFactoryManager).newDefinition(eq(DEFINITION_ID));
+
+        verify(itemDragUpdateCallback).onDragUpdateItem(eq(definition),
+                                                        eq(shapeFactory),
+                                                        eq(10.0),
+                                                        eq(20.0));
+    }
+
+    @Test
+    public void checkOnDragProxyMoveWhenCallbackIsNotSet() {
+        widget.onDragProxyMove(DEFINITION_ID,
+                               10.0,
+                               20.0);
+
+        verify(clientFactoryServices,
+               never()).getClientFactoryManager();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkOnDragProxyCompleteWhenCallbackIsSet() {
+        widget.onItemDrop(itemDropCallback);
+
+        widget.bind(palette);
+
+        widget.onDragProxyComplete(DEFINITION_ID,
+                                   10.0,
+                                   20.0);
+
+        verify(clientFactoryServices).getClientFactoryManager();
+        verify(clientFactoryManager).newDefinition(eq(DEFINITION_ID));
+
+        verify(itemDropCallback).onDropItem(eq(definition),
+                                            eq(shapeFactory),
+                                            eq(10.0),
+                                            eq(20.0));
+    }
+
+    @Test
+    public void checkOnDragProxyCompleteWhenCallbackIsNotSet() {
+        widget.onDragProxyComplete(DEFINITION_ID,
+                                   10.0,
+                                   20.0);
+
+        verify(clientFactoryServices,
+               never()).getClientFactoryManager();
+    }
+
+    @Test
+    public void checkGetShapeGlyphForKnownDefinition() {
+        widget.bind(palette);
+
+        assertEquals(glyph,
+                     widget.getShapeGlyph(DEFINITION_ID));
+    }
+
+    @Test
+    public void checkGetShapeGlyphForUnknownDefinition() {
+        widget.bind(palette);
+
+        assertNull(widget.getShapeGlyph(""));
+    }
+
+    @Test
+    public void checkBeforeBindClearsView() {
+        widget.beforeBind();
+
+        verify(view).clear();
+        verify(view).showEmptyView(eq(false));
+    }
+
+    @Test
+    public void checkBindInitialisesView() {
+        final DefinitionPaletteItem item1 = mock(DefinitionPaletteItem.class);
+        final DefinitionPaletteItem item2 = mock(DefinitionPaletteItem.class);
+        final List<DefinitionPaletteItem> items = new ArrayList<DefinitionPaletteItem>() {{
+            add(item1);
+            add(item2);
+        }};
+        final DMNPaletteItemWidget paletteItemWidget = mock(DMNPaletteItemWidget.class);
+
+        when(palette.getItems()).thenReturn(items);
+        when(paletteItemWidgets.get()).thenReturn(paletteItemWidget);
+
+        widget.bind(palette);
+
+        verify(paletteItemWidget,
+               times(1)).initialize(eq(item1),
+                                    eq(shapeFactory),
+                                    any(Palette.ItemMouseDownCallback.class));
+        verify(paletteItemWidget,
+               times(1)).initialize(eq(item2),
+                                    eq(shapeFactory),
+                                    any(Palette.ItemMouseDownCallback.class));
+        verify(view,
+               times(2)).add(paletteItemWidget);
+    }
+
+    @Test
+    public void checkUnbindWhenPaletteIsBound() {
+        widget.bind(palette);
+
+        reset(view);
+
+        widget.unbind();
+
+        verify(view).clear();
+        verify(view).showEmptyView(eq(true));
+    }
+
+    @Test
+    public void checkUnbindWhenPaletteIsNotBound() {
+        widget.unbind();
+
+        verify(view,
+               never()).clear();
+        verify(view,
+               never()).showEmptyView(anyBoolean());
+    }
+
+    @Test
+    public void checkDoDestroy() {
+        final BS3PaletteViewFactory viewFactory = mock(BS3PaletteViewFactory.class);
+
+        widget.setViewFactory(viewFactory);
+
+        widget.doDestroy();
+
+        verify(paletteItemWidgets).destroyAll();
+        verify(viewFactory).destroy();
+        verify(view).destroy();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidget.java
@@ -16,10 +16,10 @@
 package org.kie.workbench.common.stunner.client.widgets.palette;
 
 import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteViewFactory;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 
-public interface BS3PaletteWidget extends PaletteWidget<DefinitionSetPalette> {
+public interface BS3PaletteWidget<P extends PaletteDefinition> extends PaletteWidget<P> {
 
     BS3PaletteWidget setViewFactory(final BS3PaletteViewFactory viewFactory);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
@@ -45,7 +45,7 @@ import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull
 
 @Dependent
 public class BS3PaletteWidgetImpl extends AbstractPalette<DefinitionSetPalette>
-        implements BS3PaletteWidget,
+        implements BS3PaletteWidget<DefinitionSetPalette>,
                    IsElement {
 
     public static final String BG_COLOR = "#D3D3D3";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/DefaultDefSetPaletteDefinitionFactoryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/DefaultDefSetPaletteDefinitionFactoryImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.palette;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.factory.AbstractPaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.factory.DefaultDefSetPaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
+
+/**
+ * The default PaletteDefinition factory for a DefinitionSetPalette model.
+ * It does not accepts any identifier, it's purpose is for being injected where necessary.
+ */
+@Dependent
+public class DefaultDefSetPaletteDefinitionFactoryImpl extends AbstractPaletteDefinitionFactory<DefinitionSetPaletteBuilder, DefinitionSetPalette, BS3PaletteWidget<DefinitionSetPalette>>
+        implements DefaultDefSetPaletteDefinitionFactory<BS3PaletteWidget<DefinitionSetPalette>> {
+
+    @Inject
+    public DefaultDefSetPaletteDefinitionFactoryImpl(final ShapeManager shapeManager,
+                                                     final DefinitionSetPaletteBuilder paletteBuilder,
+                                                     final BS3PaletteWidget<DefinitionSetPalette> palette) {
+        super(shapeManager,
+              paletteBuilder,
+              palette);
+    }
+
+    @Override
+    public boolean accepts(final String defSetId) {
+        return false;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteFactory.java
@@ -18,8 +18,8 @@ package org.kie.workbench.common.stunner.client.widgets.palette.factory;
 
 import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidgetFactory;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
 
-public interface BS3PaletteFactory extends PaletteWidgetFactory<DefinitionSetPalette, BS3PaletteWidget> {
+public interface BS3PaletteFactory extends PaletteWidgetFactory<PaletteDefinition, BS3PaletteWidget<PaletteDefinition>> {
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteFactoryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteFactoryImpl.java
@@ -28,6 +28,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
@@ -36,10 +37,11 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.event.Canvas
 import org.kie.workbench.common.stunner.core.client.canvas.controls.event.CanvasShapeDragUpdateEvent;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.AbstractPaletteFactory;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.DefaultDefSetPaletteDefinitionFactory;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.factory.PaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
 
 @Dependent
-public class BS3PaletteFactoryImpl extends AbstractPaletteFactory<DefinitionSetPalette, BS3PaletteWidget>
+public class BS3PaletteFactoryImpl extends AbstractPaletteFactory<PaletteDefinition, BS3PaletteWidget<PaletteDefinition>>
         implements BS3PaletteFactory {
 
     private final Event<BuildCanvasShapeEvent> buildCanvasShapeEvent;
@@ -50,15 +52,15 @@ public class BS3PaletteFactoryImpl extends AbstractPaletteFactory<DefinitionSetP
     @Inject
     public BS3PaletteFactoryImpl(final ShapeManager shapeManager,
                                  final SyncBeanManager beanManager,
+                                 final DefinitionManager definitionManager,
                                  final ManagedInstance<DefaultDefSetPaletteDefinitionFactory> defaultPaletteDefinitionFactoryInstance,
-                                 final ManagedInstance<BS3PaletteWidget> paletteInstances,
                                  final Event<BuildCanvasShapeEvent> buildCanvasShapeEvent,
                                  final Event<CanvasShapeDragStartEvent> canvasShapeDragStartEvent,
                                  final Event<CanvasShapeDragUpdateEvent> canvasShapeDragUpdateEvent) {
         super(shapeManager,
               beanManager,
-              defaultPaletteDefinitionFactoryInstance,
-              paletteInstances);
+              definitionManager,
+              defaultPaletteDefinitionFactoryInstance);
         this.buildCanvasShapeEvent = buildCanvasShapeEvent;
         this.canvasShapeDragStartEvent = canvasShapeDragStartEvent;
         this.canvasShapeDragUpdateEvent = canvasShapeDragUpdateEvent;
@@ -76,10 +78,10 @@ public class BS3PaletteFactoryImpl extends AbstractPaletteFactory<DefinitionSetP
     }
 
     @Override
-    public BS3PaletteWidget newPalette(final String shapeSetId,
-                                       final CanvasHandler canvasHandler) {
+    public BS3PaletteWidget<PaletteDefinition> newPalette(final String shapeSetId,
+                                                          final CanvasHandler canvasHandler) {
 
-        final BS3PaletteWidget palette = super.newPalette(shapeSetId);
+        final BS3PaletteWidget<PaletteDefinition> palette = super.newPalette(shapeSetId);
         if (null != canvasHandler) {
             palette.onItemDrop((definition,
                                 factory,
@@ -108,8 +110,8 @@ public class BS3PaletteFactoryImpl extends AbstractPaletteFactory<DefinitionSetP
     }
 
     @Override
-    protected void beforeBindPalette(final DefinitionSetPalette paletteDefinition,
-                                     final BS3PaletteWidget palette,
+    protected void beforeBindPalette(final PaletteDefinition paletteDefinition,
+                                     final BS3PaletteWidget<PaletteDefinition> palette,
                                      final String shapeSetId) {
         super.beforeBindPalette(paletteDefinition,
                                 palette,
@@ -119,7 +121,7 @@ public class BS3PaletteFactoryImpl extends AbstractPaletteFactory<DefinitionSetP
         palette.setViewFactory(viewFactory);
     }
 
-    private BS3PaletteViewFactory getViewFactory(final String defSetId) {
+    BS3PaletteViewFactory getViewFactory(final String defSetId) {
         for (final BS3PaletteViewFactory factory : viewFactories) {
             if (factory.accepts(defSetId)) {
                 return factory;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/SessionPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/SessionPresenter.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.diagram.DiagramViewer;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.Toolbar;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -91,5 +92,5 @@ public interface SessionPresenter<S extends ClientSession, H extends CanvasHandl
 
     Toolbar<S> getToolbar();
 
-    PaletteWidget<DefinitionSetPalette> getPalette();
+    PaletteWidget<PaletteDefinition> getPalette();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionPresenter.java
@@ -33,7 +33,8 @@ import org.kie.workbench.common.stunner.client.widgets.toolbar.Toolbar;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.ToolbarFactory;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -44,13 +45,13 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
 
     private final SessionManager sessionManager;
     private final Optional<ToolbarFactory<S>> toolbarFactory;
-    private final Optional<PaletteWidgetFactory<DefinitionSetPalette, ?>> paletteFactory;
+    private final Optional<PaletteWidgetFactory<PaletteDefinition, ?>> paletteFactory;
     private final SessionPresenter.View view;
     private final NotificationsObserver notificationsObserver;
 
     private D diagram;
     private Toolbar<S> toolbar;
-    private PaletteWidget<DefinitionSetPalette> palette;
+    private PaletteWidget<PaletteDefinition> palette;
     private boolean hasToolbar = false;
     private boolean hasPalette = false;
     private Optional<Predicate<Notification.Type>> typePredicate;
@@ -59,7 +60,7 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
     protected AbstractSessionPresenter(final SessionManager sessionManager,
                                        final SessionPresenter.View view,
                                        final Optional<? extends ToolbarFactory<S>> toolbarFactory,
-                                       final Optional<PaletteWidgetFactory<DefinitionSetPalette, ?>> paletteFactory,
+                                       final Optional<PaletteWidgetFactory<PaletteDefinition, ?>> paletteFactory,
                                        final NotificationsObserver notificationsObserver) {
         this.sessionManager = sessionManager;
         this.toolbarFactory = (Optional<ToolbarFactory<S>>) toolbarFactory;
@@ -202,7 +203,7 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
     }
 
     @Override
-    public PaletteWidget<DefinitionSetPalette> getPalette() {
+    public PaletteWidget<PaletteDefinition> getPalette() {
         return palette;
     }
 
@@ -266,13 +267,15 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
         return toolbarFactory.get().build(session);
     }
 
-    private PaletteWidget<DefinitionSetPalette> buildPalette(final S session) {
+    @SuppressWarnings("unchecked")
+    private PaletteWidget<PaletteDefinition> buildPalette(final S session) {
         if (!paletteFactory.isPresent()) {
             throw new UnsupportedOperationException("This session presenter with type [" + this.getClass().getName() + "] does not supports the palette.");
         }
         final Diagram diagram = session.getCanvasHandler().getDiagram();
-        return paletteFactory.get().newPalette(diagram.getMetadata().getShapeSetId(),
-                                               session.getCanvasHandler());
+        return paletteFactory.get()
+                .newPalette(diagram.getMetadata().getShapeSetId(),
+                            session.getCanvasHandler());
     }
 
     private void destroyToolbar() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteFactoryImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/factory/BS3PaletteFactoryImplTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.palette.factory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.event.Event;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.ShapeSet;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.event.BuildCanvasShapeEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.event.CanvasShapeDragStartEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.event.CanvasShapeDragUpdateEvent;
+import org.kie.workbench.common.stunner.core.client.components.palette.factory.DefaultDefSetPaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.factory.PaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
+import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionSetRegistry;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BS3PaletteFactoryImplTest {
+
+    private static final String DEFINITION_SET_ID = "definitionSetId";
+
+    private static final String SHAPE_SET_ID = "shapeSetId";
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private SyncBeanManager beanManager;
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private ManagedInstance<DefaultDefSetPaletteDefinitionFactory> defaultPaletteDefinitionFactoryInstance;
+
+    @Mock
+    private Event<BuildCanvasShapeEvent> buildCanvasShapeEvent;
+
+    @Mock
+    private Event<CanvasShapeDragStartEvent> canvasShapeDragStartEvent;
+
+    @Mock
+    private Event<CanvasShapeDragUpdateEvent> canvasShapeDragUpdateEvent;
+
+    @Mock
+    private SyncBeanDef<PaletteDefinitionFactory> paletteDefinitionFactorySyncBeanDef;
+
+    @Mock
+    private SyncBeanDef<BS3PaletteViewFactory> paletteViewFactorySyncBeanDef;
+
+    @Mock
+    private PaletteDefinitionFactory paletteDefinitionFactory;
+
+    @Mock
+    private BS3PaletteViewFactory paletteViewFactory;
+
+    @Mock
+    private ShapeSet shapeSet;
+
+    @Mock
+    private CanvasHandler canvasHandler;
+
+    @Mock
+    private TypeDefinitionSetRegistry typeDefinitionSetRegistry;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private DefinitionSetAdapter definitionSetAdapter;
+
+    @Mock
+    private PaletteDefinitionBuilder paletteDefinitionBuilder;
+
+    @Mock
+    private BS3PaletteWidget paletteWidget;
+
+    @Captor
+    private ArgumentCaptor<PaletteDefinitionBuilder.Configuration> configurationArgumentCaptor;
+
+    private Object definitionSet = new Object();
+
+    private Set<String> definitions = new HashSet<>();
+
+    private BS3PaletteFactoryImpl paletteFactory;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.paletteFactory = new BS3PaletteFactoryImpl(shapeManager,
+                                                        beanManager,
+                                                        definitionManager,
+                                                        defaultPaletteDefinitionFactoryInstance,
+                                                        buildCanvasShapeEvent,
+                                                        canvasShapeDragStartEvent,
+                                                        canvasShapeDragUpdateEvent);
+        final Collection<SyncBeanDef<PaletteDefinitionFactory>> paletteFactoryBeans = new ArrayList<>();
+        final Collection<SyncBeanDef<BS3PaletteViewFactory>> beanDefSets = new ArrayList<>();
+        paletteFactoryBeans.add(paletteDefinitionFactorySyncBeanDef);
+        beanDefSets.add(paletteViewFactorySyncBeanDef);
+
+        when(beanManager.lookupBeans(eq(PaletteDefinitionFactory.class))).thenReturn(paletteFactoryBeans);
+        when(beanManager.lookupBeans(eq(BS3PaletteViewFactory.class))).thenReturn(beanDefSets);
+        when(paletteDefinitionFactorySyncBeanDef.getInstance()).thenReturn(paletteDefinitionFactory);
+        when(paletteViewFactorySyncBeanDef.getInstance()).thenReturn(paletteViewFactory);
+        when(paletteDefinitionFactory.accepts(eq(DEFINITION_SET_ID))).thenReturn(true);
+        when(paletteViewFactory.accepts(eq(DEFINITION_SET_ID))).thenReturn(true);
+
+        final Collection<ShapeSet<?>> shapeSets = new ArrayList<>();
+        shapeSets.add(shapeSet);
+
+        when(shapeManager.getShapeSets()).thenReturn(shapeSets);
+        when(shapeSet.getId()).thenReturn(SHAPE_SET_ID);
+        when(shapeSet.getDefinitionSetId()).thenReturn(DEFINITION_SET_ID);
+
+        when(definitionManager.definitionSets()).thenReturn(typeDefinitionSetRegistry);
+        when(typeDefinitionSetRegistry.getDefinitionSetById(eq(DEFINITION_SET_ID))).thenReturn(definitionSet);
+
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.forDefinitionSet()).thenReturn(definitionSetAdapter);
+        when(definitionSetAdapter.getDefinitions(eq(definitionSet))).thenReturn(definitions);
+
+        when(paletteDefinitionFactory.newBuilder(eq(DEFINITION_SET_ID))).thenReturn(paletteDefinitionBuilder);
+        when(paletteDefinitionFactory.newPalette()).thenReturn(paletteWidget);
+    }
+
+    @Test
+    public void checkInit() {
+        paletteFactory.init();
+
+        assertEquals(paletteViewFactory,
+                     paletteFactory.getViewFactory(DEFINITION_SET_ID));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkNewPalette() {
+        paletteFactory.init();
+
+        paletteFactory.newPalette(SHAPE_SET_ID,
+                                  canvasHandler);
+
+        verify(paletteDefinitionBuilder).build(configurationArgumentCaptor.capture(),
+                                               any(PaletteDefinitionBuilder.Callback.class));
+
+        final PaletteDefinitionBuilder.Configuration configuration = configurationArgumentCaptor.getValue();
+        assertEquals(DEFINITION_SET_ID,
+                     configuration.getDefinitionSetId());
+        assertEquals(definitions,
+                     configuration.getDefinitionIds());
+
+        verify(paletteWidget).onItemDrop(any(PaletteWidget.ItemDropCallback.class));
+        verify(paletteWidget).onItemDragStart(any(PaletteWidget.ItemDragStartCallback.class));
+        verify(paletteWidget).onItemDragUpdate(any(PaletteWidget.ItemDragUpdateCallback.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/PaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/PaletteDefinitionFactory.java
@@ -16,9 +16,11 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
 
-public interface PaletteDefinitionFactory<B extends PaletteDefinitionBuilder> {
+public interface PaletteDefinitionFactory<B extends PaletteDefinitionBuilder, I extends HasPaletteItems, P extends Palette<I>> {
 
     /**
      * Returns if this provider accepts the given Definition Set identifier.
@@ -29,4 +31,6 @@ public interface PaletteDefinitionFactory<B extends PaletteDefinitionBuilder> {
      * Builds the palette definition for the given Definition Set identifier.
      */
     B newBuilder(final String defSetId);
+
+    P newPalette();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/PaletteDefinition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/PaletteDefinition.java
@@ -18,4 +18,6 @@ package org.kie.workbench.common.stunner.core.client.components.palette.model;
 
 public interface PaletteDefinition<I extends PaletteItem> extends HasPaletteItems<I> {
 
+    String getDefinitionSetId();
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/PaletteDefinitionBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/PaletteDefinitionBuilder.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.model;
 
+import java.util.Set;
+
 public interface PaletteDefinitionBuilder<T, P, E> {
 
     interface Callback<P, E> {
@@ -23,6 +25,14 @@ public interface PaletteDefinitionBuilder<T, P, E> {
         void onSuccess(final P paletteDefinition);
 
         void onError(final E error);
+    }
+
+    interface Configuration {
+
+        String getDefinitionSetId();
+
+        Set<String> getDefinitionIds();
+
     }
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/command/palette/AbstractPaletteCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/command/palette/AbstractPaletteCommand.java
@@ -142,7 +142,22 @@ public abstract class AbstractPaletteCommand<I> extends AbstractToolboxCommand<I
         log(Level.FINE,
             "Allowed Definitions -> " + allowedDefinitions);
         if (null != allowedDefinitions && !allowedDefinitions.isEmpty()) {
-            definitionsPaletteBuilder.build(allowedDefinitions,
+
+            final String definitionSetId = canvasHandler.getDiagram().getMetadata().getDefinitionSetId();
+            final PaletteDefinitionBuilder.Configuration configuration = new PaletteDefinitionBuilder.Configuration() {
+
+                @Override
+                public String getDefinitionSetId() {
+                    return definitionSetId;
+                }
+
+                @Override
+                public Set<String> getDefinitionIds() {
+                    return allowedDefinitions;
+                }
+            };
+
+            definitionsPaletteBuilder.build(configuration,
                                             new PaletteDefinitionBuilder.Callback<DefinitionsPalette, ClientRuntimeError>() {
 
                                                 @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteDefinitionFactory.java
@@ -17,22 +17,33 @@
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
 
-public abstract class AbstractPaletteDefinitionFactory<B extends PaletteDefinitionBuilder>
-        implements PaletteDefinitionFactory<B> {
+public abstract class AbstractPaletteDefinitionFactory<B extends PaletteDefinitionBuilder, I extends HasPaletteItems, P extends Palette<I>>
+        implements PaletteDefinitionFactory<B, I, P> {
 
     protected ShapeManager shapeManager;
     protected B paletteBuilder;
+    protected P palette;
 
     public AbstractPaletteDefinitionFactory(final ShapeManager shapeManager,
-                                            final B paletteBuilder) {
+                                            final B paletteBuilder,
+                                            final P palette) {
         this.shapeManager = shapeManager;
         this.paletteBuilder = paletteBuilder;
+        this.palette=palette;
     }
 
     @Override
     public B newBuilder(final String defSetId) {
         return paletteBuilder;
     }
+
+    @Override
+    public P newPalette() {
+        return palette;
+    }
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteFactory.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -26,6 +27,7 @@ import com.google.gwt.logging.client.LogConfiguration;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.ShapeSet;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
@@ -40,32 +42,32 @@ public abstract class AbstractPaletteFactory<I extends HasPaletteItems, P extend
     private static Logger LOGGER = Logger.getLogger(AbstractPaletteFactory.class.getName());
 
     protected final SyncBeanManager beanManager;
-    protected final ManagedInstance<DefaultDefSetPaletteDefinitionFactory> defaultPaletteDefinitionFactoryInstance;
-    protected final ManagedInstance<P> paletteInstances;
     protected final ShapeManager shapeManager;
+    protected final DefinitionManager definitionManager;
 
-    protected final List<DefSetPaletteDefinitionFactory> paletteDefinitionFactories = new LinkedList<>();
+    protected final List<PaletteDefinitionFactory> paletteDefinitionFactories = new LinkedList<>();
+    protected final ManagedInstance<DefaultDefSetPaletteDefinitionFactory> defaultPaletteDefinitionFactoryInstance;
 
     public AbstractPaletteFactory(final ShapeManager shapeManager,
                                   final SyncBeanManager beanManager,
-                                  final ManagedInstance<DefaultDefSetPaletteDefinitionFactory> defaultPaletteDefinitionFactoryInstance,
-                                  final ManagedInstance<P> paletteInstances) {
+                                  final DefinitionManager definitionManager,
+                                  final ManagedInstance<DefaultDefSetPaletteDefinitionFactory> defaultPaletteDefinitionFactoryInstance) {
         this.shapeManager = shapeManager;
         this.beanManager = beanManager;
+        this.definitionManager = definitionManager;
         this.defaultPaletteDefinitionFactoryInstance = defaultPaletteDefinitionFactoryInstance;
-        this.paletteInstances = paletteInstances;
     }
 
     public void init() {
-        Collection<SyncBeanDef<DefSetPaletteDefinitionFactory>> factorySets = beanManager.lookupBeans(DefSetPaletteDefinitionFactory.class);
-        for (SyncBeanDef<DefSetPaletteDefinitionFactory> defSet : factorySets) {
-            DefSetPaletteDefinitionFactory factory = defSet.getInstance();
+        Collection<SyncBeanDef<PaletteDefinitionFactory>> paletteFactoryBeans = beanManager.lookupBeans(PaletteDefinitionFactory.class);
+        for (SyncBeanDef<PaletteDefinitionFactory> paletteFactoryBean : paletteFactoryBeans) {
+            PaletteDefinitionFactory factory = paletteFactoryBean.getInstance();
             paletteDefinitionFactories.add(factory);
         }
     }
 
     protected PaletteDefinitionFactory getPaletteDefinitionFactory(final String defSetId) {
-        for (final DefSetPaletteDefinitionFactory factory : paletteDefinitionFactories) {
+        for (final PaletteDefinitionFactory factory : paletteDefinitionFactories) {
             if (factory.accepts(defSetId)) {
                 return factory;
             }
@@ -83,11 +85,27 @@ public abstract class AbstractPaletteFactory<I extends HasPaletteItems, P extend
     @SuppressWarnings("unchecked")
     public P newPalette(final String shapeSetId,
                         final PaletteGrid grid) {
-        final P palette = paletteInstances.get();
-        final String defSetId = getShapeSet(shapeSetId).getDefinitionSetId();
-        final PaletteDefinitionFactory<PaletteDefinitionBuilder<Object, I, ClientRuntimeError>> paletteDefinitionFactory = getPaletteDefinitionFactory(defSetId);
-        final PaletteDefinitionBuilder<Object, I, ClientRuntimeError> paletteDefinitionBuilder = paletteDefinitionFactory.newBuilder(defSetId);
-        paletteDefinitionBuilder.build(defSetId,
+        final String definitionSetId = getShapeSet(shapeSetId).getDefinitionSetId();
+        final Object definitionSet = definitionManager.definitionSets().getDefinitionSetById(definitionSetId);
+        final Set<String> definitions = definitionManager.adapters().forDefinitionSet().getDefinitions(definitionSet);
+
+        final PaletteDefinitionFactory<PaletteDefinitionBuilder<PaletteDefinitionBuilder.Configuration, I, ClientRuntimeError>, I, P> paletteDefinitionFactory = getPaletteDefinitionFactory(definitionSetId);
+        final PaletteDefinitionBuilder<PaletteDefinitionBuilder.Configuration, I, ClientRuntimeError> paletteDefinitionBuilder = paletteDefinitionFactory.newBuilder(definitionSetId);
+        final P palette = paletteDefinitionFactory.newPalette();
+
+        final PaletteDefinitionBuilder.Configuration configuration = new PaletteDefinitionBuilder.Configuration() {
+
+            @Override
+            public String getDefinitionSetId() {
+                return definitionSetId;
+            }
+
+            @Override
+            public Set<String> getDefinitionIds() {
+                return definitions;
+            }
+        };
+        paletteDefinitionBuilder.build(configuration,
                                        new PaletteDefinitionBuilder.Callback<I, ClientRuntimeError>() {
 
                                            @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindableDefSetPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindableDefSetPaletteDefinitionFactory.java
@@ -17,17 +17,22 @@
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 
-public abstract class BindableDefSetPaletteDefinitionFactory
-        extends BindablePaletteDefinitionFactory<DefinitionSetPaletteBuilder>
-        implements DefSetPaletteDefinitionFactory {
+public abstract class BindableDefSetPaletteDefinitionFactory<I extends HasPaletteItems, P extends Palette<I>>
+        extends BindablePaletteDefinitionFactory<DefinitionSetPaletteBuilder, I, P>
+        implements DefSetPaletteDefinitionFactory<I, P> {
+
 
     public BindableDefSetPaletteDefinitionFactory(final ShapeManager shapeManager,
-                                                  final DefinitionSetPaletteBuilder paletteBuilder) {
+                                                  final DefinitionSetPaletteBuilder paletteBuilder,
+                                                  final P palette) {
         super(shapeManager,
-              paletteBuilder);
+              paletteBuilder,
+              palette);
     }
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindablePaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindablePaletteDefinitionFactory.java
@@ -17,16 +17,20 @@
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 
-public abstract class BindablePaletteDefinitionFactory<B extends PaletteDefinitionBuilder>
-        extends AbstractPaletteDefinitionFactory<B> {
+public abstract class BindablePaletteDefinitionFactory<B extends PaletteDefinitionBuilder, I extends HasPaletteItems, P extends Palette<I>>
+        extends AbstractPaletteDefinitionFactory<B, I, P> {
 
     public BindablePaletteDefinitionFactory(final ShapeManager shapeManager,
-                                            final B paletteBuilder) {
+                                            final B paletteBuilder,
+                                            final P palette) {
         super(shapeManager,
-              paletteBuilder);
+              paletteBuilder,
+              palette);
     }
 
     protected abstract Class<?> getDefinitionSetType();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/DefSetPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/DefSetPaletteDefinitionFactory.java
@@ -16,8 +16,10 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
 
-public interface DefSetPaletteDefinitionFactory extends PaletteDefinitionFactory<DefinitionSetPaletteBuilder> {
+public interface DefSetPaletteDefinitionFactory<I extends HasPaletteItems, P extends Palette<I>> extends PaletteDefinitionFactory<DefinitionSetPaletteBuilder, I, P> {
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/DefaultDefSetPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/DefaultDefSetPaletteDefinitionFactory.java
@@ -16,29 +16,10 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
+import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 
-import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
+public interface DefaultDefSetPaletteDefinitionFactory<P extends Palette<DefinitionSetPalette>>
+        extends DefSetPaletteDefinitionFactory<DefinitionSetPalette, P> {
 
-/**
- * The default PaletteDefinition factory for a DefinitionSetPalette model.
- * It does not accepts any identifier, it's purpose is for being injected where necessary.
- */
-@Dependent
-public class DefaultDefSetPaletteDefinitionFactory extends AbstractPaletteDefinitionFactory<DefinitionSetPaletteBuilder>
-        implements DefSetPaletteDefinitionFactory {
-
-    @Inject
-    public DefaultDefSetPaletteDefinitionFactory(final ShapeManager shapeManager,
-                                                 final DefinitionSetPaletteBuilder paletteBuilder) {
-        super(shapeManager,
-              paletteBuilder);
-    }
-
-    @Override
-    public boolean accepts(final String defSetId) {
-        return false;
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/AbstractPaletteDefinition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/AbstractPaletteDefinition.java
@@ -21,13 +21,21 @@ import java.util.List;
 public abstract class AbstractPaletteDefinition<I extends PaletteItem> implements PaletteDefinition<I> {
 
     protected final List<I> items;
+    protected String defSetId;
 
-    protected AbstractPaletteDefinition(final List<I> groups) {
+    protected AbstractPaletteDefinition(final List<I> groups,
+                                        final String defSetId) {
         this.items = groups;
+        this.defSetId = defSetId;
     }
 
     @Override
     public List<I> getItems() {
         return items;
+    }
+
+    @Override
+    public String getDefinitionSetId() {
+        return defSetId;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/DefinitionSetPalette.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/DefinitionSetPalette.java
@@ -26,5 +26,4 @@ import org.kie.workbench.common.stunner.core.client.components.palette.model.Pal
  */
 public interface DefinitionSetPalette extends PaletteDefinition<DefinitionPaletteCategory> {
 
-    String getDefinitionSetId();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/DefinitionSetPaletteBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/DefinitionSetPaletteBuilder.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.stunner.core.client.components.palette.model.de
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 
-public interface DefinitionSetPaletteBuilder extends PaletteDefinitionBuilder<Object, DefinitionSetPalette, ClientRuntimeError> {
+public interface DefinitionSetPaletteBuilder extends PaletteDefinitionBuilder<PaletteDefinitionBuilder.Configuration, DefinitionSetPalette, ClientRuntimeError> {
 
     interface PaletteCategoryProvider {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/DefinitionsPaletteBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/DefinitionsPaletteBuilder.java
@@ -16,16 +16,9 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.model.definition;
 
-import java.util.List;
-
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 
-public interface DefinitionsPaletteBuilder extends PaletteDefinitionBuilder<Iterable<String>, DefinitionsPalette, ClientRuntimeError> {
+public interface DefinitionsPaletteBuilder extends PaletteDefinitionBuilder<PaletteDefinitionBuilder.Configuration, DefinitionsPalette, ClientRuntimeError> {
 
-    void buildFromDefinitionSet(final String defintionSetId,
-                                final Callback<DefinitionsPalette, ClientRuntimeError> callback);
-
-    void buildFromPaletteItems(final List<DefinitionPaletteItem> definitionPaletteItems,
-                               final Callback<DefinitionsPalette, ClientRuntimeError> callback);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionSetPaletteBuilderImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionSetPaletteBuilderImpl.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.AbstractPaletteDefinitionBuilder;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteCategory;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
@@ -41,7 +42,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
  */
 @Dependent
 public class DefinitionSetPaletteBuilderImpl
-        extends AbstractPaletteDefinitionBuilder<Object, DefinitionSetPalette, ClientRuntimeError>
+        extends AbstractPaletteDefinitionBuilder<PaletteDefinitionBuilder.Configuration, DefinitionSetPalette, ClientRuntimeError>
         implements DefinitionSetPaletteBuilder {
 
     private final DefinitionUtils definitionUtils;
@@ -64,12 +65,11 @@ public class DefinitionSetPaletteBuilderImpl
         this.paletteMorphGroupProvider = MORPH_GROUP_PROVIDER;
     }
 
-    public void build(final Object definitionSet,
+    public void build(final PaletteDefinitionBuilder.Configuration configuration,
                       final Callback<DefinitionSetPalette, ClientRuntimeError> callback) {
-        final Object definitionSetObject = definitionSet instanceof String ?
-                getDefinitionManager().definitionSets().getDefinitionSetById((String) definitionSet) : definitionSet;
-        final String defSetId = getDefinitionManager().adapters().forDefinitionSet().getId(definitionSetObject);
-        final Collection<String> definitions = getDefinitionManager().adapters().forDefinitionSet().getDefinitions(definitionSetObject);
+        final String defSetId = configuration.getDefinitionSetId();
+        final Collection<String> definitions = configuration.getDefinitionIds();
+
         if (null != definitions) {
             final List<DefinitionPaletteCategoryImpl.DefinitionPaletteCategoryBuilder> categoryBuilders = new LinkedList<>();
             for (final String defId : definitions) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionSetPaletteImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionSetPaletteImpl.java
@@ -26,16 +26,9 @@ public final class DefinitionSetPaletteImpl
         extends AbstractPaletteDefinition<DefinitionPaletteCategory>
         implements DefinitionSetPalette {
 
-    private final String defSetId;
-
     public DefinitionSetPaletteImpl(final List<DefinitionPaletteCategory> categories,
                                     final String defSetId) {
-        super(categories);
-        this.defSetId = defSetId;
-    }
-
-    @Override
-    public String getDefinitionSetId() {
-        return defSetId;
+        super(categories,
+              defSetId);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionsPaletteImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionsPaletteImpl.java
@@ -26,7 +26,9 @@ public final class DefinitionsPaletteImpl
         extends AbstractPaletteDefinition<DefinitionPaletteItem>
         implements DefinitionsPalette {
 
-    protected DefinitionsPaletteImpl(final List<DefinitionPaletteItem> items) {
-        super(items);
+    protected DefinitionsPaletteImpl(final List<DefinitionPaletteItem> items,
+                                     final String defSetId) {
+        super(items,
+              defSetId);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionSetPaletteBuilderImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionSetPaletteBuilderImplTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.components.palette.model.definition.impl;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteCategory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
+import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefinitionSetPaletteBuilderImplTest {
+
+    private static final String DEFINITION_SET_ID = "definitionSetId";
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private ClientFactoryService clientFactoryServices;
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private DefinitionAdapter definitionAdapter;
+
+    private Set<String> definitionIds = new HashSet<>();
+
+    private PaletteDefinitionBuilder.Configuration configuration;
+
+    private PaletteDefinitionBuilder.Callback<DefinitionSetPalette, ClientRuntimeError> callback;
+
+    private Object defId1 = new Object();
+
+    private Object defId2 = new Object();
+
+    private Object defId3 = new Object();
+
+    private DefinitionSetPalette paletteDefinition;
+
+    private DefinitionSetPaletteBuilderImpl paletteBuilder;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        paletteBuilder = new DefinitionSetPaletteBuilderImpl(definitionUtils,
+                                                             clientFactoryServices);
+        definitionIds.add("id1");
+        definitionIds.add("id2");
+        definitionIds.add("id3");
+
+        configuration = new PaletteDefinitionBuilder.Configuration() {
+            @Override
+            public String getDefinitionSetId() {
+                return DEFINITION_SET_ID;
+            }
+
+            @Override
+            public Set<String> getDefinitionIds() {
+                return definitionIds;
+            }
+        };
+        callback = new PaletteDefinitionBuilder.Callback<DefinitionSetPalette, ClientRuntimeError>() {
+            @Override
+            public void onSuccess(final DefinitionSetPalette paletteDefinition) {
+                DefinitionSetPaletteBuilderImplTest.this.paletteDefinition = paletteDefinition;
+            }
+
+            @Override
+            public void onError(final ClientRuntimeError error) {
+                fail(error.getMessage());
+            }
+        };
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final String id = (String) invocation.getArguments()[0];
+            final ServiceCallback callback = (ServiceCallback) invocation.getArguments()[1];
+            if (id.equals("id1")) {
+                callback.onSuccess(defId1);
+            } else if (id.equals("id2")) {
+                callback.onSuccess(defId2);
+            } else if (id.equals("id3")) {
+                callback.onSuccess(defId3);
+            } else {
+                callback.onError(new ClientRuntimeError("Not found"));
+            }
+            return null;
+        }).when(clientFactoryServices).newDefinition(anyString(),
+                                                     any(ServiceCallback.class));
+
+        when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "id1";
+            } else if (o == defId2) {
+                return "id2";
+            } else if (o == defId3) {
+                return "id3";
+            }
+            return null;
+        }).when(definitionAdapter).getId(anyObject());
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "category1";
+            } else if (o == defId2) {
+                return "category2";
+            } else if (o == defId3) {
+                return "category2";
+            }
+            return null;
+        }).when(definitionAdapter).getCategory(anyObject());
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "defId1-title";
+            } else if (o == defId2) {
+                return "defId2-title";
+            } else if (o == defId3) {
+                return "defId3-title";
+            }
+            return null;
+        }).when(definitionAdapter).getTitle(anyObject());
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "defId1-description";
+            } else if (o == defId2) {
+                return "defId2-description";
+            } else if (o == defId3) {
+                return "defId3-description";
+            }
+            return null;
+        }).when(definitionAdapter).getDescription(anyObject());
+    }
+
+    @Test
+    public void checkBuildWithNoExclusions() {
+        paletteBuilder.build(configuration,
+                             callback);
+
+        assertNotNull(paletteDefinition);
+        assertEquals(2,
+                     paletteDefinition.getItems().size());
+        final DefinitionPaletteCategory category1 = assertPaletteContainsCategory("category1");
+        final DefinitionPaletteCategory category2 = assertPaletteContainsCategory("category2");
+
+        assertPaletteCategoryContains(category1,
+                                      "id1");
+        assertPaletteCategoryContains(category2,
+                                      "id2");
+        assertPaletteCategoryContains(category2,
+                                      "id3");
+    }
+
+    @Test
+    public void checkBuildWithCategoryExclusion() {
+        paletteBuilder.excludeCategory("category1");
+
+        paletteBuilder.build(configuration,
+                             callback);
+
+        assertNotNull(paletteDefinition);
+        assertEquals(1,
+                     paletteDefinition.getItems().size());
+        final DefinitionPaletteCategory category2 = assertPaletteContainsCategory("category2");
+
+        assertPaletteCategoryContains(category2,
+                                      "id2");
+        assertPaletteCategoryContains(category2,
+                                      "id3");
+    }
+
+    @Test
+    public void checkBuildWithDefinitionExclusion() {
+        paletteBuilder.excludeDefinition("id3");
+
+        paletteBuilder.build(configuration,
+                             callback);
+
+        assertNotNull(paletteDefinition);
+        assertEquals(2,
+                     paletteDefinition.getItems().size());
+        final DefinitionPaletteCategory category1 = assertPaletteContainsCategory("category1");
+        final DefinitionPaletteCategory category2 = assertPaletteContainsCategory("category2");
+
+        assertPaletteCategoryContains(category1,
+                                      "id1");
+        assertPaletteCategoryContains(category2,
+                                      "id2");
+    }
+
+    private DefinitionPaletteCategory assertPaletteContainsCategory(final String category) {
+        return paletteDefinition.getItems().stream().filter(c -> c.getTitle().equals(category)).findFirst().orElseThrow(() -> new RuntimeException("Not found"));
+    }
+
+    private void assertPaletteCategoryContains(final DefinitionPaletteCategory category,
+                                               final String itemId) {
+        assertTrue(category.getItems().stream().filter(i -> i.getId().equals(itemId)).findFirst().isPresent());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionsPaletteBuilderImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/model/definition/impl/DefinitionsPaletteBuilderImplTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.components.palette.model.definition.impl;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteItem;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefinitionsPaletteBuilderImplTest {
+
+    private static final String DEFINITION_SET_ID = "definitionSetId";
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private ClientFactoryService clientFactoryServices;
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private DefinitionAdapter definitionAdapter;
+
+    private Set<String> definitionIds = new HashSet<>();
+
+    private PaletteDefinitionBuilder.Configuration configuration;
+
+    private PaletteDefinitionBuilder.Callback<DefinitionsPalette, ClientRuntimeError> callback;
+
+    private Object defId1 = new Object();
+
+    private Object defId2 = new Object();
+
+    private Object defId3 = new Object();
+
+    private DefinitionsPalette paletteDefinition;
+
+    private DefinitionsPaletteBuilderImpl paletteBuilder;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        paletteBuilder = new DefinitionsPaletteBuilderImpl(definitionUtils,
+                                                           clientFactoryServices);
+        definitionIds.add("id1");
+        definitionIds.add("id2");
+        definitionIds.add("id3");
+
+        configuration = new PaletteDefinitionBuilder.Configuration() {
+            @Override
+            public String getDefinitionSetId() {
+                return DEFINITION_SET_ID;
+            }
+
+            @Override
+            public Set<String> getDefinitionIds() {
+                return definitionIds;
+            }
+        };
+        callback = new PaletteDefinitionBuilder.Callback<DefinitionsPalette, ClientRuntimeError>() {
+            @Override
+            public void onSuccess(final DefinitionsPalette paletteDefinition) {
+                DefinitionsPaletteBuilderImplTest.this.paletteDefinition = paletteDefinition;
+            }
+
+            @Override
+            public void onError(final ClientRuntimeError error) {
+                fail(error.getMessage());
+            }
+        };
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final String id = (String) invocation.getArguments()[0];
+            final ServiceCallback callback = (ServiceCallback) invocation.getArguments()[1];
+            if (id.equals("id1")) {
+                callback.onSuccess(defId1);
+            } else if (id.equals("id2")) {
+                callback.onSuccess(defId2);
+            } else if (id.equals("id3")) {
+                callback.onSuccess(defId3);
+            } else {
+                callback.onError(new ClientRuntimeError("Not found"));
+            }
+            return null;
+        }).when(clientFactoryServices).newDefinition(anyString(),
+                                                     any(ServiceCallback.class));
+
+        when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "id1";
+            } else if (o == defId2) {
+                return "id2";
+            } else if (o == defId3) {
+                return "id3";
+            }
+            return null;
+        }).when(definitionAdapter).getId(anyObject());
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "category1";
+            } else if (o == defId2) {
+                return "category2";
+            } else if (o == defId3) {
+                return "category2";
+            }
+            return null;
+        }).when(definitionAdapter).getCategory(anyObject());
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "defId1-title";
+            } else if (o == defId2) {
+                return "defId2-title";
+            } else if (o == defId3) {
+                return "defId3-title";
+            }
+            return null;
+        }).when(definitionAdapter).getTitle(anyObject());
+
+        doAnswer((InvocationOnMock invocation) -> {
+            final Object o = invocation.getArguments()[0];
+            if (o == defId1) {
+                return "defId1-description";
+            } else if (o == defId2) {
+                return "defId2-description";
+            } else if (o == defId3) {
+                return "defId3-description";
+            }
+            return null;
+        }).when(definitionAdapter).getDescription(anyObject());
+    }
+
+    @Test
+    public void checkBuildWithNoExclusions() {
+        paletteBuilder.build(configuration,
+                             callback);
+
+        assertNotNull(paletteDefinition);
+        assertEquals(3,
+                     paletteDefinition.getItems().size());
+        assertPaletteContainsId("id1");
+        assertPaletteContainsId("id2");
+        assertPaletteContainsId("id3");
+    }
+
+    @Test
+    public void checkBuildWithCategoryExclusion() {
+        paletteBuilder.excludeCategory("category1");
+
+        paletteBuilder.build(configuration,
+                             callback);
+
+        assertNotNull(paletteDefinition);
+        assertEquals(2,
+                     paletteDefinition.getItems().size());
+        assertPaletteContainsId("id2");
+        assertPaletteContainsId("id3");
+    }
+
+    @Test
+    public void checkBuildWithDefinitionExclusion() {
+        paletteBuilder.excludeDefinition("id3");
+
+        paletteBuilder.build(configuration,
+                             callback);
+
+        assertNotNull(paletteDefinition);
+        assertEquals(2,
+                     paletteDefinition.getItems().size());
+        assertPaletteContainsId("id1");
+        assertPaletteContainsId("id2");
+    }
+
+    private DefinitionPaletteItem assertPaletteContainsId(final String id) {
+        return paletteDefinition.getItems().stream().filter(c -> c.getId().equals(id)).findFirst().orElseThrow(() -> new RuntimeException("Not found"));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-basicset/kie-wb-common-stunner-basicset-client/src/main/java/org/kie/workbench/common/stunner/basicset/client/components/palette/factory/BasicSetPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-basicset/kie-wb-common-stunner-basicset-client/src/main/java/org/kie/workbench/common/stunner/basicset/client/components/palette/factory/BasicSetPaletteDefinitionFactory.java
@@ -25,13 +25,15 @@ import org.kie.workbench.common.stunner.basicset.BasicSet;
 import org.kie.workbench.common.stunner.basicset.definition.BasicConnector;
 import org.kie.workbench.common.stunner.basicset.definition.Categories;
 import org.kie.workbench.common.stunner.basicset.definition.Rectangle;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.BindableDefSetPaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
 
 // TODO: i18n.
 @Dependent
-public class BasicSetPaletteDefinitionFactory extends BindableDefSetPaletteDefinitionFactory {
+public class BasicSetPaletteDefinitionFactory extends BindableDefSetPaletteDefinitionFactory<DefinitionSetPalette, BS3PaletteWidget<DefinitionSetPalette>> {
 
     private static final Map<String, String> CAT_TITLES = new HashMap<String, String>(6) {{
         put(Categories.BASIC,
@@ -52,9 +54,11 @@ public class BasicSetPaletteDefinitionFactory extends BindableDefSetPaletteDefin
 
     @Inject
     public BasicSetPaletteDefinitionFactory(final ShapeManager shapeManager,
-                                            final DefinitionSetPaletteBuilder paletteBuilder) {
+                                            final DefinitionSetPaletteBuilder paletteBuilder,
+                                            final BS3PaletteWidget<DefinitionSetPalette> palette) {
         super(shapeManager,
-              paletteBuilder);
+              paletteBuilder,
+              palette);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/factory/BPMNPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/factory/BPMNPaletteDefinitionFactory.java
@@ -41,17 +41,18 @@ import org.kie.workbench.common.stunner.bpmn.definition.SequenceFlow;
 import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.StartSignalEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.StartTimerEvent;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.BindableDefSetPaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
 import org.kie.workbench.common.stunner.core.i18n.AbstractTranslationService;
 
 // TODO: i18n.
 @Dependent
-public class BPMNPaletteDefinitionFactory extends BindableDefSetPaletteDefinitionFactory {
+public class BPMNPaletteDefinitionFactory extends BindableDefSetPaletteDefinitionFactory<DefinitionSetPalette, BS3PaletteWidget<DefinitionSetPalette>> {
 
   private final AbstractTranslationService translationService;
-
 
   private static final Map<String, Class<?>> CAT_DEF_IDS = new HashMap<String, Class<?>>(1) {{
     put(Categories.ACTIVITIES,
@@ -82,9 +83,11 @@ public class BPMNPaletteDefinitionFactory extends BindableDefSetPaletteDefinitio
   @Inject
   public BPMNPaletteDefinitionFactory(final ShapeManager shapeManager,
                                       final DefinitionSetPaletteBuilder paletteBuilder,
-                                      final AbstractTranslationService translationService) {
+                                      final AbstractTranslationService translationService,
+                                      final BS3PaletteWidget<DefinitionSetPalette> palette) {
     super(shapeManager,
-          paletteBuilder);
+          paletteBuilder,
+          palette);
     this.translationService = translationService;
   }
 
@@ -145,4 +148,5 @@ public class BPMNPaletteDefinitionFactory extends BindableDefSetPaletteDefinitio
   protected Class<?> getDefinitionSetType() {
     return BPMNDefinitionSet.class;
   }
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementDefinitionSetPaletteBuilderImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementDefinitionSetPaletteBuilderImpl.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.stunner.cm.definition.ReusableSubprocess;
 import org.kie.workbench.common.stunner.cm.qualifiers.CaseManagementEditor;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.AbstractPaletteDefinitionBuilder;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteCategory;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
@@ -47,7 +48,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 @Dependent
 @CaseManagementEditor
 public class CaseManagementDefinitionSetPaletteBuilderImpl
-        extends AbstractPaletteDefinitionBuilder<Object, DefinitionSetPalette, ClientRuntimeError>
+        extends AbstractPaletteDefinitionBuilder<PaletteDefinitionBuilder.Configuration, DefinitionSetPalette, ClientRuntimeError>
         implements DefinitionSetPaletteBuilder {
 
     private final DefinitionUtils definitionUtils;
@@ -81,12 +82,11 @@ public class CaseManagementDefinitionSetPaletteBuilderImpl
         this.paletteCategoryProvider = CATEGORY_PROVIDER;
     }
 
-    public void build(final Object definitionSet,
+    public void build(final PaletteDefinitionBuilder.Configuration configuration,
                       final Callback<DefinitionSetPalette, ClientRuntimeError> callback) {
-        final Object definitionSetObject = definitionSet instanceof String ?
-                getDefinitionManager().definitionSets().getDefinitionSetById((String) definitionSet) : definitionSet;
-        final String defSetId = getDefinitionManager().adapters().forDefinitionSet().getId(definitionSetObject);
-        final Collection<String> definitions = getDefinitionManager().adapters().forDefinitionSet().getDefinitions(definitionSetObject);
+        final String defSetId = configuration.getDefinitionSetId();
+        final Collection<String> definitions = configuration.getDefinitionIds();
+
         if (null != definitions) {
             final List<DefinitionPaletteCategoryImpl.DefinitionPaletteCategoryBuilder> categoryBuilders = new LinkedList<>();
             for (final String defId : definitions) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactory.java
@@ -32,15 +32,17 @@ import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
 import org.kie.workbench.common.stunner.bpmn.definition.SequenceFlow;
 import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.cm.CaseManagementDefinitionSet;
 import org.kie.workbench.common.stunner.cm.definition.CaseManagementDiagram;
 import org.kie.workbench.common.stunner.cm.qualifiers.CaseManagementEditor;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.BindableDefSetPaletteDefinitionFactory;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
 
 @Dependent
-public class CaseManagementPaletteDefinitionFactory extends BindableDefSetPaletteDefinitionFactory {
+public class CaseManagementPaletteDefinitionFactory extends BindableDefSetPaletteDefinitionFactory<DefinitionSetPalette, BS3PaletteWidget<DefinitionSetPalette>> {
 
     public static final String STAGES = "Stages";
     public static final String ACTIVITIES = "Activities";
@@ -61,9 +63,11 @@ public class CaseManagementPaletteDefinitionFactory extends BindableDefSetPalett
 
     @Inject
     public CaseManagementPaletteDefinitionFactory(final ShapeManager shapeManager,
-                                                  final @CaseManagementEditor DefinitionSetPaletteBuilder paletteBuilder) {
+                                                  final @CaseManagementEditor DefinitionSetPaletteBuilder paletteBuilder,
+                                                  final BS3PaletteWidget<DefinitionSetPalette> palette) {
         super(shapeManager,
-              paletteBuilder);
+              paletteBuilder,
+              palette);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementDefinitionSetPaletteBuilderImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementDefinitionSetPaletteBuilderImplTest.java
@@ -55,6 +55,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.StartTimerEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.StartTimerEvent.StartTimerEventBuilder;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask.UserTaskBuilder;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.cm.CaseManagementDefinitionSet;
 import org.kie.workbench.common.stunner.cm.definition.CaseManagementDiagram;
 import org.kie.workbench.common.stunner.cm.definition.ReusableSubprocess;
@@ -106,6 +107,9 @@ public class CaseManagementDefinitionSetPaletteBuilderImplTest {
 
     @Mock
     private ShapeManager shapeManager;
+
+    @Mock
+    private BS3PaletteWidget palette;
 
     @Mock
     private DefinitionManager definitionManager;
@@ -196,13 +200,24 @@ public class CaseManagementDefinitionSetPaletteBuilderImplTest {
     public void checkConstruction() {
         //Must use PaletteDefinitionFactory to correctly initialise the builder
         final CaseManagementPaletteDefinitionFactory factory = new CaseManagementPaletteDefinitionFactory(shapeManager,
-                                                                                                          builder);
+                                                                                                          builder,
+                                                                                                          palette);
         factory.configureBuilder();
 
         //Construct palette
-        final Object definitionSet = new CaseManagementDefinitionSet();
+        final PaletteDefinitionBuilder.Configuration configuration = new PaletteDefinitionBuilder.Configuration() {
+            @Override
+            public String getDefinitionSetId() {
+                return CaseManagementDefinitionSet.class.getName();
+            }
 
-        builder.build(definitionSet,
+            @Override
+            public Set<String> getDefinitionIds() {
+                return definitions;
+            }
+        };
+
+        builder.build(configuration,
                       new PaletteDefinitionBuilder.Callback<DefinitionSetPalette, ClientRuntimeError>() {
                           @Override
                           public void onSuccess(final DefinitionSetPalette paletteDefinition) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactoryTest.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
 import org.kie.workbench.common.stunner.bpmn.definition.SequenceFlow;
 import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.cm.CaseManagementDefinitionSet;
 import org.kie.workbench.common.stunner.cm.definition.CaseManagementDiagram;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
@@ -48,12 +49,16 @@ public class CaseManagementPaletteDefinitionFactoryTest {
     @Mock
     private DefinitionSetPaletteBuilder paletteBuilder;
 
+    @Mock
+    private BS3PaletteWidget palette;
+
     private CaseManagementPaletteDefinitionFactory factory;
 
     @Before
     public void setup() {
         factory = new CaseManagementPaletteDefinitionFactory(shapeManager,
-                                                             paletteBuilder);
+                                                             paletteBuilder,
+                                                             palette);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3290

This PR moves provisioning of the "Palette widget" to ```PaletteDefinitionFactory``` and allows the DMN Editor to provide a different implementation of ```BS3PaletteWidget``` that uses the flat ```DefinitionsPalette``` model rather than ```DefinitionSetPalette``` that uses top-level ```DefinitionPaletteCategory``` items.