### PR TITLE
JBPM-6220: Unable to complete your request after setting the Show Time property to false.

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/date/DatePickerFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/date/DatePickerFieldRenderer.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date;
 import javax.enterprise.context.Dependent;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.extras.datepicker.client.ui.DatePicker;
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.DateTimePicker;
@@ -56,6 +57,7 @@ public class DatePickerFieldRenderer extends FieldRenderer<DatePickerFieldDefini
             box.setAutoClose(true);
             box.setHighlightToday(true);
             box.setShowTodayButton(true);
+            box.setContainer(RootPanel.get());
             handler = readOnly -> box.setEnabled(!readOnly);
             input = box;
         }


### PR DESCRIPTION
There was two issues here:
- a JS error going on when the component floating div was added to the DOM because the container for it wasn't initialized.
- a CSS issue when displaying the DatePicker floating div appear on scroll bars instead of overflow the layout element container.

This PR initializes the DatePicker with the container for the floating div, now it's being added to the body (as the DateTimePicker does by default) to avoid overflow issues.

@jsoltes can you review?