### PR TITLE
JBPM-6164: Stunner - Adding new nodes from toolbox can fail with containment rule violations

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/index/bounds/CanvasBoundsIndexerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/index/bounds/CanvasBoundsIndexerImpl.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.index.bounds.CanvasBoundsIndexer;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.processing.index.bounds.BoundsIndexer;
@@ -32,7 +33,7 @@ import org.kie.workbench.common.stunner.core.graph.processing.index.bounds.Bound
 @Dependent
 public class CanvasBoundsIndexerImpl implements CanvasBoundsIndexer<AbstractCanvasHandler> {
 
-    private AbstractCanvasHandler canvasHandler;
+    AbstractCanvasHandler canvasHandler;
 
     public BoundsIndexer<AbstractCanvasHandler, Node<View<?>, Edge>> build(final AbstractCanvasHandler context) {
         this.canvasHandler = context;
@@ -54,6 +55,81 @@ public class CanvasBoundsIndexerImpl implements CanvasBoundsIndexer<AbstractCanv
                 return canvasHandler.getGraphIndex().getNode(shape.getUUID());
             }
         }
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Node<View<?>, Edge> getAt(final double x,
+                                     final double y,
+                                     final double width,
+                                     final double height,
+                                     final Element parentNode) {
+        final AbstractCanvas canvas = canvasHandler.getAbstractCanvas();
+        final LienzoLayer lienzoLayer = (LienzoLayer) canvas.getLayer();
+        Node node;
+
+        final String viewUUID_UL = LienzoLayerUtils.getUUID_At(lienzoLayer,
+                                                               x,
+                                                               y);
+
+        final String viewUUID_UR = LienzoLayerUtils.getUUID_At(lienzoLayer,
+                                                               x + width,
+                                                               y);
+
+        final String viewUUID_CC = LienzoLayerUtils.getUUID_At(lienzoLayer,
+                                                               x + (width / 2),
+                                                               y + (height / 2));
+        final String viewUUID_LL = LienzoLayerUtils.getUUID_At(lienzoLayer,
+                                                               x,
+                                                               y + height);
+        final String viewUUID_LR = LienzoLayerUtils.getUUID_At(lienzoLayer,
+                                                               x + width,
+                                                               y + height);
+
+        if (null != viewUUID_UL && viewUUID_UL.trim().length() > 0) {
+            final Shape<?> shape = canvas.getShape(viewUUID_UL);
+            if (null != shape) {
+
+                node = canvasHandler.getGraphIndex().getNode(shape.getUUID());
+                if (node != parentNode) {
+                    return node;
+                }
+            }
+        } else if (null != viewUUID_UR && viewUUID_UR.trim().length() > 0) {
+            final Shape<?> shape = canvas.getShape(viewUUID_UR);
+            if (null != shape) {
+                node = canvasHandler.getGraphIndex().getNode(shape.getUUID());
+                if (node != parentNode) {
+                    return node;
+                }
+            }
+        } else if (null != viewUUID_CC && viewUUID_CC.trim().length() > 0) {
+            final Shape<?> shape = canvas.getShape(viewUUID_CC);
+            if (null != shape) {
+                node = canvasHandler.getGraphIndex().getNode(shape.getUUID());
+                if (node != parentNode) {
+                    return node;
+                }
+            }
+        } else if (null != viewUUID_LL && viewUUID_LL.trim().length() > 0) {
+            final Shape<?> shape = canvas.getShape(viewUUID_LL);
+            if (null != shape) {
+                node = canvasHandler.getGraphIndex().getNode(shape.getUUID());
+                if (node != parentNode) {
+                    return node;
+                }
+            }
+        } else if (null != viewUUID_LR && viewUUID_LR.trim().length() > 0) {
+            final Shape<?> shape = canvas.getShape(viewUUID_LR);
+            if (null != shape) {
+                node = canvasHandler.getGraphIndex().getNode(shape.getUUID());
+                if (node != parentNode) {
+                    return node;
+                }
+            }
+        }
+
         return null;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/index/bounds/CanvasBoundsIndexerImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/index/bounds/CanvasBoundsIndexerImplTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.canvas.index.bounds;
+
+import com.ait.lienzo.client.core.shape.Layer;
+import com.ait.lienzo.client.core.shape.Shape;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoLayer;
+import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresUtils;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CanvasBoundsIndexerImplTest {
+
+    private static final String SHAPE_UUID = "test";
+    @Mock
+    private AbstractCanvasHandler abstractCanvasHandler;
+
+    @Mock
+    private LienzoLayer lienzoLayer;
+
+    @Mock
+    private Layer layer;
+
+    @Mock
+    private AbstractCanvas abstractCanvas;
+
+    @Mock
+    private Shape shape;
+
+    @Mock
+    private WiresUtils.UserData userdata;
+
+    @Mock
+    private org.kie.workbench.common.stunner.core.client.shape.Shape canvasShape;
+
+    @Mock
+    private Index graphIndex;
+
+    @Mock
+    private Node node1;
+
+    @Mock
+    private Node parentNode;
+
+    private CanvasBoundsIndexerImpl canvasBoundsIndexerImpl;
+
+    @Before
+    public void setup() {
+        when(abstractCanvasHandler.getAbstractCanvas()).thenReturn(abstractCanvas);
+        when(abstractCanvasHandler.getAbstractCanvas().getLayer()).thenReturn(lienzoLayer);
+        when(lienzoLayer.getLienzoLayer()).thenReturn(layer);
+        when(lienzoLayer.getLienzoLayer().getLayer()).thenReturn(layer);
+
+        when(shape.getUserData()).thenReturn(userdata);
+
+        when(userdata.getUuid()).thenReturn(SHAPE_UUID);
+        when(abstractCanvas.getShape(SHAPE_UUID)).thenReturn(canvasShape);
+
+        when(abstractCanvasHandler.getGraphIndex()).thenReturn(graphIndex);
+
+        when(abstractCanvasHandler.getGraphIndex().getNode(SHAPE_UUID)).thenReturn(node1);
+        when(canvasShape.getUUID()).thenReturn(SHAPE_UUID);
+
+        canvasBoundsIndexerImpl = new CanvasBoundsIndexerImpl();
+        canvasBoundsIndexerImpl.build(
+                abstractCanvasHandler);
+    }
+
+    @Test
+    public void testGetAt() {
+        when(lienzoLayer.getLienzoLayer().getLayer().findShapeAtPoint(eq(20),
+                                                                      eq(20))).thenReturn(shape);
+        Node<View<?>, Edge> node = canvasBoundsIndexerImpl.getAt(20,
+                                                                 20);
+        assertNotNull(node);
+        Node<View<?>, Edge> nodeAtFreePosition = canvasBoundsIndexerImpl.getAt(400,
+                                                                               400);
+        assertNull(nodeAtFreePosition);
+    }
+
+    @Test
+    public void testGetAreaAtUL() {
+        when(lienzoLayer.getLienzoLayer().getLayer().findShapeAtPoint(eq(20),
+                                                                      eq(20))).thenReturn(shape);
+        Node<View<?>, Edge> node = canvasBoundsIndexerImpl.getAt(20,
+                                                                 20,
+                                                                 100,
+                                                                 100,
+                                                                 parentNode);
+        assertNotNull(node);
+    }
+
+    @Test
+    public void testGetAreaAtUR() {
+        when(lienzoLayer.getLienzoLayer().getLayer().findShapeAtPoint(eq(120),
+                                                                      eq(20))).thenReturn(shape);
+        Node<View<?>, Edge> node = canvasBoundsIndexerImpl.getAt(20,
+                                                                 20,
+                                                                 100,
+                                                                 100,
+                                                                 parentNode);
+        assertNotNull(node);
+    }
+
+    @Test
+    public void testGetAreaAtCC() {
+        when(lienzoLayer.getLienzoLayer().getLayer().findShapeAtPoint(eq(70),
+                                                                      eq(70))).thenReturn(shape);
+        Node<View<?>, Edge> node = canvasBoundsIndexerImpl.getAt(20,
+                                                                 20,
+                                                                 100,
+                                                                 100,
+                                                                 parentNode);
+        assertNotNull(node);
+    }
+
+    @Test
+    public void testGetAreaAtWhitParentLL() {
+        when(lienzoLayer.getLienzoLayer().getLayer().findShapeAtPoint(eq(20),
+                                                                      eq(120))).thenReturn(shape);
+        Node<View<?>, Edge> node = canvasBoundsIndexerImpl.getAt(20,
+                                                                 20,
+                                                                 100,
+                                                                 100,
+                                                                 parentNode);
+        assertNotNull(node);
+    }
+
+    @Test
+    public void testGetAreaAtWhitParentLR() {
+        when(lienzoLayer.getLienzoLayer().getLayer().findShapeAtPoint(eq(120),
+                                                                      eq(120))).thenReturn(shape);
+        Node<View<?>, Edge> node = canvasBoundsIndexerImpl.getAt(20,
+                                                                 20,
+                                                                 100,
+                                                                 100,
+                                                                 parentNode);
+        assertNotNull(node);
+    }
+
+    @Test
+    public void testGetAreaAtFreePosition() {
+        Node<View<?>, Edge> nodeFreePosition = canvasBoundsIndexerImpl.getAt(0,
+                                                                             600,
+                                                                             100,
+                                                                             10,
+                                                                             parentNode);
+        assertNull(nodeFreePosition);
+    }
+
+    @Test
+    public void testDestroy() {
+        canvasBoundsIndexerImpl.destroy();
+        assertNull(canvasBoundsIndexerImpl.canvasHandler);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/index/bounds/BoundsIndexer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/index/bounds/BoundsIndexer.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.graph.processing.index.bounds;
 
+import org.kie.workbench.common.stunner.core.graph.Element;
+
 public interface BoundsIndexer<C, T> {
 
     /**
@@ -28,6 +30,15 @@ public interface BoundsIndexer<C, T> {
      */
     T getAt(final double x,
             final double y);
+
+    /**
+     * Return the graph element at the given area starting from x,y cartesian coordinate, checking 5 points.
+     */
+    T getAt(final double x,
+            final double y,
+            final double width,
+            final double height,
+            final Element parentNode);
 
     /**
      * Determines a rectangle area which area is given as:

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/AbstractElementBuilderControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/AbstractElementBuilderControl.java
@@ -143,15 +143,12 @@ public abstract class AbstractElementBuilderControl extends AbstractCanvasHandle
         }
         double x = 0;
         double y = 0;
-        if (request.getX() == -1 || request.getY() == -1) {
-            // TODO: Use the right size of the target element to be created.
-            final double[] p = canvasLayoutUtils.getNext(canvasHandler,
-                                                         75);
-            x = p[0] + 50;
-            y = p[1] > 0 ? p[1] : 200;
-        } else {
+
+        if ((x>=0) && (y>=0)){
             x = request.getX();
             y = request.getY();
+        } else {
+            throw new IllegalArgumentException("Coordinates locations cannot be negative");
         }
         final Object definition = request.getDefinition();
         // Notify processing starts.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeAction.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -51,9 +52,8 @@ import org.kie.workbench.common.stunner.core.util.UUID;
 @Dependent
 public class CreateNodeAction extends AbstractToolboxAction {
 
-    private static Logger LOGGER = Logger.getLogger(CreateNodeAction.class.getName());
     static final String KEY_TITLE = "org.kie.workbench.common.stunner.core.client.toolbox.createNewNode";
-
+    private static Logger LOGGER = Logger.getLogger(CreateNodeAction.class.getName());
     private final ClientFactoryManager clientFactoryManager;
     private final NodeBuilderControl<AbstractCanvasHandler> nodeBuilderControl;
     private final CanvasLayoutUtils canvasLayoutUtils;
@@ -80,22 +80,22 @@ public class CreateNodeAction extends AbstractToolboxAction {
         this.sessionCommandManager = sessionCommandManager;
     }
 
+    public String getNodeId() {
+        return nodeId;
+    }
+
     public CreateNodeAction setNodeId(final String nodeId) {
         this.nodeId = nodeId;
         return this;
     }
 
+    public String getEdgeId() {
+        return edgeId;
+    }
+
     public CreateNodeAction setEdgeId(final String edgeId) {
         this.edgeId = edgeId;
         return this;
-    }
-
-    public String getNodeId() {
-        return nodeId;
-    }
-
-    public String getEdgeId() {
-        return edgeId;
     }
 
     @Override
@@ -142,16 +142,16 @@ public class CreateNodeAction extends AbstractToolboxAction {
         connector.setTargetNode(targetNode);
 
         // Obtain the candidate locatrions for the target node.
-        final double[] location = canvasLayoutUtils.getNext(canvasHandler,
-                                                            sourceNode,
-                                                            targetNode);
+        final Point2D location = canvasLayoutUtils.getNext(canvasHandler,
+                                                           sourceNode,
+                                                           targetNode);
 
         // Build both node and connector elements, shapes, etc etc.
         final MagnetConnection sourceConnection = MagnetConnection.Builder.forElement(element);
         final MagnetConnection targetConnection = MagnetConnection.Builder.forElement(targetNode);
         final NodeBuildRequestImpl buildRequest =
-                new NodeBuildRequestImpl(location[0],
-                                         location[1],
+                new NodeBuildRequestImpl(location.getX(),
+                                         location.getY(),
                                          targetNode,
                                          connector,
                                          sourceConnection,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeActionTest.java
@@ -42,6 +42,7 @@ import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -208,7 +209,8 @@ public class CreateNodeActionTest {
         when(canvasLayoutUtils.getNext(eq(canvasHandler),
                                        eq(element),
                                        eq(targetNode)))
-                .thenReturn(new double[]{100d, 500d});
+                .thenReturn(new Point2D(100d,
+                                        500d));
         final MouseClickEvent event = mock(MouseClickEvent.class);
         when(event.getX()).thenReturn(100d);
         when(event.getY()).thenReturn(500d);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/processing/indexing/bounds/GraphBoundsIndexerImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/processing/indexing/bounds/GraphBoundsIndexerImplTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.processing.indexing.bounds;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
+import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.processing.index.bounds.GraphBoundsIndexerImpl;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessor;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessorImpl;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessorImpl;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GraphBoundsIndexerImplTest {
+
+    private TestingGraphMockHandler graphTestHandler;
+    private TestingGraphInstanceBuilder.TestGraph1 graphInstance;
+
+    private TestingGraphMockHandler graphTestHandlerParent;
+    private TestingGraphInstanceBuilder.TestGraph2 graphInstanceParent;
+
+    private GraphBoundsIndexerImpl graphBoundsIndexerImpl;
+
+    @Before
+    public void setup() {
+        this.graphTestHandlerParent = new TestingGraphMockHandler();
+        graphInstanceParent = TestingGraphInstanceBuilder.newGraph2(graphTestHandlerParent);
+
+        ChildrenTraverseProcessor childrenTraverseProcessor = new ChildrenTraverseProcessorImpl(new TreeWalkTraverseProcessorImpl());
+        graphBoundsIndexerImpl = new GraphBoundsIndexerImpl(childrenTraverseProcessor);
+        graphBoundsIndexerImpl.build(graphInstanceParent.graph);
+    }
+
+    @Test
+    public void testGetAt() {
+
+        Point2D position = GraphUtils.getPosition((View) graphInstanceParent.startNode.getContent());
+        double[] size = GraphUtils.getNodeSize((View) graphInstanceParent.startNode.getContent());
+        double getAtX = position.getX() + (size[0] / 2);
+        double getAtY = position.getY() + (size[1] / 2);
+        Node<View<?>, Edge> node = graphBoundsIndexerImpl.getAt(getAtX,
+                                                                getAtY);
+        assertNotNull(node);
+    }
+
+    @Test
+    public void testGetAreaAt() {
+
+        Point2D position = GraphUtils.getPosition((View) graphInstanceParent.startNode.getContent());
+        double[] size = GraphUtils.getNodeSize((View) graphInstanceParent.startNode.getContent());
+        double getAtX = position.getX() + (size[0] / 2);
+        double getAtY = position.getY() + (size[1] / 2);
+
+        Node<View<?>, Edge> node = graphBoundsIndexerImpl.getAt(getAtX,
+                                                                getAtY,
+                                                                size[0],
+                                                                size[1],
+                                                                null);
+        assertNotNull(node);
+        Node<View<?>, Edge> nodeFreePosition = graphBoundsIndexerImpl.getAt(getAtX,
+                                                                            getAtY + 200,
+                                                                            size[0],
+                                                                            size[1],
+                                                                            null);
+        assertNull(nodeFreePosition);
+    }
+
+    @Test
+    public void testGetAreaAtWithParent() {
+        Point2D position = GraphUtils.getPosition((View) graphInstanceParent.startNode.getContent());
+        double[] size = GraphUtils.getNodeSize((View) graphInstanceParent.startNode.getContent());
+        double getAtX = position.getX() + (size[0] / 2);
+        double getAtY = position.getY() + (size[1] / 2);
+        Node<View<?>, Edge> node = graphBoundsIndexerImpl.getAt(getAtX,
+                                                                getAtY,
+                                                                size[0],
+                                                                size[1],
+                                                                graphInstanceParent.parentNode);
+
+        assertNotNull(node);
+        Node<View<?>, Edge> nodeAtFreePosition = graphBoundsIndexerImpl.getAt(getAtX,
+                                                                              getAtY + 200,
+                                                                              size[0],
+                                                                              size[1],
+                                                                              graphInstanceParent.parentNode);
+        assertNull(nodeAtFreePosition);
+    }
+
+    @Test
+    public void testGetTrimmedBounds() {
+        Point2D position = GraphUtils.getPosition((View) graphInstanceParent.startNode.getContent());
+        double[] size = GraphUtils.getNodeSize((View) graphInstanceParent.startNode.getContent());
+        double[] trimmedBounds = graphBoundsIndexerImpl.getTrimmedBounds();
+        assertEquals(trimmedBounds[0],
+                     position.getX(),
+                     0.001);
+        assertEquals(trimmedBounds[1],
+                     position.getY(),
+                     0.001);
+        assertEquals(trimmedBounds[2],
+                     size[0],
+                     0.001);
+        assertEquals(trimmedBounds[3],
+                     size[1],
+                     0.001);
+    }
+}


### PR DESCRIPTION
Hi @hasys , @manstis , @romartin ,
Now It's possible to add  new nodes from toolbox without containment rule violations. 
The final position for the new target node is dinamically evaluated.

For more information see [this ticket](https://issues.jboss.org/browse/JBPM-6164).

Could you please review this PR?

Thanks.