### PR TITLE
[7.3.x] JBPM-6389 : Upload file in task form is not working for eap7

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/document/DocumentFieldRendererViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/document/DocumentFieldRendererViewImpl.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsonUtils;
+import com.google.gwt.core.shared.GWT;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style;
@@ -43,6 +44,7 @@ import org.uberfire.ext.widgets.common.client.common.FileUploadFormEncoder;
 
 @Templated
 public class DocumentFieldRendererViewImpl extends Composite implements DocumentFieldRendererView {
+    public static String UPLOAD_FILE_SERVLET_URL_PATTERN = "documentUploadServlet";
 
     public final String SIZE_UNITS[] = new String[]{"bytes", "Kb", "Mb"};
 
@@ -54,9 +56,9 @@ public class DocumentFieldRendererViewImpl extends Composite implements Document
     protected DivElement inputContainer = Document.get().createDivElement();
 
     @DataField
-    protected Form documentForm = new Form();
+    protected Form documentForm = GWT.create(Form.class);
 
-    private FileUploadFormEncoder formEncoder = new FileUploadFormEncoder();
+    private FileUploadFormEncoder formEncoder = GWT.create(FileUploadFormEncoder.class);
 
     protected FileUpload uploader;
 
@@ -79,7 +81,7 @@ public class DocumentFieldRendererViewImpl extends Composite implements Document
         uploader.setName("document");
         documentForm.setEncoding(FormPanel.ENCODING_MULTIPART);
         documentForm.setMethod(FormPanel.METHOD_POST);
-        documentForm.setAction("/documentUploadServlet");
+        documentForm.setAction(UPLOAD_FILE_SERVLET_URL_PATTERN);
         formEncoder.addUtf8Charset(documentForm);
         documentForm.add(uploader);
         documentForm.addSubmitCompleteHandler(event -> {

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/test/java/org/kie/workbench/common/forms/jbpm/client/document/DocumentFieldRendererViewImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/test/java/org/kie/workbench/common/forms/jbpm/client/document/DocumentFieldRendererViewImplTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.jbpm.client.document;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.Form;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DocumentFieldRendererViewImplTest {
+
+    @GwtMock
+    protected Form documentForm;
+
+    @InjectMocks
+    private DocumentFieldRendererViewImpl documentFieldRendererView;
+
+    @Test
+    public void testInitDocumentFieldActionWithRelativeURL() {
+        documentFieldRendererView.initForm();
+        final ArgumentCaptor<String> actionCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(documentForm).setAction(actionCaptor.capture());
+
+        assertFalse(actionCaptor.getValue().startsWith("/"));
+        assertEquals(DocumentFieldRendererViewImpl.UPLOAD_FILE_SERVLET_URL_PATTERN, actionCaptor.getValue());
+    }
+
+}


### PR DESCRIPTION
changed the reference to the document upload file servlet, making it relative removing the slash