### PR TITLE
GUVNOR-3374: [Stunner] Add support to enable/disable KeyboardEvent handling

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/DMNCanvasFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/DMNCanvasFactory.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.C
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.drag.DragControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
@@ -59,12 +60,14 @@ public class DMNCanvasFactory
     private final ManagedInstance<EdgeBuilderControl> edgeBuilderControls;
     private final ManagedInstance<ZoomControl> zoomControls;
     private final ManagedInstance<PanControl> panControls;
+    private final ManagedInstance<KeyboardControl> keyboardControls;
     private final ManagedInstance<AbstractCanvas> canvasInstances;
     private final ManagedInstance<AbstractCanvasHandler> canvasHandlerInstances;
 
     // Required by CDI proxies.
     protected DMNCanvasFactory() {
         this(null,
+             null,
              null,
              null,
              null,
@@ -95,6 +98,7 @@ public class DMNCanvasFactory
                             final ManagedInstance<EdgeBuilderControl> edgeBuilderControls,
                             final ManagedInstance<ZoomControl> zoomControls,
                             final ManagedInstance<PanControl> panControls,
+                            final ManagedInstance<KeyboardControl> keyboardControls,
                             final @Default ManagedInstance<AbstractCanvas> canvasInstances,
                             final @Default ManagedInstance<AbstractCanvasHandler> canvasHandlerInstances) {
         this.resizeControls = resizeControls;
@@ -110,6 +114,7 @@ public class DMNCanvasFactory
         this.edgeBuilderControls = edgeBuilderControls;
         this.zoomControls = zoomControls;
         this.panControls = panControls;
+        this.keyboardControls = keyboardControls;
         this.canvasInstances = canvasInstances;
         this.canvasHandlerInstances = canvasHandlerInstances;
     }
@@ -142,7 +147,9 @@ public class DMNCanvasFactory
                 .register(ZoomControl.class,
                           zoomControls)
                 .register(PanControl.class,
-                          panControls);
+                          panControls)
+                .register(KeyboardControl.class,
+                          keyboardControls);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNClientFullSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNClientFullSession.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.C
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.drag.DragControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
@@ -37,6 +38,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomCon
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -48,7 +50,7 @@ public class DMNClientFullSession extends AbstractClientFullSession {
 
     private DragControl<AbstractCanvasHandler, Element> dragControl;
     private ResizeControl<AbstractCanvasHandler, Element> resizeControl;
-    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> canvasInPlaceTextEditorControl;
+    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, AbstractClientFullSession, Element> canvasInPlaceTextEditorControl;
     private ToolboxControl<AbstractCanvasHandler, Element> toolboxControl;
 
     @Inject
@@ -70,7 +72,8 @@ public class DMNClientFullSession extends AbstractClientFullSession {
               factory.newControl(ConnectionAcceptorControl.class),
               factory.newControl(ContainmentAcceptorControl.class),
               factory.newControl(DockingAcceptorControl.class),
-              factory.newControl(ElementBuilderControl.class));
+              factory.newControl(ElementBuilderControl.class),
+              factory.newControl(KeyboardControl.class));
         this.dragControl = factory.newControl(DragControl.class);
         this.resizeControl = factory.newControl(ResizeControl.class);
         this.canvasInPlaceTextEditorControl = factory.newControl(CanvasInPlaceTextEditorControl.class);
