### PR TITLE
GUVNOR-3357 Full screen Preview does not hide Palette

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidget.java
@@ -207,4 +207,9 @@ public class DMNPaletteWidget extends AbstractPalette<DefinitionsPalette>
         view.destroy();
         this.itemDropCallback = null;
     }
+
+    @Override
+    public void setVisible(boolean visible) {
+        view.showEmptyView(!visible);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPresenterFactoryImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/presenters/impl/SessionPresenterFactoryImpl.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.stunner.client.widgets.event.SessionDiagramOpenedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenResizeEventObserver;
 import org.kie.workbench.common.stunner.client.widgets.notification.NotificationsObserver;
 import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteFactory;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionDiagramPreview;
@@ -49,7 +50,9 @@ public class SessionPresenterFactoryImpl extends org.kie.workbench.common.stunne
                                        final ManagedInstance<SessionPresenter.View> viewInstances,
                                        final ManagedInstance<NotificationsObserver> notificationsObserverInstances,
                                        final BS3PaletteFactory paletteWidgetFactory,
-                                       final Event<SessionDiagramOpenedEvent> sessionDiagramOpenedEventInstances) {
+                                       final Event<SessionDiagramOpenedEvent> sessionDiagramOpenedEventInstances,
+                                       final ScreenResizeEventObserver screenResizeEventObserver
+    ) {
         super(sessionManager,
               commandManagerInstances,
               viewerToolbarFactoryInstances,
@@ -59,6 +62,8 @@ public class SessionPresenterFactoryImpl extends org.kie.workbench.common.stunne
               viewInstances,
               notificationsObserverInstances,
               paletteWidgetFactory,
-              sessionDiagramOpenedEventInstances);
+              sessionDiagramOpenedEventInstances,
+              screenResizeEventObserver
+              );
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.factory.DMNGraphFactory;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
+import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
@@ -56,6 +57,7 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.Menus;
 
 @Dependent
+@DiagramEditor
 @WorkbenchEditor(identifier = DMNDiagramEditor.EDITOR_ID, supportedTypes = {DMNDiagramResourceType.class})
 public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramResourceType> {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.EditorToolba
 import org.kie.workbench.common.stunner.client.widgets.views.session.ScreenErrorView;
 import org.kie.workbench.common.stunner.client.widgets.views.session.ScreenPanelView;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
@@ -80,6 +81,7 @@ import org.uberfire.workbench.model.menu.Menus;
 import static java.util.logging.Level.FINE;
 
 @Dependent
+@DiagramEditor
 @WorkbenchScreen(identifier = SessionDiagramEditorScreen.SCREEN_ID)
 public class SessionDiagramEditorScreen {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
@@ -151,6 +151,11 @@ public class BS3PaletteWidgetImpl extends AbstractPalette<DefinitionSetPalette>
         }
     }
 
+    @Override
+    public void setVisible(boolean visible) {
+        view.showEmptyView(!visible);
+    }
+
     protected ShapeFactory getShapeFactory() {
         final DefinitionSetPalette palette = paletteDefinition;
         return shapeManager.getDefaultShapeSet(palette.getDefinitionSetId()).getShapeFactory();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetViewImpl.java
@@ -119,5 +119,6 @@ public class BS3PaletteWidgetViewImpl implements BS3PaletteWidgetView,
     @Override
     public void showEmptyView(boolean showEmptyView) {
         palette.setHidden(showEmptyView);
+        ul.setHidden(showEmptyView);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/PaletteWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/PaletteWidget.java
@@ -57,5 +57,7 @@ public interface PaletteWidget<D extends PaletteDefinition>
 
     void unbind();
 
+    void setVisible(boolean visible);
+
     HTMLElement getElement();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/SessionPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/SessionPresenter.java
@@ -26,7 +26,6 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.diagram.Diagra
 import org.kie.workbench.common.stunner.client.widgets.toolbar.Toolbar;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 
@@ -71,7 +70,7 @@ public interface SessionPresenter<S extends ClientSession, H extends CanvasHandl
 
         View setToolbarWidget(final IsWidget widget);
 
-        View setPaletteWidget(final IsWidget widget);
+        View setPaletteWidget(final PaletteWidget<PaletteDefinition> paletteWidget);
 
         View showLoading(final boolean loading);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/AbstractSessionPresenter.java
@@ -19,8 +19,6 @@ package org.kie.workbench.common.stunner.client.widgets.presenters.session.impl;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.kie.workbench.common.stunner.client.widgets.notification.CommandNotification;
 import org.kie.workbench.common.stunner.client.widgets.notification.Notification;
 import org.kie.workbench.common.stunner.client.widgets.notification.NotificationContext;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.stunner.client.widgets.toolbar.ToolbarFactory;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -71,10 +68,6 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
         this.hasToolbar = true;
         this.hasPalette = true;
         this.typePredicate = Optional.empty();
-    }
-
-    private static String buildHtmlEscapedText(final String message) {
-        return new SafeHtmlBuilder().appendEscapedLines(message).toSafeHtml().asString();
     }
 
     public abstract E getDisplayer();
@@ -234,7 +227,7 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
         }
         if (hasPalette) {
             this.palette = buildPalette(session);
-            getView().setPaletteWidget(ElementWrapperWidget.getWidget(getPalette().getElement()));
+            getView().setPaletteWidget(getPalette());
         }
         getView().setCanvasWidget(getDisplayer().getView());
         getView().showLoading(false);
