### PR TITLE
JBPM-6052 Stunner: fixing toolbar panel that was missing with fixed palette

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/BaseNavigateCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/BaseNavigateCommand.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.client.commands;
 
 import java.util.Optional;
 
-import com.google.gwt.dom.client.Style;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
@@ -111,9 +110,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
     }
 
     protected void hidePaletteWidget(final boolean hidden) {
-        final com.google.gwt.dom.client.Element palette = presenter.getView().getPaletteWidget().asWidget().getElement();
-        palette.getStyle().setVisibility(hidden ? Style.Visibility.HIDDEN : Style.Visibility.VISIBLE);
-        palette.getStyle().setDisplay(hidden ? Style.Display.NONE : Style.Display.INITIAL);
+        presenter.getPalette().setVisible(!hidden);
     }
 
     private CanvasHandler getCanvasHandler() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.css
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.css
@@ -1,9 +1,7 @@
 .kie-palette {
     background: #fff;
     border-collapse: collapse;
-    overflow: visible;
     width: calc(48px);
-    position: absolute;
     z-index: 1;
 }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetViewImpl.html
@@ -1,6 +1,4 @@
-<div>
-    <div class="kie-palette" data-field="kie-palette">
-        <ul class="list-group">
-        </ul>
-    </div>
+<div class="kie-palette" data-field="kie-palette">
+    <ul class="list-group">
+    </ul>
 </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
@@ -23,20 +23,40 @@
         .kie-dmn-container {
             width: 1415px;
             height: 500px;
-            padding: 10px;
+            position: relative;
+            top: 0;
+            overflow: hidden;
         }
+
+        .select-expression-editor {
+            position: relative;
+            top:0;
+            z-index: 1000;
+        }
+
+        .expression-editor {
+            position: absolute;
+            z-index: 1;
+        }
+
+        .exit-button{
+            position: absolute;
+            bottom: 0;
+            z-index: 1000;
+        }
+
     </style>
 
     <div class="kie-dmn-container">
-        <select class="bootstrap-select" data-field="expressionEditorDefinition"></select>
+        <div class="select-expression-editor">
+            <select class="bootstrap-select" data-field="expressionEditorDefinition"></select>
+        </div>
 
-        <hr/>
+        <div class="expression-editor">
+            <div data-field="expressionEditor"></div>
+        </div>
 
-        <div data-field="expressionEditor"></div>
-
-        <hr/>
-
-        <div>
+        <div class="exit-button">
             <button class="btn btn-danger" type="button" data-field="exitButton" data-i18n-key="exitButton"></button>
         </div>
     </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -18,12 +18,12 @@ package org.kie.workbench.common.dmn.showcase.client.screens.editor;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.dom.client.Style;
 import com.google.gwt.logging.client.LogConfiguration;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
@@ -296,9 +296,6 @@ public class SessionDiagramEditorScreen {
                       session,
                       new ScreenPresenterCallback(callback));
         expressionEditor.init(presenter);
-        final com.google.gwt.dom.client.Element palette = presenter.getView().getPaletteWidget().asWidget().getElement();
-        palette.getStyle().setVisibility(Style.Visibility.VISIBLE);
-        palette.getStyle().setDisplay(Style.Display.INITIAL);
     }
 
     @OnOpen

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.css
@@ -3,8 +3,9 @@
     border-collapse: collapse;
     overflow: visible;
     width: calc(48px);
-    position: absolute;
     z-index: 1;
