### PR TITLE
[7.3.x] Remove redundant else branch from getFQCNByFactName method (#1175)

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImpl.java
@@ -255,11 +255,9 @@ public class AsyncPackageDataModelOracleImpl implements AsyncPackageDataModelOra
         return result;
     }
 
-    public String getFQCNByFactName( final String factName ) {
-        if ( factNameToFQCNHandleRegistry.contains( factName ) ) {
-            return factNameToFQCNHandleRegistry.get( factName );
-        } else if ( factName.contains( "." ) ) {
-            return factName;
+    public String getFQCNByFactName(final String factName) {
+        if (factNameToFQCNHandleRegistry.contains(factName)) {
+            return factNameToFQCNHandleRegistry.get(factName);
         } else {
             return factName;
         }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImplTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImplTest.java
@@ -323,12 +323,34 @@ public class AsyncPackageDataModelOracleImplTest {
     }
 
     @Test
-    public void testName() throws Exception {
-        assertEquals( "org.test.Person",
-                      oracle.getFQCNByFactName( "Person" ) );
-        assertEquals( "Person",
-                      oracle.getFieldClassName( "Person",
-                                                "this" ) );
+    public void testGetFieldClassName() throws Exception {
+        assertEquals("Person",
+                     oracle.getFieldClassName("Person",
+                                              "this"));
+    }
+
+    @Test
+    public void testGetFQCNByFactNameInRegistry() throws Exception {
+        assertEquals("org.test.Person",
+                     oracle.getFQCNByFactName("Person"));
+    }
+
+    @Test
+    public void testGetFQCNByFactNameInRegistryWithPackage() throws Exception {
+        assertEquals("org.test.Person",
+                     oracle.getFQCNByFactName("org.test.Person"));
+    }
+
+    @Test
+    public void testGetFQCNByFactNameUnknown() throws Exception {
+        assertEquals("UnknownPerson",
+                     oracle.getFQCNByFactName("UnknownPerson"));
+    }
+
+    @Test
+    public void testGetFQCNByFactNameUnknownWithPackage() throws Exception {
+        assertEquals("org.test.UnknownPerson",
+                     oracle.getFQCNByFactName("org.test.UnknownPerson"));
     }
 
     @Test


### PR DESCRIPTION
This is cherry-pick of #1175 