### PR TITLE
[7.3.x] JBPM-6284: Slider and Multiple SubForm break the consistency with "ReadOnly" and "ValidateOnChange" labels.

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/DoubleSliderDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/slider/definition/DoubleSliderDefinition.java
@@ -26,31 +26,31 @@ import org.kie.workbench.common.forms.model.FieldDefinition;
 @Portable
 @Bindable
 @FormDefinition(
-        i18n = @I18nSettings(keyPreffix = "FieldProperties.slider"),
+        i18n = @I18nSettings(keyPreffix = "FieldProperties"),
         startElement = "label"
 )
 public class DoubleSliderDefinition extends SliderBaseDefinition<Double> {
 
     @FormField(
-            labelKey = "min",
+            labelKey = "slider.min",
             afterElement = "label"
     )
     protected Double min;
 
     @FormField(
-            labelKey = "max",
+            labelKey = "slider.max",
             afterElement = "min"
     )
     protected Double max;
 
     @FormField(
-            labelKey = "precision",
+            labelKey = "slider.precision",
             afterElement = "max"
     )
     protected Double precision;
 
     @FormField(
-            labelKey = "step",
+            labelKey = "slider.step",
             afterElement = "precision"
     )
     protected Double step;

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinition.java
@@ -38,7 +38,7 @@ import org.kie.workbench.common.forms.model.impl.TypeInfoImpl;
 @Portable
 @Bindable
 @FormDefinition(
-        i18n = @I18nSettings(keyPreffix = "FieldProperties.multipleSubform"),
+        i18n = @I18nSettings(keyPreffix = "FieldProperties"),
         startElement = "label"
 )
 public class MultipleSubFormFieldDefinition extends AbstractFieldDefinition implements IsCRUDDefinition {
@@ -46,7 +46,7 @@ public class MultipleSubFormFieldDefinition extends AbstractFieldDefinition impl
     public static final MultipleSubFormFieldType FIELD_TYPE = new MultipleSubFormFieldType();
 
     @FormField(
-            labelKey = "creationForm",
+            labelKey = "multipleSubform.creationForm",
             type = ListBoxFieldType.class,
             afterElement = "label"
     )
@@ -57,7 +57,7 @@ public class MultipleSubFormFieldDefinition extends AbstractFieldDefinition impl
     protected String creationForm = "";
 
     @FormField(
-            labelKey = "editionForm",
+            labelKey = "multipleSubform.editionForm",
             type = ListBoxFieldType.class,
             afterElement = "creationForm"
     )
@@ -68,7 +68,7 @@ public class MultipleSubFormFieldDefinition extends AbstractFieldDefinition impl
     protected String editionForm = "";
 
     @FormField(
-            labelKey = "columns",
+            labelKey = "multipleSubform.columns",
             afterElement = "editionForm"
     )
     private List<TableColumnMeta> columnMetas = new ArrayList<TableColumnMeta>();


### PR DESCRIPTION
This is a cherrypick from 7.2.x (https://github.com/kiegroup/kie-wb-common/pull/1040).

@manstis could you please review?