+    left: 0;
+    top: 0;
 }
 
 .kie-palette .list-group {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.html
@@ -1,6 +1,4 @@
-<div>
-    <div class="kie-palette" data-field="kie-palette">
-        <ul class="list-group">
-        </ul>
-    </div>
+<div class="kie-palette" data-field="kie-palette">
+    <ul class="list-group">
+    </ul>
 </div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.css
@@ -1,55 +1,53 @@
+.session-container {
+    position: absolute;
+    overflow: auto;
+    width: 100%;
+    height: 100%;
+}
+
+.diagram-container {
+    display: flex;
+}
+
 .loading-panel {
     margin: 5px;
     position: absolute;
+    z-index: 1000;
     padding: 5px;
 }
 
 .toolbar-panel {
-    width: 100%;
+    position: relative;
+    z-index: 1;
+    top: 0;
     margin: 5px;
     text-align: center;
 }
 
-.canvas-view {
+.palette-panel {
     position: relative;
-    padding-right: 10px;
-    padding-top: 5px;
-    padding-bottom: 10px;
+    float: left;
+    z-index: 1;
+    left: 0;
+    height: 100%;
+    transition: 0ms linear;
+    -webkit-transition: 0ms linear; /* Safari 3.1 to 6.0 */
+
     -moz-user-select: -moz-none;
     -khtml-user-select: none;
     -webkit-user-select: none;
-    /*
-      Introduced in IE 10.
-      See http://ie.microsoft.com/testdrive/HTML5/msUserSelect/
+    /* Introduced in IE 10.
+       See http://ie.microsoft.com/testdrive/HTML5/msUserSelect/
     */
     -ms-user-select: none;
     user-select: none;
 }
 
-.canvas-view > div:first-child {
-    position: absolute;
-}
-
-.toolbar-view {
-    position: absolute;
-    z-index: 500;
-}
-
-.toolbar-view-fixed {
-    position: fixed;
-    z-index: 500;
-}
-
-.palette-panel,.palette-panel-fixed {
-    width: 100%;
-}
-
-.palette-panel-fixed {
-    position:fixed;
-}
-
 .canvas-panel {
-    width: 100%;
     position: relative;
-    left: 48px;
+    float: right;
+    z-index: 0;
+    left: 0;
+    padding-right: 10px;
+    padding-bottom: 10px;
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.html
@@ -34,33 +34,20 @@
 </table>
 
 -->
-
-<table>
-    <tr>
-        <td>
+<div>
+    <div class="session-container" data-field="sessionContainer">
+        <div>
             <span data-field="loadingPanel" class="label label-danger loading-panel">Loading</span>
-        </td>
-        <td>
-            <div data-field="toolbarPanel" class="toolbar-panel"></div>
-        </td>
-    </tr>
-    <tr>
+        </div>
 
-        <td colspan="2" class="canvas-view">
+        <div data-field="toolbarPanel" class="toolbar-panel">
+        </div>
 
-            <div>
+        <div class="diagram-container">
 
-                <div data-field="toolbar-view" class="toolbar-view">
-
-                    <div data-field="palettePanel" class="palette-panel"></div>
-
-                </div>
-
-            </div>
+            <div data-field="palettePanel" class="palette-panel"></div>
 
             <div data-field="canvasPanel" class="canvas-panel"></div>
-
-        </td>
-    </tr>
-</table>
-
+        </div>
+    </div>
+</div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
@@ -20,7 +20,9 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -31,8 +33,11 @@ import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.gwtbootstrap3.extras.notify.client.constants.NotifyType;
 import org.gwtbootstrap3.extras.notify.client.ui.Notify;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
+import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.ForEvent;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
@@ -63,7 +68,15 @@ public class SessionPresenterView extends Composite
     @DataField
     private FlowPanel palettePanel;
 
+    @Inject
+    @DataField
+    private Div sessionContainer;
+
     private final NotifySettings settings = NotifySettings.newSettings();
+
+    private double paletteInitialTop;
+
+    private double paletteInitialLeft;
 
     @PostConstruct
     public void init() {
@@ -78,6 +91,19 @@ public class SessionPresenterView extends Composite
                       },
                       ContextMenuEvent.getType());
         showLoading(false);
+
+        //getting initial palette position
+        paletteInitialTop = palettePanel.getAbsoluteTop();
+        paletteInitialLeft = palettePanel.getAbsoluteLeft();
+    }
+
+    @EventHandler("sessionContainer")
+    protected void onScroll(@ForEvent("scroll") ScrollEvent e) {
+        // on the editor scroll recalculate palette position to be fixed on the screen
+        palettePanel.getElement().getStyle().setTop(paletteInitialTop + e.getRelativeElement().getScrollTop(), Style.Unit.PX);
+        palettePanel.getElement().getStyle().setLeft(paletteInitialLeft + e.getRelativeElement().getScrollLeft(), Style.Unit.PX);
+
+        e.preventDefault();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/impl/ToolbarViewImpl.ui.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/impl/ToolbarViewImpl.ui.xml
@@ -18,7 +18,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:b="urn:import:org.gwtbootstrap3.client.ui">
 
-  <b:ButtonGroup size="LARGE" ui:field="mainGroup">
+  <b:ButtonGroup size="LARGE" ui:field="mainGroup" height="48px">
 
   </b:ButtonGroup>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
@@ -19,9 +19,13 @@ package org.kie.workbench.common.stunner.client.widgets.presenters.session.impl;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.dom.client.ContextMenuHandler;
+import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +36,8 @@ import org.mockito.Mock;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +53,22 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
     @Mock
     private NotifySettings settings;
 
+    @Mock
+    private ScrollEvent scrollEvent;
+
+    @Mock
+    private Element element;
+
+    @Mock
+    private FlowPanel palettePanel;
+
     private ContextMenuHandler handler;
+
+    @Mock
+    private com.google.gwt.user.client.Element paletteElement;
+
+    @Mock
+    private com.google.gwt.dom.client.Style paletteStyle;
 
     @Before
     public void setup() throws Exception {
@@ -57,6 +78,9 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
             setFinal(tested,
                      SessionPresenterView.class.getDeclaredField("settings"),
                      settings);
+            setFinal(tested,
+                     SessionPresenterView.class.getDeclaredField("palettePanel"),
+                     palettePanel);
             invocation.callRealMethod();
             return null;
         }).when(tested).init();
@@ -64,8 +88,12 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
         doAnswer((invocation -> {
             invocation.callRealMethod();
             return null;
-        }))
-                .when(tested).fireEvent(any());
+        })).when(tested).fireEvent(any());
+
+        doAnswer((invocation -> {
+            invocation.callRealMethod();
+            return null;
+        })).when(tested).onScroll(scrollEvent);
 
         when(tested.addDomHandler(any(),
                                   any())).thenAnswer((invocation -> {
@@ -73,6 +101,10 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
                                                ContextMenuHandler.class);
             return null;
         }));
