### PR TITLE
JBPM-5537: Stunner - Workbench editor name have no extension and asset type

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.project.client.editor;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
@@ -87,6 +88,7 @@ import static java.util.logging.Level.FINE;
 public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType> extends KieEditor {
 
     private static Logger LOGGER = Logger.getLogger(AbstractProjectDiagramEditor.class.getName());
+    private static final String TITLE_FORMAT_TEMPLATE = "#title.#suffix - #type";
 
     public interface View extends UberView<AbstractProjectDiagramEditor>,
                                   KieEditorView,
@@ -545,9 +547,28 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
 
     private void updateTitle(final String title) {
         // Change editor's title.
-        this.title = title;
+        this.title = formatTitle(title);
         changeTitleNotificationEvent.fire(new ChangeTitleWidgetEvent(this.place,
                                                                      this.title));
+    }
+
+    /**
+     * Format the Diagram title to be displayed on the Editor.
+     * This method can be override to customization and the default implementation just return the title from the diagram metadata.
+     * @param title diagram metadata title
+     * @return formatted title
+     */
+    protected String formatTitle(final String title) {
+        if(Objects.isNull(resourceType)){
+            return title;
+        }
+        return TITLE_FORMAT_TEMPLATE
+            .replace("#title",
+                     title)
+            .replace("#suffix",
+                     resourceType.getSuffix())
+            .replace("#type",
+                     resourceType.getShortName());
     }
 
     private AbstractClientFullSession getSession() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -54,6 +54,7 @@ import org.uberfire.ext.editor.commons.client.validation.DefaultFileNameValidato
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.model.menu.MenuItem;
 
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -81,6 +82,9 @@ public class AbstractProjectDiagramEditorTest {
     @Mock
     private ProjectMessagesListener projectMessagesListener;
 
+    @Mock
+    private ClientResourceTypeMock resourceType;
+
     abstract class ClientResourceTypeMock implements ClientResourceType {
 
     }
@@ -106,7 +110,7 @@ public class AbstractProjectDiagramEditorTest {
                                                                              mock(ErrorPopupPresenter.class),
                                                                              mock(EventSourceMock.class),
                                                                              mock(SavePopUpPresenter.class),
-                                                                             mock(ClientResourceTypeMock.class),
+                                                                             resourceType,
                                                                              mock(ClientProjectDiagramService.class),
                                                                              mock(SessionManager.class),
                                                                              mock(SessionPresenterFactory.class),
@@ -171,5 +175,16 @@ public class AbstractProjectDiagramEditorTest {
                                   any(DefaultFileNameValidator.class));
         verify(fileMenuBuilder,
                never()).addDelete(any(Path.class));
+    }
+
+    @Test
+    public void testFormatTitle() {
+        String title = "testDiagram";
+        when(resourceType.getSuffix()).thenReturn("bpmn");
+        when(resourceType.getShortName()).thenReturn("Business Process");
+
+        String formattedTitle = presenter.formatTitle(title);
+        assertEquals(formattedTitle,
+                     "testDiagram.bpmn - Business Process");
     }
 }


### PR DESCRIPTION
Now the diagram title on the Stunner Diagram Editor is displayed on the proper format.
Basically it was implemented a method to format the tittle on the **AbstractProjectDiagramEditor** and the concrete classes may override the format if necessary.
@manstis 
@hasys 