### PR TITLE
JBPM-6426: Use of Errai's embedded Wildfly server 10.1.0.Final

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
@@ -943,9 +943,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.wildfly</groupId>
+                  <groupId>org.jboss.errai</groupId>
                   <artifactId>wildfly-dist</artifactId>
-                  <version>${version.org.wildfly.gwt.sdm}</version>
+                  <version>${version.org.jboss.errai.wildfly}</version>
                   <type>zip</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}</outputDirectory>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/README.md
@@ -32,6 +32,7 @@ Running the application
         -Djava.util.prefs.syncInterval=2000000
         -Dorg.uberfire.async.executor.safemode=true
         -Dorg.uberfire.nio.git.dir=/tmp/dir
+        -Derrai.dynamic_validation.enabled=true
 
                       
   - *Dev mode parameters*: 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -952,9 +952,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.wildfly</groupId>
+                  <groupId>org.jboss.errai</groupId>
                   <artifactId>wildfly-dist</artifactId>
-                  <version>${version.org.wildfly.gwt.sdm}</version>
+                  <version>${version.org.jboss.errai.wildfly}</version>
                   <type>zip</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}</outputDirectory>


### PR DESCRIPTION
Hey @manstis @mbarkley @psiroky 
Here is the fix for using the version `10.1.0.Final` of the errai's embedded wildfly server.
Depends on this one https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/550 !!
Thanks!