### PR TITLE
[JBPM-6045] Use correct Canvas position after scaling/panning

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Transform.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Transform.java
@@ -18,9 +18,10 @@ package org.kie.workbench.common.stunner.core.client.canvas;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 
 /**
- * The current transforms that are supported for canvas layers.
- * See <a>org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl</a>
- * See <a>org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl</a>
+ * The current transforms that are supported for canvas layers. See
+ * <a>org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl</a>
+ * See
+ * <a>org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl</a>
  */
 public interface Transform {
 
@@ -35,9 +36,14 @@ public interface Transform {
     Point2D getScale();
 
     /**
-     * Returns the cartesian coordinates resulting after applying this
-     * instance' transforms.
+     * Returns the cartesian coordinates resulting after applying this instance's
+     * transforms.
      */
-    Point2D transform(final double x,
-                      final double y);
+    Point2D transform(final double x, final double y);
+
+    /**
+     * Returns the cartesian coordinates resulting after applying this instance's
+     * transform inverses.
+     */
+    Point2D inverse(final double x, final double y);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/TransformImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/TransformImpl.java
@@ -22,13 +22,9 @@ public class TransformImpl implements Transform {
     private final Point2D translate;
     private final Point2D scale;
 
-    public static final TransformImpl NO_TRANSFORM = new TransformImpl(new Point2D(0,
-                                                                                   0),
-                                                                       new Point2D(1,
-                                                                                   1));
+    public static final TransformImpl NO_TRANSFORM = new TransformImpl(new Point2D(0, 0), new Point2D(1, 1));
 
-    TransformImpl(final Point2D translate,
-                  final Point2D scale) {
+    TransformImpl(final Point2D translate, final Point2D scale) {
         this.translate = translate;
         this.scale = scale;
     }
@@ -44,11 +40,12 @@ public class TransformImpl implements Transform {
     }
 
     @Override
-    public Point2D transform(final double x,
-                             final double y) {
-        return new Point2D(
-                (x * scale.getX()) + translate.getX(),
-                (y * scale.getY()) + translate.getY()
-        );
+    public Point2D transform(final double x, final double y) {
+        return new Point2D((x * scale.getX()) + translate.getX(), (y * scale.getY()) + translate.getY());
+    }
+
+    @Override
+    public Point2D inverse(final double x, final double y) {
+        return new Point2D((x - translate.getX()) / scale.getX(), (y - translate.getY()) / scale.getY());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/BuildCanvasShapeEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/BuildCanvasShapeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 
 /**
  * Event for requesting the canvas builder control to add a new shape.
@@ -32,9 +33,7 @@ public final class BuildCanvasShapeEvent extends AbstractCanvasHandlerEvent<Abst
     private double x;
     private double y;
 
-    public BuildCanvasShapeEvent(final AbstractCanvasHandler abstractCanvasHandler,
-                                 final Object definition,
-                                 final ShapeFactory<?, ? extends Shape> shapeFactory) {
+    public BuildCanvasShapeEvent(final AbstractCanvasHandler abstractCanvasHandler, final Object definition, final ShapeFactory<?, ? extends Shape> shapeFactory) {
         super(abstractCanvasHandler);
         this.definition = definition;
         this.shapeFactory = shapeFactory;
@@ -42,16 +41,13 @@ public final class BuildCanvasShapeEvent extends AbstractCanvasHandlerEvent<Abst
         this.y = -1;
     }
 
-    public BuildCanvasShapeEvent(final AbstractCanvasHandler abstractCanvasHandler,
-                                 final Object definition,
-                                 final ShapeFactory<?, ? extends Shape> shapeFactory,
-                                 final double x,
-                                 final double y) {
+    public BuildCanvasShapeEvent(final AbstractCanvasHandler abstractCanvasHandler, final Object definition, final ShapeFactory<?, ? extends Shape> shapeFactory, final double x, final double y) {
         super(abstractCanvasHandler);
         this.definition = definition;
         this.shapeFactory = shapeFactory;
-        this.x = x;
-        this.y = y;
+        final Point2D transformed = abstractCanvasHandler.getAbstractCanvas().getLayer().getTransform().inverse(x, y);
+        this.x = transformed.getX();
+        this.y = transformed.getY();
     }
 
     public Object getDefinition() {
@@ -72,7 +68,6 @@ public final class BuildCanvasShapeEvent extends AbstractCanvasHandlerEvent<Abst
 
     @Override
     public String toString() {
-        return "BuildCanvasShapeEvent [definition=" + definition + ", factory=" + shapeFactory.toString() +
-                ", x=" + x + ", y=" + y + "]";
+        return "BuildCanvasShapeEvent [definition=" + definition + ", factory=" + shapeFactory.toString() + ", x=" + x + ", y=" + y + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/CanvasShapeDragStartEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/CanvasShapeDragStartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 
 /**
  * Event for the start of a drag operation for a prospective new shape.
@@ -32,9 +33,7 @@ public final class CanvasShapeDragStartEvent extends AbstractCanvasHandlerEvent<
     private double x;
     private double y;
 
-    public CanvasShapeDragStartEvent(final AbstractCanvasHandler abstractCanvasHandler,
-                                     final Object definition,
-                                     final ShapeFactory<?, ? extends Shape> shapeFactory) {
+    public CanvasShapeDragStartEvent(final AbstractCanvasHandler abstractCanvasHandler, final Object definition, final ShapeFactory<?, ? extends Shape> shapeFactory) {
         super(abstractCanvasHandler);
         this.definition = definition;
         this.shapeFactory = shapeFactory;
@@ -42,16 +41,13 @@ public final class CanvasShapeDragStartEvent extends AbstractCanvasHandlerEvent<
         this.y = -1;
     }
 
-    public CanvasShapeDragStartEvent(final AbstractCanvasHandler abstractCanvasHandler,
-                                     final Object definition,
-                                     final ShapeFactory<?, ? extends Shape> shapeFactory,
-                                     final double x,
-                                     final double y) {
+    public CanvasShapeDragStartEvent(final AbstractCanvasHandler abstractCanvasHandler, final Object definition, final ShapeFactory<?, ? extends Shape> shapeFactory, final double x, final double y) {
         super(abstractCanvasHandler);
         this.definition = definition;
         this.shapeFactory = shapeFactory;
-        this.x = x;
-        this.y = y;
+        final Point2D transformed = abstractCanvasHandler.getAbstractCanvas().getLayer().getTransform().inverse(x, y);
+        this.x = transformed.getX();
+        this.y = transformed.getY();
     }
 
     public Object getDefinition() {
@@ -72,7 +68,6 @@ public final class CanvasShapeDragStartEvent extends AbstractCanvasHandlerEvent<
 
     @Override
     public String toString() {
-        return "CanvasShapeDragUpdateEvent [definition=" + definition + ", factory=" + shapeFactory.toString() +
-                ", x=" + x + ", y=" + y + "]";
+        return "CanvasShapeDragUpdateEvent [definition=" + definition + ", factory=" + shapeFactory.toString() + ", x=" + x + ", y=" + y + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/CanvasShapeDragUpdateEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/CanvasShapeDragUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 
 /**
  * Event for updating drag progress of a prospective new shape.
@@ -32,9 +33,7 @@ public final class CanvasShapeDragUpdateEvent extends AbstractCanvasHandlerEvent
     private double x;
     private double y;
 
-    public CanvasShapeDragUpdateEvent(final AbstractCanvasHandler abstractCanvasHandler,
-                                      final Object definition,
-                                      final ShapeFactory<?, ? extends Shape> shapeFactory) {
+    public CanvasShapeDragUpdateEvent(final AbstractCanvasHandler abstractCanvasHandler, final Object definition, final ShapeFactory<?, ? extends Shape> shapeFactory) {
         super(abstractCanvasHandler);
         this.definition = definition;
         this.shapeFactory = shapeFactory;
@@ -42,16 +41,13 @@ public final class CanvasShapeDragUpdateEvent extends AbstractCanvasHandlerEvent
         this.y = -1;
     }
 
-    public CanvasShapeDragUpdateEvent(final AbstractCanvasHandler abstractCanvasHandler,
-                                      final Object definition,
-                                      final ShapeFactory<?, ? extends Shape> shapeFactory,
-                                      final double x,
-                                      final double y) {
+    public CanvasShapeDragUpdateEvent(final AbstractCanvasHandler abstractCanvasHandler, final Object definition, final ShapeFactory<?, ? extends Shape> shapeFactory, final double x, final double y) {
         super(abstractCanvasHandler);
         this.definition = definition;
         this.shapeFactory = shapeFactory;
-        this.x = x;
-        this.y = y;
+        final Point2D transformed = abstractCanvasHandler.getAbstractCanvas().getLayer().getTransform().inverse(x, y);
+        this.x = transformed.getX();
+        this.y = transformed.getY();
     }
 
     public Object getDefinition() {
@@ -72,7 +68,6 @@ public final class CanvasShapeDragUpdateEvent extends AbstractCanvasHandlerEvent
 
     @Override
     public String toString() {
-        return "CanvasShapeDragUpdateEvent [definition=" + definition + ", factory=" + shapeFactory.toString() +
-                ", x=" + x + ", y=" + y + "]";
+        return "CanvasShapeDragUpdateEvent [definition=" + definition + ", factory=" + shapeFactory.toString() + ", x=" + x + ", y=" + y + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/BuildCanvasShapeEventTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/event/BuildCanvasShapeEventTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.event;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.Layer;
+import org.kie.workbench.common.stunner.core.client.canvas.Transform;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BuildCanvasShapeEventTest {
+
+    private final double ALLOWED_ERROR = 0.00001;
+    @Mock
+    AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    AbstractCanvas canvas;
+
+    @Mock
+    Layer layer;
+
+    @Mock
+    Transform transform;
+
+    BuildCanvasShapeEvent tested;
+
+    @Before
+    public void setup() throws Exception {
+        canvasHandler = mock(AbstractCanvasHandler.class);
+        canvas = mock(AbstractCanvas.class);
+        layer = mock(Layer.class);
+        transform = mock(Transform.class);
+        when(layer.getTransform()).thenReturn(transform);
+        when(canvas.getLayer()).thenReturn(layer);
+        when(canvasHandler.getAbstractCanvas()).thenReturn(canvas);
+    }
+
+    @Test
+    public void testBuildWithoutTransform() {
+        when(transform.inverse(anyDouble(), anyDouble())).thenAnswer((invocation -> new Point2D(invocation.getArgumentAt(0, Double.class), invocation.getArgumentAt(1, Double.class))));
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 0, 0);
+        assertEquals(0, tested.getX(), ALLOWED_ERROR);
+        assertEquals(0, tested.getY(), ALLOWED_ERROR);
+
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 5, 15);
+        assertEquals(5, tested.getX(), ALLOWED_ERROR);
+        assertEquals(15, tested.getY(), ALLOWED_ERROR);
+    }
+
+    @Test
+    public void testBuildWithPan() {
+        when(transform.inverse(anyDouble(), anyDouble())).thenAnswer((invocation -> new Point2D(invocation.getArgumentAt(0, Double.class) + 5, invocation.getArgumentAt(1, Double.class) - 10)));
+
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 0, 0);
+        assertEquals(5, tested.getX(), ALLOWED_ERROR);
+        assertEquals(-10, tested.getY(), ALLOWED_ERROR);
+
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 5, 15);
+        assertEquals(10, tested.getX(), ALLOWED_ERROR);
+        assertEquals(5, tested.getY(), ALLOWED_ERROR);
+    }
+
+    @Test
+    public void testBuildWithZoom() {
+        when(transform.inverse(anyDouble(), anyDouble())).thenAnswer((invocation -> new Point2D(invocation.getArgumentAt(0, Double.class) * 0.5, invocation.getArgumentAt(1, Double.class) * 2)));
+
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 0, 0);
+        assertEquals(0, tested.getX(), ALLOWED_ERROR);
+        assertEquals(0, tested.getY(), ALLOWED_ERROR);
+
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 5, 15);
+        assertEquals(2.5, tested.getX(), ALLOWED_ERROR);
+        assertEquals(30, tested.getY(), ALLOWED_ERROR);
+    }
+
+    @Test
+    public void testBuildWithPanAndZoom() {
+        when(transform.inverse(anyDouble(), anyDouble())).thenAnswer((invocation -> new Point2D((invocation.getArgumentAt(0, Double.class) + 5) * 0.5, (invocation.getArgumentAt(1, Double.class) - 5) * 2)));
+
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 0, 0);
+        assertEquals(2.5, tested.getX(), ALLOWED_ERROR);
+        assertEquals(-10, tested.getY(), ALLOWED_ERROR);
+
+        tested = new BuildCanvasShapeEvent(canvasHandler, null, null, 5, 15);
+        assertEquals(5, tested.getX(), ALLOWED_ERROR);
+        assertEquals(20, tested.getY(), ALLOWED_ERROR);
+    }
+}


### PR DESCRIPTION
This is a partial fix for JBPM-6045: It now places new nodes correctly after a pan. It it is offset a variable amount to the left and up based on scale; if we could discover the exact amount this can be accounted for in the current implementation. The rest of the issues in JBPM-6045 remain unresolved. Does anyone know what classes handles Lane containment highlighted and the like so I can fix them?