### PR TITLE
JBPM-5425 Unnecessary field type selector when there is only one field type to select

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererViewImpl.java
@@ -122,6 +122,10 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
 
         List<String> types = presenter.getCompatibleFieldTypes();
 
+        if (types.size() == 1) {
+            fieldType.setEnabled(false);
+        }
+
         types.forEach(fieldType::addItem);
 
         String currentType = presenter.getCurrentField().getFieldType().getTypeName();


### PR DESCRIPTION
After merging, when there is only one available type, the field type selector will show the only available type, and will be disabled.

@pefernan @jsoltes could you have a look?

(See also https://github.com/kiegroup/kie-wb-common/pull/1008)