### PR TITLE
[7.3.x] JBPM-6324: Inconsistency between field types and field bindings with slider.

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/FieldManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/FieldManager.java
@@ -38,6 +38,8 @@ public interface FieldManager {
 
     Collection<String> getCompatibleFields(FieldDefinition fieldDefinition);
 
+    Collection<String> getCompatibleTypes(FieldDefinition fieldDefinition);
+
     FieldDefinition getFieldFromProvider(String typeCode,
                                          TypeInfo typeInfo);
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/AbstractFieldManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/AbstractFieldManager.java
@@ -195,6 +195,20 @@ public abstract class AbstractFieldManager implements FieldManager {
     }
 
     @Override
+    public Collection<String> getCompatibleTypes(FieldDefinition fieldDefinition) {
+        FieldProvider provider = providersByFieldCode.get(fieldDefinition.getFieldType().getTypeName());
+
+        if(provider == null) {
+            throw new IllegalArgumentException("Unexpected field type '" + fieldDefinition.getFieldType().getTypeName() + "'");
+        }
+
+        if (provider instanceof BasicTypeFieldProvider) {
+            return Arrays.asList(((BasicTypeFieldProvider)provider).getSupportedTypes());
+        }
+        return Arrays.asList(fieldDefinition.getStandaloneClassName());
+    }
+
+    @Override
     public FieldDefinition getFieldFromProvider(String typeCode,
                                                 TypeInfo typeInfo) {
         Assert.notNull("TypeInfo cannot be null",

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/pom.xml
@@ -208,5 +208,11 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
@@ -184,19 +184,15 @@ public class FormEditorHelper {
     }
 
     public List<String> getCompatibleModelFields(FieldDefinition field) {
-        Collection<String> compatibles = fieldManager.getCompatibleFields(field);
+        Collection<String> compatibles = fieldManager.getCompatibleTypes(field);
 
         Set<String> result = new TreeSet<>();
         if (field.getBinding() != null && !field.getBinding().isEmpty()) {
             result.add(field.getBinding());
         }
-        for (String compatibleType : compatibles) {
-            for (FieldDefinition definition : availableFields.values()) {
-                if (definition.getFieldType().getTypeName().equals(compatibleType) && definition.getBinding() != null) {
-                    result.add(definition.getBinding());
-                }
-            }
-        }
+
+        availableFields.values().stream().filter(availableField -> compatibles.contains(availableField.getStandaloneClassName())).forEach(availableField -> result.add(availableField.getBinding()));
+
         return new ArrayList<>(result);
     }
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRenderer.java
@@ -151,8 +151,8 @@ public class FieldPropertiesRenderer implements IsWidget {
                             FormEditorRenderingContext context) {
         FormModel roodFormModel = helper.getCurrentRenderingContext().getRootForm().getModel();
         final DataBindingEditor editor = roodFormModel instanceof DynamicModel ? dynamicDataBindingEditor : staticDataBindingEditor;
-        editor.init(helper,
-                    fieldCopy.getBinding(),
+        editor.init(fieldCopy,
+                    helper,
                     () -> onFieldBindingChange(editor.getBinding()));
         view.render(helper,
                     context,

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererHelper.java
@@ -28,7 +28,7 @@ public interface FieldPropertiesRendererHelper {
 
     FieldDefinition getCurrentField();
 
-    List<String> getAvailableModelFields();
+    List<String> getAvailableModelFields(FieldDefinition fieldDefinition);
 
     List<String> getCompatibleFieldTypes(FieldDefinition fieldDefinition);
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/DataBindingEditor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/DataBindingEditor.java
@@ -18,12 +18,13 @@ package org.kie.workbench.common.forms.editor.client.editor.properties.binding;
 
 import org.jboss.errai.common.client.api.IsElement;
 import org.kie.workbench.common.forms.editor.client.editor.properties.FieldPropertiesRendererHelper;
+import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.uberfire.mvp.Command;
 
 public interface DataBindingEditor extends IsElement {
 
-    void init(FieldPropertiesRendererHelper helper,
-              String binding,
+    void init(FieldDefinition fieldDefinition,
+              FieldPropertiesRendererHelper helper,
               Command onChangeCallback);
 
     String getBinding();

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/dynamic/DynamicDataBinderEditor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/dynamic/DynamicDataBinderEditor.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.forms.editor.client.editor.properties.binding.dynamic;
 
+import java.util.Optional;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -24,6 +25,7 @@ import org.jboss.errai.common.client.dom.HTMLElement;
 import org.kie.workbench.common.forms.editor.client.editor.properties.FieldPropertiesRendererHelper;
 import org.kie.workbench.common.forms.editor.client.editor.properties.binding.DataBindingEditor;
 import org.kie.workbench.common.forms.editor.client.editor.properties.binding.DynamicFormModel;
+import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.uberfire.mvp.Command;
 
 @DynamicFormModel
@@ -46,19 +48,15 @@ public class DynamicDataBinderEditor implements DataBindingEditor,
     }
 
     @Override
-    public void init(FieldPropertiesRendererHelper helper,
-                     String binding,
-                     Command onChangeCallback) {
+    public void init(final FieldDefinition fieldDefinition,
+                     final FieldPropertiesRendererHelper helper,
+                     final Command onChangeCallback) {
 
         view.clear();
 
         this.onChangeCallback = onChangeCallback;
 
-        if (binding == null) {
-            binding = "";
-        }
-
-        view.setFieldBinding(binding);
+        view.setFieldBinding(Optional.ofNullable(fieldDefinition.getBinding()).orElse(""));
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/statik/StaticDataBinderEditor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/statik/StaticDataBinderEditor.java
@@ -24,6 +24,7 @@ import org.jboss.errai.common.client.dom.HTMLElement;
 import org.kie.workbench.common.forms.editor.client.editor.properties.FieldPropertiesRendererHelper;
 import org.kie.workbench.common.forms.editor.client.editor.properties.binding.DataBindingEditor;
 import org.kie.workbench.common.forms.editor.client.editor.properties.binding.StaticFormModel;
+import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.uberfire.mvp.Command;
 
 @StaticFormModel
@@ -48,9 +49,9 @@ public class StaticDataBinderEditor implements DataBindingEditor,
     }
 
     @Override
-    public void init(FieldPropertiesRendererHelper helper,
-                     String binding,
-                     Command onChangeCallback) {
+    public void init(final FieldDefinition fieldDefinition,
+                     final FieldPropertiesRendererHelper helper,
+                     final Command onChangeCallback) {
 
         view.clear();
 
@@ -58,10 +59,10 @@ public class StaticDataBinderEditor implements DataBindingEditor,
 
         hasSelectedValue = false;
 
-        helper.getAvailableModelFields().forEach(property -> {
+        helper.getAvailableModelFields(fieldDefinition).forEach(property -> {
             if (property != null) {
 
-                boolean isSelected = property.equals(binding);
+                boolean isSelected = property.equals(fieldDefinition.getBinding());
 
                 view.addModelField(property,
                                    isSelected);

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponent.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponent.java
@@ -103,8 +103,8 @@ public class EditorFieldLayoutComponent extends FieldLayoutComponent implements 
             }
 
             @Override
-            public List<String> getAvailableModelFields() {
-                return editorHelper.getCompatibleModelFields(field);
+            public List<String> getAvailableModelFields(final FieldDefinition fieldDefinition) {
+                return editorHelper.getCompatibleModelFields(fieldDefinition);
             }
 
             @Override

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelperTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelperTest.java
@@ -17,13 +17,13 @@ package org.kie.workbench.common.forms.editor.client.editor;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.apache.deltaspike.core.util.StringUtils;
+import org.assertj.core.api.Assertions;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -38,6 +38,9 @@ import org.kie.workbench.common.forms.editor.service.shared.FormEditorRenderingC
 import org.kie.workbench.common.forms.editor.service.shared.FormEditorService;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.definition.CheckBoxFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.definition.DecimalBoxFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.definition.IntegerBoxFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition.IntegerSliderDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition;
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
@@ -66,7 +69,13 @@ public class FormEditorHelperTest {
 
     private FieldDefinition nameField;
 
+    private TextBoxFieldDefinition lastNameField;
+
     private FieldDefinition marriedField;
+
+    private IntegerBoxFieldDefinition ageField;
+
+    private DecimalBoxFieldDefinition weightField;
 
     private TestFormEditorHelper formEditorHelper;
 
@@ -299,10 +308,37 @@ public class FormEditorHelperTest {
     }
 
     @Test
-    public void testGetCompatibleFieldCodes() {
-        List<String> compatibleFieldIds = formEditorHelper.getCompatibleModelFields(nameField);
-        assertTrue(compatibleFieldIds.size() > 0);
-        assertTrue(compatibleFieldIds.contains(nameField.getId()));
+    public void testGetCompatibleModelFields() {
+        List<String> compatibleModelFields = formEditorHelper.getCompatibleModelFields(nameField);
+        assertEquals(2,
+                     compatibleModelFields.size());
+        Assertions.assertThat(compatibleModelFields).containsExactly(lastNameField.getId(),
+                                                                     nameField.getId());
+
+        // Getting compatible model propertynames for an integerbox field -> only checks integer properties (age -> integer)
+        compatibleModelFields = formEditorHelper.getCompatibleModelFields(ageField);
+        assertEquals(1,
+                     compatibleModelFields.size());
+        Assertions.assertThat(compatibleModelFields).containsOnly(ageField.getId());
+
+        // Getting compatible model propertynames for an decimalbox field -> only checks decimal properties (weight -> double)
+        compatibleModelFields = formEditorHelper.getCompatibleModelFields(weightField);
+        assertEquals(1,
+                     compatibleModelFields.size());
+        Assertions.assertThat(compatibleModelFields).containsOnly(weightField.getId());
+
+        IntegerSliderDefinition slider = new IntegerSliderDefinition();
+        slider.setId("slider");
+        slider.setName("slider");
+        slider.setLabel("slider");
+
+        // Getting compatible model propertynames for an integer slider field -> slider's are available for integer &
+        // decimal properties (age -> integer & weight -> double)
+        compatibleModelFields = formEditorHelper.getCompatibleModelFields(slider);
+        assertEquals(2,
+                     compatibleModelFields.size());
+        Assertions.assertThat(compatibleModelFields).containsExactly(ageField.getId(),
+                                                                     weightField.getId());
     }
 
     @Test
@@ -358,7 +394,6 @@ public class FormEditorHelperTest {
         name.setLabel("Name");
         name.setPlaceHolder("Name");
         name.setBinding("name");
-        name.setStandaloneClassName(String.class.getName());
         nameField = name;
 
         TextBoxFieldDefinition lastName = new TextBoxFieldDefinition();
@@ -367,28 +402,42 @@ public class FormEditorHelperTest {
         lastName.setLabel("Last Name");
         lastName.setPlaceHolder("Last Name");
         lastName.setBinding("lastName");
-        lastName.setStandaloneClassName(String.class.getName());
+        lastNameField = lastName;
 
         DatePickerFieldDefinition birthday = new DatePickerFieldDefinition();
         birthday.setId("birthday");
         birthday.setName("employee_birthday");
         birthday.setLabel("Birthday");
         birthday.setBinding("birthday");
-        birthday.setStandaloneClassName(Date.class.getName());
 
         CheckBoxFieldDefinition married = new CheckBoxFieldDefinition();
         married.setId("married");
         married.setName("employee_married");
         married.setLabel("Married");
         married.setBinding("married");
-        married.setStandaloneClassName(Boolean.class.getName());
         marriedField = married;
+
+        IntegerBoxFieldDefinition age = new IntegerBoxFieldDefinition();
+        age.setId("age");
+        age.setName("employee_age");
+        age.setLabel("Age");
+        age.setBinding("age");
+        ageField = age;
+
+        DecimalBoxFieldDefinition weight = new DecimalBoxFieldDefinition();
+        weight.setId("weight");
+        weight.setName("employee_weight");
+        weight.setLabel("Weight");
+        weight.setBinding("weight");
+        weightField = weight;
 
         employeeFields = new ArrayList<>();
         employeeFields.add(name);
         employeeFields.add(lastName);
         employeeFields.add(birthday);
         employeeFields.add(married);
+        employeeFields.add(age);
+        employeeFields.add(weight);
 
         modelProperties = new ArrayList<>();
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/DataBinderEditorTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/DataBinderEditorTest.java
@@ -56,7 +56,7 @@ public abstract class DataBinderEditorTest<EDITOR extends DataBindingEditor> {
         fields.add(CP);
 
         when(helper.getCurrentField()).thenReturn(fieldDefinition);
-        when(helper.getAvailableModelFields()).thenReturn(fields);
+        when(helper.getAvailableModelFields(fieldDefinition)).thenReturn(fields);
 
         when(fieldDefinition.getBinding()).thenReturn(FIELD_BINDING);
     }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/dynamic/DynamicDataBinderEditorTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/dynamic/DynamicDataBinderEditorTest.java
@@ -43,8 +43,8 @@ public class DynamicDataBinderEditorTest extends DataBinderEditorTest<DynamicDat
         editor.setUp();
         verify(view).init(editor);
 
-        editor.init(helper,
-                    FIELD_BINDING,
+        editor.init(fieldDefinition,
+                    helper,
                     mock(Command.class));
 
         verify(view).clear();

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/statik/StaticDataBinderEditorTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/properties/binding/statik/StaticDataBinderEditorTest.java
@@ -42,11 +42,14 @@ public class StaticDataBinderEditorTest extends DataBinderEditorTest<StaticDataB
 
     @Test
     public void testFunctionallity() {
+        when(fieldDefinition.getBinding()).thenReturn(NAME);
+
         editor.setUp();
+
         verify(view).init(editor);
 
-        editor.init(helper,
-                    NAME,
+        editor.init(fieldDefinition,
+                    helper,
                     mock(Command.class));
 
         verify(view).clear();


### PR DESCRIPTION
Copy of https://github.com/kiegroup/kie-wb-common/pull/1117

Changed the way compatible properties are calculated to use the providers supported types.

@jsoltes can you review?