### PR TITLE
JBPM-6304 Stunner - gateway doesn't show properties

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/gateway/DefaultRouteFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/gateway/DefaultRouteFormProvider.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.gateway;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class DefaultRouteFormProvider implements SelectorDataProvider {
     @Override
     public SelectorData getSelectorData(FormRenderingContext context) {
         List<Edge> outEdges = getGatewayOutEdges(context);
-        Map<String, String> values = new TreeMap<>();
+        Map<String, String> values = new HashMap<>();
         if (outEdges != null) {
             for (Edge outEdge : outEdges) {
                 // routeIdentifier is flowName followed by flowId
@@ -97,7 +98,7 @@ public class DefaultRouteFormProvider implements SelectorDataProvider {
             }
         }
         return new SelectorData(values,
-                                "");
+                                null);
     }
 
     protected List<Edge> getGatewayOutEdges(FormRenderingContext context) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/gateway/DefaultRouteFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/gateway/DefaultRouteFormProviderTest.java
@@ -193,5 +193,6 @@ public class DefaultRouteFormProviderTest {
                      values.get("sequence : Edge4"));
         assertEquals("Exclusive Gateway",
                      values.get("sequence : Edge5"));
+        assertNull(values.get(null));
     }
 }


### PR DESCRIPTION
Now it is possible to open the Exclusive Gateway properties panel.
The problem was that the **DefaultRouteFormProvider** was using a **TreeMap** implementation to provide SelectorData to the Combobox of the DefultRoute property.
The methods **get(key)** and **containsKey(key)** of the **TreeMap** class throws NullPointerException whether the key parameter is null. The HashMap doesn't throw Exception in case key is null.

Reference:
https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html
https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html

@hasys 
@manstis 