### PR TITLE
[7.2.x] JBPM-6103 Fix removing unnecessary depencency from showcase standalone 

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -341,12 +341,6 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-cdi-shared</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-jaxrs-client</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Portback the fix of JBPM-6103, the original PR is https://github.com/kiegroup/kie-wb-common/pull/1054/ to 7.2.x.
The referred commit is 56390b3db9a1538d66d5009fcae157c59bc7a9d1.
@romartin 
@manstis 