### PR TITLE
JBPM-6210: Triple click on full screen button breaks layout

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspective.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspective.java
@@ -29,6 +29,7 @@ import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.workbench.model.PerspectiveDefinitionOption;
 import org.uberfire.workbench.model.impl.PerspectiveDefinitionImpl;
 
 @ApplicationScoped
@@ -53,6 +54,7 @@ public class LibraryPerspective {
     public PerspectiveDefinition buildPerspective() {
         perspectiveDefinition = new PerspectiveDefinitionImpl(MultiListWorkbenchPanelPresenter.class.getName());
         perspectiveDefinition.setName("Library Perspective");
+        perspectiveDefinition.setOptions(PerspectiveDefinitionOption.MAXIMIZATION_DISABLED);
 
         return perspectiveDefinition;
     }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
@@ -21,7 +21,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
 import org.mockito.Mock;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.workbench.model.PerspectiveDefinitionOption;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 @RunWith(GwtMockitoTestRunner.class)
@@ -49,5 +52,12 @@ public class LibraryPerspectiveTest {
         perspective.onClose();
 
         verify(libraryPlaces).hideDocks();
+    }
+
+    @Test
+    public void maximizationIsDisabledForLibrary() {
+        final PerspectiveDefinition perspectiveDefinition = perspective.buildPerspective();
+
+        assertTrue(perspectiveDefinition.hasOption(PerspectiveDefinitionOption.MAXIMIZATION_DISABLED));
     }
 }


### PR DESCRIPTION
Maximization button was disabled on the Library Perspective, because it has no function there anymore, since the new menu has no compact view.