### PR TITLE
GUVNOR-3198: [Guided Decision Table] Visual indication where the current view of Decision Table is located

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/DMNBaseGridWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/DMNBaseGridWidget.java
@@ -79,6 +79,16 @@ public class DMNBaseGridWidget extends BaseGridWidget {
             }
 
             @Override
+            public void addOnEnterPinnedModeCommand(final Command command) {
+                //Do nothing. The DMN Editor does not support interaction with a PinnedModeManager.
+            }
+
+            @Override
+            public void addOnExitPinnedModeCommand(final Command command) {
+                //Do nothing. The DMN Editor does not support interaction with a PinnedModeManager.
+            }
+
+            @Override
             public PinnedContext getPinnedContext() {
                 return gridLayer.getPinnedContext();
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorViewImplTest.java
@@ -72,11 +72,11 @@ public class LiteralExpressionEditorViewImplTest {
         final Mediators m = view.getGridPanel().getViewport().getMediators();
         final List<IMediator> mediators = new ArrayList<>();
         m.iterator().forEachRemaining(mediators::add);
-        assertEquals(1,
+        assertEquals(2,
                      mediators.size());
-        assertTrue(mediators.get(0) instanceof RestrictedMousePanMediator);
+        assertTrue(mediators.get(1) instanceof RestrictedMousePanMediator);
 
-        final RestrictedMousePanMediator mediator = (RestrictedMousePanMediator) mediators.get(0);
+        final RestrictedMousePanMediator mediator = (RestrictedMousePanMediator) mediators.get(1);
         assertTrue(mediator.getTransformMediator() instanceof BoundaryTransformMediator);
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3198

![Demo](https://user-images.githubusercontent.com/1079279/29538280-760f6c58-869b-11e7-921b-f046cc91b728.gif)

---

Part of an ensemble:
- https://github.com/AppFormer/uberfire/pull/808
- https://github.com/kiegroup/drools-wb/pull/583
- https://github.com/kiegroup/kie-wb-common/pull/1110
