### PR TITLE
Fix for random fails in Indexer tests.

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/indexing/FormDefinitionIndexerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/indexing/FormDefinitionIndexerTest.java
@@ -97,6 +97,7 @@ public class FormDefinitionIndexerTest extends BaseIndexingTest<FormResourceType
     public void testFormsIndexing() throws Exception {
         List<Path> pathList = new ArrayList<>();
 
+        ioService().startBatch(ioService().getFileSystem(basePath.toUri()));
         for (String formFile : FORMS) {
             Path path = basePath.resolve(formFile);
             pathList.add(path);
@@ -104,6 +105,7 @@ public class FormDefinitionIndexerTest extends BaseIndexingTest<FormResourceType
             ioService().write(path,
                               formContent);
         }
+        ioService().endBatch();
 
         Path[] paths = pathList.toArray(new Path[pathList.size()]);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/indexing/BpmnFileIndexerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/indexing/BpmnFileIndexerTest.java
@@ -92,13 +92,13 @@ public class BpmnFileIndexerTest extends BaseIndexingTest<BPMNDefinitionSetResou
     }
 
     private static final long WAIT_TIME_MILLIS = 2000;
-
     private static final int MAX_WAIT_TIMES = 8;
 
     @Test
     public void testBpmnIndexing() throws Exception {
 
         List<Path> pathList = new ArrayList<>();
+        ioService().startBatch(ioService().getFileSystem(basePath.toUri()));
         for (int i = 0; i < BPMN_FILES.length; ++i) {
             String bpmnFile = BPMN_FILES[i];
             if (bpmnFile.endsWith("bpmn")) {
@@ -109,6 +109,7 @@ public class BpmnFileIndexerTest extends BaseIndexingTest<BPMNDefinitionSetResou
                                   bpmnStr);
             }
         }
+        ioService().endBatch();
         Path[] paths = pathList.toArray(new Path[pathList.size()]);
 
         {


### PR DESCRIPTION
Hi @pefernan, @romartin,

I used IntelliJ _rerun until fail_ feature to test my fix. And this test passed about 100 times in a row without any problem. Without fix it failed in first 5 execution. So, I hope, it will help.