### PR TITLE
[7.3.x] JBPM-6354, GUVNOR-3457, GUVNOR-3176

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/LibraryService.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/LibraryService.java
@@ -19,7 +19,9 @@ package org.kie.workbench.common.screens.library.api;
 import java.util.List;
 import java.util.Set;
 
+import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.DeploymentMode;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.repositories.Repository;
 import org.jboss.errai.bus.server.annotations.Remote;
@@ -43,7 +45,8 @@ public interface LibraryService {
                              final OrganizationalUnit selectedOrganizationalUnit,
                              final Repository selectedRepository,
                              final String baseURL,
-                             final String projectDescription);
+                             final String projectDescription,
+                             final DeploymentMode mode);
 
     Boolean thereIsAProjectInTheWorkbench();
 
@@ -64,4 +67,7 @@ public interface LibraryService {
     Project importProject(final ExampleProject exampleProject);
 
     List<OrganizationalUnit> getOrganizationalUnits();
+
+    GAV createGAV(final String projectName,
+                  final OrganizationalUnit selectedOrganizationalUnit);
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
@@ -167,17 +167,15 @@ public class LibraryServiceImpl implements LibraryService {
                                     final OrganizationalUnit selectedOrganizationalUnit,
                                     final Repository selectedRepository,
                                     final String baseURL,
-                                    final String projectDescription) {
+                                    final String projectDescription,
+                                    final DeploymentMode mode) {
         final Path selectedRepositoryRootPath = selectedRepository.getRoot();
-        final LibraryPreferences preferences = getPreferences();
 
         final GAV gav = createGAV(projectName,
-                                  preferences,
                                   selectedOrganizationalUnit);
         final POM pom = createPOM(projectName,
                                   projectDescription,
                                   gav);
-        final DeploymentMode mode = DeploymentMode.VALIDATED;
 
         final KieProject kieProject = kieProjectService.newProject(selectedRepositoryRootPath,
                                                                    pom,
@@ -318,6 +316,16 @@ public class LibraryServiceImpl implements LibraryService {
         return new ArrayList<>(ouService.getOrganizationalUnits());
     }
 
+    @Override
+    public GAV createGAV(final String projectName,
+                         final OrganizationalUnit selectedOrganizationalUnit) {
+        final LibraryPreferences preferences = getPreferences();
+        return new GAV(selectedOrganizationalUnit.getDefaultGroupId(),
+                       projectName.replace(" ",
+                                           ""),
+                       preferences.getProjectPreferences().getVersion());
+    }
+
     LibraryPreferences getPreferences() {
         preferences.load();
         return preferences;
@@ -334,15 +342,6 @@ public class LibraryServiceImpl implements LibraryService {
         return new POM(projectName,
                        projectDescription,
                        gav);
-    }
-
-    GAV createGAV(final String projectName,
-                  final LibraryPreferences preferences,
-                  final OrganizationalUnit selectedOrganizationalUnit) {
-        return new GAV(selectedOrganizationalUnit.getDefaultGroupId(),
-                       projectName.replace(" ",
-                                           ""),
-                       preferences.getProjectPreferences().getVersion());
     }
 
     private Optional<Object> getAttribute(final String attribute,

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
@@ -27,6 +27,7 @@ import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.common.services.project.model.POM;
 import org.guvnor.common.services.project.model.Package;
 import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.DeploymentMode;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
 import org.guvnor.structure.repositories.Repository;
@@ -279,12 +280,13 @@ public class LibraryServiceImplTest {
                                      organizationalUnit,
                                      repository,
                                      "baseURL",
-                                     "description");
+                                     "description",
+                                     DeploymentMode.VALIDATED);
 
         verify(kieProjectService).newProject(eq(projectRootPath),
                                              pomArgumentCaptor.capture(),
                                              eq("baseURL"),
-                                             any());
+                                             eq(DeploymentMode.VALIDATED));
 
         final POM pom = pomArgumentCaptor.getValue();
         assertEquals("ouGroupID",
@@ -581,7 +583,6 @@ public class LibraryServiceImplTest {
         when(preferences.getProjectPreferences().getDescription()).thenReturn("desc");
 
         GAV gav = libraryService.createGAV("proj",
-                                           preferences,
                                            organizationalUnit);
         POM proj = libraryService.createPOM("proj",
                                             "description",
@@ -603,7 +604,6 @@ public class LibraryServiceImplTest {
         when(preferences.getProjectPreferences().getVersion()).thenReturn("1.0");
 
         GAV gav = libraryService.createGAV("proj",
-                                           preferences,
                                            organizationalUnit);
 
         assertEquals(organizationalUnit.getDefaultGroupId(),

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryScreen.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.screens.library.client.screens;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
@@ -86,6 +87,7 @@ public class LibraryScreen {
         this.projectDetailEvent = projectDetailEvent;
         this.libraryService = libraryService;
         this.projectController = projectController;
+        this.projects = Collections.emptyList();
     }
 
     @PostConstruct
@@ -119,7 +121,7 @@ public class LibraryScreen {
 
     public List<Project> filterProjects(final String filter) {
         List<Project> filteredProjects = projects.stream()
-                .filter(p -> p.getProjectName().toUpperCase().startsWith(filter.toUpperCase()))
+                .filter(p -> p.getProjectName().toUpperCase().contains(filter.toUpperCase()))
                 .collect(Collectors.toList());
 
         updateView(filteredProjects);

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/LibraryScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/LibraryScreenTest.java
@@ -150,6 +150,10 @@ public class LibraryScreenTest {
                      libraryScreen.projects.size());
         assertEquals(1,
                      libraryScreen.filterProjects("project1").size());
+        assertEquals(1,
+                     libraryScreen.filterProjects("roject1").size());
+        assertEquals(0,
+                     libraryScreen.filterProjects("unexistent").size());
     }
 
     @Test
@@ -158,5 +162,17 @@ public class LibraryScreenTest {
 
         verify(view).setFilterName("name");
         verify(libraryScreen).filterProjects("name");
+    }
+
+    @Test
+    public void projectsAreNotNullAfterInjection() {
+        final LibraryScreen libraryScreen = spy(new LibraryScreen(view,
+                                                                  placeManager,
+                                                                  libraryPlaces,
+                                                                  projectDetailEvent,
+                                                                  libraryServiceCaller,
+                                                                  projectController));
+
+        assertNotNull(libraryScreen.projects);
     }
 }


### PR DESCRIPTION
JBPM-6354: Cryptic error message when trying to create a project with name that already exists in Maven repo
GUVNOR-3457: [Library] edge case when filtering projects by name leads to javascript error
GUVNOR-3176: [Library] Filtering assets and projects is not unified