### PR TITLE
[8.0.x] JBPM-6282: The "show options inline" checkbox gets unchecked on each edit.

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/AbstractFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/AbstractFieldDefinition.java
@@ -208,7 +208,7 @@ public abstract class AbstractFieldDefinition implements FieldDefinition {
     public int hashCode() {
         int result = id.hashCode();
         result = ~~result;
-        result = 31 * result + name.hashCode();
+        result = 31 * result + (name != null ? name.hashCode() : 0);
         result = ~~result;
         result = 31 * result + (label != null ? label.hashCode() : 0);
         result = ~~result;

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/datePicker/definition/DatePickerFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/datePicker/definition/DatePickerFieldDefinition.java
@@ -87,4 +87,34 @@ public class DatePickerFieldDefinition extends AbstractFieldDefinition implement
             setPlaceHolder(((HasPlaceHolder) other).getPlaceHolder());
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DatePickerFieldDefinition that = (DatePickerFieldDefinition) o;
+
+        if (placeHolder != null ? !placeHolder.equals(that.placeHolder) : that.placeHolder != null) {
+            return false;
+        }
+        return showTime != null ? showTime.equals(that.showTime) : that.showTime == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (placeHolder != null ? placeHolder.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (showTime != null ? showTime.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/decimalBox/definition/DecimalBoxFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/decimalBox/definition/DecimalBoxFieldDefinition.java
@@ -91,4 +91,34 @@ public class DecimalBoxFieldDefinition extends AbstractFieldDefinition implement
             setPlaceHolder(((HasPlaceHolder) other).getPlaceHolder());
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DecimalBoxFieldDefinition that = (DecimalBoxFieldDefinition) o;
+
+        if (placeHolder != null ? !placeHolder.equals(that.placeHolder) : that.placeHolder != null) {
+            return false;
+        }
+        return maxLength != null ? maxLength.equals(that.maxLength) : that.maxLength == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (placeHolder != null ? placeHolder.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/image/definition/PictureFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/image/definition/PictureFieldDefinition.java
@@ -60,6 +60,34 @@ public class PictureFieldDefinition extends AbstractFieldDefinition {
 
     @Override
     protected void doCopyFrom(FieldDefinition other) {
+        if (other instanceof PictureFieldDefinition) {
+            PictureFieldDefinition otherPicture = (PictureFieldDefinition) other;
+            setSize(otherPicture.getSize());
+        }
+    }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PictureFieldDefinition that = (PictureFieldDefinition) o;
+
+        return size == that.size;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (size != null ? size.hashCode() : 0);
+        result = ~~result;
+        return result;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/integerBox/definition/IntegerBoxFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/integerBox/definition/IntegerBoxFieldDefinition.java
@@ -91,4 +91,34 @@ public class IntegerBoxFieldDefinition extends AbstractFieldDefinition implement
             setPlaceHolder(((HasPlaceHolder) other).getPlaceHolder());
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        IntegerBoxFieldDefinition that = (IntegerBoxFieldDefinition) o;
+
+        if (placeHolder != null ? !placeHolder.equals(that.placeHolder) : that.placeHolder != null) {
+            return false;
+        }
+        return maxLength != null ? maxLength.equals(that.maxLength) : that.maxLength == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (placeHolder != null ? placeHolder.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/DefaultSelectorOption.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/DefaultSelectorOption.java
@@ -69,4 +69,30 @@ public class DefaultSelectorOption<T> implements SelectorOption<Object> {
     public void setText(String text) {
         this.text = text;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultSelectorOption<?> that = (DefaultSelectorOption<?>) o;
+
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        return text != null ? text.equals(that.text) : that.text == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/EnumSelectorOption.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/EnumSelectorOption.java
@@ -46,6 +46,11 @@ public class EnumSelectorOption implements SelectorOption<Enum> {
     public EnumSelectorOption() {
     }
 
+    public EnumSelectorOption(Enum value) {
+        this(value,
+             value.toString());
+    }
+
     public EnumSelectorOption(@MapsTo("value") Enum value,
                               @MapsTo("text") String text) {
         this.value = value;
@@ -68,5 +73,31 @@ public class EnumSelectorOption implements SelectorOption<Enum> {
 
     public void setText(String text) {
         this.text = text;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EnumSelectorOption that = (EnumSelectorOption) o;
+
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        return text != null ? text.equals(that.text) : that.text == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = ~~result;
+        return result;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/SelectorFieldBaseDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/SelectorFieldBaseDefinition.java
@@ -70,4 +70,38 @@ public abstract class SelectorFieldBaseDefinition<OPTION extends SelectorOption<
             }
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        SelectorFieldBaseDefinition<?, ?> that = (SelectorFieldBaseDefinition<?, ?>) o;
+
+        if (dataProvider != null ? !dataProvider.equals(that.dataProvider) : that.dataProvider != null) {
+            return false;
+        }
+        if (relatedField != null ? !relatedField.equals(that.relatedField) : that.relatedField != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (dataProvider != null ? dataProvider.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (relatedField != null ? relatedField.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/StringSelectorOption.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/StringSelectorOption.java
@@ -69,4 +69,30 @@ public class StringSelectorOption implements SelectorOption<String> {
     public void setText(String text) {
         this.text = text;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        StringSelectorOption that = (StringSelectorOption) o;
+
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        return text != null ? text.equals(that.text) : that.text == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/EnumListBoxFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/EnumListBoxFieldDefinition.java
@@ -79,4 +79,34 @@ public class EnumListBoxFieldDefinition extends ListBoxBaseDefinition<EnumSelect
     public void setDefaultValue(Enum defaultValue) {
         this.defaultValue = defaultValue;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        EnumListBoxFieldDefinition that = (EnumListBoxFieldDefinition) o;
+
+        if (options != null ? !options.equals(that.options) : that.options != null) {
+            return false;
+        }
+        return defaultValue != null ? defaultValue.equals(that.defaultValue) : that.defaultValue == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (options != null ? options.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/ListBoxBaseDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/ListBoxBaseDefinition.java
@@ -20,7 +20,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.S
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
 
-public abstract class ListBoxBaseDefinition<OPTIONS extends SelectorOption<TYPE>,TYPE> extends SelectorFieldBaseDefinition<OPTIONS, TYPE> {
+public abstract class ListBoxBaseDefinition<OPTIONS extends SelectorOption<TYPE>, TYPE> extends SelectorFieldBaseDefinition<OPTIONS, TYPE> {
 
     public static final ListBoxFieldType FIELD_TYPE = new ListBoxFieldType();
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/StringListBoxFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/StringListBoxFieldDefinition.java
@@ -76,4 +76,34 @@ public class StringListBoxFieldDefinition extends ListBoxBaseDefinition<StringSe
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        StringListBoxFieldDefinition that = (StringListBoxFieldDefinition) o;
+
+        if (options != null ? !options.equals(that.options) : that.options != null) {
+            return false;
+        }
+        return defaultValue != null ? defaultValue.equals(that.defaultValue) : that.defaultValue == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (options != null ? options.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/radioGroup/definition/RadioGroupBaseDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/radioGroup/definition/RadioGroupBaseDefinition.java
@@ -20,6 +20,7 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorFieldBaseDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.type.RadioGroupFieldType;
+import org.kie.workbench.common.forms.model.FieldDefinition;
 
 public abstract class RadioGroupBaseDefinition<OPTIONS extends SelectorOption<TYPE>, TYPE> extends SelectorFieldBaseDefinition<OPTIONS, TYPE> {
 
@@ -46,5 +47,14 @@ public abstract class RadioGroupBaseDefinition<OPTIONS extends SelectorOption<TY
 
     public void setInline(Boolean inline) {
         this.inline = inline;
+    }
+
+    @Override
+    protected void doCopyFrom(FieldDefinition other) {
+        super.doCopyFrom(other);
+        if (other instanceof RadioGroupBaseDefinition) {
+            RadioGroupBaseDefinition otherRadio = (RadioGroupBaseDefinition) other;
+            setInline(otherRadio.getInline());
+        }
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/radioGroup/definition/StringRadioGroupFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/radioGroup/definition/StringRadioGroupFieldDefinition.java
@@ -26,7 +26,6 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.annotations.field.selector.SelectorDataProvider;
 import org.kie.workbench.common.forms.adf.definitions.annotations.i18n.I18nSettings;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
 
@@ -76,5 +75,35 @@ public class StringRadioGroupFieldDefinition extends RadioGroupBaseDefinition<St
     @Override
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        StringRadioGroupFieldDefinition that = (StringRadioGroupFieldDefinition) o;
+
+        if (options != null ? !options.equals(that.options) : that.options != null) {
+            return false;
+        }
+        return defaultValue != null ? defaultValue.equals(that.defaultValue) : that.defaultValue == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (options != null ? options.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+        result = ~~result;
+        return result;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/DoubleSliderDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/DoubleSliderDefinition.java
@@ -113,4 +113,44 @@ public class DoubleSliderDefinition extends SliderBaseDefinition<Double> {
             step = otherSlider.getStep().doubleValue();
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DoubleSliderDefinition that = (DoubleSliderDefinition) o;
+
+        if (min != null ? !min.equals(that.min) : that.min != null) {
+            return false;
+        }
+        if (max != null ? !max.equals(that.max) : that.max != null) {
+            return false;
+        }
+        if (precision != null ? !precision.equals(that.precision) : that.precision != null) {
+            return false;
+        }
+        return step != null ? step.equals(that.step) : that.step == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (min != null ? min.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (max != null ? max.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (precision != null ? precision.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (step != null ? step.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/IntegerSliderDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/IntegerSliderDefinition.java
@@ -105,4 +105,39 @@ public class IntegerSliderDefinition extends SliderBaseDefinition<Integer> {
             step = otherSlider.getStep().intValue();
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        IntegerSliderDefinition that = (IntegerSliderDefinition) o;
+
+        if (min != null ? !min.equals(that.min) : that.min != null) {
+            return false;
+        }
+        if (max != null ? !max.equals(that.max) : that.max != null) {
+            return false;
+        }
+        return step != null ? step.equals(that.step) : that.step == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (min != null ? min.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (max != null ? max.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (step != null ? step.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/CharacterBoxFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/CharacterBoxFieldDefinition.java
@@ -49,6 +49,30 @@ public class CharacterBoxFieldDefinition extends TextBoxBaseDefinition {
 
     @Override
     public void setMaxLength(Integer maxLength) {
-        this.maxLength = maxLength;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        CharacterBoxFieldDefinition that = (CharacterBoxFieldDefinition) o;
+
+        return maxLength != null ? maxLength.equals(that.maxLength) : that.maxLength == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
+        result = ~~result;
+        return result;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/TextBoxBaseDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/TextBoxBaseDefinition.java
@@ -62,4 +62,29 @@ public abstract class TextBoxBaseDefinition extends AbstractFieldDefinition impl
             setPlaceHolder(((HasPlaceHolder) other).getPlaceHolder());
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        TextBoxBaseDefinition that = (TextBoxBaseDefinition) o;
+
+        return placeHolder != null ? placeHolder.equals(that.placeHolder) : that.placeHolder == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (placeHolder != null ? placeHolder.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/TextBoxFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/TextBoxFieldDefinition.java
@@ -58,4 +58,29 @@ public class TextBoxFieldDefinition extends TextBoxBaseDefinition {
     protected void doCopyFrom(FieldDefinition other) {
         super.doCopyFrom(other);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        TextBoxFieldDefinition that = (TextBoxFieldDefinition) o;
+
+        return maxLength != null ? maxLength.equals(that.maxLength) : that.maxLength == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/TableColumnMeta.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/TableColumnMeta.java
@@ -80,4 +80,30 @@ public class TableColumnMeta {
     public void setProperty(String property) {
         this.property = property;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TableColumnMeta that = (TableColumnMeta) o;
+
+        if (label != null ? !label.equals(that.label) : that.label != null) {
+            return false;
+        }
+        return property != null ? property.equals(that.property) : that.property == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = label != null ? label.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (property != null ? property.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinition.java
@@ -129,4 +129,39 @@ public class MultipleSubFormFieldDefinition extends AbstractFieldDefinition impl
         }
         setStandaloneClassName(other.getStandaloneClassName());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        MultipleSubFormFieldDefinition that = (MultipleSubFormFieldDefinition) o;
+
+        if (creationForm != null ? !creationForm.equals(that.creationForm) : that.creationForm != null) {
+            return false;
+        }
+        if (editionForm != null ? !editionForm.equals(that.editionForm) : that.editionForm != null) {
+            return false;
+        }
+        return columnMetas != null ? columnMetas.equals(that.columnMetas) : that.columnMetas == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (creationForm != null ? creationForm.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (editionForm != null ? editionForm.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (columnMetas != null ? columnMetas.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/subForm/definition/SubFormFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/subForm/definition/SubFormFieldDefinition.java
@@ -85,6 +85,33 @@ public class SubFormFieldDefinition extends AbstractFieldDefinition implements H
 
     @Override
     public TypeInfo getFieldTypeInfo() {
-        return new TypeInfoImpl(TypeKind.OBJECT, standaloneClassName, false);
+        return new TypeInfoImpl(TypeKind.OBJECT,
+                                standaloneClassName,
+                                false);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        SubFormFieldDefinition that = (SubFormFieldDefinition) o;
+
+        return nestedForm != null ? nestedForm.equals(that.nestedForm) : that.nestedForm == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (nestedForm != null ? nestedForm.hashCode() : 0);
+        result = ~~result;
+        return result;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/AbstractFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/AbstractFieldDefinitionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes;
+
+import org.junit.Test;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.HasMaxLength;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.HasPlaceHolder;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.HasRows;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+
+import static org.junit.Assert.*;
+
+public abstract class AbstractFieldDefinitionTest<FIELD extends FieldDefinition> {
+
+    public static final String ID = "id";
+    public static final String NAME = "name";
+    public static final String LABEL = "label";
+    public static final String BINDING = "binding";
+    public static final String STANDALONE_CLASS_NAME = "class";
+
+    public static final String PLACE_HOLDER = "placeHolder";
+    public static final Integer MAX_LENGTH = 255;
+    public static final Integer MAX_ROWS = 255;
+
+    public static final Boolean READONLY = Boolean.TRUE;
+    public static final Boolean REQUIRED = Boolean.TRUE;
+    public static final Boolean VALIDATE_ON_CHANGE = Boolean.FALSE;
+
+    @Test
+    public void testCopyFrom() {
+        FIELD originalFieldDefinition = getEmptyFieldDefinition();
+
+        FIELD newFieldDefinition = getNewFieldDefinition();
+
+        assertFalse(originalFieldDefinition.equals(newFieldDefinition));
+
+        originalFieldDefinition.copyFrom(newFieldDefinition);
+
+        // COPYING fields not affected by copyFrom to make equals work
+        originalFieldDefinition.setId(newFieldDefinition.getId());
+        originalFieldDefinition.setName(newFieldDefinition.getName());
+
+        assertTrue(originalFieldDefinition.equals(newFieldDefinition));
+    }
+
+    private FIELD getNewFieldDefinition() {
+        FIELD field = getFullFieldDefinition();
+
+        field.setId(ID);
+        field.setName(NAME);
+        field.setLabel(LABEL);
+        field.setBinding(BINDING);
+        field.setReadOnly(READONLY);
+        field.setRequired(REQUIRED);
+        field.setStandaloneClassName(STANDALONE_CLASS_NAME);
+        field.setValidateOnChange(VALIDATE_ON_CHANGE);
+
+        if (field instanceof HasMaxLength) {
+            ((HasMaxLength) field).setMaxLength(MAX_LENGTH);
+        }
+
+        if (field instanceof HasPlaceHolder) {
+            ((HasPlaceHolder) field).setPlaceHolder(PLACE_HOLDER);
+        }
+
+        if (field instanceof HasRows) {
+            ((HasRows) field).setRows(MAX_ROWS);
+        }
+
+        return field;
+    }
+
+    protected abstract FIELD getEmptyFieldDefinition();
+
+    protected abstract FIELD getFullFieldDefinition();
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/checkBox/definition/CheckBoxFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/checkBox/definition/CheckBoxFieldDefinitionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class CheckBoxFieldDefinitionTest extends AbstractFieldDefinitionTest<CheckBoxFieldDefinition> {
+
+    @Override
+    protected CheckBoxFieldDefinition getEmptyFieldDefinition() {
+        return new CheckBoxFieldDefinition();
+    }
+
+    @Override
+    protected CheckBoxFieldDefinition getFullFieldDefinition() {
+        return new CheckBoxFieldDefinition();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/datePicker/definition/DatePickerFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/datePicker/definition/DatePickerFieldDefinitionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class DatePickerFieldDefinitionTest extends AbstractFieldDefinitionTest<DatePickerFieldDefinition> {
+
+    @Override
+    protected DatePickerFieldDefinition getEmptyFieldDefinition() {
+        return new DatePickerFieldDefinition();
+    }
+
+    @Override
+    protected DatePickerFieldDefinition getFullFieldDefinition() {
+        DatePickerFieldDefinition datePickerFieldDefinition = new DatePickerFieldDefinition();
+
+        datePickerFieldDefinition.setPlaceHolder(LABEL);
+        datePickerFieldDefinition.setShowTime(false);
+
+        return datePickerFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/decimalBox/definition/DecimalBoxFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/decimalBox/definition/DecimalBoxFieldDefinitionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class DecimalBoxFieldDefinitionTest extends AbstractFieldDefinitionTest<DecimalBoxFieldDefinition> {
+
+    @Override
+    protected DecimalBoxFieldDefinition getEmptyFieldDefinition() {
+        return new DecimalBoxFieldDefinition();
+    }
+
+    @Override
+    protected DecimalBoxFieldDefinition getFullFieldDefinition() {
+        return new DecimalBoxFieldDefinition();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/image/definition/PictureFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/image/definition/PictureFieldDefinitionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.image.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class PictureFieldDefinitionTest extends AbstractFieldDefinitionTest<PictureFieldDefinition> {
+
+    @Override
+    protected PictureFieldDefinition getEmptyFieldDefinition() {
+        return new PictureFieldDefinition();
+    }
+
+    @Override
+    protected PictureFieldDefinition getFullFieldDefinition() {
+        PictureFieldDefinition pictureFieldDefinition = new PictureFieldDefinition();
+        pictureFieldDefinition.setSize(PictureSize.MEDIUM);
+        return pictureFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/integerBox/definition/IntegerBoxFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/integerBox/definition/IntegerBoxFieldDefinitionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class IntegerBoxFieldDefinitionTest extends AbstractFieldDefinitionTest<IntegerBoxFieldDefinition> {
+
+    @Override
+    protected IntegerBoxFieldDefinition getEmptyFieldDefinition() {
+        return new IntegerBoxFieldDefinition();
+    }
+
+    @Override
+    protected IntegerBoxFieldDefinition getFullFieldDefinition() {
+        return new IntegerBoxFieldDefinition();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/EnumListBoxFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/EnumListBoxFieldDefinitionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.EnumSelectorOption;
+
+public class EnumListBoxFieldDefinitionTest extends AbstractFieldDefinitionTest<EnumListBoxFieldDefinition> {
+
+    @Override
+    protected EnumListBoxFieldDefinition getEmptyFieldDefinition() {
+        return new EnumListBoxFieldDefinition();
+    }
+
+    @Override
+    protected EnumListBoxFieldDefinition getFullFieldDefinition() {
+        EnumListBoxFieldDefinition enumListBoxFieldDefinition = new EnumListBoxFieldDefinition();
+
+        List<EnumSelectorOption> options = new ArrayList<>();
+        options.add(new EnumSelectorOption(Values.ONE));
+        options.add(new EnumSelectorOption(Values.TWO));
+        options.add(new EnumSelectorOption(Values.THREE));
+
+        enumListBoxFieldDefinition.setOptions(options);
+
+        enumListBoxFieldDefinition.setDefaultValue(Values.ONE);
+
+        return enumListBoxFieldDefinition;
+    }
+
+    public enum Values {
+        ONE,
+        TWO,
+        THREE
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/StringListBoxFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/StringListBoxFieldDefinitionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
+
+public class StringListBoxFieldDefinitionTest extends AbstractFieldDefinitionTest<StringListBoxFieldDefinition> {
+
+    @Override
+    protected StringListBoxFieldDefinition getEmptyFieldDefinition() {
+        return new StringListBoxFieldDefinition();
+    }
+
+    @Override
+    protected StringListBoxFieldDefinition getFullFieldDefinition() {
+        StringListBoxFieldDefinition stringListBoxFieldDefinition = new StringListBoxFieldDefinition();
+
+        List<StringSelectorOption> options = new ArrayList<>();
+        options.add(new StringSelectorOption("a",
+                                             "a"));
+        options.add(new StringSelectorOption("b",
+                                             "b"));
+        options.add(new StringSelectorOption("c",
+                                             "c"));
+
+        stringListBoxFieldDefinition.setOptions(options);
+
+        stringListBoxFieldDefinition.setDefaultValue("a");
+
+        return stringListBoxFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/radioGroup/definition/StringRadioGroupFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/radioGroup/definition/StringRadioGroupFieldDefinitionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
+
+public class StringRadioGroupFieldDefinitionTest extends AbstractFieldDefinitionTest<StringRadioGroupFieldDefinition> {
+
+    @Override
+    protected StringRadioGroupFieldDefinition getEmptyFieldDefinition() {
+        return new StringRadioGroupFieldDefinition();
+    }
+
+    @Override
+    protected StringRadioGroupFieldDefinition getFullFieldDefinition() {
+        StringRadioGroupFieldDefinition stringRadioGroupFieldDefinition = new StringRadioGroupFieldDefinition();
+
+        List<StringSelectorOption> options = new ArrayList<>();
+        options.add(new StringSelectorOption("a",
+                                             "a"));
+        options.add(new StringSelectorOption("b",
+                                             "b"));
+        options.add(new StringSelectorOption("c",
+                                             "c"));
+
+        stringRadioGroupFieldDefinition.setOptions(options);
+
+        stringRadioGroupFieldDefinition.setDefaultValue("a");
+
+        return stringRadioGroupFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/DoubleSliderDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/DoubleSliderDefinitionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class DoubleSliderDefinitionTest extends AbstractFieldDefinitionTest<DoubleSliderDefinition> {
+
+    @Override
+    protected DoubleSliderDefinition getEmptyFieldDefinition() {
+        return new DoubleSliderDefinition();
+    }
+
+    @Override
+    protected DoubleSliderDefinition getFullFieldDefinition() {
+        DoubleSliderDefinition doubleSliderDefinition = new DoubleSliderDefinition();
+
+        doubleSliderDefinition.setMin(-5.3);
+        doubleSliderDefinition.setMax(25.8);
+        doubleSliderDefinition.setStep(1.23);
+        doubleSliderDefinition.setPrecision(2.0);
+
+        return doubleSliderDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/IntegerSliderDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/IntegerSliderDefinitionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class IntegerSliderDefinitionTest extends AbstractFieldDefinitionTest<IntegerSliderDefinition> {
+
+    @Override
+    protected IntegerSliderDefinition getEmptyFieldDefinition() {
+        return new IntegerSliderDefinition();
+    }
+
+    @Override
+    protected IntegerSliderDefinition getFullFieldDefinition() {
+        IntegerSliderDefinition integerSliderDefinition = new IntegerSliderDefinition();
+
+        integerSliderDefinition.setMin(-5);
+        integerSliderDefinition.setMax(25);
+        integerSliderDefinition.setStep(1);
+
+        return integerSliderDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textArea/definition/TextAreaFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textArea/definition/TextAreaFieldDefinitionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class TextAreaFieldDefinitionTest extends AbstractFieldDefinitionTest<TextAreaFieldDefinition> {
+
+    @Override
+    protected TextAreaFieldDefinition getEmptyFieldDefinition() {
+        return new TextAreaFieldDefinition();
+    }
+
+    @Override
+    protected TextAreaFieldDefinition getFullFieldDefinition() {
+        return new TextAreaFieldDefinition();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/CharacterBoxFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/CharacterBoxFieldDefinitionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class CharacterBoxFieldDefinitionTest extends AbstractFieldDefinitionTest<CharacterBoxFieldDefinition> {
+
+    @Override
+    protected CharacterBoxFieldDefinition getEmptyFieldDefinition() {
+        return new CharacterBoxFieldDefinition();
+    }
+
+    @Override
+    protected CharacterBoxFieldDefinition getFullFieldDefinition() {
+        return new CharacterBoxFieldDefinition();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/TextBoxFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textBox/definition/TextBoxFieldDefinitionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class TextBoxFieldDefinitionTest extends AbstractFieldDefinitionTest<TextBoxFieldDefinition> {
+
+    @Override
+    public TextBoxFieldDefinition getEmptyFieldDefinition() {
+        return new TextBoxFieldDefinition();
+    }
+
+    @Override
+    protected TextBoxFieldDefinition getFullFieldDefinition() {
+        return new TextBoxFieldDefinition();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinitionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.definition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.TableColumnMeta;
+
+public class MultipleSubFormFieldDefinitionTest extends AbstractFieldDefinitionTest<MultipleSubFormFieldDefinition> {
+
+    @Override
+    protected MultipleSubFormFieldDefinition getEmptyFieldDefinition() {
+        return new MultipleSubFormFieldDefinition();
+    }
+
+    @Override
+    protected MultipleSubFormFieldDefinition getFullFieldDefinition() {
+        MultipleSubFormFieldDefinition multipleSubFormFieldDefinition = new MultipleSubFormFieldDefinition();
+
+        multipleSubFormFieldDefinition.setCreationForm("creationForm");
+        multipleSubFormFieldDefinition.setEditionForm("editionForm");
+
+        List<TableColumnMeta> columns = new ArrayList<>();
+        columns.add(new TableColumnMeta("prop",
+                                        "prop"));
+        columns.add(new TableColumnMeta("prop2",
+                                        "prop2"));
+
+        multipleSubFormFieldDefinition.setColumnMetas(columns);
+
+        return multipleSubFormFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/subForm/definition/SubFormFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/subForm/definition/SubFormFieldDefinitionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class SubFormFieldDefinitionTest extends AbstractFieldDefinitionTest<SubFormFieldDefinition> {
+
+    @Override
+    protected SubFormFieldDefinition getEmptyFieldDefinition() {
+        return new SubFormFieldDefinition();
+    }
+
+    @Override
+    protected SubFormFieldDefinition getFullFieldDefinition() {
+        SubFormFieldDefinition subFormFieldDefinition = new SubFormFieldDefinition();
+
+        subFormFieldDefinition.setNestedForm("nestedForm");
+
+        return subFormFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/pom.xml
@@ -61,6 +61,14 @@
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-fields</artifactId>
     </dependency>
+
+    <!-- test -->
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-fields</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/test/java/org/kie/workbench/common/forms/jbpm/model/authoring/document/definition/DocumentFieldDefinitionTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/test/java/org/kie/workbench/common/forms/jbpm/model/authoring/document/definition/DocumentFieldDefinitionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.jbpm.model.authoring.document.definition;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.AbstractFieldDefinitionTest;
+
+public class DocumentFieldDefinitionTest extends AbstractFieldDefinitionTest<DocumentFieldDefinition> {
+
+    @Override
+    protected DocumentFieldDefinition getEmptyFieldDefinition() {
+        return new DocumentFieldDefinition();
+    }
+
+    @Override
+    protected DocumentFieldDefinition getFullFieldDefinition() {
+        return new DocumentFieldDefinition();
+    }
+}


### PR DESCRIPTION
There were some FieldDefinitions which the copyFrom method had some missing statements. Fixed that and added tests.

@jsoltes    could you please take a look?