### PR TITLE
GUVNOR-3479 : [GSS-RFE] Add support for missing keywords like "not matches" condition in Guided Rule

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImplTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImplTest.java
@@ -480,7 +480,7 @@ public class AsyncPackageDataModelOracleImplTest {
         Callback<String[]> callback = spy(new Callback<String[]>() {
             @Override
             public void callback(String[] result) {
-                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "soundslike", "== null", "!= null", "in", "not in"},
+                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null", "in", "not in"},
                                   result);
             }
         });

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelOracleCompletionsTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelOracleCompletionsTest.java
@@ -15,8 +15,6 @@
 
 package org.kie.workbench.common.widgets.client.datamodel;
 
-import javax.enterprise.inject.Instance;
-
 import org.appformer.project.datamodel.oracle.DataType;
 import org.appformer.project.datamodel.oracle.FieldAccessorsAndMutators;
 import org.appformer.project.datamodel.oracle.ModelField;
@@ -33,8 +31,10 @@ import org.mockito.Mock;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.callbacks.Callback;
 
-import static org.junit.Assert.*;
-import static org.kie.workbench.common.widgets.client.datamodel.PackageDataModelOracleTestUtils.*;
+import javax.enterprise.inject.Instance;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.widgets.client.datamodel.PackageDataModelOracleTestUtils.assertContains;
 import static org.mockito.Mockito.*;
 
 /**
@@ -338,7 +338,7 @@ public class PackageDataModelOracleCompletionsTest {
         Callback<String[]> personNameCallback = spy( new Callback<String[]>() {
             @Override
             public void callback( final String[] personNameOperators ) {
-                assertEquals( 12,
+                assertEquals( 14,
                               personNameOperators.length );
                 assertEquals( "==",
                               personNameOperators[ 0 ] );
@@ -353,17 +353,21 @@ public class PackageDataModelOracleCompletionsTest {
                 assertEquals( ">=",
                               personNameOperators[ 5 ] );
                 assertEquals( "matches",
-                              personNameOperators[ 6 ] );
+                              personNameOperators[ 6 ]);
+                assertEquals( "not matches",
+                              personNameOperators[ 7 ]);
                 assertEquals( "soundslike",
-                              personNameOperators[ 7 ] );
+                              personNameOperators[ 8 ]);
+                assertEquals( "not soundslike",
+                              personNameOperators[ 9 ]);
                 assertEquals( "== null",
-                              personNameOperators[ 8 ] );
+                              personNameOperators[ 10 ]);
                 assertEquals( "!= null",
-                              personNameOperators[ 9 ] );
-                assertEquals( "in",
-                              personNameOperators[ 10 ] );
-                assertEquals( "not in",
                               personNameOperators[ 11 ] );
+                assertEquals( "in",
+                              personNameOperators[ 12 ] );
+                assertEquals( "not in",
+                              personNameOperators[ 13 ] );
             }
         } );
         oracle.getOperatorCompletions( "Person",


### PR DESCRIPTION
https://issues.jboss.org/browse/GUVNOR-3479

Looks like there were tests after all.