### PR TITLE
[7.3.x] JBPM-6052: Stunner - Component Library is hidden after scrolling canvas 

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.css
@@ -5,6 +5,8 @@
     width: calc(48px);
     position: absolute;
     z-index: 1;
+    left: 0;
+    top: 0;
 }
 
 .kie-palette .list-group {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.html
@@ -1,6 +1,4 @@
-<div>
-    <div class="kie-palette" data-field="kie-palette">
-        <ul class="list-group">
-        </ul>
-    </div>
+<div class="kie-palette" data-field="kie-palette">
+    <ul class="list-group">
+    </ul>
 </div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.css
@@ -11,7 +11,11 @@
 }
 
 .canvas-view {
-    position: relative;
+    position: absolute;
+    top:0;
+    bottom: 0;
+    right: 0;
+    left: 0;
     padding-right: 10px;
     padding-top: 5px;
     padding-bottom: 10px;
@@ -50,6 +54,11 @@
 
 .canvas-panel {
     width: 100%;
-    position: relative;
-    left: 48px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    padding-left: 48px;
+    overflow: scroll;
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.html
@@ -45,22 +45,11 @@
         </td>
     </tr>
     <tr>
-
         <td colspan="2" class="canvas-view">
-
-            <div>
-
-                <div data-field="toolbar-view" class="toolbar-view">
-
-                    <div data-field="palettePanel" class="palette-panel"></div>
-
-                </div>
-
+            <div data-field="toolbar-view" class="toolbar-view">
+                <div data-field="palettePanel" class="palette-panel"></div>
             </div>
-
             <div data-field="canvasPanel" class="canvas-panel"></div>
-
         </td>
     </tr>
 </table>
-


### PR DESCRIPTION
Port back commit 21fa7410ece16686383f150f5b17002611f08196 to 7.3.x.
Related PR https://github.com/kiegroup/kie-wb-common/pull/1081

@manstis 
@hasys 