+
+        when(scrollEvent.getRelativeElement()).thenReturn(element);
+        when(palettePanel.getElement()).thenReturn(paletteElement);
+        when(paletteElement.getStyle()).thenReturn(paletteStyle);
 
         tested.init();
     }
@@ -100,5 +132,18 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
                               field.getModifiers() & ~Modifier.FINAL);
         field.set(instance,
                   newValue);
+    }
+
+    @Test
+    public void testOnScroll(){
+        reset(element);
+
+        when(element.getScrollTop()).thenReturn(100);
+        when(element.getScrollLeft()).thenReturn(200);
+
+        tested.onScroll(scrollEvent);
+
+        verify(paletteStyle, times(1)).setTop(100, Style.Unit.PX);
+        verify(paletteStyle, times(1)).setLeft(200, Style.Unit.PX);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionDiagramEditorScreen.java
@@ -240,16 +240,8 @@ public class SessionDiagramEditorScreen {
                                                  final Metadata metadata = diagram.getMetadata();
                                                  metadata.setShapeSetId(shapeSetId);
                                                  metadata.setTitle(title);
-                                                 final AbstractClientFullSession session = newSession(diagram);
-                                                 presenter = sessionPresenterFactory.newPresenterEditor();
-                                                 screenPanelView.setWidget(presenter.getView());
-                                                 presenter
-                                                         .withToolbar(true)
-                                                         .withPalette(true)
-                                                         .displayNotifications(type -> true)
-                                                         .open(diagram,
-                                                               session,
-                                                               new ScreenPresenterCallback(callback));
+                                                 openDiagram(diagram,
+                                                             callback);
                                              }
 
                                              @Override
@@ -258,6 +250,20 @@ public class SessionDiagramEditorScreen {
                                                  callback.execute();
                                              }
                                          });
+    }
+
+    private void openDiagram(Diagram diagram,
+                             Command callback) {
+        final AbstractClientFullSession session = newSession(diagram);
+        presenter = sessionPresenterFactory.newPresenterEditor();
+        screenPanelView.setWidget(presenter.getView());
+        presenter
+                .withToolbar(true)
+                .withPalette(true)
+                .displayNotifications(type -> true)
+                .open(diagram,
+                      session,
+                      new ScreenPresenterCallback(callback));
     }
 
     private Metadata buildMetadata(final String defSetId,
@@ -277,16 +283,8 @@ public class SessionDiagramEditorScreen {
                                   new ServiceCallback<Diagram>() {
                                       @Override
                                       public void onSuccess(final Diagram diagram) {
-                                          final AbstractClientFullSession session = newSession(diagram);
-                                          presenter = sessionPresenterFactory.newPresenterEditor();
-                                          screenPanelView.setWidget(presenter.getView());
-                                          presenter
-                                                  .withToolbar(true)
-                                                  .withPalette(true)
-                                                  .displayNotifications(type -> true)
-                                                  .open(diagram,
-                                                        session,
-                                                        new ScreenPresenterCallback(callback));
+                                          openDiagram(diagram,
+                                                      callback);
                                       }
 
                                       @Override


### PR DESCRIPTION
Fix for the reopened issue JBPM-6052 according to the comment of @manstis regarding the commit [1]. 
Now the palette is fixed and the toolbar is not missed, tested on the project, standalone and kie-drools-wb. Some videos were attached to the JIRA [2]. If it is ok after the merge it is necessary the port back to the 7.3.x.

@ibek @hasys can you please help to validate.

Thanks.

**[1]** https://github.com/kiegroup/kie-wb-common/commit/9fe2a86f4609968fd030ae8ff5be308b92d3470a
**[2]** https://issues.jboss.org/browse/JBPM-6052