### PR TITLE
GUVNOR-3354: [DMN Editor] Toolbar: Add support for using different SessionCommandFactory

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/DMNCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/DMNCommand.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands;
+
+/**
+ * Marker for DMN-Editor centric commands
+ */
+public interface DMNCommand {
+
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/DeleteCellValueCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/DeleteCellValueCommand.java
@@ -34,7 +34,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
-public class DeleteCellValueCommand extends AbstractCanvasGraphCommand {
+public class DeleteCellValueCommand extends AbstractCanvasGraphCommand implements VetoExecutionCommand,
+                                                                                  VetoUndoCommand {
 
     private int rowIndex;
     private int columnIndex;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/NavigateToDRGEditorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/NavigateToDRGEditorCommand.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-public class NavigateToDRGEditorCommand extends BaseNavigateCommand {
+public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements VetoUndoCommand {
 
     public NavigateToDRGEditorCommand(final ExpressionEditorView.Presenter editor,
                                       final SessionPresenter<AbstractClientFullSession, ?, Diagram> presenter,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/NavigateToExpressionEditorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/NavigateToExpressionEditorCommand.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-public class NavigateToExpressionEditorCommand extends BaseNavigateCommand {
+public class NavigateToExpressionEditorCommand extends BaseNavigateCommand implements VetoExecutionCommand {
 
     public NavigateToExpressionEditorCommand(final ExpressionEditorView.Presenter editor,
                                              final SessionPresenter<AbstractClientFullSession, ?, Diagram> presenter,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/SetCellValueCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/SetCellValueCommand.java
@@ -34,7 +34,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
-public class SetCellValueCommand<T> extends AbstractCanvasGraphCommand {
+public class SetCellValueCommand<T> extends AbstractCanvasGraphCommand implements VetoExecutionCommand,
+                                                                                  VetoUndoCommand {
 
     private int rowIndex;
     private int columnIndex;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/SetExpressionTypeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/SetExpressionTypeCommand.java
@@ -33,7 +33,8 @@ import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBui
 import org.kie.workbench.common.stunner.core.graph.command.impl.AbstractGraphCommand;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-public class SetExpressionTypeCommand extends AbstractCanvasGraphCommand {
+public class SetExpressionTypeCommand extends AbstractCanvasGraphCommand implements VetoExecutionCommand,
+                                                                                    VetoUndoCommand {
 
     private HasExpression hasExpression;
     private Optional<Expression> expression;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/VetoExecutionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/VetoExecutionCommand.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands;
+
+/**
+ * Marker for DMN-Editor centric commands who's 'execution' should be vetoed by Observers.
+ */
+public interface VetoExecutionCommand extends DMNCommand {
+
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/VetoUndoCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/VetoUndoCommand.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands;
+
+/**
+ * Marker for DMN-Editor centric commands who's 'undo' should be vetoed by Observers.
+ */
+public interface VetoUndoCommand extends DMNCommand {
+
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/command/impl/ClearSessionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/command/impl/ClearSessionCommand.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session.command.impl;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
+import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.Session;
+
+@DMNEditor
+@Dependent
+public class ClearSessionCommand extends org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand {
+
+    public ClearSessionCommand() {
+        //CDI proxy
+    }
+
+    @Inject
+    public ClearSessionCommand(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                               final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager) {
+        super(canvasCommandFactory,
+              sessionCommandManager);
+    }
+
+    @Override
+    protected void onCommandExecuted(final @Observes CanvasCommandExecutedEvent commandExecutedEvent) {
+        if (commandExecutedEvent.getCommand() instanceof VetoExecutionCommand) {
+            return;
+        }
+        super.onCommandExecuted(commandExecutedEvent);
+    }
+
+    @Override
+    protected void onCommandUndoExecuted(final @Observes CanvasUndoCommandExecutedEvent commandUndoExecutedEvent) {
+        if (commandUndoExecutedEvent.getCommand() instanceof VetoUndoCommand) {
+            return;
+        }
+        super.onCommandUndoExecuted(commandUndoExecutedEvent);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/command/impl/SessionCommandFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/command/impl/SessionCommandFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session.command.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearStatesSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToJpgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPdfSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
+
+@DMNEditor
+@ApplicationScoped
+public class SessionCommandFactory extends org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory {
+
+    public SessionCommandFactory() {
+        //CDI proxy
+    }
+
+    @Inject
+    public SessionCommandFactory(final ManagedInstance<ClearStatesSessionCommand> clearStatesCommand,
+                                 final ManagedInstance<VisitGraphSessionCommand> visitGraphCommand,
+                                 final ManagedInstance<SwitchGridSessionCommand> switchGridCommand,
+                                 final @DMNEditor ManagedInstance<ClearSessionCommand> clearCommand,
+                                 final ManagedInstance<DeleteSelectionSessionCommand> deleteSelectionCommand,
+                                 final ManagedInstance<UndoSessionCommand> undoCommand,
+                                 final ManagedInstance<RedoSessionCommand> redoCommand,
+                                 final ManagedInstance<ValidateSessionCommand> validateCommand,
+                                 final ManagedInstance<ExportToPngSessionCommand> exportImageSessionCommand,
+                                 final ManagedInstance<ExportToJpgSessionCommand> exportImageJPGSessionCommand,
+                                 final ManagedInstance<ExportToPdfSessionCommand> exportPDFSessionCommand) {
+        super(clearStatesCommand,
+              visitGraphCommand,
+              switchGridCommand,
+              clearCommand,
+              deleteSelectionCommand,
+              undoCommand,
+              redoCommand,
+              validateCommand,
+              exportImageSessionCommand,
+              exportImageJPGSessionCommand,
+              exportPDFSessionCommand);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/presenters/session/impl/SessionPresenterFactoryImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/presenters/session/impl/SessionPresenterFactoryImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.presenters.session.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.client.widgets.event.SessionDiagramOpenedEvent;
+import org.kie.workbench.common.stunner.client.widgets.notification.NotificationsObserver;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteFactory;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionDiagramPreview;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.EditorToolbarFactory;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.ViewerToolbarFactory;
+import org.kie.workbench.common.stunner.client.widgets.views.WidgetWrapperView;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientSession;
+
+@DMNEditor
+@ApplicationScoped
+public class SessionPresenterFactoryImpl extends org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionPresenterFactoryImpl {
+
+    @Inject
+    public SessionPresenterFactoryImpl(final SessionManager sessionManager,
+                                       final ManagedInstance<CanvasCommandManager<AbstractCanvasHandler>> commandManagerInstances,
+                                       final ManagedInstance<ViewerToolbarFactory> viewerToolbarFactoryInstances,
+                                       final @DMNEditor ManagedInstance<EditorToolbarFactory> editorToolbarFactoryInstances,
+                                       final ManagedInstance<SessionDiagramPreview<AbstractClientSession>> sessionPreviewInstances,
+                                       final ManagedInstance<WidgetWrapperView> diagramViewerViewInstances,
+                                       final ManagedInstance<SessionPresenter.View> viewInstances,
+                                       final ManagedInstance<NotificationsObserver> notificationsObserverInstances,
+                                       final BS3PaletteFactory paletteWidgetFactory,
+                                       final Event<SessionDiagramOpenedEvent> sessionDiagramOpenedEventInstances) {
+        super(sessionManager,
+              commandManagerInstances,
+              viewerToolbarFactoryInstances,
+              editorToolbarFactoryInstances,
+              sessionPreviewInstances,
+              diagramViewerViewInstances,
+              viewInstances,
+              notificationsObserverInstances,
+              paletteWidgetFactory,
+              sessionDiagramOpenedEventInstances);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/command/ClearToolbarCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/command/ClearToolbarCommand.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.toolbar.command;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
+
+@DMNEditor
+@Dependent
+public class ClearToolbarCommand extends org.kie.workbench.common.stunner.client.widgets.toolbar.command.ClearToolbarCommand {
+
+    @Inject
+    public ClearToolbarCommand(final @DMNEditor SessionCommandFactory sessionCommandFactory) {
+        super(sessionCommandFactory);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/command/ToolbarCommandFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/command/ToolbarCommandFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.toolbar.command;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ClearStatesToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ClearToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.DeleteSelectionToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ExportToJpgToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ExportToPdfToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ExportToPngToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.RedoToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.SwitchGridToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.UndoToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ValidateToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.VisitGraphToolbarCommand;
+
+@DMNEditor
+@Dependent
+public class ToolbarCommandFactory extends org.kie.workbench.common.stunner.client.widgets.toolbar.command.ToolbarCommandFactory {
+
+    public ToolbarCommandFactory() {
+        //CDI proxy
+    }
+
+    @Inject
+    public ToolbarCommandFactory(final ManagedInstance<ClearStatesToolbarCommand> clearStatesCommand,
+                                 final ManagedInstance<VisitGraphToolbarCommand> visitGraphCommand,
+                                 final ManagedInstance<SwitchGridToolbarCommand> switchGridCommand,
+                                 final @DMNEditor ManagedInstance<ClearToolbarCommand> clearCommand,
+                                 final ManagedInstance<DeleteSelectionToolbarCommand> deleteSelectionCommand,
+                                 final ManagedInstance<UndoToolbarCommand> undoCommand,
+                                 final ManagedInstance<RedoToolbarCommand> redoCommand,
+                                 final ManagedInstance<ValidateToolbarCommand> validateCommand,
+                                 final ManagedInstance<ExportToPngToolbarCommand> exportToPngToolbarCommand,
+                                 final ManagedInstance<ExportToJpgToolbarCommand> exportToJpgToolbarCommand,
+                                 final ManagedInstance<ExportToPdfToolbarCommand> exportToPdfToolbarCommand) {
+        super(clearStatesCommand,
+              visitGraphCommand,
+              switchGridCommand,
+              clearCommand,
+              deleteSelectionCommand,
+              undoCommand,
+              redoCommand,
+              validateCommand,
+              exportToPngToolbarCommand,
+              exportToJpgToolbarCommand,
+              exportToPdfToolbarCommand);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/impl/EditorToolbarFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/impl/EditorToolbarFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.toolbar.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.ToolbarView;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ToolbarCommandFactory;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.AbstractToolbar;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.item.AbstractToolbarItem;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
+
+@DMNEditor
+@ApplicationScoped
+public class EditorToolbarFactory extends org.kie.workbench.common.stunner.client.widgets.toolbar.impl.EditorToolbarFactory {
+
+    @Inject
+    public EditorToolbarFactory(final @DMNEditor ToolbarCommandFactory commandFactory,
+                                final ManagedInstance<AbstractToolbarItem<AbstractClientFullSession>> itemInstances,
+                                final ManagedInstance<ToolbarView<AbstractToolbar>> viewInstances) {
+        super(commandFactory,
+              itemInstances,
+              viewInstances);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/DeleteCellValueCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/DeleteCellValueCommandTest.java
@@ -178,4 +178,10 @@ public class DeleteCellValueCommandTest {
 
         verify(gridLayer).batch();
     }
+
+    @Test
+    public void checkCommandDefinition() {
+        assertTrue(command instanceof VetoExecutionCommand);
+        assertTrue(command instanceof VetoUndoCommand);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/NavigateToDRGEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/NavigateToDRGEditorCommandTest.java
@@ -63,4 +63,9 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
         verify(command).hidePaletteWidget(eq(true));
         verify(command).addExpressionEditorToCanvasWidget();
     }
+
+    @Test
+    public void checkCommandDefinition() {
+        assertTrue(command instanceof VetoUndoCommand);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/NavigateToExpressionEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/NavigateToExpressionEditorCommandTest.java
@@ -63,4 +63,9 @@ public class NavigateToExpressionEditorCommandTest extends BaseNavigationCommand
         verify(command).hidePaletteWidget(eq(false));
         verify(command).addDRGEditorToCanvasWidget();
     }
+
+    @Test
+    public void checkCommandDefinition() {
+        assertTrue(command instanceof VetoExecutionCommand);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/SetCellValueCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/SetCellValueCommandTest.java
@@ -190,4 +190,10 @@ public class SetCellValueCommandTest {
 
         verify(gridLayer).batch();
     }
+
+    @Test
+    public void checkCommandDefinition() {
+        assertTrue(command instanceof VetoExecutionCommand);
+        assertTrue(command instanceof VetoUndoCommand);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/SetExpressionEditorDefinitionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/SetExpressionEditorDefinitionCommandTest.java
@@ -134,4 +134,10 @@ public class SetExpressionEditorDefinitionCommandTest {
         assertEquals(expression,
                      oExpression.get());
     }
+
+    @Test
+    public void checkCommandDefinition() {
+        assertTrue(command instanceof VetoExecutionCommand);
+        assertTrue(command instanceof VetoUndoCommand);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/command/impl/ClearSessionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/command/impl/ClearSessionCommandTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session.command.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
+import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClearSessionCommandTest {
+
+    @Mock
+    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private org.uberfire.mvp.Command callback;
+
+    private ClearSessionCommand command;
+
+    @Before
+    public void setup() {
+        this.command = new ClearSessionCommand(canvasCommandFactory,
+                                               sessionCommandManager);
+        this.command.listen(callback);
+    }
+
+    @Test
+    public void checkExecutionCommands() {
+        command.onCommandExecuted(makeCommandExecutionContext(new MockCommand()));
+
+        verify(callback).execute();
+    }
+
+    @Test
+    public void checkVetoExecutionCommands() {
+        command.onCommandExecuted(makeCommandExecutionContext(new MockVetoExecutionCommand()));
+
+        verify(callback,
+               never()).execute();
+    }
+
+    @Test
+    public void checkUndoCommands() {
+        command.onCommandUndoExecuted(makeCommandUndoContext(new MockCommand()));
+
+        verify(callback).execute();
+    }
+
+    @Test
+    public void checkVetoUndoCommands() {
+        command.onCommandUndoExecuted(makeCommandUndoContext(new MockVetoUndoCommand()));
+
+        verify(callback,
+               never()).execute();
+    }
+
+    @SuppressWarnings("unchecked")
+    private CanvasCommandExecutedEvent makeCommandExecutionContext(final Command command) {
+        return new CanvasCommandExecutedEvent(canvasHandler,
+                                              command,
+                                              CanvasCommandResultBuilder.SUCCESS);
+    }
+
+    @SuppressWarnings("unchecked")
+    private CanvasUndoCommandExecutedEvent makeCommandUndoContext(final Command command) {
+        return new CanvasUndoCommandExecutedEvent(canvasHandler,
+                                                  command,
+                                                  CanvasCommandResultBuilder.SUCCESS);
+    }
+
+    private static class MockCommand extends AbstractCanvasGraphCommand {
+
+        @Override
+        protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
+            return null;
+        }
+
+        @Override
+        protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
+            return null;
+        }
+    }
+
+    private static class MockVetoExecutionCommand extends MockCommand implements VetoExecutionCommand {
+
+    }
+
+    private static class MockVetoUndoCommand extends MockCommand implements VetoUndoCommand {
+
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.kie.workbench.common.dmn.api.factory.DMNGraphFactory;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -69,7 +70,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final DMNDiagramResourceType resourceType,
                             final ClientProjectDiagramService projectDiagramServices,
                             final SessionManager sessionManager,
-                            final SessionPresenterFactory<Diagram, AbstractClientReadOnlySession, AbstractClientFullSession> sessionPresenterFactory,
+                            final @DMNEditor SessionPresenterFactory<Diagram, AbstractClientReadOnlySession, AbstractClientFullSession> sessionPresenterFactory,
                             final SessionCommandFactory sessionCommandFactory,
                             final ProjectDiagramEditorMenuItemsBuilder menuItemsBuilder,
                             final Event<OnDiagramFocusEvent> onDiagramFocusEvent,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.logging.client.LogConfiguration;
 import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
@@ -110,7 +111,7 @@ public class SessionDiagramEditorScreen {
                                       final ShowcaseDiagramService diagramService,
                                       final SessionManager sessionManager,
                                       final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                      final SessionPresenterFactory<Diagram, AbstractClientReadOnlySession, AbstractClientFullSession> sessionPresenterFactory,
+                                      final @DMNEditor SessionPresenterFactory<Diagram, AbstractClientReadOnlySession, AbstractClientFullSession> sessionPresenterFactory,
                                       final Event<ChangeTitleWidgetEvent> changeTitleNotificationEvent,
                                       final MenuDevCommandsBuilder menuDevCommandsBuilder,
                                       final ScreenPanelView screenPanelView,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ClearSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ClearSessionCommand.java
@@ -96,13 +96,13 @@ public class ClearSessionCommand extends AbstractClientSessionCommand<ClientFull
         sessionCommandManager.getRegistry().clear();
     }
 
-    void onCommandExecuted(final @Observes CanvasCommandExecutedEvent commandExecutedEvent) {
+    protected void onCommandExecuted(final @Observes CanvasCommandExecutedEvent commandExecutedEvent) {
         checkNotNull("commandExecutedEvent",
                      commandExecutedEvent);
         checkState();
     }
 
-    void onCommandUndoExecuted(final @Observes CanvasUndoCommandExecutedEvent commandUndoExecutedEvent) {
+    protected void onCommandUndoExecuted(final @Observes CanvasUndoCommandExecutedEvent commandUndoExecutedEvent) {
         checkNotNull("commandUndoExecutedEvent",
                      commandUndoExecutedEvent);
         checkState();


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3354

This PR adds a new ```SessionCommandFactory``` for the DMN Editor; with a ```ClearSessionCommand``` that does not respond to DMN-centric events that would lead to the Toolbar button becoming enabled.