### PR TITLE
[7.3.x] JBPM-5429: AssigneeEditor should not appear in the form-modeler.

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/EditorFieldTypesProvider.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/EditorFieldTypesProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.forms.editor.client;
+package org.kie.workbench.common.forms.editor.client.editor;
 
 import java.util.Collection;
 
@@ -24,5 +24,7 @@ public interface EditorFieldTypesProvider {
 
     int getPriority();
 
-    Collection<FieldType> getFieldTypes();
+    Collection<FieldType> getPaletteFieldTypes();
+
+    Collection<FieldType> getFieldPropertiesFieldTypes();
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/EditorFieldTypesProviderImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/EditorFieldTypesProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.forms.editor.client;
+package org.kie.workbench.common.forms.editor.client.editor;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import javax.annotation.Priority;
+import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.type.CheckBoxFieldType;
@@ -31,10 +32,32 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.r
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.type.SliderFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.type.TextBoxFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.type.MultipleSubFormFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.type.SubFormFieldType;
 import org.kie.workbench.common.forms.model.FieldType;
 
 @ApplicationScoped
 public class EditorFieldTypesProviderImpl implements EditorFieldTypesProvider {
+
+    private List<FieldType> paletteFieldTypes = new ArrayList<>();
+    private List<FieldType> fieldPropertiesFieldTypes = new ArrayList<>();
+
+    @PostConstruct
+    public void init() {
+        paletteFieldTypes.add(new TextBoxFieldType());
+        paletteFieldTypes.add(new TextAreaFieldType());
+        paletteFieldTypes.add(new IntegerBoxFieldType());
+        paletteFieldTypes.add(new DecimalBoxFieldType());
+        paletteFieldTypes.add(new CheckBoxFieldType());
+        paletteFieldTypes.add(new DatePickerFieldType());
+        paletteFieldTypes.add(new SliderFieldType());
+        paletteFieldTypes.add(new ListBoxFieldType());
+        paletteFieldTypes.add(new RadioGroupFieldType());
+        paletteFieldTypes.add(new PictureFieldType());
+        fieldPropertiesFieldTypes.addAll(paletteFieldTypes);
+        fieldPropertiesFieldTypes.add(new SubFormFieldType());
+        fieldPropertiesFieldTypes.add(new MultipleSubFormFieldType());
+    }
 
     @Override
     public int getPriority() {
@@ -42,21 +65,12 @@ public class EditorFieldTypesProviderImpl implements EditorFieldTypesProvider {
     }
 
     @Override
-    public Collection<FieldType> getFieldTypes() {
+    public Collection<FieldType> getPaletteFieldTypes() {
+        return paletteFieldTypes;
+    }
 
-        ArrayList<FieldType> types = new ArrayList<>();
-
-        types.add(new TextBoxFieldType());
-        types.add(new TextAreaFieldType());
-        types.add(new IntegerBoxFieldType());
-        types.add(new DecimalBoxFieldType());
-        types.add(new CheckBoxFieldType());
-        types.add(new DatePickerFieldType());
-        types.add(new SliderFieldType());
-        types.add(new ListBoxFieldType());
-        types.add(new RadioGroupFieldType());
-        types.add(new PictureFieldType());
-
-        return types;
+    @Override
+    public Collection<FieldType> getFieldPropertiesFieldTypes() {
+        return fieldPropertiesFieldTypes;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
@@ -33,7 +33,6 @@ import javax.inject.Inject;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
-import org.kie.workbench.common.forms.editor.client.EditorFieldTypesProvider;
 import org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent;
 import org.kie.workbench.common.forms.editor.model.FormModelerContent;
 import org.kie.workbench.common.forms.editor.service.shared.FormEditorRenderingContext;
@@ -61,14 +60,18 @@ public class FormEditorHelper {
 
     protected Map<String, Pair<EditorFieldLayoutComponent, FieldDefinition>> unbindedFields = new HashMap<>();
 
-    protected Collection<FieldType> editorFieldTypes = new ArrayList<>();
+    protected Collection<FieldType> enabledPaletteFieldTypes = new ArrayList<>();
+    protected Collection<FieldType> enabledFieldPropertiesFieldTypes = new ArrayList<>();
 
     @PostConstruct
     public void init() {
         Collection<SyncBeanDef<EditorFieldTypesProvider>> providers = IOC.getBeanManager().lookupBeans(EditorFieldTypesProvider.class);
         providers.stream().map(SyncBeanDef::getInstance)
                 .sorted((EditorFieldTypesProvider providerA, EditorFieldTypesProvider providerB) -> providerA.getPriority() - providerB.getPriority())
-                .forEach((EditorFieldTypesProvider editorProvider) -> editorFieldTypes.addAll(editorProvider.getFieldTypes()));
+                .forEach((EditorFieldTypesProvider editorProvider) -> {
+                    enabledPaletteFieldTypes.addAll(editorProvider.getPaletteFieldTypes());
+                    enabledFieldPropertiesFieldTypes.addAll(editorProvider.getFieldPropertiesFieldTypes());
+                });
     }
 
     @Inject
@@ -89,7 +92,7 @@ public class FormEditorHelper {
             return;
         }
 
-        for (FieldType baseType : editorFieldTypes) {
+        for (FieldType baseType : enabledPaletteFieldTypes) {
             EditorFieldLayoutComponent layoutComponent = editorFieldLayoutComponents.get();
             if (layoutComponent != null) {
                 FieldDefinition field = fieldManager.getDefinitionByFieldType(baseType);
@@ -208,7 +211,7 @@ public class FormEditorHelper {
     }
 
     public List<String> getCompatibleFieldTypes(FieldDefinition field) {
-        List<String> editorFieldTypeCodes = editorFieldTypes.stream().map(FieldType::getTypeName).collect(Collectors.toList());
+        List<String> editorFieldTypeCodes = enabledFieldPropertiesFieldTypes.stream().map(FieldType::getTypeName).collect(Collectors.toList());
         return fieldManager.getCompatibleFields(field).stream().filter((fieldCode) -> editorFieldTypeCodes.contains(fieldCode))
                 .collect(Collectors.toList());
     }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/EditorFieldTypesProviderImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/EditorFieldTypesProviderImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.editor.client.editor;
+
+import java.util.Collection;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.forms.model.FieldType;
+
+public class EditorFieldTypesProviderImplTest {
+
+    private static final int PALETTE_FIELD_TYPES_SIZE = 10;
+    private static final int EDITOR_FIELD_TYPES_SIZE = 12;
+
+    private EditorFieldTypesProviderImpl provider;
+
+    @Before
+    public void init() {
+        provider = new EditorFieldTypesProviderImpl();
+        provider.init();
+    }
+
+    @Test
+    public void testFunctionallity() {
+        Collection<FieldType> paletteComponents = provider.getPaletteFieldTypes();
+
+        Collection<FieldType> propertiesFieldType = provider.getFieldPropertiesFieldTypes();
+
+        Assertions.assertThat(paletteComponents)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(PALETTE_FIELD_TYPES_SIZE);
+
+        Assertions.assertThat(propertiesFieldType)
+                .isNotNull()
+                .isNotEmpty()
+                .containsAll(paletteComponents)
+                .hasSize(EDITOR_FIELD_TYPES_SIZE);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/test/TestFormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/test/TestFormEditorHelper.java
@@ -34,7 +34,8 @@ public class TestFormEditorHelper extends FormEditorHelper {
         super(fieldManager,
               editorFieldLayoutComponents);
         fieldManager.getAllBasicTypeProviders().stream().forEach((provider) -> {
-            editorFieldTypes.add(provider.getDefaultField().getFieldType());
+            enabledPaletteFieldTypes.add(provider.getDefaultField().getFieldType());
+            enabledFieldPropertiesFieldTypes.add(provider.getDefaultField().getFieldType());
         });
     }
 
@@ -43,6 +44,6 @@ public class TestFormEditorHelper extends FormEditorHelper {
     }
 
     public Collection<FieldType> getEditorFieldTypes() {
-        return editorFieldTypes;
+        return enabledPaletteFieldTypes;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/pom.xml
@@ -104,5 +104,11 @@
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/JBPMEditorFieldTypeProviderImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/JBPMEditorFieldTypeProviderImpl.java
@@ -18,14 +18,23 @@ package org.kie.workbench.common.forms.jbpm.client;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 
-import org.kie.workbench.common.forms.editor.client.EditorFieldTypesProvider;
+import org.kie.workbench.common.forms.editor.client.editor.EditorFieldTypesProvider;
 import org.kie.workbench.common.forms.jbpm.model.authoring.document.type.DocumentFieldType;
 import org.kie.workbench.common.forms.model.FieldType;
 
 @ApplicationScoped
 public class JBPMEditorFieldTypeProviderImpl implements EditorFieldTypesProvider {
+
+    private List<FieldType> supportedFieldTypes = new ArrayList<>();
+
+    @PostConstruct
+    public void init() {
+        supportedFieldTypes.add(new DocumentFieldType());
+    }
 
     @Override
     public int getPriority() {
@@ -33,12 +42,12 @@ public class JBPMEditorFieldTypeProviderImpl implements EditorFieldTypesProvider
     }
 
     @Override
-    public Collection<FieldType> getFieldTypes() {
+    public Collection<FieldType> getPaletteFieldTypes() {
+        return supportedFieldTypes;
+    }
 
-        ArrayList<FieldType> types = new ArrayList<>();
-
-        types.add(new DocumentFieldType());
-
-        return types;
+    @Override
+    public Collection<FieldType> getFieldPropertiesFieldTypes() {
+        return supportedFieldTypes;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/test/java/org/kie/workbench/common/forms/jbpm/client/JBPMEditorFieldTypeProviderImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/test/java/org/kie/workbench/common/forms/jbpm/client/JBPMEditorFieldTypeProviderImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.jbpm.client;
+
+import java.util.Collection;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.forms.model.FieldType;
+
+public class JBPMEditorFieldTypeProviderImplTest {
+
+    private static final int PALETTE_FIELD_TYPES_SIZE = 1;
+    private static final int EDITOR_FIELD_TYPES_SIZE = 1;
+
+    private JBPMEditorFieldTypeProviderImpl provider;
+
+    @Before
+    public void init() {
+        provider = new JBPMEditorFieldTypeProviderImpl();
+        provider.init();
+    }
+
+    @Test
+    public void testFunctionallity() {
+        Collection<FieldType> paletteComponents = provider.getPaletteFieldTypes();
+
+        Collection<FieldType> propertiesFieldType = provider.getFieldPropertiesFieldTypes();
+
+        Assertions.assertThat(paletteComponents)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(PALETTE_FIELD_TYPES_SIZE);
+
+        Assertions.assertThat(propertiesFieldType)
+                .isNotNull()
+                .isNotEmpty()
+                .containsAll(paletteComponents)
+                .hasSize(EDITOR_FIELD_TYPES_SIZE);
+    }
+}


### PR DESCRIPTION
Copy of https://github.com/kiegroup/kie-wb-common/pull/1177

This PR fixes a smaill issue introduced by previous commit.

@jsoltes could you please review?