### PR TITLE
Index test stabilization

### DIFF
--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/IndexingTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/IndexingTest.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -216,7 +218,7 @@ public abstract class IndexingTest<T extends ResourceTypeDefinition> {
         return mockProject;
     }
 
-    protected void assertContains(final List<KObject> results,
+    protected void assertContains(final Iterable<KObject> results,
                                   final Path path) {
         for (KObject kObject : results) {
             final String key = kObject.getKey();
@@ -257,15 +259,14 @@ public abstract class IndexingTest<T extends ResourceTypeDefinition> {
                             collector);
             final ScoreDoc[] hits = collector.topDocs().scoreDocs;
 
-            assertEquals("Number of docs fulfilling the given query criteria",
-                         expectedNumHits,
-                         hits.length);
-
             if (paths != null && paths.length > 0) {
-                final List<KObject> results = new ArrayList<KObject>();
+                final Set<KObject> results = new HashSet<>();
                 for (int i = 0; i < hits.length; i++) {
                     results.add(KObjectUtil.toKObject(searcher.doc(hits[i].doc)));
                 }
+                assertEquals("Number of docs fulfilling the given query criteria",
+                             expectedNumHits,
+                             results.size());
                 for (Path path : paths) {
                     assertContains(results,
                                    path);

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldCombinedTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldCombinedTest.java
@@ -35,6 +35,7 @@ public class IndexDrlLHSTypeExpressionFieldCombinedTest extends BaseIndexingTest
 
     @Test
     public void testIndexDrlLHSTypeExpressionField() throws IOException, InterruptedException {
+        ioService().startBatch(ioService().getFileSystem(basePath.toUri()));
         //Add test files
         final Path path1 = basePath.resolve( "drl3.drl" );
         final String drl1 = loadText( "drl3.drl" );
@@ -48,8 +49,9 @@ public class IndexDrlLHSTypeExpressionFieldCombinedTest extends BaseIndexingTest
         final String drl3 = loadText( "drl5.drl" );
         ioService().write( path3,
                            drl3 );
+        ioService().endBatch();
 
-        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep( 7000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
         final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeFieldTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeFieldTest.java
@@ -35,6 +35,7 @@ public class IndexDrlLHSTypeFieldTest extends BaseIndexingTest<TestDrlFileTypeDe
 
     @Test
     public void testIndexDrlLHSTypeField() throws IOException, InterruptedException {
+        ioService().startBatch(ioService().getFileSystem(basePath.toUri()));
         //Add test files
         final Path path1 = basePath.resolve( "drl1.drl" );
         final String drl1 = loadText( "drl1.drl" );
@@ -44,8 +45,9 @@ public class IndexDrlLHSTypeFieldTest extends BaseIndexingTest<TestDrlFileTypeDe
         final String drl2 = loadText( "drl4.drl" );
         ioService().write( path2,
                            drl2 );
+        ioService().endBatch();
 
-        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep( 7000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
         final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeTest.java
@@ -36,6 +36,7 @@ public class IndexDrlLHSTypeTest extends BaseIndexingTest<TestDrlFileTypeDefinit
 
     @Test
     public void testIndexDrlLHSType() throws IOException, InterruptedException {
+        ioService().startBatch(ioService().getFileSystem(basePath.toUri()));
         //Add test files
         final Path path1 = basePath.resolve( "drl1.drl" );
         final String drl1 = loadText( "drl1.drl" );
@@ -49,8 +50,9 @@ public class IndexDrlLHSTypeTest extends BaseIndexingTest<TestDrlFileTypeDefinit
         final String drl3 = loadText( "drl3.drl" );
         ioService().write( path3,
                            drl3 );
+        ioService().endBatch();
 
-        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep( 7000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
         final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
 


### PR DESCRIPTION
Hi @manstis,

There are tree changes:

- Increase wait time (will fix ~ 4% of random fails)
- Use FS Batch operation (will fix ~ 80% of random fails)
- shadow the Uberfire bug. I will send a PR directly to Uberfire to test it. After that I will make a same PR (with Set instead of List) for Forms and Stunner. (have to fix the rest ~ 15%) of fails

P.S. But there are still small chance for random fail in case of sleep time won't be enough.  