### PR TITLE
JBPM-6103 Fix removing unnecessary depencency from showcase standalone

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -341,12 +341,6 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-cdi-shared</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-jaxrs-client</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
@romartin just removing the shared dependency that is not necessary on the showcase standalone module in response to the comment on: https://github.com/kiegroup/kie-wb-common/commit/a33699b8e0d6b64ec6a946449e80af960124a1c8#commitcomment-23545859