### PR TITLE
[6.5.x] RHBRMS-2874: Start/stop container buttons should be enabled/disabled only when the operation finished

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/runtime/AsyncKieServerInstanceManager.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/runtime/AsyncKieServerInstanceManager.java
@@ -116,8 +116,8 @@ public class AsyncKieServerInstanceManager extends KieServerInstanceManager {
     }
 
     @Override
-    public List<Container> startContainer( final ServerTemplate serverTemplate,
-                                           final ContainerSpec containerSpec ) {
+    public synchronized List<Container> startContainer( final ServerTemplate serverTemplate,
+                                                        final ContainerSpec containerSpec ) {
         executor.execute( new Runnable() {
             @Override
             public void run() {
@@ -131,8 +131,8 @@ public class AsyncKieServerInstanceManager extends KieServerInstanceManager {
     }
 
     @Override
-    public List<Container> stopContainer( final ServerTemplate serverTemplate,
-                                          final ContainerSpec containerSpec ) {
+    public synchronized List<Container> stopContainer( final ServerTemplate serverTemplate,
+                                                       final ContainerSpec containerSpec ) {
         executor.execute( new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
Cherry picked from https://github.com/kiegroup/kie-wb-common/pull/995