### PR TITLE
[7.2.x] RHBRMS-2874: Start/stop container buttons should be enabled/disabled only when the operation finished

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/runtime/AsyncKieServerInstanceManager.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/runtime/AsyncKieServerInstanceManager.java
@@ -137,8 +137,8 @@ public class AsyncKieServerInstanceManager extends KieServerInstanceManager {
     }
 
     @Override
-    public List<Container> startContainer(final ServerTemplate serverTemplate,
-                                          final ContainerSpec containerSpec) {
+    public synchronized List<Container> startContainer(final ServerTemplate serverTemplate,
+                                                       final ContainerSpec containerSpec) {
         executor.execute(new Runnable() {
             @Override
             public void run() {
@@ -158,8 +158,8 @@ public class AsyncKieServerInstanceManager extends KieServerInstanceManager {
     }
 
     @Override
-    public List<Container> stopContainer(final ServerTemplate serverTemplate,
-                                         final ContainerSpec containerSpec) {
+    public synchronized List<Container> stopContainer(final ServerTemplate serverTemplate,
+                                                      final ContainerSpec containerSpec) {
         executor.execute(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
Cherry picked from https://github.com/kiegroup/kie-wb-common/pull/995

---

Part of an ensemble:
- https://github.com/kiegroup/kie-wb-common/pull/1002
- https://github.com/kiegroup/droolsjbpm-integration/pull/1082