@@ -261,7 +254,7 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
     private void showError(final ClientRuntimeError error) {
         if (isDisplayErrors()) {
             getView().showLoading(false);
-            getView().showError(buildHtmlEscapedText(error.getMessage()));
+            getView().showError(error.getMessage());
         }
     }
 
@@ -299,22 +292,22 @@ public abstract class AbstractSessionPresenter<D extends Diagram, H extends Abst
 
     private void showNotificationMessage(final Notification notification) {
         if (isThisContext(notification)) {
-            showMessage(buildHtmlEscapedText(notification.getMessage()));
+            showMessage(notification.getMessage());
         }
     }
 
     private void showCommandError(final CommandNotification notification) {
         if (isThisContext(notification)) {
-            showError(buildHtmlEscapedText(notification.getMessage()));
+            showError(notification.getMessage());
         }
     }
 
     private void showValidationError(final ValidationFailedNotification notification) {
         if (isThisContext(notification)) {
             if (Notification.Type.ERROR.equals(notification.getType())) {
-                showError(buildHtmlEscapedText(notification.getMessage()));
+                showError(notification.getMessage());
             } else {
-                showWarning(buildHtmlEscapedText(notification.getMessage()));
+                showWarning(notification.getMessage());
             }
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenter.java
@@ -30,6 +30,9 @@ import org.kie.workbench.common.stunner.client.widgets.views.WidgetWrapperView;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMinimizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenResizeEventObserver;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 
@@ -57,7 +60,8 @@ public class SessionEditorPresenter<S extends AbstractClientFullSession, H exten
                            final BS3PaletteFactory paletteWidgetFactory,
                            final WidgetWrapperView diagramEditorView,
                            final NotificationsObserver notificationsObserver,
-                           final View view) {
+                           final View view,
+                           final ScreenResizeEventObserver screenResizeEventObserver) {
         super(sessionManager,
               view,
               Optional.of((ToolbarFactory<S>) toolbarFactory),
@@ -66,6 +70,18 @@ public class SessionEditorPresenter<S extends AbstractClientFullSession, H exten
         this.sessionDiagramOpenedEvent = sessionDiagramOpenedEvent;
         this.editor = new CustomSessionEditor(commandManager,
                                               diagramEditorView);
+
+        //Registering event observers
+        screenResizeEventObserver.registerEventCallback(ScreenMaximizedEvent.class, event -> onScreenMaximized(event));
+        screenResizeEventObserver.registerEventCallback(ScreenMinimizedEvent.class, event -> onScreenMinimized(event));
+    }
+
+    private void onScreenMaximized(ScreenMaximizedEvent event) {
+        getPalette().setVisible(event.isDiagramScreen());
+    }
+
+    private void onScreenMinimized(ScreenMinimizedEvent event) {
+        getPalette().setVisible(true);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterFactoryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterFactoryImpl.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.stunner.client.widgets.views.WidgetWrapperView;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenResizeEventObserver;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientSession;
@@ -54,9 +55,11 @@ public class SessionPresenterFactoryImpl implements SessionPresenterFactory<Diag
     private final ManagedInstance<NotificationsObserver> notificationsObserverInstances;
     private final BS3PaletteFactory paletteWidgetFactory;
     private final Event<SessionDiagramOpenedEvent> sessionDiagramOpenedEventInstances;
+    private final ScreenResizeEventObserver screenResizeEventObserver;
 
     protected SessionPresenterFactoryImpl() {
         this(null,
+             null,
              null,
              null,
              null,
@@ -78,7 +81,8 @@ public class SessionPresenterFactoryImpl implements SessionPresenterFactory<Diag
                                        final ManagedInstance<SessionPresenter.View> viewInstances,
                                        ManagedInstance<NotificationsObserver> notificationsObserverInstances,
                                        final BS3PaletteFactory paletteWidgetFactory,
-                                       final Event<SessionDiagramOpenedEvent> sessionDiagramOpenedEventInstances) {
+                                       final Event<SessionDiagramOpenedEvent> sessionDiagramOpenedEventInstances,
+                                       final ScreenResizeEventObserver screenResizeEventObserver) {
         this.sessionManager = sessionManager;
         this.commandManagerInstances = commandManagerInstances;
         this.viewerToolbarFactoryInstances = viewerToolbarFactoryInstances;
@@ -89,6 +93,7 @@ public class SessionPresenterFactoryImpl implements SessionPresenterFactory<Diag
         this.notificationsObserverInstances = notificationsObserverInstances;
         this.viewInstances = viewInstances;
         this.sessionDiagramOpenedEventInstances = sessionDiagramOpenedEventInstances;
+        this.screenResizeEventObserver = screenResizeEventObserver;
     }
 
     @Override
@@ -129,6 +134,7 @@ public class SessionPresenterFactoryImpl implements SessionPresenterFactory<Diag
                                             paletteWidgetFactory,
                                             diagramViewerViewInstances.get(),
                                             notificationsObserverInstances.get(),
-                                            viewInstances.get());
+                                            viewInstances.get(),
+                                            screenResizeEventObserver);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
@@ -30,9 +31,12 @@ import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.gwtbootstrap3.extras.notify.client.constants.NotifyType;
 import org.gwtbootstrap3.extras.notify.client.ui.Notify;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
+import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
 
 // TODO: i18n.
 @Dependent
@@ -99,9 +103,9 @@ public class SessionPresenterView extends Composite
     }
 
     @Override
-    public SessionPresenterView setPaletteWidget(final IsWidget widget) {
+    public SessionPresenterView setPaletteWidget(final PaletteWidget<PaletteDefinition> paletteWidget) {
         setWidgetForPanel(palettePanel,
-                          widget);
+                          ElementWrapperWidget.getWidget(paletteWidget.getElement()));
         return this;
     }
 
@@ -109,7 +113,7 @@ public class SessionPresenterView extends Composite
     public SessionPresenterView showError(final String message) {
         settings.setType(NotifyType.DANGER);
         showNotification("Error",
-                         message,
+                         buildHtmlEscapedText(message),
                          IconType.CLOSE);
         return this;
     }
@@ -118,7 +122,7 @@ public class SessionPresenterView extends Composite
     public SessionPresenter.View showWarning(final String message) {
         settings.setType(NotifyType.WARNING);
         showNotification("Warning",
-                         message,
+                         buildHtmlEscapedText(message),
                          IconType.CLOSE);
         return this;
     }
@@ -127,7 +131,7 @@ public class SessionPresenterView extends Composite
     public SessionPresenterView showMessage(final String message) {
         settings.setType(NotifyType.SUCCESS);
         showNotification("Info",
-                         message,
+                         buildHtmlEscapedText(message),
                          IconType.STICKY_NOTE);
         return this;
     }
@@ -136,7 +140,7 @@ public class SessionPresenterView extends Composite
                                   final String message,
                                   final IconType icon) {
         Notify.notify(title,
-                      message,
+                      buildHtmlEscapedText(message),
                       icon,
                       settings);
     }
