### PR TITLE
GUVNOR-3356: [DMN Editor] Add support for filtering events

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPresenterFactoryImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPresenterFactoryImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.client.widgets.presenters.session.impl;
+package org.kie.workbench.common.dmn.client.session.presenters.impl;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -44,7 +44,7 @@ public class SessionPresenterFactoryImpl extends org.kie.workbench.common.stunne
                                        final ManagedInstance<CanvasCommandManager<AbstractCanvasHandler>> commandManagerInstances,
                                        final ManagedInstance<ViewerToolbarFactory> viewerToolbarFactoryInstances,
                                        final @DMNEditor ManagedInstance<EditorToolbarFactory> editorToolbarFactoryInstances,
-                                       final ManagedInstance<SessionDiagramPreview<AbstractClientSession>> sessionPreviewInstances,
+                                       final @DMNEditor ManagedInstance<SessionDiagramPreview<AbstractClientSession>> sessionPreviewInstances,
                                        final ManagedInstance<WidgetWrapperView> diagramViewerViewInstances,
                                        final ManagedInstance<SessionPresenter.View> viewInstances,
                                        final ManagedInstance<NotificationsObserver> notificationsObserverInstances,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPreviewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPreviewImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session.presenters.impl;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.DMNCommand;
+import org.kie.workbench.common.stunner.client.widgets.views.WidgetWrapperView;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.BaseCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+
+@DMNEditor
+@Dependent
+public class SessionPreviewImpl extends org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionPreviewImpl {
+
+    @Inject
+    public SessionPreviewImpl(final DefinitionManager definitionManager,
+                              final ShapeManager shapeManager,
+                              final TextPropertyProviderFactory textPropertyProviderFactory,
+                              final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager,
+                              final DefinitionUtils definitionUtils,
+                              final GraphUtils graphUtils,
+                              final @Any ManagedInstance<BaseCanvasHandler> canvasHandlerFactories,
+                              final @Any ManagedInstance<CanvasCommandFactory> canvasCommandFactories,
+                              final SelectionControl<AbstractCanvasHandler, ?> selectionControl,
+                              final WidgetWrapperView view) {
+        super(definitionManager,
+              shapeManager,
+              textPropertyProviderFactory,
+              canvasCommandManager,
+              definitionUtils,
+              graphUtils,
+              canvasHandlerFactories,
+              canvasCommandFactories,
+              selectionControl,
+              view);
+    }
+
+    @Override
+    protected void handleCanvasCommandExecutedEvent(final CanvasCommandExecutedEvent event) {
+        if (event.getCommand() instanceof DMNCommand) {
+            return;
+        }
+        super.handleCanvasCommandExecutedEvent(event);
+    }
+
+    @Override
+    protected void handleCanvasUndoCommandExecutedEvent(final CanvasUndoCommandExecutedEvent event) {
+        if (event.getCommand() instanceof DMNCommand) {
+            return;
+        }
+        super.handleCanvasUndoCommandExecutedEvent(event);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/BaseCommandsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/BaseCommandsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session;
+
+import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
+import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.BaseCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.mockito.Mock;
+
+public abstract class BaseCommandsTest {
+
+    @Mock
+    protected BaseCanvasHandler canvasHandler;
+
+    @SuppressWarnings("unchecked")
+    protected CanvasCommandExecutedEvent makeCommandExecutionContext(final Command command) {
+        return new CanvasCommandExecutedEvent(canvasHandler,
+                                              command,
+                                              CanvasCommandResultBuilder.SUCCESS);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected CanvasUndoCommandExecutedEvent makeCommandUndoContext(final Command command) {
+        return new CanvasUndoCommandExecutedEvent(canvasHandler,
+                                                  command,
+                                                  CanvasCommandResultBuilder.SUCCESS);
+    }
+
+    public static class MockCommand extends AbstractCanvasGraphCommand {
+
+        @Override
+        protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
+            return null;
+        }
+
+        @Override
+        protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
+            return null;
+        }
+    }
+
+    public static class MockVetoExecutionCommand extends MockCommand implements VetoExecutionCommand {
+
+    }
+
+    public static class MockVetoUndoCommand extends MockCommand implements VetoUndoCommand {
+
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/command/impl/ClearSessionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/command/impl/ClearSessionCommandTest.java
@@ -19,35 +19,23 @@ package org.kie.workbench.common.dmn.client.session.command.impl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
-import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
+import org.kie.workbench.common.dmn.client.session.BaseCommandsTest;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
-import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
-import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
-import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ClearSessionCommandTest {
+public class ClearSessionCommandTest extends BaseCommandsTest {
 
     @Mock
     private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
 
     @Mock
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-
-    @Mock
-    private AbstractCanvasHandler canvasHandler;
 
     @Mock
     private org.uberfire.mvp.Command callback;
@@ -89,40 +77,5 @@ public class ClearSessionCommandTest {
 
         verify(callback,
                never()).execute();
-    }
-
-    @SuppressWarnings("unchecked")
-    private CanvasCommandExecutedEvent makeCommandExecutionContext(final Command command) {
-        return new CanvasCommandExecutedEvent(canvasHandler,
-                                              command,
-                                              CanvasCommandResultBuilder.SUCCESS);
-    }
-
-    @SuppressWarnings("unchecked")
-    private CanvasUndoCommandExecutedEvent makeCommandUndoContext(final Command command) {
-        return new CanvasUndoCommandExecutedEvent(canvasHandler,
-                                                  command,
-                                                  CanvasCommandResultBuilder.SUCCESS);
-    }
-
-    private static class MockCommand extends AbstractCanvasGraphCommand {
-
-        @Override
-        protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
-            return null;
-        }
-
-        @Override
-        protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
-            return null;
-        }
-    }
-
-    private static class MockVetoExecutionCommand extends MockCommand implements VetoExecutionCommand {
-
-    }
-
-    private static class MockVetoUndoCommand extends MockCommand implements VetoUndoCommand {
-
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPreviewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPreviewImplTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session.presenters.impl;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.session.BaseCommandsTest;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionViewer;
+import org.kie.workbench.common.stunner.client.widgets.views.WidgetWrapperView;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.BaseCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientSession;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.DiagramImpl;
+import org.kie.workbench.common.stunner.core.diagram.MetadataImpl;
+import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSetImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.impl.GraphImpl;
+import org.kie.workbench.common.stunner.core.graph.store.GraphNodeStoreImpl;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionPreviewImplTest extends BaseCommandsTest {
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private TextPropertyProviderFactory textPropertyProviderFactory;
+
+    @Mock
+    private CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private GraphUtils graphUtils;
+
+    @Mock
+    private ManagedInstance<BaseCanvasHandler> canvasHandlerFactories;
+
+    @Mock
+    private ManagedInstance<CanvasCommandFactory> canvasCommandFactories;
+
+    @Mock
+    private SelectionControl<AbstractCanvasHandler, ?> selectionControl;
+
+    @Mock
+    private WidgetWrapperView view;
+
+    @Mock
+    private AbstractClientSession session;
+
+    @Mock
+    private SessionViewer.SessionViewerCallback callback;
+
+    @Mock
+    private CanvasFactory canvasFactory;
+
+    @Mock
+    private ZoomControl zoomControl;
+
+    @Mock
+    private AbstractCanvas canvas;
+
+    @Mock
+    private AbstractCanvas.View canvasView;
+
+    private SessionPreviewImpl preview;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.preview = new SessionPreviewImpl(definitionManager,
+                                              shapeManager,
+                                              textPropertyProviderFactory,
+                                              canvasCommandManager,
+                                              definitionUtils,
+                                              graphUtils,
+                                              canvasHandlerFactories,
+                                              canvasCommandFactories,
+                                              selectionControl,
+                                              view);
+        final DiagramImpl diagram = new DiagramImpl("diagram",
+                                                    new MetadataImpl());
+        final GraphImpl graph = new GraphImpl("graph",
+                                              new GraphNodeStoreImpl());
+        final DefinitionSetImpl definitionSet = new DefinitionSetImpl("id");
+        diagram.setGraph(graph);
+        graph.setContent(definitionSet);
+        definitionSet.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                             0.0),
+                                               new BoundImpl(100.0,
+                                                             100.0)));
+
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(session.getCanvas()).thenReturn(canvas);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(shapeManager.getCanvasFactory(any(Diagram.class))).thenReturn(canvasFactory);
+        when(canvasFactory.newCanvas()).thenReturn(canvas);
+        when(canvasFactory.newControl(eq(ZoomControl.class))).thenReturn(zoomControl);
+        when(canvasHandlerFactories.select(any(Annotation.class))).thenReturn(canvasHandlerFactories);
+        when(canvasHandlerFactories.get()).thenReturn(canvasHandler);
+        when(canvas.getView()).thenReturn(canvasView);
+
+        preview.open(session,
+                     callback);
+    }
+
+    @Test
+    public void checkExecutionCommands() {
+        final AbstractCanvasGraphCommand command = new MockCommand();
+        preview.handleCanvasCommandExecutedEvent(makeCommandExecutionContext(command));
+
+        verify(canvasCommandManager).execute(any(BaseCanvasHandler.class),
+                                             eq(command));
+    }
+
+    @Test
+    public void checkVetoExecutionCommands() {
+        final AbstractCanvasGraphCommand command = new MockVetoExecutionCommand();
+        preview.handleCanvasCommandExecutedEvent(makeCommandExecutionContext(command));
+
+        verify(canvasCommandManager,
+               never()).execute(any(AbstractCanvasHandler.class),
+                                any(AbstractCanvasGraphCommand.class));
+    }
+
+    @Test
+    public void checkUndoCommands() {
+        final AbstractCanvasGraphCommand command = new MockCommand();
+        preview.handleCanvasUndoCommandExecutedEvent(makeCommandUndoContext(command));
+
+        verify(canvasCommandManager).undo(any(BaseCanvasHandler.class),
+                                          eq(command));
+    }
+
+    @Test
+    public void checkVetoUndoCommands() {
+        final AbstractCanvasGraphCommand command = new MockVetoUndoCommand();
+        preview.handleCanvasUndoCommandExecutedEvent(makeCommandUndoContext(command));
+
+        verify(canvasCommandManager,
+               never()).undo(any(AbstractCanvasHandler.class),
+                             any(AbstractCanvasGraphCommand.class));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/preview/SessionDiagramPreviewScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/preview/SessionDiagramPreviewScreen.java
@@ -24,6 +24,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.constants.ButtonSize;
 import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.showcase.client.screens.BaseSessionScreen;
 import org.kie.workbench.common.dmn.showcase.client.screens.SessionScreenView;
 import org.kie.workbench.common.stunner.client.widgets.menu.MenuUtils;
@@ -76,7 +77,7 @@ public class SessionDiagramPreviewScreen extends BaseSessionScreen {
 
     @Inject
     public SessionDiagramPreviewScreen(final SessionScreenView view,
-                                       final SessionPresenterFactory<Diagram, AbstractClientReadOnlySession, AbstractClientFullSession> sessionPresenterFactory) {
+                                       final @DMNEditor SessionPresenterFactory<Diagram, AbstractClientReadOnlySession, AbstractClientFullSession> sessionPresenterFactory) {
         this.view = view;
         this.sessionPresenterFactory = sessionPresenterFactory;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPreviewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPreviewImpl.java
@@ -93,7 +93,7 @@ public class SessionPreviewImpl
                               final WidgetWrapperView view) {
         this.definitionManager = definitionManager;
         this.shapeManager = shapeManager;
-        this.textPropertyProviderFactory=textPropertyProviderFactory;
+        this.textPropertyProviderFactory = textPropertyProviderFactory;
         this.canvasCommandManager = canvasCommandManager;
 
         this.definitionUtils = definitionUtils;
@@ -215,11 +215,19 @@ public class SessionPreviewImpl
     }
 
     void commandExecutedFired(@Observes CanvasCommandExecutedEvent commandExecutedEvent) {
-        super.onCommandExecuted(commandExecutedEvent);
+        handleCanvasCommandExecutedEvent(commandExecutedEvent);
     }
 
     void commandUndoExecutedFired(@Observes CanvasUndoCommandExecutedEvent commandUndoExecutedEvent) {
-        super.onCommandUndoExecuted(commandUndoExecutedEvent);
+        handleCanvasUndoCommandExecutedEvent(commandUndoExecutedEvent);
+    }
+
+    protected void handleCanvasCommandExecutedEvent(final CanvasCommandExecutedEvent event) {
+        super.onCommandExecuted(event);
+    }
+
+    protected void handleCanvasUndoCommandExecutedEvent(final CanvasUndoCommandExecutedEvent event) {
+        super.onCommandUndoExecuted(event);
     }
 
     @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3356

This PR adds a different ```SessionPreviewImpl``` implementation for the DMN Editor that does not replay commands implementing ```DMNCommand```. There will be no tangible differences from a Users perspective. If however you were to put a break point in (for example) ```NavigateToExpressionEditorCommand.execute()``` you'd notice it is now only executed once. Previously it was executed twice: Once for the main "view" and again for the "preview".