@@ -82,6 +85,18 @@ public class DMNClientFullSession extends AbstractClientFullSession {
         getRegistrationHandler().registerCanvasHandlerControl(toolboxControl);
         getRegistrationHandler().registerCanvasHandlerControl(canvasInPlaceTextEditorControl);
         canvasInPlaceTextEditorControl.setCommandManagerProvider(() -> sessionCommandManager);
+    }
+
+    @Override
+    protected void doPause() {
+        getKeyboardControl().disable();
+        super.doPause();
+    }
+
+    @Override
+    protected void doResume() {
+        getKeyboardControl().enable(getCanvas());
+        super.doResume();
     }
 
     public DragControl<AbstractCanvasHandler, Element> getDragControl() {
@@ -96,7 +111,7 @@ public class DMNClientFullSession extends AbstractClientFullSession {
         return toolboxControl;
     }
 
-    public CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> getCanvasInPlaceTextEditorControl() {
+    public CanvasInPlaceTextEditorControl<AbstractCanvasHandler, AbstractClientFullSession, Element> getCanvasInPlaceTextEditorControl() {
         return canvasInPlaceTextEditorControl;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNClientFullSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNClientFullSessionTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
@@ -29,6 +30,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.C
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.drag.DragControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
@@ -38,6 +40,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElemen
 import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasShapeListener;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.mockito.Mock;
@@ -102,7 +105,10 @@ public class DMNClientFullSessionTest {
     private ElementBuilderControl<AbstractCanvasHandler> builderControl;
 
     @Mock
-    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> canvasInPlaceTextEditorControl;
+    private KeyboardControl<Canvas, ClientSession> keyboardControl;
+
+    @Mock
+    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, ClientSession, Element> canvasInPlaceTextEditorControl;
 
     private DMNClientFullSession session;
 
@@ -121,6 +127,7 @@ public class DMNClientFullSessionTest {
         when(factory.newControl(eq(DockingAcceptorControl.class))).thenReturn(dockingAcceptorControl);
         when(factory.newControl(eq(ToolboxControl.class))).thenReturn(toolboxControl);
         when(factory.newControl(eq(ElementBuilderControl.class))).thenReturn(builderControl);
+        when(factory.newControl(eq(KeyboardControl.class))).thenReturn(keyboardControl);
         when(canvasHandler.getCanvas()).thenReturn(canvas);
         this.session = new DMNClientFullSession(factory,
                                                 canvasCommandManager,
@@ -143,6 +150,10 @@ public class DMNClientFullSessionTest {
                      session.getCanvasInPlaceTextEditorControl());
         assertEquals(dragControl,
                      session.getDragControl());
+        assertEquals(resizeControl,
+                     session.getResizeControl());
+        assertEquals(toolboxControl,
+                     session.getToolboxControl());
         assertEquals(panControl,
                      session.getPanControl());
         assertEquals(canvasCommandManager,
@@ -155,6 +166,8 @@ public class DMNClientFullSessionTest {
                      session.getDockingAcceptorControl());
         assertEquals(builderControl,
                      session.getBuilderControl());
+        assertEquals(keyboardControl,
+                     session.getKeyboardControl());
     }
 
     @Test
@@ -183,6 +196,8 @@ public class DMNClientFullSessionTest {
                times(1)).enable(eq(canvasHandler));
         verify(builderControl,
                times(1)).enable(eq(canvasHandler));
+        verify(keyboardControl,
+               times(1)).bind(eq(session));
     }
 
     @Test
@@ -216,5 +231,30 @@ public class DMNClientFullSessionTest {
                times(1)).disable();
         verify(builderControl,
                times(1)).disable();
+        verify(keyboardControl,
+               times(1)).unbind();
+    }
+
+    @Test
+    public void testPauseSession() {
+        session.open();
+
+        session.pause();
+
+        verify(keyboardControl,
+               times(1)).disable();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testResumeSession() {
+        session.open();
+
+        reset(keyboardControl);
+
+        session.resume();
+
+        verify(keyboardControl,
+               times(1)).enable(eq(canvas));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramEditorImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramEditorImpl.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.select.Selec
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 
 /**
@@ -38,7 +39,7 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
  * @param <D> The diagram type.
  * @param <H> The canvas handler type.
  */
-public class DiagramEditorImpl<D extends Diagram, H extends AbstractCanvasHandler>
+public class DiagramEditorImpl<D extends Diagram, H extends AbstractCanvasHandler, S extends ClientSession>
         implements DiagramEditor<D, H> {
 
     private final DiagramViewer<D, H> viewer;
@@ -47,7 +48,7 @@ public class DiagramEditorImpl<D extends Diagram, H extends AbstractCanvasHandle
     private final ContainmentAcceptorControl<H> containmentAcceptorControl;
     private final DockingAcceptorControl<H> dockingAcceptorControl;
 
-    private CanvasControlRegistrationHandler<AbstractCanvas, H> registrationHandler;
+    private CanvasControlRegistrationHandler<AbstractCanvas, H, S> registrationHandler;
 
     DiagramEditorImpl(final DiagramViewer<D, H> viewer,
                       final CanvasCommandManager<H> commandManager,
@@ -180,8 +181,8 @@ public class DiagramEditorImpl<D extends Diagram, H extends AbstractCanvasHandle
 
     private void prepareEdit() {
         registrationHandler =
-                new CanvasControlRegistrationHandler<AbstractCanvas, H>((AbstractCanvas) getHandler().getCanvas(),
-                                                                        getHandler());
+                new CanvasControlRegistrationHandler<AbstractCanvas, H, S>((AbstractCanvas) getHandler().getCanvas(),
+                                                                           getHandler());
         registrationHandler.setCommandManagerProvider(this::getCommandManager);
         // Register the canvas controls that the aggregated diagram viewer instance does not provide.
         registrationHandler.registerCanvasHandlerControl(connectionAcceptorControl);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramViewerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramViewerImpl.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControlRegistrationHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Element;
 
@@ -32,7 +33,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
  * It provides a zoom and selection control that third parties can interacti with, but it does not provide
  * any controls that allow the diagram's authoring.
  */
-public class DiagramViewerImpl<D extends Diagram, H extends AbstractCanvasHandler>
+public class DiagramViewerImpl<D extends Diagram, H extends AbstractCanvasHandler, S extends ClientSession>
         extends AbstractDiagramViewer<D, H> {
 
     private final AbstractCanvas canvas;
@@ -40,7 +41,7 @@ public class DiagramViewerImpl<D extends Diagram, H extends AbstractCanvasHandle
     private final ZoomControl<AbstractCanvas> zoomControl;
     private final SelectionControl<H, Element> selectionControl;
 
-    private CanvasControlRegistrationHandler<AbstractCanvas, H> registrationHandler;
+    private CanvasControlRegistrationHandler<AbstractCanvas, H, S> registrationHandler;
 
     DiagramViewerImpl(final AbstractCanvas canvas,
                       final H canvasHandler,
@@ -70,13 +71,13 @@ public class DiagramViewerImpl<D extends Diagram, H extends AbstractCanvasHandle
     @Override
     protected void enableControls() {
         registrationHandler =
-                new CanvasControlRegistrationHandler<AbstractCanvas, H>(getHandler().getAbstractCanvas(),
-                                                                        getHandler());
+                new CanvasControlRegistrationHandler<AbstractCanvas, H, S>(getHandler().getAbstractCanvas(),
+                                                                           getHandler());
         registerControls(registrationHandler);
         registrationHandler.enable();
     }
 
-    protected void registerControls(final CanvasControlRegistrationHandler<AbstractCanvas, H> registrationHandler) {
+    protected void registerControls(final CanvasControlRegistrationHandler<AbstractCanvas, H, S> registrationHandler) {
         registrationHandler.registerCanvasControl(getZoomControl());
         registrationHandler.registerCanvasHandlerControl(getSelectionControl());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramEditorTest.java
@@ -27,10 +27,8 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.C
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.graph.content.Bounds;
-import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
-import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
 import org.mockito.Mock;
 
 import static org.junit.Assert.*;
@@ -41,25 +39,25 @@ import static org.mockito.Mockito.*;
 @RunWith(GwtMockitoTestRunner.class)
 public class DiagramEditorTest extends AbstractCanvasHandlerViewerTest {
 
-    private final static Bounds GRAPH_BOUNDS = new BoundsImpl(new BoundImpl(0d,
-                                                                            0d),
-                                                              new BoundImpl(100d,
-                                                                            100d));
-
     @Mock
     DiagramViewer viewer;
+
     @Mock
     CanvasCommandManager<AbstractCanvasHandler> commandManager;
+
     @Mock
     ConnectionAcceptorControl<AbstractCanvasHandler> connectionAcceptorControl;
+
     @Mock
     ContainmentAcceptorControl<AbstractCanvasHandler> containmentAcceptorControl;
+
     @Mock
     DockingAcceptorControl<AbstractCanvasHandler> dockingAcceptorControl;
+
     @Mock
     DiagramViewer.DiagramViewerCallback<Diagram> callback;
 
-    private DiagramEditorImpl<Diagram, AbstractCanvasHandler> tested;
+    private DiagramEditorImpl<Diagram, AbstractCanvasHandler, ClientSession> tested;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -83,11 +81,11 @@ public class DiagramEditorTest extends AbstractCanvasHandlerViewerTest {
             return null;
         }).when(viewer).destroy();
         this.tested =
-                new DiagramEditorImpl<Diagram, AbstractCanvasHandler>(viewer,
-                                                                      commandManager,
-                                                                      connectionAcceptorControl,
-                                                                      containmentAcceptorControl,
-                                                                      dockingAcceptorControl);
+                new DiagramEditorImpl<>(viewer,
+                                        commandManager,
+                                        connectionAcceptorControl,
+                                        containmentAcceptorControl,
+                                        dockingAcceptorControl);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramViewerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramViewerTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
@@ -43,32 +44,30 @@ import static org.mockito.Mockito.*;
 @RunWith(GwtMockitoTestRunner.class)
 public class DiagramViewerTest extends AbstractCanvasHandlerViewerTest {
 
-    private final static Bounds GRAPH_BOUNDS = new BoundsImpl(new BoundImpl(0d,
-                                                                            0d),
-                                                              new BoundImpl(100d,
-                                                                            100d));
-
     @Mock
     ZoomControl<AbstractCanvas> zoomControl;
+
     @Mock
     SelectionControl<AbstractCanvasHandler, Element> selectionControl;
+
     @Mock
     WidgetWrapperView view;
+
     @Mock
     DiagramViewer.DiagramViewerCallback<Diagram> callback;
 
-    private DiagramViewerImpl<Diagram, AbstractCanvasHandler> tested;
+    private DiagramViewerImpl<Diagram, AbstractCanvasHandler, ClientSession> tested;
 
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         super.init();
         this.tested =
-                new DiagramViewerImpl<Diagram, AbstractCanvasHandler>(canvas,
-                                                                      canvasHandler,
-                                                                      view,
-                                                                      zoomControl,
-                                                                      selectionControl);
+                new DiagramViewerImpl<>(canvas,
+                                        canvasHandler,
+                                        view,
+                                        zoomControl,
+                                        selectionControl);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/CanvasControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/CanvasControl.java
@@ -16,12 +16,21 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls;
 
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+
 /**
  * A canvas control.
  * It can implement <code>IsWidget</code> if the control have to include views outside the canvas itself,
  * such as floating widgets.
  */
 public interface CanvasControl<C> {
+
+    interface SessionAware<S extends ClientSession> {
+
+        void bind(final S session);
+
+        void unbind();
+    }
 
     /**
      * This method is called when the control is enabled for a canvas.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControl.java
@@ -17,20 +17,23 @@
 package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
 
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasRegistationControl;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.Element;
 
 /**
  * Provides element's name edition via some widget.
  */
-public interface CanvasInPlaceTextEditorControl<C extends CanvasHandler, E extends Element>
+public interface CanvasInPlaceTextEditorControl<C extends CanvasHandler, S extends ClientSession, E extends Element>
         extends CanvasRegistationControl<C, E>,
-                RequiresCommandManager<C> {
+                RequiresCommandManager<C>,
+                CanvasControl.SessionAware<S> {
 
-    CanvasInPlaceTextEditorControl<C, E> show(final E item,
-                                              final double x,
-                                              final double y);
+    CanvasInPlaceTextEditorControl<C, S, E> show(final E item,
+                                                 final double x,
+                                                 final double y);
 
-    CanvasInPlaceTextEditorControl<C, E> hide();
+    CanvasInPlaceTextEditorControl<C, S, E> hide();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControl.java
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.workbench.common.stunner.core.client.session.command;
 
+package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard;
+
+import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
-import org.uberfire.mvp.Command;
 
-public interface ClientSessionCommand<S extends ClientSession> extends CanvasControl.SessionAware<S> {
+public interface KeyboardControl<C extends Canvas, S extends ClientSession> extends CanvasControl<C>,
+                                                                                    CanvasControl.SessionAware<S> {
 
-    interface Callback<V> {
+    KeyboardControl<C, S> addKeyShortcutCallback(final KeyShortcutCallback shortcutCallback);
 
-        void onSuccess();
+    interface KeyShortcutCallback {
 
-        void onError(final V error);
+        void onKeyShortcut(final KeyboardEvent.Key... keys);
     }
-
-    ClientSessionCommand<S> listen(final Command statusCallback);
-
-    <V> void execute(final Callback<V> callback);
-
-    boolean isEnabled();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/session/ClientFullSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/session/ClientFullSession.java
@@ -22,6 +22,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.Elem
 import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.ConnectionAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -34,7 +35,7 @@ import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
  * @param <C> The canvas.
  * @param <H> The canvas handler.
  */
-public interface ClientFullSession<C extends Canvas, H extends CanvasHandler>
+public interface ClientFullSession<C extends Canvas, H extends CanvasHandler, S extends ClientSession>
         extends ClientReadOnlySession<C, H> {
 
     CanvasCommandManager<H> getCommandManager();
@@ -48,4 +49,6 @@ public interface ClientFullSession<C extends Canvas, H extends CanvasHandler>
     DockingAcceptorControl<H> getDockingAcceptorControl();
 
     ElementBuilderControl<H> getBuilderControl();
+
+    KeyboardControl<C, S> getKeyboardControl();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/DefaultCanvasFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/DefaultCanvasFactory.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.C
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.drag.DragControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
@@ -63,12 +64,14 @@ public class DefaultCanvasFactory
     private final ManagedInstance<EdgeBuilderControl> edgeBuilderControls;
     private final ManagedInstance<ZoomControl> zoomControls;
     private final ManagedInstance<PanControl> panControls;
+    private final ManagedInstance<KeyboardControl> keyboardControls;
     private final ManagedInstance<AbstractCanvas> canvasInstances;
     private final ManagedInstance<AbstractCanvasHandler> canvasHandlerInstances;
 
     // Required by CDI proxies.
     protected DefaultCanvasFactory() {
         this(null,
+             null,
              null,
              null,
              null,
@@ -99,6 +102,7 @@ public class DefaultCanvasFactory
                                 final ManagedInstance<EdgeBuilderControl> edgeBuilderControls,
                                 final ManagedInstance<ZoomControl> zoomControls,
                                 final ManagedInstance<PanControl> panControls,
+                                final ManagedInstance<KeyboardControl> keyboardControls,
                                 final @Default ManagedInstance<AbstractCanvas> canvasInstances,
                                 final @Default ManagedInstance<AbstractCanvasHandler> canvasHandlerInstances) {
         this.resizeControls = resizeControls;
@@ -114,6 +118,7 @@ public class DefaultCanvasFactory
         this.edgeBuilderControls = edgeBuilderControls;
         this.zoomControls = zoomControls;
         this.panControls = panControls;
+        this.keyboardControls = keyboardControls;
         this.canvasInstances = canvasInstances;
         this.canvasHandlerInstances = canvasHandlerInstances;
     }
@@ -146,7 +151,9 @@ public class DefaultCanvasFactory
                 .register(ZoomControl.class,
                           zoomControls)
                 .register(PanControl.class,
-                          panControls);
+                          panControls)
+                .register(KeyboardControl.class,
+                          keyboardControls);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/CanvasControlRegistrationHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/CanvasControlRegistrationHandler.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -24,6 +25,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElementListener;
 import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasShapeListener;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.graph.Element;
 
@@ -32,8 +34,9 @@ import org.kie.workbench.common.stunner.core.graph.Element;
  * @param <C> The canvas type.
  * @param <H> The canvas handler type.
  */
-public class CanvasControlRegistrationHandler<C extends AbstractCanvas, H extends AbstractCanvasHandler>
-        implements RequiresCommandManager<H> {
+public class CanvasControlRegistrationHandler<C extends AbstractCanvas, H extends AbstractCanvasHandler, S extends ClientSession>
+        implements RequiresCommandManager<H>,
+                   CanvasControl.SessionAware<S> {
 
     private final List<CanvasControl<C>> canvasControls = new LinkedList<>();
     private final List<CanvasControl<H>> canvasHandlerControls = new LinkedList<>();
@@ -64,6 +67,27 @@ public class CanvasControlRegistrationHandler<C extends AbstractCanvas, H extend
      */
     public void registerCanvasHandlerControl(final CanvasControl<H> control) {
         this.canvasHandlerControls.add(control);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void bind(final ClientSession session) {
+        final List<CanvasControl> allControls = new ArrayList<>();
+        allControls.addAll(canvasControls);
+        allControls.addAll(canvasHandlerControls);
+        allControls.stream()
+                .filter(c -> c instanceof CanvasControl.SessionAware)
+                .forEach(c -> ((CanvasControl.SessionAware) c).bind(session));
+    }
+
+    @Override
+    public void unbind() {
+        final List<CanvasControl> allControls = new ArrayList<>();
+        allControls.addAll(canvasControls);
+        allControls.addAll(canvasHandlerControls);
+        allControls.stream()
+                .filter(c -> c instanceof CanvasControl.SessionAware)
+                .forEach(c -> ((CanvasControl.SessionAware) c).unbind());
     }
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControlImpl.java
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.client.event.keyboard;
+package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasControl;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 
 /**
@@ -28,39 +31,51 @@ import org.kie.workbench.common.stunner.core.client.session.ClientSession;
  * session bind to this component.
  */
 @Dependent
-public class SessionKeyShortcutsHandler {
+public class KeyboardControlImpl extends AbstractCanvasControl<AbstractCanvas> implements KeyboardControl<AbstractCanvas, ClientSession> {
 
     private final SessionManager clientSessionManager;
-    private final ClientKeyShortcutsHandler keyShortcutsHandler;
+    private final KeyEventHandler keyEventHandler;
     private ClientSession session;
 
     @Inject
-    public SessionKeyShortcutsHandler(final SessionManager clientSessionManager,
-                                      final ClientKeyShortcutsHandler keyShortcutsHandler) {
+    public KeyboardControlImpl(final SessionManager clientSessionManager,
+                               final KeyEventHandler keyEventHandler) {
         this.clientSessionManager = clientSessionManager;
-        this.keyShortcutsHandler = keyShortcutsHandler;
+        this.keyEventHandler = keyEventHandler;
     }
 
-    public SessionKeyShortcutsHandler setKeyShortcutCallback(final ClientKeyShortcutsHandler.KeyShortcutCallback shortcutCallback) {
-        this.keyShortcutsHandler.setKeyShortcutCallback(new SessionKeyShortcutCallback(shortcutCallback));
+    @Override
+    public KeyboardControl<AbstractCanvas, ClientSession> addKeyShortcutCallback(final KeyShortcutCallback shortcutCallback) {
+        this.keyEventHandler.addKeyShortcutCallback(new SessionKeyShortcutCallback(shortcutCallback));
         return this;
     }
 
-    public SessionKeyShortcutsHandler bind(final ClientSession session) {
+    @Override
+    public void enable(final AbstractCanvas canvas) {
+        super.enable(canvas);
+        this.keyEventHandler.setEnabled(true);
+    }
+
+    @Override
+    protected void doDisable() {
+        this.keyEventHandler.setEnabled(false);
+    }
+
+    @Override
+    public void bind(final ClientSession session) {
         this.session = session;
-        return this;
     }
 
-    public SessionKeyShortcutsHandler unbind() {
+    @Override
+    public void unbind() {
         this.session = null;
-        return this;
     }
 
-    class SessionKeyShortcutCallback implements ClientKeyShortcutsHandler.KeyShortcutCallback {
+    class SessionKeyShortcutCallback implements KeyShortcutCallback {
 
-        private final ClientKeyShortcutsHandler.KeyShortcutCallback delegate;
+        private final KeyShortcutCallback delegate;
 
-        private SessionKeyShortcutCallback(final ClientKeyShortcutsHandler.KeyShortcutCallback delegate) {
+        private SessionKeyShortcutCallback(final KeyShortcutCallback delegate) {
             this.delegate = delegate;
         }
 
@@ -71,7 +86,7 @@ public class SessionKeyShortcutsHandler {
             }
         }
 
-        public ClientKeyShortcutsHandler.KeyShortcutCallback getDelegate() {
+        public KeyShortcutCallback getDelegate() {
             return delegate;
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeysMatcher.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeysMatcher.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+
+public class KeysMatcher {
+
+    public static boolean doKeysMatch(final KeyboardEvent.Key[] actualKeys,
+                                      final KeyboardEvent.Key... expectedKeys) {
+        if (actualKeys == null) {
+            return expectedKeys == null;
+        } else if (expectedKeys == null) {
+            return false;
+        }
+        if (actualKeys.length != expectedKeys.length) {
+            return false;
+        }
+        final Set<KeyboardEvent.Key> matches = new HashSet<>();
+        matches.addAll(Arrays.asList(actualKeys));
+        matches.retainAll(Arrays.asList(expectedKeys));
+
+        return matches.size() == expectedKeys.length;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
@@ -95,8 +95,8 @@ public class CanvasFileExport {
                                               Layer.URLDataType.JPG);
         final String title = canvasHandler.getDiagram().getMetadata().getTitle();
         final PdfDocument content = PdfDocument.create(PdfExportPreferences.create(PdfExportPreferences.Orientation.LANDSCAPE,
-                                                                             pdfPreferences.getUnit(),
-                                                                             pdfPreferences.getFormat()));
+                                                                                   pdfPreferences.getUnit(),
+                                                                                   pdfPreferences.getFormat()));
         content.addText(title,
                         5,
                         15);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasLayoutUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasLayoutUtils.java
@@ -47,7 +47,7 @@ import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull
  * In both cases the resulting coordinates are given from the coordinates of the visible element in the graph, which
  * is position is on bottom right rather than the others, plus a given <code>PADDING</code> anb some
  * error margin given by the <code>MARGIN</code> floating point.
- * <p>
+ * <p/>
  * TODO: This has to be refactored by the use of a good impl that achieve good dynamic layouts. Probably each
  * Definition Set / Diagram will require a different layout manager as well.
  */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/AbstractSessionCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/AbstractSessionCommandManager.java
@@ -89,7 +89,7 @@ public abstract class AbstractSessionCommandManager
     @Override
     @SuppressWarnings("unchecked")
     protected CommandManager<AbstractCanvasHandler, CanvasViolation> getDelegate() {
-        final ClientFullSession<AbstractCanvas, AbstractCanvasHandler> session = getFullSession();
+        final ClientFullSession<AbstractCanvas, AbstractCanvasHandler, ClientSession> session = getFullSession();
         if (null != session) {
             final CanvasCommandManager<AbstractCanvasHandler> commandManager = session.getCommandManager();
             try {
@@ -108,17 +108,17 @@ public abstract class AbstractSessionCommandManager
 
     @Override
     public CommandRegistry<Command<AbstractCanvasHandler, CanvasViolation>> getRegistry() {
-        final ClientFullSession<AbstractCanvas, AbstractCanvasHandler> session = getFullSession();
+        final ClientFullSession<AbstractCanvas, AbstractCanvasHandler, ClientSession> session = getFullSession();
         if (null != session) {
             return session.getCommandRegistry();
         }
         return null;
     }
 
-    private ClientFullSession<AbstractCanvas, AbstractCanvasHandler> getFullSession() {
+    private ClientFullSession<AbstractCanvas, AbstractCanvasHandler, ClientSession> getFullSession() {
         final ClientSession<AbstractCanvas, AbstractCanvasHandler> session = getCurrentSession();
         try {
-            return (ClientFullSession<AbstractCanvas, AbstractCanvasHandler>) session;
+            return (ClientFullSession<AbstractCanvas, AbstractCanvasHandler, ClientSession>) session;
         } catch (final ClassCastException e) {
             LOGGER.log(Level.WARNING,
                        "Session is not type of client full session.");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteDefinitionFactory.java
@@ -33,7 +33,7 @@ public abstract class AbstractPaletteDefinitionFactory<B extends PaletteDefiniti
                                             final P palette) {
         this.shapeManager = shapeManager;
         this.paletteBuilder = paletteBuilder;
-        this.palette=palette;
+        this.palette = palette;
     }
 
     @Override
@@ -45,5 +45,4 @@ public abstract class AbstractPaletteDefinitionFactory<B extends PaletteDefiniti
     public P newPalette() {
         return palette;
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindableDefSetPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindableDefSetPaletteDefinitionFactory.java
@@ -26,7 +26,6 @@ public abstract class BindableDefSetPaletteDefinitionFactory<I extends HasPalett
         extends BindablePaletteDefinitionFactory<DefinitionSetPaletteBuilder, I, P>
         implements DefSetPaletteDefinitionFactory<I, P> {
 
-
     public BindableDefSetPaletteDefinitionFactory(final ShapeManager shapeManager,
                                                   final DefinitionSetPaletteBuilder paletteBuilder,
                                                   final P palette) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ActionsToolbox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ActionsToolbox.java
@@ -31,7 +31,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
  * A default toolbox implementation that decouples
  * the actions/operations to perform for an element
  * and the concrete toolbox' view implementation.
- * <p>
+ * <p/>
  * Several <code>ToolboxAction</code> instances can be added in this
  * toolbox, depending on the current context. On the other hand,
  * this toolbox uses a concrete inmutable view, given at instance

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactory.java
@@ -37,12 +37,12 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 /**
  * This factory builds a toolbox with a button for each candidate connector and target node that
  * can be attached as from the toolbox' related node.
- * <p>
+ * <p/>
  * This toolbox factory creates actions for:
  * - Each connector that is allowed be created as from the source toolbox' node.
  * - Each target node that is allowed be created as from the source toolbox' node, and by only using
  * the "default" connector for the specified definition set.
- * <p>
+ * <p/>
  * It also groups the resulting nodes to be created by their morph base type, this way
  * provides an action for creating nodes but only for each common morph base, not for each
  * target node that can be created.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ToolboxAction.java
@@ -23,7 +23,7 @@ import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 /**
  * It describes and performs an action/operation that can be done
  * from a Toolbox.
- * <p>
+ * <p/>
  * It's displayed as a button for the ActionsToolbox.
  * @param <H> The canvas handler type.
  */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/AbstractClientSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/AbstractClientSessionCommand.java
@@ -34,9 +34,13 @@ public abstract class AbstractClientSessionCommand<S extends ClientSession> impl
     }
 
     @Override
-    public AbstractClientSessionCommand<S> bind(final S session) {
+    public void bind(final S session) {
         this.session = session;
-        return this;
+    }
+
+    @Override
+    public void unbind() {
+        this.session = null;
     }
 
     @Override
@@ -57,11 +61,6 @@ public abstract class AbstractClientSessionCommand<S extends ClientSession> impl
                            error.toString());
             }
         });
-    }
-
-    @Override
-    public void unbind() {
-        this.session = null;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ClearSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ClearSessionCommand.java
@@ -67,10 +67,9 @@ public class ClearSessionCommand extends AbstractClientSessionCommand<ClientFull
     }
 
     @Override
-    public AbstractClientSessionCommand<ClientFullSession> bind(final ClientFullSession session) {
+    public void bind(final ClientFullSession session) {
         super.bind(session);
         checkState();
-        return this;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ClearStatesSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ClearStatesSessionCommand.java
@@ -28,7 +28,7 @@ import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull
 /**
  * Clears the state for all canvas shapes by setting each
  * one's state the value <code>NONE</code>.
- * <p>
+ * <p/>
  * This way selected, highlighted or invalid states for current canvas
  * shapes will be clear.
  */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SwitchGridSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SwitchGridSessionCommand.java
@@ -30,6 +30,7 @@ public class SwitchGridSessionCommand extends AbstractClientSessionCommand<Abstr
             CanvasGrid.SMALL_POINT_GRID, CanvasGrid.DEFAULT_GRID,
             CanvasGrid.DRAG_GRID, null
     };
+
     private static final byte DEFAULT_GRID_INDEX = 0;
     private byte gridIndex;
 
@@ -38,10 +39,9 @@ public class SwitchGridSessionCommand extends AbstractClientSessionCommand<Abstr
     }
 
     @Override
-    public SwitchGridSessionCommand bind(final AbstractClientSession session) {
+    public void bind(final AbstractClientSession session) {
         super.bind(session);
         resetGrid();
-        return this;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/AbstractClientReadOnlySession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/AbstractClientReadOnlySession.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanContr
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
 import org.kie.workbench.common.stunner.core.client.session.ClientReadOnlySession;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.Element;
 
 public abstract class AbstractClientReadOnlySession extends AbstractClientSession
@@ -32,7 +33,7 @@ public abstract class AbstractClientReadOnlySession extends AbstractClientSessio
     protected ZoomControl<AbstractCanvas> zoomControl;
     protected PanControl<AbstractCanvas> panControl;
 
-    private final CanvasControlRegistrationHandler<AbstractCanvas, AbstractCanvasHandler> registrationHandler;
+    private final CanvasControlRegistrationHandler<AbstractCanvas, AbstractCanvasHandler, ClientSession> registrationHandler;
 
     public AbstractClientReadOnlySession(final AbstractCanvas canvas,
                                          final AbstractCanvasHandler canvasHandler,
@@ -44,8 +45,8 @@ public abstract class AbstractClientReadOnlySession extends AbstractClientSessio
         this.selectionControl = selectionControl;
         this.zoomControl = zoomControl;
         this.panControl = panControl;
-        this.registrationHandler = new CanvasControlRegistrationHandler<AbstractCanvas, AbstractCanvasHandler>(canvas,
-                                                                                                               canvasHandler);
+        this.registrationHandler = new CanvasControlRegistrationHandler<AbstractCanvas, AbstractCanvasHandler, ClientSession>(canvas,
+                                                                                                                              canvasHandler);
         this.registrationHandler.registerCanvasHandlerControl(selectionControl);
         this.registrationHandler.registerCanvasControl(zoomControl);
         this.registrationHandler.registerCanvasControl(panControl);
@@ -71,7 +72,7 @@ public abstract class AbstractClientReadOnlySession extends AbstractClientSessio
         // TODO: Performance improvements: Re-enable controls here.
     }
 
-    protected CanvasControlRegistrationHandler<AbstractCanvas, AbstractCanvasHandler> getRegistrationHandler() {
+    protected CanvasControlRegistrationHandler<AbstractCanvas, AbstractCanvasHandler, ClientSession> getRegistrationHandler() {
         return registrationHandler;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ClientFullSessionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ClientFullSessionFactory.java
@@ -15,7 +15,6 @@
  */
 package org.kie.workbench.common.stunner.core.client.session.impl;
 
-import java.util.logging.Logger;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ClientFullSessionImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ClientFullSessionImpl.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.C
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.drag.DragControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
@@ -45,7 +46,7 @@ public class ClientFullSessionImpl extends AbstractClientFullSession {
 
     private DragControl<AbstractCanvasHandler, Element> dragControl;
     private ResizeControl<AbstractCanvasHandler, Element> resizeControl;
-    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> canvasInPlaceTextEditorControl;
+    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, AbstractClientFullSession, Element> canvasInPlaceTextEditorControl;
     private ToolboxControl<AbstractCanvasHandler, Element> toolboxControl;
 
     @Inject
@@ -67,7 +68,8 @@ public class ClientFullSessionImpl extends AbstractClientFullSession {
               factory.newControl(ConnectionAcceptorControl.class),
               factory.newControl(ContainmentAcceptorControl.class),
               factory.newControl(DockingAcceptorControl.class),
-              factory.newControl(ElementBuilderControl.class));
+              factory.newControl(ElementBuilderControl.class),
+              factory.newControl(KeyboardControl.class));
         this.dragControl = factory.newControl(DragControl.class);
         this.resizeControl = factory.newControl(ResizeControl.class);
         this.canvasInPlaceTextEditorControl = factory.newControl(CanvasInPlaceTextEditorControl.class);
@@ -93,7 +95,7 @@ public class ClientFullSessionImpl extends AbstractClientFullSession {
         return toolboxControl;
     }
 
-    public CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> getCanvasInPlaceTextEditorControl() {
+    public CanvasInPlaceTextEditorControl<AbstractCanvasHandler, AbstractClientFullSession, Element> getCanvasInPlaceTextEditorControl() {
         return canvasInPlaceTextEditorControl;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/SvgDataUriGlyph.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/SvgDataUriGlyph.java
@@ -30,7 +30,7 @@ import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
  * A glyph that represents an SVG image.
  * Additional SVG declarations can be added for inserting
  * into the <code>SVG def</code> generated.
- * <p>
+ * <p/>
  * Default renderers display this image by parsing or attaching the svg declarations
  * into the client response, this way it provides full DOM support for the SVG, as it's not
  * just being rendered as an image (as when using an ImageDataUriGlyph).

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ConnectorShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ConnectorShape.java
@@ -31,9 +31,9 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 
 /**
  * The default Shape implementation for edges with ViewContent type, so basically connectors.
- * <p>
+ * <p/>
  * It acts as the bridge between the edge and the shape view.
- * <p>
+ * <p/>
  * This implementation relies on ShapeDefinitions. This way provides the bridge between the edge and it's
  * bean definition instance, and delegates the interaction logic between the definition instance and the shape's
  * view to a ShapeDefViewHandler type.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/NodeShapeImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/NodeShapeImpl.java
@@ -31,7 +31,7 @@ import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 
 /**
  * The default Shape implementation for nodes. It acts as the bridge between a node and the shape view.
- * <p>
+ * <p/>
  * This implementation relies on ShapeDefinitions. This way provides the bridge between the node and it's
  * bean definition instance, and delegates the interaction logic between the definition instance and the shape's
  * view to a ShapeDefViewHandler type.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeDefViewHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeDefViewHandler.java
@@ -23,7 +23,7 @@ import org.kie.workbench.common.stunner.core.definition.shape.MutableShapeDef;
 
 /**
  * An util class that handles the shape's view properties that are coming from a MutableShapeDef type.
- * <p>
+ * <p/>
  * It adds some checks and constraints that can be used  across different implementation
  * for updating the views using the shape definition instance as input.
  * @param <W> The bean type.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeViewHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeViewHandler.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 
 /**
  * An util class that handles the different calls to a ShapeView.
- * <p>
+ * <p/>
  * It adds some checks and constraints that can be used  across different implementation
  * for updating the views.
  * @param <V>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/SvgDataUriGenerator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/SvgDataUriGenerator.java
@@ -68,7 +68,7 @@ public class SvgDataUriGenerator {
 
     /**
      * Generates an SVG data-uri with no external resource references, if any.
-     * <p>
+     * <p/>
      * GWT DataResource does not support external references, used for example
      * by the <code>use</code> element.
      */
@@ -81,18 +81,18 @@ public class SvgDataUriGenerator {
 
     /**
      * Generates a single SVG data-uri from different input SVG declarations.
-     * <p>
+     * <p/>
      * As GWT DataResource does not like SVG external references, this is an alternative
      * solution that creates a composite SVG declaration by joining each SVG declaration
      * given from the arguments.
-     * <p>
+     * <p/>
      * Given a parent SVG declaration, which contain external resource references to other
      * SVG declarations, and its given SVG referenced declarations, it aggregates the
      * referenced elements in a SVG <code>Def</code> element, and generates a composite
      * SVG which encapsulates the parent and referenced ones in a single declaration. It also
      * handles the external resource references, within the parent SVG, in order to match the actual
      * content, and removes the invalid references.
-     * <p>
+     * <p/>
      * It generates a valid SVG declaration as:
      * <svg id="composite">
      * <svg id="parent">

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyEventHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyEventHandlerTest.java
@@ -14,35 +14,45 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.client.event.keyboard;
+package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard;
+
+import java.util.List;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyDownEvent;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyUpEvent;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
-import static org.mockito.Matchers.eq;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class ClientKeyShortcutsHandlerTest {
+public class KeyEventHandlerTest {
 
     @Mock
-    ClientKeyShortcutsHandler.KeyShortcutCallback shortcutCallback;
+    private KeyboardControl.KeyShortcutCallback shortcutCallback;
 
     @Mock
-    KeyUpEvent keyUpEvent;
+    private KeyUpEvent keyUpEvent;
 
     @Mock
-    KeyDownEvent keyDownEvent;
+    private KeyDownEvent keyDownEvent;
 
-    private ClientKeyShortcutsHandler tested;
+    @Captor
+    private ArgumentCaptor<KeyboardEvent.Key> keysArgumentCaptor;
+
+    private KeyEventHandler tested;
 
     @Before
     public void setup() throws Exception {
-        this.tested = new ClientKeyShortcutsHandler();
-        this.tested.setKeyShortcutCallback(shortcutCallback);
+        this.tested = spy(new KeyEventHandler());
+        this.tested.addKeyShortcutCallback(shortcutCallback);
     }
 
     @Test
@@ -54,8 +64,14 @@ public class ClientKeyShortcutsHandlerTest {
         when(keyDownEvent.getKey()).thenReturn(key2);
         tested.onKeyDownEvent(keyDownEvent);
         tested.keysTimerTimeIsUp();
+
         verify(shortcutCallback,
-               times(1)).onKeyShortcut(eq(key1),
-                                       eq(key2));
+               times(1)).onKeyShortcut(keysArgumentCaptor.capture());
+        verify(tested,
+               times(1)).reset();
+
+        final List<KeyboardEvent.Key> keys = keysArgumentCaptor.getAllValues();
+        assertTrue(keys.contains(key1));
+        assertTrue(keys.contains(key2));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeyboardControlImplTest.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.client.event.keyboard;
+package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -28,10 +29,10 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SessionKeyShortcutsHandlerTest {
+public class KeyboardControlImplTest {
 
     @Mock
-    private ClientKeyShortcutsHandler clientKeyShortcutsHandler;
+    private KeyEventHandler keyEventHandler;
 
     @Mock
     private SessionManager clientSessionManager;
@@ -39,24 +40,24 @@ public class SessionKeyShortcutsHandlerTest {
     @Mock
     private ClientSession session;
 
-    private SessionKeyShortcutsHandler tested;
+    private KeyboardControlImpl tested;
 
     @Before
     public void setup() throws Exception {
         when(clientSessionManager.getCurrentSession()).thenReturn(session);
-        this.tested = new SessionKeyShortcutsHandler(clientSessionManager,
-                                                     clientKeyShortcutsHandler);
+        this.tested = new KeyboardControlImpl(clientSessionManager,
+                                              keyEventHandler);
     }
 
     @Test
     public void testCallbacksWithBindUnbindSession() {
-        final SessionKeyShortcutsHandler.SessionKeyShortcutCallback[] sessionCallback = new SessionKeyShortcutsHandler.SessionKeyShortcutCallback[1];
+        final KeyboardControlImpl.SessionKeyShortcutCallback[] sessionCallback = new KeyboardControlImpl.SessionKeyShortcutCallback[1];
         doAnswer(invocationOnMock -> {
-            sessionCallback[0] = (SessionKeyShortcutsHandler.SessionKeyShortcutCallback) invocationOnMock.getArguments()[0];
+            sessionCallback[0] = (KeyboardControlImpl.SessionKeyShortcutCallback) invocationOnMock.getArguments()[0];
             return null;
-        }).when(clientKeyShortcutsHandler).setKeyShortcutCallback(any(ClientKeyShortcutsHandler.KeyShortcutCallback.class));
-        final ClientKeyShortcutsHandler.KeyShortcutCallback callback = mock(ClientKeyShortcutsHandler.KeyShortcutCallback.class);
-        tested.setKeyShortcutCallback(callback);
+        }).when(keyEventHandler).addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class));
+        final KeyboardControl.KeyShortcutCallback callback = mock(KeyboardControl.KeyShortcutCallback.class);
+        tested.addKeyShortcutCallback(callback);
         assertEquals(callback,
                      sessionCallback[0].getDelegate());
         verify(callback,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeysMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/KeysMatcherTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent.Key;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class KeysMatcherTest {
+
+    @Parameterized.Parameters(name = "{index}: matches[{0}] : {1}={2}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {true, new Keys(Key.Z), new Keys(Key.Z)},
+                {false, new Keys(Key.Z,
+                                 Key.SHIFT), new Keys(Key.Z)},
+                {false, new Keys(Key.Z), new Keys(Key.Z,
+                                                  Key.SHIFT)},
+                {true, new Keys(Key.Z,
+                                Key.SHIFT), new Keys(Key.Z,
+                                                     Key.SHIFT)},
+                {true, new Keys(Key.SHIFT,
+                                Key.Z), new Keys(Key.Z,
+                                                 Key.SHIFT)},
+                {false, new Keys(Key.SHIFT,
+                                 Key.DELETE), new Keys(Key.SHIFT,
+                                                       Key.Z)}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public boolean matches;
+
+    @Parameterized.Parameter(1)
+    public Keys keysActual;
+
+    @Parameterized.Parameter(2)
+    public Keys keysExpected;
+
+    @Test
+    public void checkMatch() {
+        final boolean match = KeysMatcher.doKeysMatch(keysActual.keys,
+                                                      keysExpected.keys);
+        assertEquals(matches,
+                     match);
+    }
+
+    private static class Keys {
+
+        Key[] keys;
+
+        Keys(final Key... keys) {
+            this.keys = keys;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("{");
+            for (Key key : keys) {
+                sb.append(key).append(" ,");
+            }
+            sb.setLength(sb.length() - 2);
+            sb.append("}");
+            return sb.toString();
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl.KeyShortcutCallback;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+public abstract class BaseSessionCommandKeyboardTest {
+
+    @Mock
+    protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    protected CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+
+    @Mock
+    protected KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
+
+    @Mock
+    protected ClientFullSession session;
+
+    @Captor
+    protected ArgumentCaptor<KeyShortcutCallback> keyShortcutCallbackCaptor;
+
+    protected AbstractClientSessionCommand<ClientFullSession> command;
+
+    @Before
+    public void setup() {
+        this.command = spy(getCommand());
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+    }
+
+    @Test
+    public void checkBindAttachesKeyHandler() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(any(KeyShortcutCallback.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRespondsToExpectedKeys() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(getExpectedKeys());
+
+        verify(command,
+               times(1)).execute(any(ClientSessionCommand.Callback.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkDoesNotRespondToOtherKey() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(getUnexpectedKeys());
+
+        verify(command,
+               never()).execute(any(ClientSessionCommand.Callback.class));
+    }
+
+    protected abstract AbstractClientSessionCommand<ClientFullSession> getCommand();
+
+    protected abstract KeyboardEvent.Key[] getExpectedKeys();
+
+    protected abstract KeyboardEvent.Key[] getUnexpectedKeys();
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl.KeyShortcutCallback;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeleteSelectionSessionCommandTest {
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+
+    @Mock
+    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
+
+    @Mock
+    private ClientFullSession session;
+
+    @Captor
+    private ArgumentCaptor<KeyShortcutCallback> keyShortcutCallbackCaptor;
+
+    private DeleteSelectionSessionCommand command;
+
+    @Before
+    public void setup() {
+        this.command = spy(new DeleteSelectionSessionCommand(sessionCommandManager,
+                                                             canvasCommandFactory));
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+    }
+
+    @Test
+    public void checkBindAttachesKeyHandler() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(any(KeyShortcutCallback.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRespondsToDeleteKey() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.DELETE);
+
+        verify(command,
+               times(1)).execute(any(ClientSessionCommand.Callback.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
@@ -16,73 +16,28 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl.KeyShortcutCallback;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
-import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
+import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.*;
-
 @RunWith(MockitoJUnitRunner.class)
-public class DeleteSelectionSessionCommandTest {
+public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboardTest {
 
-    @Mock
-    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-
-    @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
-
-    @Mock
-    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
-
-    @Mock
-    private ClientFullSession session;
-
-    @Captor
-    private ArgumentCaptor<KeyShortcutCallback> keyShortcutCallbackCaptor;
-
-    private DeleteSelectionSessionCommand command;
-
-    @Before
-    public void setup() {
-        this.command = spy(new DeleteSelectionSessionCommand(sessionCommandManager,
-                                                             canvasCommandFactory));
-        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+    @Override
+    protected AbstractClientSessionCommand<ClientFullSession> getCommand() {
+        return new DeleteSelectionSessionCommand(sessionCommandManager,
+                                                 canvasCommandFactory);
     }
 
-    @Test
-    public void checkBindAttachesKeyHandler() {
-        command.bind(session);
-
-        verify(keyboardControl,
-               times(1)).addKeyShortcutCallback(any(KeyShortcutCallback.class));
+    @Override
+    protected KeyboardEvent.Key[] getExpectedKeys() {
+        return new KeyboardEvent.Key[]{KeyboardEvent.Key.DELETE};
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void checkRespondsToDeleteKey() {
-        command.bind(session);
-
-        verify(keyboardControl,
-               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
-
-        final KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
-        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.DELETE);
-
-        verify(command,
-               times(1)).execute(any(ClientSessionCommand.Callback.class));
+    @Override
+    protected KeyboardEvent.Key[] getUnexpectedKeys() {
+        return new KeyboardEvent.Key[]{KeyboardEvent.Key.ESC};
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
@@ -16,83 +16,36 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
-import java.util.Collections;
-
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
-import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
+import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.util.RedoCommandHandler;
-import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.*;
-
 @RunWith(MockitoJUnitRunner.class)
-public class RedoSessionCommandTest {
+public class RedoSessionCommandTest extends BaseSessionCommandKeyboardTest {
 
     @Mock
-    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+    private RedoCommandHandler<Command<AbstractCanvasHandler, CanvasViolation>> redoCommandHandler;
 
-    @Mock
-    private RedoCommandHandler redoCommandHandler;
-
-    @Mock
-    private CommandRegistry commandRegistry;
-
-    @Mock
-    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
-
-    @Mock
-    private ClientFullSession session;
-
-    @Captor
-    private ArgumentCaptor<KeyboardControl.KeyShortcutCallback> keyShortcutCallbackCaptor;
-
-    private RedoSessionCommand command;
-
-    @Before
-    @SuppressWarnings("unchecked")
-    public void setup() {
-        this.command = spy(new RedoSessionCommand(sessionCommandManager,
-                                                  redoCommandHandler));
-        when(session.getKeyboardControl()).thenReturn(keyboardControl);
-        when(sessionCommandManager.getRegistry()).thenReturn(commandRegistry);
-        when(commandRegistry.getCommandHistory()).thenReturn(Collections.emptyList());
+    @Override
+    protected AbstractClientSessionCommand<ClientFullSession> getCommand() {
+        return new RedoSessionCommand(sessionCommandManager,
+                                      redoCommandHandler);
     }
 
-    @Test
-    public void checkBindAttachesKeyHandler() {
-        command.bind(session);
-
-        verify(keyboardControl,
-               times(1)).addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class));
+    @Override
+    protected KeyboardEvent.Key[] getExpectedKeys() {
+        return new KeyboardEvent.Key[]{KeyboardEvent.Key.CONTROL, KeyboardEvent.Key.SHIFT, KeyboardEvent.Key.Z};
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void checkRespondsToCtrlShiftZKey() {
-        command.bind(session);
-
-        verify(keyboardControl,
-               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
-
-        final KeyboardControl.KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
-        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.CONTROL,
-                                          KeyboardEvent.Key.SHIFT,
-                                          KeyboardEvent.Key.Z);
-
-        verify(command,
-               times(1)).execute(any(ClientSessionCommand.Callback.class));
+    @Override
+    protected KeyboardEvent.Key[] getUnexpectedKeys() {
+        return new KeyboardEvent.Key[]{KeyboardEvent.Key.ESC};
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.kie.workbench.common.stunner.core.command.util.RedoCommandHandler;
+import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RedoSessionCommandTest {
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private RedoCommandHandler redoCommandHandler;
+
+    @Mock
+    private CommandRegistry commandRegistry;
+
+    @Mock
+    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
+
+    @Mock
+    private ClientFullSession session;
+
+    @Captor
+    private ArgumentCaptor<KeyboardControl.KeyShortcutCallback> keyShortcutCallbackCaptor;
+
+    private RedoSessionCommand command;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.command = spy(new RedoSessionCommand(sessionCommandManager,
+                                                  redoCommandHandler));
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+        when(sessionCommandManager.getRegistry()).thenReturn(commandRegistry);
+        when(commandRegistry.getCommandHistory()).thenReturn(Collections.emptyList());
+    }
+
+    @Test
+    public void checkBindAttachesKeyHandler() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRespondsToCtrlShiftZKey() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyboardControl.KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.CONTROL,
+                                          KeyboardEvent.Key.SHIFT,
+                                          KeyboardEvent.Key.Z);
+
+        verify(command,
+               times(1)).execute(any(ClientSessionCommand.Callback.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
@@ -19,74 +19,44 @@ package org.kie.workbench.common.stunner.core.client.session.command.impl;
 import java.util.Collections;
 
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
-import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
+import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class UndoSessionCommandTest {
+public class UndoSessionCommandTest extends BaseSessionCommandKeyboardTest {
 
     @Mock
-    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-
-    @Mock
-    private CommandRegistry commandRegistry;
-
-    @Mock
-    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
-
-    @Mock
-    private ClientFullSession session;
-
-    @Captor
-    private ArgumentCaptor<KeyboardControl.KeyShortcutCallback> keyShortcutCallbackCaptor;
-
-    private UndoSessionCommand command;
+    private CommandRegistry<Command<AbstractCanvasHandler, CanvasViolation>> commandRegistry;
 
     @Before
-    @SuppressWarnings("unchecked")
     public void setup() {
-        this.command = spy(new UndoSessionCommand(sessionCommandManager));
-        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+        super.setup();
         when(sessionCommandManager.getRegistry()).thenReturn(commandRegistry);
         when(commandRegistry.getCommandHistory()).thenReturn(Collections.emptyList());
     }
 
-    @Test
-    public void checkBindAttachesKeyHandler() {
-        command.bind(session);
-
-        verify(keyboardControl,
-               times(1)).addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class));
+    @Override
+    protected AbstractClientSessionCommand<ClientFullSession> getCommand() {
+        return new UndoSessionCommand(sessionCommandManager);
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void checkRespondsToCtrlZKey() {
-        command.bind(session);
+    @Override
+    protected KeyboardEvent.Key[] getExpectedKeys() {
+        return new KeyboardEvent.Key[]{KeyboardEvent.Key.CONTROL, KeyboardEvent.Key.Z};
+    }
 
-        verify(keyboardControl,
-               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
-
-        final KeyboardControl.KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
-        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.CONTROL,
-                                          KeyboardEvent.Key.Z);
-
-        verify(command,
-               times(1)).execute(any(ClientSessionCommand.Callback.class));
+    @Override
+    protected KeyboardEvent.Key[] getUnexpectedKeys() {
+        return new KeyboardEvent.Key[]{KeyboardEvent.Key.ESC};
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UndoSessionCommandTest {
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private CommandRegistry commandRegistry;
+
+    @Mock
+    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
+
+    @Mock
+    private ClientFullSession session;
+
+    @Captor
+    private ArgumentCaptor<KeyboardControl.KeyShortcutCallback> keyShortcutCallbackCaptor;
+
+    private UndoSessionCommand command;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.command = spy(new UndoSessionCommand(sessionCommandManager));
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+        when(sessionCommandManager.getRegistry()).thenReturn(commandRegistry);
+        when(commandRegistry.getCommandHistory()).thenReturn(Collections.emptyList());
+    }
+
+    @Test
+    public void checkBindAttachesKeyHandler() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRespondsToCtrlZKey() {
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyboardControl.KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.CONTROL,
+                                          KeyboardEvent.Key.Z);
+
+        verify(command,
+               times(1)).execute(any(ClientSessionCommand.Callback.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/ClientFullSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/ClientFullSessionTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
@@ -29,6 +30,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.C
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.drag.DragControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
@@ -39,6 +41,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasShapeL
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.mockito.ArgumentCaptor;
@@ -53,41 +56,61 @@ import static org.mockito.Mockito.*;
 public class ClientFullSessionTest {
 
     @Mock
-    CanvasFactory<AbstractCanvas, AbstractCanvasHandler> factory;
+    private CanvasFactory<AbstractCanvas, AbstractCanvasHandler> factory;
+
     @Mock
-    AbstractCanvas canvas;
+    private AbstractCanvas canvas;
+
     @Mock
-    AbstractCanvasHandler canvasHandler;
+    private AbstractCanvasHandler canvasHandler;
+
     @Mock
-    SelectionControl<AbstractCanvasHandler, Element> selectionControl;
+    private SelectionControl<AbstractCanvasHandler, Element> selectionControl;
+
     @Mock
-    ZoomControl<AbstractCanvas> zoomControl;
+    private ZoomControl<AbstractCanvas> zoomControl;
+
     @Mock
-    PanControl<AbstractCanvas> panControl;
+    private PanControl<AbstractCanvas> panControl;
+
     @Mock
-    ResizeControl<AbstractCanvasHandler, Element> resizeControl;
+    private ResizeControl<AbstractCanvasHandler, Element> resizeControl;
+
     @Mock
-    CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
+    private CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
+
     @Mock
-    SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
     @Mock
-    SessionCommandManager<AbstractCanvasHandler> requestCommandManager;
+    private SessionCommandManager<AbstractCanvasHandler> requestCommandManager;
+
     @Mock
-    RegistryFactory registryFactory;
+    private RegistryFactory registryFactory;
+
     @Mock
-    ConnectionAcceptorControl<AbstractCanvasHandler> connectionAcceptorControl;
+    private ConnectionAcceptorControl<AbstractCanvasHandler> connectionAcceptorControl;
+
     @Mock
-    ContainmentAcceptorControl<AbstractCanvasHandler> containmentAcceptorControl;
+    private ContainmentAcceptorControl<AbstractCanvasHandler> containmentAcceptorControl;
+
     @Mock
-    DockingAcceptorControl<AbstractCanvasHandler> dockingAcceptorControl;
+    private DockingAcceptorControl<AbstractCanvasHandler> dockingAcceptorControl;
+
     @Mock
-    CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> canvasInPlaceTextEditorControl;
+    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, ClientSession, Element> canvasInPlaceTextEditorControl;
+
     @Mock
-    DragControl<AbstractCanvasHandler, Element> dragControl;
+    private DragControl<AbstractCanvasHandler, Element> dragControl;
+
     @Mock
-    ToolboxControl<AbstractCanvasHandler, Element> toolboxControl;
+    private ToolboxControl<AbstractCanvasHandler, Element> toolboxControl;
+
     @Mock
-    ElementBuilderControl<AbstractCanvasHandler> builderControl;
+    private ElementBuilderControl<AbstractCanvasHandler> builderControl;
+
+    @Mock
+    private KeyboardControl<Canvas, ClientSession> keyboardControl;
 
     private ClientFullSessionImpl tested;
 
@@ -106,6 +129,7 @@ public class ClientFullSessionTest {
         when(factory.newControl(eq(CanvasInPlaceTextEditorControl.class))).thenReturn(canvasInPlaceTextEditorControl);
         when(factory.newControl(eq(ToolboxControl.class))).thenReturn(toolboxControl);
         when(factory.newControl(eq(ElementBuilderControl.class))).thenReturn(builderControl);
+        when(factory.newControl(eq(KeyboardControl.class))).thenReturn(keyboardControl);
         when(canvasHandler.getCanvas()).thenReturn(canvas);
     }
 
@@ -142,6 +166,9 @@ public class ClientFullSessionTest {
                      tested.getToolboxControl());
         assertEquals(builderControl,
                      tested.getBuilderControl());
+        assertEquals(keyboardControl,
+                     tested.getKeyboardControl());
+
         // Assert setting the right command manager for each control.
         final ArgumentCaptor<RequiresCommandManager.CommandManagerProvider> conn =
                 ArgumentCaptor.forClass(RequiresCommandManager.CommandManagerProvider.class);
@@ -217,6 +244,8 @@ public class ClientFullSessionTest {
                times(1)).enable(eq(canvasHandler));
         verify(builderControl,
                times(1)).enable(eq(canvasHandler));
+        verify(keyboardControl,
+               times(1)).bind(eq(tested));
     }
 
     @Test
@@ -254,6 +283,8 @@ public class ClientFullSessionTest {
                times(1)).disable();
         verify(builderControl,
                times(1)).disable();
+        verify(keyboardControl,
+               times(1)).unbind();
     }
 
     private void buildTestedInstance() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementClientFullSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementClientFullSession.java
@@ -27,12 +27,14 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.Elem
 import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.ConnectionAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -42,7 +44,7 @@ import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 @CaseManagementEditor
 public class CaseManagementClientFullSession extends AbstractClientFullSession {
 
-    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> canvasInPlaceTextEditorControl;
+    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, ClientSession, Element> canvasInPlaceTextEditorControl;
 
     @Inject
     @SuppressWarnings("unchecked")
@@ -63,14 +65,15 @@ public class CaseManagementClientFullSession extends AbstractClientFullSession {
               factory.newControl(ConnectionAcceptorControl.class),
               factory.newControl(ContainmentAcceptorControl.class),
               factory.newControl(DockingAcceptorControl.class),
-              factory.newControl(ElementBuilderControl.class));
+              factory.newControl(ElementBuilderControl.class),
+              factory.newControl(KeyboardControl.class));
 
         this.canvasInPlaceTextEditorControl = factory.newControl(CanvasInPlaceTextEditorControl.class);
         getRegistrationHandler().registerCanvasHandlerControl(canvasInPlaceTextEditorControl);
         canvasInPlaceTextEditorControl.setCommandManagerProvider(() -> sessionCommandManager);
     }
 
-    CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> getCanvasInPlaceTextEditorControl() {
+    CanvasInPlaceTextEditorControl<AbstractCanvasHandler, ClientSession, Element> getCanvasInPlaceTextEditorControl() {
         return canvasInPlaceTextEditorControl;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementClientFullSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementClientFullSessionTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.Elem
 import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.ConnectionAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
@@ -37,6 +38,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElemen
 import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasShapeListener;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.mockito.Mock;
@@ -92,13 +94,16 @@ public class CaseManagementClientFullSessionTest {
     private DockingAcceptorControl<AbstractCanvasHandler> dockingAcceptorControl;
 
     @Mock
-    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, Element> canvasInPlaceTextEditorControl;
+    private CanvasInPlaceTextEditorControl<AbstractCanvasHandler, ClientSession, Element> canvasInPlaceTextEditorControl;
 
     @Mock
     private ToolboxControl<AbstractCanvasHandler, Element> toolboxControl;
 
     @Mock
     private ElementBuilderControl<AbstractCanvasHandler> builderControl;
+
+    @Mock
+    private KeyboardControl keyboardControl;
 
     private CaseManagementClientFullSession session;
 
@@ -116,6 +121,7 @@ public class CaseManagementClientFullSessionTest {
         when(factory.newControl(eq(CanvasInPlaceTextEditorControl.class))).thenReturn(canvasInPlaceTextEditorControl);
         when(factory.newControl(eq(ToolboxControl.class))).thenReturn(toolboxControl);
         when(factory.newControl(eq(ElementBuilderControl.class))).thenReturn(builderControl);
+        when(factory.newControl(eq(KeyboardControl.class))).thenReturn(keyboardControl);
         when(canvasHandler.getCanvas()).thenReturn(canvas);
         this.session = new CaseManagementClientFullSession(factory,
                                                            canvasCommandManager,


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3374

This PR introduces a new ```CanvasControl``` for ```KeyboardControl``` that is instantiated when a session is created - as with all other controls. All existing keyboard (shortcut) code has been moved to the new control. A new ```SessionAware``` interface has been added and used on controls and commands that need to be bound to a session. These changes allow the ```KeyboardControl``` to be enabled/disabled (which is used to have a different keyboard handler used by the DMN Editor when in "Expression editing" mode of operation).

@jomarko The only "testable" Use Case is to navigate to a (Literal) Expression select the table and press ```DELETE```. Before this change Stunner's ```DeleteSelectionSessionCommand``` would execute and the selected Node on the graph deleted (you'd see it disappear in the preview panel and navigating back to the DRG Editor would show the node had been deleted). The ```DELETE``` key in the Expression Editor will clear a cell (but that'll be implemented with https://issues.jboss.org/browse/GUVNOR-3266).