@@ -162,5 +166,9 @@ public class SessionPresenterView extends Composite
 
     public void destroy() {
         this.removeFromParent();
+    }
+
+    private String buildHtmlEscapedText(final String message) {
+        return new SafeHtmlBuilder().appendEscapedLines(message).toSafeHtml().asString();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenterTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.presenters.session.impl;
+
+import javax.enterprise.event.Event;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.event.SessionDiagramOpenedEvent;
+import org.kie.workbench.common.stunner.client.widgets.notification.NotificationsObserver;
+import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteFactory;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionDiagramPreview;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.EditorToolbar;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.EditorToolbarFactory;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.ViewerToolbarFactory;
+import org.kie.workbench.common.stunner.client.widgets.views.WidgetWrapperView;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMinimizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenResizeEventObserver;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientSession;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionEditorPresenterTest {
+
+    private SessionEditorPresenter<AbstractClientFullSession, AbstractCanvasHandler> sessionEditorPresenter;
+
+    private ScreenResizeEventObserver screenResizeEventObserver;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private CanvasCommandManager<AbstractCanvasHandler> commandManagerInstances;
+
+    @Mock
+    private ViewerToolbarFactory viewerToolbarFactoryInstances;
+
+    @Mock
+    private EditorToolbarFactory editorToolbarFactoryInstances;
+
+    @Mock
+    private SessionDiagramPreview<AbstractClientSession> sessionPreviewInstances;
+
+    @Mock
+    private WidgetWrapperView diagramViewerViewInstances;
+
+    @Mock
+    private SessionPresenter.View viewInstances;
+
+    @Mock
+    private NotificationsObserver notificationsObserverInstances;
+
+    @Mock
+    private BS3PaletteFactory paletteWidgetFactory;
+
+    @Mock
+    private Event<SessionDiagramOpenedEvent> sessionDiagramOpenedEventInstances;
+
+    @Mock
+    private BS3PaletteWidget paletteWidget;
+
+    @Mock
+    private AbstractClientFullSession clientFullSession;
+
+    @Mock
+    private EditorToolbar toolbar;
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private Diagram diagram;
+
+    @Before
+    public void init() throws Exception {
+
+        screenResizeEventObserver = new ScreenResizeEventObserver();
+
+        sessionEditorPresenter = new SessionEditorPresenter<>(sessionManager,
+                                                              commandManagerInstances,
+                                                              sessionDiagramOpenedEventInstances,
+                                                              editorToolbarFactoryInstances,
+                                                              paletteWidgetFactory,
+                                                              diagramViewerViewInstances,
+                                                              notificationsObserverInstances,
+                                                              viewInstances,
+                                                              screenResizeEventObserver);
+
+        when(paletteWidgetFactory.newPalette(anyString())).thenReturn(paletteWidget);
+        when(editorToolbarFactoryInstances.build(clientFullSession)).thenReturn(toolbar);
+
+        when(clientFullSession.getCanvasHandler()).thenReturn(canvasHandler);
+
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+
+        when(diagram.getMetadata()).thenReturn(Mockito.mock(Metadata.class));
+
+        when(paletteWidgetFactory.newPalette(anyString(),
+                                             any())).thenReturn(paletteWidget);
+
+        when(viewInstances.setPaletteWidget(any())).thenReturn(viewInstances);
+
+        sessionEditorPresenter.onSessionOpened(clientFullSession);
+    }
+
+    @Test
+    public void screenResizeEventTest() throws Exception {
+        screenResizeEventObserver.onEventReceived(new ScreenMaximizedEvent(true));
+        screenResizeEventObserver.onEventReceived(new ScreenMaximizedEvent(false));
+        screenResizeEventObserver.onEventReceived(new ScreenMinimizedEvent(true));
+        screenResizeEventObserver.onEventReceived(new ScreenMinimizedEvent(false));
+
+        InOrder inOrder = inOrder(paletteWidget);
+        inOrder.verify(paletteWidget).setVisible(true);
+        inOrder.verify(paletteWidget).setVisible(false);
+        inOrder.verify(paletteWidget,
+                       times(2)).setVisible(true);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -120,6 +120,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/annotation/DiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/annotation/DiagramEditor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenEventPublisher;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Qualifier to indicate a screen is a Stunner Diagram Editor. This information is mainly used to publish and
+ * observes events.
+ * See {@link ScreenEventPublisher}.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+public @interface DiagramEditor {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenEventPublisher.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenEventPublisher.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.event.screen;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
+import org.uberfire.client.mvp.ActivityBeansCache;
+import org.uberfire.client.workbench.events.AbstractPlaceEvent;
+import org.uberfire.client.workbench.events.PlaceMaximizedEvent;
+import org.uberfire.client.workbench.events.PlaceMinimizedEvent;
+
+/**
+ * Observes screen events and publish Stunner related events, e.g.
+ * {@link ScreenMaximizedEvent}, {@link ScreenMinimizedEvent}.
+ */
+@ApplicationScoped
+public class ScreenEventPublisher {
+
+  private Event<ScreenMaximizedEvent> diagramEditorMaximizedEventEvent;
+  private Event<ScreenMinimizedEvent> diagramEditorMinimizedEventEvent;
+  private ActivityBeansCache activityBeansCache;
+
+  @Inject
+  public ScreenEventPublisher(Event<ScreenMaximizedEvent> diagramEditorMaximizedEventEvent,
+                              Event<ScreenMinimizedEvent> diagramEditorMinimizedEventEvent,
+                              ActivityBeansCache activityBeansCache) {
+    this.diagramEditorMaximizedEventEvent = diagramEditorMaximizedEventEvent;
+    this.diagramEditorMinimizedEventEvent = diagramEditorMinimizedEventEvent;
+    this.activityBeansCache = activityBeansCache;
+  }
+
+  protected void onPlaceMaximizedEvent(@Observes PlaceMaximizedEvent event) {
+    diagramEditorMaximizedEventEvent.fire(new ScreenMaximizedEvent(verifyEventIdentifier(event)));
+  }
+
+  protected void onPlaceMinimizedEvent(@Observes PlaceMinimizedEvent event) {
+    diagramEditorMinimizedEventEvent.fire(new ScreenMinimizedEvent(verifyEventIdentifier(event)));
+  }
+
+  private boolean verifyEventIdentifier(AbstractPlaceEvent event) {
+    return activityBeansCache.getActivity(event.getPlace().getIdentifier()).getQualifiers().stream()
+        .anyMatch(a -> a instanceof DiagramEditor);
+  }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenMaximizedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenMaximizedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.event.screen;
+
+public class ScreenMaximizedEvent extends ScreenResizeEvent {
+
+    public ScreenMaximizedEvent(boolean diagramScreen) {
+        super(diagramScreen);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenMinimizedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenMinimizedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.event.screen;
+
+public class ScreenMinimizedEvent extends ScreenResizeEvent {
+
+    public ScreenMinimizedEvent(boolean diagramScreen) {
+        super(diagramScreen);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenResizeEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenResizeEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.event.screen;
+
+import java.util.Objects;
+
+public abstract class ScreenResizeEvent {
+
+    private boolean diagramScreen;
+
+    protected ScreenResizeEvent(boolean diagramScreen) {
+        this.diagramScreen = diagramScreen;
+    }
+
+    public boolean isDiagramScreen() {
+        return diagramScreen;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (Objects.isNull(obj) || getClass() != obj.getClass()){
+            return false;
+        }
+        return ((ScreenResizeEvent) obj).isDiagramScreen() == this.isDiagramScreen();
+    }
+
+    @Override
+    public int hashCode() {
+        return Boolean.hashCode(isDiagramScreen());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenResizeEventObserver.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenResizeEventObserver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.event.screen;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+
+/**
+ * Observes events {@link ScreenMaximizedEvent}, {@link ScreenMinimizedEvent} and trigger callbacks registered to
+ * events. This class is used when it is necessary to observe events on non CDI managed bean classes.
+ */
+@Dependent
+public class ScreenResizeEventObserver {
+
+    private Map<Class<? extends ScreenResizeEvent>, List<Consumer<? extends ScreenResizeEvent>>> consumers;
+
+    public ScreenResizeEventObserver(){
+        init();
+    }
+
+    private void init() {
+        consumers = new HashMap<>();
+    }
+
+    public void onEventReceived(@Observes ScreenMaximizedEvent event) {
+        consumers.get(event.getClass()).forEach(consumer -> ((Consumer<ScreenMaximizedEvent>) consumer).accept(event));
+    }
+
+    public void onEventReceived(@Observes ScreenMinimizedEvent event) {
+        consumers.get(event.getClass()).forEach(consumer -> ((Consumer<ScreenMinimizedEvent>) consumer).accept(event));
+    }
+
+    public <T extends ScreenResizeEvent> void registerEventCallback(Class<T> eventClass,
+                                                                    Consumer<T> callback) {
+        if (!this.consumers.containsKey(eventClass)) {
+            consumers.put(eventClass,
+                          new ArrayList<>());
+        }
+        this.consumers.get(eventClass).add(callback);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenEventPublisherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenEventPublisherTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.event.screen;
+
+import java.util.HashMap;
+import java.util.stream.Stream;
+import javax.enterprise.event.Event;
+
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.ActivityBeansCache;
+import org.uberfire.client.workbench.events.PlaceMaximizedEvent;
+import org.uberfire.client.workbench.events.PlaceMinimizedEvent;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+
+import static java.util.stream.Collectors.toSet;
+import static org.mockito.Mockito.*;
+import static sun.reflect.annotation.AnnotationParser.annotationForMap;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScreenEventPublisherTest {
+
+    private ScreenEventPublisher screenEventPublisher;
+
+    @Mock
+    private Event<ScreenMaximizedEvent> diagramEditorMaximizedEventEvent;
+
+    @Mock
+    private Event<ScreenMinimizedEvent> diagramEditorMinimizedEventEvent;
+
+    @Mock
+    private ActivityBeansCache activityBeansCache;
+
+    @Mock
+    private PlaceMaximizedEvent placeMaximizedEvent;
+
+    @Mock
+    private PlaceMinimizedEvent placeMinimizedEvent;
+
+    @Mock
+    private SyncBeanDef syncBeanDef;
+
+    @Before
+    public void setUp() throws Exception {
+
+        screenEventPublisher = new ScreenEventPublisher(diagramEditorMaximizedEventEvent,
+                                                        diagramEditorMinimizedEventEvent, activityBeansCache);
+
+        String screenId = "editor";
+        PlaceRequest placeRequest = new DefaultPlaceRequest(screenId);
+        when(placeMaximizedEvent.getPlace()).thenReturn(placeRequest);
+        when(placeMinimizedEvent.getPlace()).thenReturn(placeRequest);
+        when(activityBeansCache.getActivity(screenId)).thenReturn(syncBeanDef);
+
+        when(syncBeanDef.getQualifiers()).thenReturn(Stream.of(annotationForMap(
+                DiagramEditor.class, new HashMap<>())).collect(toSet()));
+
+    }
+
+    @Test
+    public void onPlaceMaximizedEventTest(){
+        screenEventPublisher.onPlaceMaximizedEvent(placeMaximizedEvent);
+        verify(diagramEditorMaximizedEventEvent, Mockito.times(1)).fire(new ScreenMaximizedEvent(true));
+
+        reset(syncBeanDef);
+
+        screenEventPublisher.onPlaceMaximizedEvent(placeMaximizedEvent);
+        verify(diagramEditorMaximizedEventEvent, Mockito.times(1)).fire(new ScreenMaximizedEvent(false));
+    }
+
+    @Test
+    public void onPlaceMinimizedEventTest(){
+        screenEventPublisher.onPlaceMinimizedEvent(placeMinimizedEvent);
+        verify(diagramEditorMinimizedEventEvent, Mockito.times(1)).fire(new ScreenMinimizedEvent(true));
+
+        reset(syncBeanDef);
+
+        screenEventPublisher.onPlaceMinimizedEvent(placeMinimizedEvent);
+        verify(diagramEditorMinimizedEventEvent, Mockito.times(1)).fire(new ScreenMinimizedEvent(false));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/docks/StunnerDocksHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/docks/StunnerDocksHandler.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramFocusEvent;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramLoseFocusEvent;
 import org.kie.workbench.common.workbench.client.docks.impl.AbstractWorkbenchDocksHandler;
@@ -58,5 +59,10 @@ public class StunnerDocksHandler extends AbstractWorkbenchDocksHandler {
     public void onDiagramLoseFocusEvent(@Observes OnDiagramLoseFocusEvent event) {
         refreshDocks(true,
                      true);
+    }
+
+    private void onDiagramEditorMaximized(@Observes ScreenMaximizedEvent event) {
+        refreshDocks(true,
+                     false);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -70,6 +70,7 @@ import org.kie.workbench.common.widgets.metadata.client.KieEditorView;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberView;
+import org.uberfire.client.workbench.events.AbstractPlaceEvent;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.events.PlaceGainFocusEvent;
 import org.uberfire.client.workbench.events.PlaceHiddenEvent;
@@ -118,15 +119,10 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
     private ExportToPngSessionCommand sessionExportImagePNGCommand;
     private ExportToJpgSessionCommand sessionExportImageJPGCommand;
     private ExportToPdfSessionCommand sessionExportPDFCommand;
-
     private Event<OnDiagramFocusEvent> onDiagramFocusEvent;
     private Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent;
     protected SessionPresenter<AbstractClientFullSession, ?, Diagram> presenter;
     private String title = "Project Diagram Editor";
-
-    AbstractProjectDiagramEditor() {
-
-    }
 
     @Inject
     public AbstractProjectDiagramEditor(final View view,
@@ -671,16 +667,21 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
         return getCurrentDiagramHash() != originalHash;
     }
 
+    private boolean verifyEventIdentifier(AbstractPlaceEvent event) {
+        return (Objects.equals(getEditorIdentifier(),
+                               event.getPlace().getIdentifier()) &&
+            Objects.equals(place,
+                           event.getPlace()));
+    }
+
     public void hideDiagramEditorDocks(@Observes PlaceHiddenEvent event) {
-        if (getEditorIdentifier().equals(event.getPlace().getIdentifier()) &&
-                place != null && place.equals(event.getPlace())) {
+        if (verifyEventIdentifier(event)) {
             onDiagramLostFocusEvent.fire(new OnDiagramLoseFocusEvent());
         }
     }
 
     public void showDiagramEditorDocks(@Observes PlaceGainFocusEvent event) {
-        if (getEditorIdentifier().equals(event.getPlace().getIdentifier()) &&
-                place != null && place.equals(event.getPlace())) {
+        if (verifyEventIdentifier(event)) {
             onDiagramFocusEvent.fire(new OnDiagramFocusEvent());
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
@@ -25,6 +25,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.kie.workbench.common.stunner.bpmn.factory.BPMNGraphFactory;
 import org.kie.workbench.common.stunner.bpmn.project.client.type.BPMNDiagramResourceType;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
+import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
@@ -56,6 +57,7 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.Menus;
 
 @Dependent
+@DiagramEditor
 @WorkbenchEditor(identifier = BPMNDiagramEditor.EDITOR_ID, supportedTypes = {BPMNDiagramResourceType.class})
 public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramResourceType> {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
@@ -25,6 +25,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.kie.workbench.common.stunner.bpmn.factory.BPMNGraphFactory;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
 import org.kie.workbench.common.stunner.cm.project.client.type.CaseManagementDiagramResourceType;
+import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
@@ -57,6 +58,7 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.Menus;
 
 @Dependent
+@DiagramEditor
 @WorkbenchEditor(identifier = CaseManagementDiagramEditor.EDITOR_ID, supportedTypes = {CaseManagementDiagramResourceType.class})
 public class CaseManagementDiagramEditor extends AbstractProjectDiagramEditor<CaseManagementDiagramResourceType> {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionDiagramEditorScreen.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.client.widgets.toolbar.impl.EditorToolba
 import org.kie.workbench.common.stunner.client.widgets.views.session.ScreenErrorView;
 import org.kie.workbench.common.stunner.client.widgets.views.session.ScreenPanelView;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
@@ -76,6 +77,7 @@ import static java.util.logging.Level.FINE;
 
 // TODO: i18n.
 @Dependent
+@DiagramEditor
 @WorkbenchScreen(identifier = SessionDiagramEditorScreen.SCREEN_ID)
 public class SessionDiagramEditorScreen {
 


### PR DESCRIPTION
Now the palette is being hidden when screens are maximized unless it is a diagram editor.

It was added an DiagramEditor annotation to identify screens that contains diagram editor and observer/publisher of this events.
SessionEditorPresenter is responsible to hide the palette based on the screen resize events.
StunnerDocksHandler hide docks when diagram is maximized, just used in project, not on standalone.
If you have any  questions or suggestions, it is always welcome.

@jomarko 
@hasys 
@manstis 