### PR TITLE
JBPM-6103 Stunner - Script Language values are not persist to Embedded subprocess

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/annotation/RuntimePropertyAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/annotation/RuntimePropertyAdapter.java
@@ -210,8 +210,7 @@ public class RuntimePropertyAdapter<T> extends AbstractRuntimeAdapter<T> impleme
                          final Object value) {
         if (null != property) {
             if (isReadOnly(property)) {
-                // throw new RuntimeException( "Cannot set new value for property [" + getId( property ) + "] as it is read only! " );
-                return;
+                throw new RuntimeException( "Cannot set new value for property [" + getId( property ) + "] as it is read only! " );
             }
             Class<?> c = property.getClass();
             boolean done = false;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
@@ -27,7 +27,6 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.annotations.field.selector.SelectorDataProvider;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
 import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOModel;
@@ -40,6 +39,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnEntryAct
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnExitAction;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.ScriptLanguage;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldType;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.Description;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
@@ -100,17 +100,21 @@ public class EmbeddedSubprocess extends BaseSubprocess implements DataIOModel {
 
     @Property
     @FormField(
-            type = TextAreaFieldType.class,
-            afterElement = "onEntryAction",
-            settings = {@FieldParam(name = "rows", value = "5")}
+        type = TextAreaFieldType.class,
+        afterElement = "onEntryAction",
+        settings = {@FieldParam(name = "rows", value = "5")}
     )
     @Valid
     private OnExitAction onExitAction;
 
     @Property
     @FormField(
-            type = ListBoxFieldType.class,
-            afterElement = "onExitAction"
+        type = ConditionalComboBoxFieldType.class,
+        afterElement = "onExitAction",
+        settings = {
+            @FieldParam(name = "relatedField", value = "onEntryAction;onExitAction"),
+            @FieldParam(name = "allowCustomValue", value = "false")
+        }
     )
     @SelectorDataProvider(
             type = SelectorDataProvider.ProviderType.REMOTE,
@@ -154,8 +158,7 @@ public class EmbeddedSubprocess extends BaseSubprocess implements DataIOModel {
         this.onEntryAction = onEntryAction;
         this.onExitAction = onExitAction;
         this.scriptLanguage = scriptLanguage;
-        this.isAsync = isAsync;
-        this.processData = processData;
+        this.isAsync = isAsync;this.processData = processData;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/ComboBoxFieldDefinition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/ComboBoxFieldDefinition.java
@@ -21,9 +21,11 @@ import java.util.List;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.adf.definitions.annotations.SkipFormField;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorFieldBaseDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
 import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.FieldType;
 
 @Portable
 @Bindable
@@ -31,16 +33,19 @@ public class ComboBoxFieldDefinition extends SelectorFieldBaseDefinition<StringS
 
     public static final ComboBoxFieldType FIELD_TYPE = new ComboBoxFieldType();
 
-    private String defaultValue;
+    protected String defaultValue;
 
     protected List<StringSelectorOption> options = new ArrayList<>();
+
+    @SkipFormField
+    protected Boolean allowCustomValue = Boolean.TRUE;
 
     public ComboBoxFieldDefinition() {
         super(String.class.getName());
     }
 
     @Override
-    public ComboBoxFieldType getFieldType() {
+    public FieldType getFieldType() {
         return FIELD_TYPE;
     }
 
@@ -69,5 +74,13 @@ public class ComboBoxFieldDefinition extends SelectorFieldBaseDefinition<StringS
         if (other instanceof ComboBoxFieldDefinition) {
             this.setDefaultValue(((ComboBoxFieldDefinition) other).getDefaultValue());
         }
+    }
+
+    public Boolean isAllowCustomValue() {
+        return allowCustomValue;
+    }
+
+    public void setAllowCustomValue(Boolean allowCustomValue) {
+        this.allowCustomValue = allowCustomValue;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/ConditionalComboBoxFieldDefinition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/ConditionalComboBoxFieldDefinition.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+
+@Portable
+@Bindable
+public class ConditionalComboBoxFieldDefinition extends ComboBoxFieldDefinition {
+
+  public static final ConditionalComboBoxFieldType FIELD_TYPE = new ConditionalComboBoxFieldType();
+
+  @Override
+  public ConditionalComboBoxFieldType getFieldType() {
+    return FIELD_TYPE;
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/ConditionalComboBoxFieldType.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/ConditionalComboBoxFieldType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
+
+@Portable
+public class ConditionalComboBoxFieldType extends ListBoxFieldType {
+
+    public static final String NAME = "ConditionalComboBox";
+
+    @Override
+    public String getTypeName() {
+        return NAME;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/ConditionalComboBoxFieldProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/ConditionalComboBoxFieldProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.service.fieldProviders;
+
+import javax.enterprise.inject.Model;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.BasicTypeFieldProvider;
+import org.kie.workbench.common.forms.model.TypeInfo;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldType;
+
+@Model
+public class ConditionalComboBoxFieldProvider extends BasicTypeFieldProvider<ConditionalComboBoxFieldDefinition> {
+
+  @Override
+  public int getPriority() {
+    return 1000;
+  }
+
+  @Override
+  protected void doRegisterFields() {
+    registerPropertyType(String.class);
+  }
+
+  @Override
+  public ConditionalComboBoxFieldDefinition createFieldByType(TypeInfo typeInfo) {
+    return getDefaultField();
+  }
+
+  @Override
+  public Class<ConditionalComboBoxFieldType> getFieldType() {
+    return ConditionalComboBoxFieldType.class;
+  }
+
+  @Override
+  public String getFieldTypeName() {
+    return ConditionalComboBoxFieldDefinition.FIELD_TYPE.getTypeName();
+  }
+
+  @Override
+  public ConditionalComboBoxFieldDefinition getDefaultField() {
+    return new ConditionalComboBoxFieldDefinition();
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/util/MultipleFieldStringSerializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/util/MultipleFieldStringSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.util;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Serialize/Deserialize a set of {@link String} fields to a String.
+ */
+public class MultipleFieldStringSerializer {
+
+  public static final String SEPARATOR = ";";
+
+  public static final String serialize(String... fields) {
+    return Stream.of(fields).collect(Collectors.joining(SEPARATOR));
+  }
+
+  public static List<String> deserialize(String value) {
+    return MultipleFieldStringSerializer.split(value,
+                             SEPARATOR);
+  }
+
+  private static List<String> split(String input, String delim){
+    if(Objects.isNull(input)){
+      throw new IllegalArgumentException("Null input");
+    }
+
+    if(Objects.isNull(delim)){
+      throw new IllegalArgumentException("Null delimiter");
+    }
+    return Stream.of(input.split(delim)).collect(Collectors.toList());
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/util/MultipleFieldStringSerializerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/util/MultipleFieldStringSerializerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.util;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MultipleFieldStringSerializerTest {
+
+  private static final String SERIALIZED_FIELDS = "tiago;dolphine";
+  private static final String[] DESERIALIZED_FIELDS = {"tiago", "dolphine"};
+
+  @Test
+  public void testSerialize() throws Exception {
+    Assert.assertEquals(Arrays.asList(DESERIALIZED_FIELDS),
+                        MultipleFieldStringSerializer.deserialize(SERIALIZED_FIELDS));
+  }
+
+  @Test
+  public void testDeserialize() throws Exception {
+    Assert.assertEquals(SERIALIZED_FIELDS,
+                        MultipleFieldStringSerializer.serialize(DESERIALIZED_FIELDS));
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -114,6 +114,11 @@
       <artifactId>kie-wb-common-dynamic-forms-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-processing-engine</artifactId>
+    </dependency>
+
     <!-- TODO: Really necessary? . -->
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRenderer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.SelectorFieldRenderer;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
+
+@Dependent
+public abstract class AbstractComboBoxFieldRenderer<T extends ComboBoxFieldDefinition>
+    extends SelectorFieldRenderer<T, StringSelectorOption, String> {
+
+  private ComboBoxWidgetView view;
+
+  private ListBoxValues valueListBoxValues;
+
+  @Inject
+  public AbstractComboBoxFieldRenderer(final ComboBoxWidgetView comboBoxEditor) {
+    this.view = comboBoxEditor;
+  }
+
+  @Override
+  protected void refreshInput(Map<String, String> optionsValues,
+                              String defaultValue) {
+    List<String> values = new ArrayList<String>(optionsValues.keySet());
+    java.util.Collections.sort(values);
+    setComboBoxValues(values);
+  }
+
+  protected void setComboBoxValues(final List<String> values) {
+    valueListBoxValues = new ListBoxValues(ComboBoxWidgetView.CUSTOM_PROMPT,
+                                           "Edit" + " ",
+                                           null);
+    valueListBoxValues.addValues(values);
+    view.setComboBoxValues(valueListBoxValues);
+  }
+
+  @Override
+  public void initInputWidget() {
+    view.setReadOnly(field.getReadOnly());
+    refreshSelectorOptions();
+  }
+
+  @Override
+  public IsWidget getInputWidget() {
+    return (ComboBoxWidgetViewImpl) view;
+  }
+
+  @Override
+  public IsWidget getPrettyViewWidget() {
+    initInputWidget();
+    return getInputWidget();
+  }
+
+  @Override
+  protected void setReadOnly(boolean readOnly) {
+    view.setReadOnly(readOnly);
+    field.setReadOnly(readOnly);
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRenderer.java
@@ -16,81 +16,34 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.ui.IsWidget;
-import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.SelectorFieldRenderer;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
-import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
 
 @Dependent
 public class ComboBoxFieldRenderer
-        extends SelectorFieldRenderer<ComboBoxFieldDefinition, StringSelectorOption, String> {
+    extends AbstractComboBoxFieldRenderer<ComboBoxFieldDefinition> {
 
-    private ComboBoxWidgetView view;
+  public static final String TYPE_NAME = ComboBoxFieldDefinition.FIELD_TYPE.getTypeName();
 
-    private ListBoxValues valueListBoxValues;
+  @Inject
+  public ComboBoxFieldRenderer(final ComboBoxWidgetView comboBoxEditor) {
+    super(comboBoxEditor);
+  }
 
-    @Inject
-    public ComboBoxFieldRenderer(final ComboBoxWidgetView comboBoxEditor) {
-        this.view = comboBoxEditor;
-    }
+  @Override
+  public String getName() {
+    return TYPE_NAME;
+  }
 
-    @Override
-    protected void refreshInput(Map<String, String> optionsValues,
-                                String defaultValue) {
-        List<String> values = new ArrayList<String>(optionsValues.keySet());
-        java.util.Collections.sort(values);
-        setComboBoxValues(values);
-    }
+  @Override
+  public String getSupportedCode() {
+    return TYPE_NAME;
+  }
 
-    protected void setComboBoxValues(final List<String> values) {
-        valueListBoxValues = new ListBoxValues(ComboBoxWidgetView.CUSTOM_PROMPT,
-                                               "Edit" + " ",
-                                               null);
-        valueListBoxValues.addValues(values);
-        view.setComboBoxValues(valueListBoxValues);
-    }
-
-    @Override
-    public String getName() {
-        return ComboBoxFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public void initInputWidget() {
-        view.setReadOnly(field.getReadOnly());
-        refreshSelectorOptions();
-    }
-
-    @Override
-    public IsWidget getInputWidget() {
-        return (ComboBoxWidgetViewImpl) view;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return ComboBoxFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public IsWidget getPrettyViewWidget() {
-        initInputWidget();
-        return getInputWidget();
-    }
-
-    @Override
-    protected void setReadOnly(boolean readOnly) {
-        view.setReadOnly(readOnly);
-    }
-
-    @Override
-    public Class<ComboBoxFieldDefinition> getSupportedFieldDefinition() {
-        return ComboBoxFieldDefinition.class;
-    }
+  @Override
+  public Class<ComboBoxFieldDefinition> getSupportedFieldDefinition() {
+    return ComboBoxFieldDefinition.class;
+  }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFixedValuesWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFixedValuesWidgetView.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
+
+public interface ComboBoxFixedValuesWidgetView extends ComboBoxWidgetView {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFixedValuesWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFixedValuesWidgetViewImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
+
+import javax.annotation.PostConstruct;
+
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor.annotation.FixedValues;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
+
+/**
+ * Combobox with fixed list of values, it doesn't allow custom values to be inserted.
+ */
+@FixedValues
+@Templated("ComboBoxWidget.html")
+public class ComboBoxFixedValuesWidgetViewImpl extends ComboBoxWidgetViewImpl implements ComboBoxFixedValuesWidgetView {
+
+  @PostConstruct
+  public void init() {
+    super.init();
+    //Do not allow custom values to be inserted on the combobox
+    valueComboBox.setShowCustomValues(false);
+  }
+
+  @Override
+  public void setComboBoxValues(final ListBoxValues valueListBoxValues) {
+    valueComboBox.setListBoxValues(valueListBoxValues);
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRenderer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
+
+import java.util.List;
+import java.util.Objects;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
+import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeListener;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor.annotation.FixedValues;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.util.MultipleFieldStringSerializer;
+import org.kie.workbench.common.stunner.core.client.definition.adapter.binding.ClientBindingUtils;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+
+/**
+ * Render a {@link ConditionalComboBoxFieldDefinition} based on a relatedField with condition to be {@code not empty} or {@code null} to be editable.
+ */
+@Dependent
+public class ConditionalComboBoxFieldRenderer extends AbstractComboBoxFieldRenderer<ConditionalComboBoxFieldDefinition> {
+
+  public static final String TYPE_NAME = ConditionalComboBoxFieldDefinition.FIELD_TYPE.getTypeName();
+
+  private AdapterManager adapterManager;
+
+  @Inject
+  public ConditionalComboBoxFieldRenderer(@FixedValues final ComboBoxFixedValuesWidgetView comboBoxEditor,
+                                          AdapterManager adapterManager) {
+    super(comboBoxEditor);
+    this.adapterManager = adapterManager;
+  }
+
+  @Override
+  public void init(final FormRenderingContext renderingContext,
+                   ConditionalComboBoxFieldDefinition field) {
+    super.init(renderingContext,
+               field);
+    initializeRelatedFieldCondition(renderingContext,
+                                    field);
+  }
+
+  private void initializeRelatedFieldCondition(FormRenderingContext renderingContext,
+                                               ConditionalComboBoxFieldDefinition field) {
+    if (Objects.nonNull(field.getRelatedField())) {
+      List<String> fields = extractFields(field);
+      if (Objects.isNull(field) || fields.isEmpty()) {
+        return;
+      }
+      initializeListeners(fields);
+      checkCurrentRelatedFieldValues(renderingContext,
+                                     fields);
+    }
+  }
+
+  private void checkCurrentRelatedFieldValues(FormRenderingContext renderingContext,
+                                              List<String> fields) {
+    final Object formModel = renderingContext.getModel();
+    setReadOnly(fields.stream().allMatch(f -> {
+      Object relatedFieldDefinition = ClientBindingUtils.getProxiedValue(formModel,
+                                                                         f);
+      return verifyReadOnlyCondition(adapterManager.forProperty().getValue(relatedFieldDefinition));
+    }));
+  }
+
+  private void initializeListeners(List<String> fields) {
+    fields.forEach(f -> fieldChangeListeners.add(
+        new FieldChangeListener(f,
+                                (name, value) -> refreshFieldCondition(value)))
+
+    );
+  }
+
+  private List<String> extractFields(ConditionalComboBoxFieldDefinition field) {
+    return MultipleFieldStringSerializer.deserialize(field.getRelatedField());
+  }
+
+  public void refreshFieldCondition(Object conditionValue) {
+    boolean readOnly = verifyReadOnlyCondition(conditionValue);
+    setReadOnly(readOnly);
+  }
+
+  private boolean verifyReadOnlyCondition(Object conditionValue) {
+    return Objects.isNull(conditionValue) || String.valueOf(conditionValue).trim().isEmpty();
+  }
+
+  @Override
+  public String getName() {
+    return TYPE_NAME;
+  }
+
+  @Override
+  public String getSupportedCode() {
+    return TYPE_NAME;
+  }
+
+  @Override
+  public Class<ConditionalComboBoxFieldDefinition> getSupportedFieldDefinition() {
+    return ConditionalComboBoxFieldDefinition.class;
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/annotation/FixedValues.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/annotation/FixedValues.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Qualifier to represent a fixed collection of values that cannot be changed with custom values.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+public @interface FixedValues {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRendererTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractComboBoxFieldRendererTest {
+
+  @Mock
+  private ComboBoxWidgetView comboBoxWidgetView;
+
+  @Mock
+  private ComboBoxFieldDefinition comboBoxFieldDefinition;
+
+  @Spy
+  @InjectMocks
+  private AbstractComboBoxFieldRenderer comboBoxFieldRenderer = new ComboBoxFieldRenderer(comboBoxWidgetView);
+
+  private Map<String, String> options;
+
+  @Before
+  public void setUp() {
+    options = new HashMap<String, String>();
+    options.put("age",
+                "33");
+    options.put("height",
+                "1.77");
+    options.put("gender",
+                "male");
+  }
+
+  @Test
+  public void testRefreshInput() {
+    comboBoxFieldRenderer.refreshInput(options,
+                                       null);
+    verify(comboBoxWidgetView,
+           times(1)).setComboBoxValues(any(ListBoxValues.class));
+  }
+
+  @Test
+  public void testSetComboBoxValues() {
+    List<String> values = Arrays.asList(new String[]{"age", "height", "sex"});
+    comboBoxFieldRenderer.setComboBoxValues(values);
+    verify(comboBoxWidgetView,
+           times(1)).setComboBoxValues(any(ListBoxValues.class));
+  }
+
+  @Test
+  public void setReadOnly() throws Exception {
+    comboBoxFieldRenderer.setReadOnly(true);
+    verify(comboBoxWidgetView,
+           times(1)).setReadOnly(true);
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRendererTest.java
@@ -16,63 +16,44 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.Before;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldType;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
-
 @RunWith(MockitoJUnitRunner.class)
 public class ComboBoxFieldRendererTest {
 
-    @Mock
-    private ComboBoxWidgetView comboBoxWidgetView;
+  @Mock
+  private ComboBoxWidgetView comboBoxWidgetView;
 
-    @Mock
-    ComboBoxFieldDefinition comboBoxFieldDefinition;
+  @Mock
+  private ComboBoxFieldDefinition comboBoxFieldDefinition;
 
-    @Spy
-    @InjectMocks
-    ComboBoxFieldRenderer comboBoxFieldRenderer = new ComboBoxFieldRenderer(comboBoxWidgetView);
+  @Spy
+  @InjectMocks
+  private ComboBoxFieldRenderer comboBoxFieldRenderer = new ComboBoxFieldRenderer(comboBoxWidgetView);
 
-    @Before
-    public void setUp() {
-    }
+  @Test
+  public void getName() throws Exception {
+    Assert.assertEquals(comboBoxFieldRenderer.getName(),
+                        ComboBoxFieldType.NAME);
+  }
 
-    @Test
-    public void testRefreshInput() {
-        Map<String, String> options = new HashMap<String, String>();
-        options.put("age",
-                    "age");
-        options.put("height",
-                    "height");
-        options.put("sex",
-                    "sex");
-        comboBoxFieldRenderer.refreshInput(options,
-                                           null);
+  @Test
+  public void getSupportedCode() throws Exception {
+    Assert.assertEquals(comboBoxFieldRenderer.getSupportedCode(),
+                        ComboBoxFieldType.NAME);
+  }
 
-        verify(comboBoxWidgetView,
-               times(1)).setComboBoxValues(any(ListBoxValues.class));
-    }
-
-    @Test
-    public void testSetComboBoxValues() {
-        List<String> values = Arrays.asList(new String[]{"age", "height", "sex"});
-        comboBoxFieldRenderer.setComboBoxValues(values);
-
-        verify(comboBoxWidgetView,
-               times(1)).setComboBoxValues(any(ListBoxValues.class));
-    }
+  @Test
+  public void getSupportedFieldDefinition() throws Exception {
+    Assert.assertEquals(comboBoxFieldRenderer.getSupportedFieldDefinition(),
+                        ComboBoxFieldDefinition.class);
+  }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnEntryAction;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnExitAction;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldType;
+import org.kie.workbench.common.stunner.core.client.definition.adapter.binding.ClientBindingUtils;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
+import org.mockito.BDDMockito;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ClientBindingUtils.class)
+public class ConditionalComboBoxFieldRendererTest {
+
+  @Mock
+  private ComboBoxFixedValuesWidgetView comboBoxFixedValuesWidgetView;
+
+  @Mock
+  private ConditionalComboBoxFieldDefinition conditionalComboBoxFieldDefinition;
+
+  @Mock
+  private AdapterManager adapterManager;
+
+  @Mock
+  private FormRenderingContext renderingContext;
+
+  @Spy
+  @InjectMocks
+  private ConditionalComboBoxFieldRenderer conditionalComboBoxFieldRenderer = new ConditionalComboBoxFieldRenderer(comboBoxFixedValuesWidgetView,
+                                                                                                                   adapterManager);
+
+  @Before
+  public void setup() {
+    when(conditionalComboBoxFieldDefinition.getRelatedField()).thenReturn("onEntryAction;onExitAction");
+  }
+
+  @Test
+  public void refreshFieldCondition() throws Exception {
+    reset(comboBoxFixedValuesWidgetView);
+    reset(conditionalComboBoxFieldRenderer);
+
+    conditionalComboBoxFieldRenderer.refreshFieldCondition(null);
+    conditionalComboBoxFieldRenderer.refreshFieldCondition("");
+    conditionalComboBoxFieldRenderer.refreshFieldCondition(" ");
+    conditionalComboBoxFieldRenderer.refreshFieldCondition("Value");
+
+    InOrder inOrder = Mockito.inOrder(comboBoxFixedValuesWidgetView);
+    inOrder.verify(comboBoxFixedValuesWidgetView,
+                   times(3)).setReadOnly(true);
+    inOrder.verify(comboBoxFixedValuesWidgetView,
+                   times(1)).setReadOnly(false);
+  }
+
+  @Test
+  public void init() throws Exception {
+    reset(comboBoxFixedValuesWidgetView);
+    reset(conditionalComboBoxFieldRenderer);
+    reset(adapterManager);
+    reset(renderingContext);
+
+    EmbeddedSubprocess embeddedSubprocess = new EmbeddedSubprocess.EmbeddedSubprocessBuilder().build();
+    OnEntryAction onEntryAction = embeddedSubprocess.getOnEntryAction();
+    OnExitAction onExitAction = embeddedSubprocess.getOnExitAction();
+
+    when(renderingContext.getModel()).thenReturn(embeddedSubprocess);
+    when(adapterManager.forProperty()).thenReturn(Mockito.mock(PropertyAdapter.class));
+    when(adapterManager.forProperty().getValue(onEntryAction)).thenReturn("value");
+    when(adapterManager.forProperty().getValue(onExitAction)).thenReturn("");
+
+    PowerMockito.mockStatic(ClientBindingUtils.class);
+    BDDMockito.given(ClientBindingUtils.getProxiedValue(embeddedSubprocess,
+                                                        "onEntryAction")).willReturn(onEntryAction);
+    BDDMockito.given(ClientBindingUtils.getProxiedValue(embeddedSubprocess,
+                                                        "onExitAction")).willReturn(onExitAction);
+
+    conditionalComboBoxFieldRenderer.init(renderingContext,
+                                          conditionalComboBoxFieldDefinition);
+
+    verify(conditionalComboBoxFieldRenderer,
+           never()).setReadOnly(true);
+
+    when(adapterManager.forProperty().getValue(onEntryAction)).thenReturn(null);
+    when(adapterManager.forProperty().getValue(onExitAction)).thenReturn("");
+
+    verify(conditionalComboBoxFieldRenderer,
+           times(1)).setReadOnly(false);
+  }
+
+  @Test
+  public void getName() throws Exception {
+    Assert.assertEquals(conditionalComboBoxFieldRenderer.getName(),
+                        ConditionalComboBoxFieldType.NAME);
+  }
+
+  @Test
+  public void getSupportedCode() throws Exception {
+    Assert.assertEquals(conditionalComboBoxFieldRenderer.getSupportedCode(),
+                        ConditionalComboBoxFieldType.NAME);
+  }
+
+  @Test
+  public void getSupportedFieldDefinition() throws Exception {
+    Assert.assertEquals(conditionalComboBoxFieldRenderer.getSupportedFieldDefinition(),
+                        ConditionalComboBoxFieldDefinition.class);
+  }
+}


### PR DESCRIPTION
The second part of this issue related to the **Script Language** that was not being persisted, in fact the problem is that scricpt laguage is an attribute of the **onEntryAction** and **onExitAction** fields, in this way, the user is only able to select a script language in case the **onEntryAction** and **onExitAction** are filled with values and not empty. 
For this it was implemented a Conditional ComboBox that is only enabled due to a condition of other fields being filled before.
Some refactory needed to be made to support this component and make the existing code more clear.
@romartin 
