### PR TITLE
[7.2.x] JBPM-6265 : Inserting missed dependencies on stunner project showcase

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -1101,12 +1101,22 @@
 
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-library-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-examples-screen-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-examples-screen-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-examples-screen-backend</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Cherrypick of the commit 49d1526c8a110a72c749c173aa2c43e8ed1b9674 to portback to 7.2.x

Referred PR on **Master**
https://github.com/kiegroup/kie-wb-common/pull/992

@romartin 
@manstis 