### PR TITLE
[7.3.x] JBPM-6409: In taskforms data inputs (if different than outpus) should be readonly by default. (Also fixes JBPM-5742)

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/pom.xml
@@ -130,6 +130,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-fields</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/BackendFieldManagerImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/BackendFieldManagerImpl.java
@@ -23,12 +23,15 @@ import javax.inject.Inject;
 import org.kie.workbench.common.forms.fields.shared.AbstractFieldManager;
 import org.kie.workbench.common.forms.fields.shared.FieldProvider;
 import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryManager;
 
 @ApplicationScoped
 public class BackendFieldManagerImpl extends AbstractFieldManager {
 
     @Inject
-    public BackendFieldManagerImpl(Instance<FieldProvider<? extends FieldDefinition>> providers) {
+    public BackendFieldManagerImpl(MetaDataEntryManager metaDataEntryManager,
+                                   Instance<FieldProvider<? extends FieldDefinition>> providers) {
+        super(metaDataEntryManager);
         for (FieldProvider provider : providers) {
             registerFieldProvider(provider);
         }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/fieldProcessors/TextAreaFormFieldValueProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/fieldProcessors/TextAreaFormFieldValueProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.fieldProcessors;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContext;
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.FieldValueProcessor;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
+
+@Dependent
+public class TextAreaFormFieldValueProcessor implements FieldValueProcessor<TextAreaFieldDefinition, Object, String> {
+
+    @Override
+    public Class<TextAreaFieldDefinition> getSupportedField() {
+        return TextAreaFieldDefinition.class;
+    }
+
+    @Override
+    public String toFlatValue(TextAreaFieldDefinition field,
+                              Object rawValue,
+                              BackendFormRenderingContext context) {
+        if(rawValue != null) {
+            return rawValue.toString();
+        }
+        return null;
+    }
+
+    @Override
+    public Object toRawValue(TextAreaFieldDefinition field,
+                             String flatValue,
+                             Object originalValue,
+                             BackendFormRenderingContext context) {
+        return flatValue;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/test/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/fieldProcessors/TextAreaFormFieldValueProcessorTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/test/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/fieldProcessors/TextAreaFormFieldValueProcessorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.fieldProcessors;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContext;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TextAreaFormFieldValueProcessorTest {
+
+    private TextAreaFormFieldValueProcessor processor = new TextAreaFormFieldValueProcessor();
+
+    @Mock
+    private TextAreaFieldDefinition field;
+
+    @Mock
+    private BackendFormRenderingContext context;
+
+    @Test
+    public void testProcessNullValue() {
+        String flatValue = processor.toFlatValue(field,
+                                                 null,
+                                                 context);
+
+        Assertions.assertThat(flatValue).isNull();
+
+        Object rawValue = processor.toRawValue(field,
+                                               null,
+                                               null,
+                                               context);
+        Assertions.assertThat(rawValue).isNull();
+    }
+
+    @Test
+    public void testProcessValue() {
+        Object value = new Object();
+
+        String flatValue = processor.toFlatValue(field,
+                                                 value,
+                                                 context);
+        Assertions.assertThat(flatValue)
+                .isNotNull()
+                .isNotEmpty()
+                .isEqualTo(value.toString());
+
+        Object rawValue = processor.toRawValue(field,
+                                               flatValue,
+                                               value,
+                                               context);
+
+        Assertions.assertThat(rawValue)
+                .isNotNull()
+                .hasToString(flatValue)
+                .hasToString(value.toString());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/test/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/fieldProcessors/time/LocalDateFieldValueProcessorTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/test/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/fieldProcessors/time/LocalDateFieldValueProcessorTest.java
@@ -37,13 +37,13 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class LocalDateFieldValueProcessorTest {
 
-    LocalDateFieldValueProcessor processor = new LocalDateFieldValueProcessor();
+    private LocalDateFieldValueProcessor processor = new LocalDateFieldValueProcessor();
 
     @Mock
-    DatePickerFieldDefinition field;
+    private DatePickerFieldDefinition field;
 
     @Mock
-    BackendFormRenderingContext context;
+    private BackendFormRenderingContext context;
 
     @Before
     public void init() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/helper/MapModelBindingHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/helper/MapModelBindingHelper.java
@@ -46,6 +46,8 @@ public class MapModelBindingHelper {
     @PostConstruct
     public void initialize() {
 
+        basicProperties.put(Object.class.getName(),
+                            Object.class);
         basicProperties.put(String.class.getName(),
                             String.class);
         basicProperties.put(Byte.class.getName(),

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRenderer.java
@@ -21,11 +21,13 @@ import javax.enterprise.context.Dependent;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.gwtbootstrap3.client.ui.TextArea;
+import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.ObjectToStringConverter;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
 
 @Dependent
-public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition> {
+public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition> implements RequiresValueConverter {
 
     @Override
     public String getName() {
@@ -61,5 +63,10 @@ public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition
     @Override
     protected void setReadOnly(boolean readOnly) {
         textArea.setEnabled(!readOnly);
+    }
+
+    @Override
+    public Converter getConverter() {
+        return field.getStandaloneClassName().equals(Object.class.getName()) ? new ObjectToStringConverter() : null;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/service/ClientFieldManagerImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/service/ClientFieldManagerImpl.java
@@ -18,14 +18,21 @@ package org.kie.workbench.common.forms.dynamic.client.service;
 import java.util.Collection;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.kie.workbench.common.forms.fields.shared.AbstractFieldManager;
 import org.kie.workbench.common.forms.fields.shared.FieldProvider;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryManager;
 
 @ApplicationScoped
 public class ClientFieldManagerImpl extends AbstractFieldManager {
+
+    @Inject
+    public ClientFieldManagerImpl(MetaDataEntryManager metaDataEntryManager) {
+        super(metaDataEntryManager);
+    }
 
     @PostConstruct
     protected void init() {

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/ObjectToStringConverter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/ObjectToStringConverter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.common.rendering.client.util.valueConverters;
+
+import org.jboss.errai.databinding.client.api.Converter;
+
+public class ObjectToStringConverter implements Converter<Object, String> {
+
+    @Override
+    public Class<Object> getModelType() {
+        return Object.class;
+    }
+
+    @Override
+    public Class<String> getComponentType() {
+        return String.class;
+    }
+
+    @Override
+    public Object toModelValue(String widgetValue) {
+        return widgetValue;
+    }
+
+    @Override
+    public String toWidgetValue(Object modelValue) {
+        if(modelValue != null) {
+            return modelValue.toString();
+        }
+        return null;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/ValueConvertersFactory.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/ValueConvertersFactory.java
@@ -40,6 +40,7 @@ public class ValueConvertersFactory {
         converters.put(Float.class.getName(), new FloatToDoubleConverter());
         converters.put(float.class.getName(), new FloatToDoubleConverter());
         converters.put(BigDecimal.class.getName(), new BigDecimalToDoubleConverter());
+        converters.put(Object.class.getName(), new ObjectToStringConverter());
     }
 
     public static Converter getConverterForType(String type) {

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/widgets/decimalBox/DecimalBoxViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/widgets/decimalBox/DecimalBoxViewImpl.java
@@ -48,7 +48,7 @@ public class DecimalBoxViewImpl extends Composite implements DecimalBoxView {
 
     @Override
     public void setEnabled(boolean enabled) {
-        input.setReadOnly(!enabled);
+        input.setDisabled(!enabled);
     }
 
     public void updateValue(Event event) {

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/widgets/integerBox/IntegerBoxViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/widgets/integerBox/IntegerBoxViewImpl.java
@@ -48,7 +48,7 @@ public class IntegerBoxViewImpl extends Composite implements IntegerBoxView {
 
     @Override
     public void setEnabled(boolean enabled) {
-        input.setReadOnly(!enabled);
+        input.setDisabled(!enabled);
     }
 
     public void updateValue(Event event) {

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/test/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/AbstractConverterTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/test/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/AbstractConverterTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 
 public abstract class AbstractConverterTest<MODEL_VALUE, WIDGET_VALUE> {
 
-    Converter converter;
+    protected Converter converter;
 
     @Before
     public void init() {

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/test/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/ObjectToStringConverterTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/test/java/org/kie/workbench/common/forms/common/rendering/client/util/valueConverters/ObjectToStringConverterTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.common.rendering.client.util.valueConverters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ObjectToStringConverterTest extends AbstractConverterTest<Object, String> {
+
+    private Object value = new Object();
+
+    @Override
+    Class<Object> getConverterTye() {
+        return Object.class;
+    }
+
+    @Override
+    Object getModelValue() {
+        return value;
+    }
+
+    @Override
+    String getWidgetValue() {
+        return value.toString();
+    }
+
+    protected void testToModelValue(String  widgetValue,
+                                    Object modelValue) {
+        assertNotNull(widgetValue);
+
+        Object resultModelValue = converter.toModelValue(widgetValue);
+
+        assertNotNull(resultModelValue);
+
+        assertEquals(modelValue.toString(),
+                     resultModelValue);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-serialization/src/test/java/org/kie/workbench/common/forms/serialization/impl/FormDefinitionSerializerImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-serialization/src/test/java/org/kie/workbench/common/forms/serialization/impl/FormDefinitionSerializerImplTest.java
@@ -26,8 +26,13 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.l
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.definition.MultipleSubFormFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.definition.SubFormFieldDefinition;
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
+import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
+import org.kie.workbench.common.forms.model.JavaFormModel;
+import org.kie.workbench.common.forms.model.TypeKind;
+import org.kie.workbench.common.forms.model.impl.ModelPropertyImpl;
+import org.kie.workbench.common.forms.model.impl.PortableJavaModel;
 import org.kie.workbench.common.forms.model.impl.TypeInfoImpl;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
@@ -48,9 +53,12 @@ public class FormDefinitionSerializerImplTest extends TestCase {
         fieldManager = new TestFieldManager();
 
         definitionSerializer = new FormDefinitionSerializerImpl(new FieldSerializer(),
-                                                                new FormModelSerializer());
+                                                                new FormModelSerializer(),
+                                                                new TestMetaDataEntryManager());
 
-        formDefinition = new FormDefinition();
+        JavaFormModel model = new PortableJavaModel("org.test.MyParentModel");
+
+        formDefinition = new FormDefinition(model);
         formDefinition.setId("testForm");
         formDefinition.setName("testForm");
 
@@ -71,6 +79,8 @@ public class FormDefinitionSerializerImplTest extends TestCase {
 
                 field.setBinding(fieldDescription);
 
+                model.getProperties().add(new ModelPropertyImpl(fieldDescription, new TypeInfoImpl(type)));
+
                 formDefinition.getFields().add(field);
             }
         }
@@ -84,6 +94,7 @@ public class FormDefinitionSerializerImplTest extends TestCase {
         subForm.setBinding("SubForm");
 
         formDefinition.getFields().add(subForm);
+        model.getProperties().add(new ModelPropertyImpl(subForm.getBinding(), new TypeInfoImpl(TypeKind.OBJECT, subForm.getStandaloneClassName(), false)));
 
         MultipleSubFormFieldDefinition multipleSubForm = new MultipleSubFormFieldDefinition();
 
@@ -94,6 +105,8 @@ public class FormDefinitionSerializerImplTest extends TestCase {
         multipleSubForm.setBinding("MultipleSubForm");
 
         formDefinition.getFields().add(multipleSubForm);
+        model.getProperties().add(new ModelPropertyImpl(multipleSubForm.getBinding(), new TypeInfoImpl(TypeKind.OBJECT, multipleSubForm.getStandaloneClassName(), true)));
+
 
         EnumListBoxFieldDefinition enumListBox = new EnumListBoxFieldDefinition();
 
@@ -102,6 +115,7 @@ public class FormDefinitionSerializerImplTest extends TestCase {
         enumListBox.setStandaloneClassName("org.test.MyTestModel");
 
         formDefinition.getFields().add(enumListBox);
+        model.getProperties().add(new ModelPropertyImpl(enumListBox.getBinding(), new TypeInfoImpl(TypeKind.ENUM, enumListBox.getStandaloneClassName(), false)));
     }
 
     @Test

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-backend/src/main/java/org/kie/workbench/common/forms/adf/engine/backend/formGeneration/BackendMetaDataEntryManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-backend/src/main/java/org/kie/workbench/common/forms/adf/engine/backend/formGeneration/BackendMetaDataEntryManager.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.engine.backend.formGeneration;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.forms.model.MetaDataEntry;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+import org.kie.workbench.common.forms.service.shared.meta.processing.impl.AbstractMetaDataEntryManager;
+
+@ApplicationScoped
+public class BackendMetaDataEntryManager extends AbstractMetaDataEntryManager {
+
+    @Inject
+    public BackendMetaDataEntryManager(Instance<MetaDataEntryProcessor<? extends MetaDataEntry, ?>> instance) {
+        instance.forEach(this::registerProcessor);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-backend/src/test/java/org/kie/workbench/common/forms/adf/engine/backend/formGeneration/util/BackendPropertyValueExtractorTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-backend/src/test/java/org/kie/workbench/common/forms/adf/engine/backend/formGeneration/util/BackendPropertyValueExtractorTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.forms.adf.engine.backend.formGeneration.util;
 
+import java.io.Serializable;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.Serializable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/src/main/java/org/kie/workbench/common/forms/adf/engine/client/formGeneration/ClientMetaDataEntryManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/src/main/java/org/kie/workbench/common/forms/adf/engine/client/formGeneration/ClientMetaDataEntryManager.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.engine.client.formGeneration;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.errai.ioc.client.container.IOC;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+import org.kie.workbench.common.forms.service.shared.meta.processing.impl.AbstractMetaDataEntryManager;
+
+@ApplicationScoped
+public class ClientMetaDataEntryManager extends AbstractMetaDataEntryManager {
+
+    @PostConstruct
+    public void init() {
+        IOC.getBeanManager().lookupBeans(MetaDataEntryProcessor.class).forEach(beanDef -> registerProcessor(beanDef.getInstance()));
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/DynamicModel.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/DynamicModel.java
@@ -16,6 +16,6 @@
 
 package org.kie.workbench.common.forms.model;
 
-public interface DynamicModel extends HasFormModelProperties {
+public interface DynamicModel extends FormModel {
 
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/FormModel.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/FormModel.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.forms.model;
 
+import java.util.List;
+
 /**
  * Defines the FormModel that the form is going to handle
  */
@@ -24,5 +26,15 @@ public interface FormModel {
     /**
      * Returns the name of the FormModel
      */
-    public String getName();
+    String getName();
+
+    /**
+     * Returns a {@link List} containing all the model {@link ModelProperty}
+     */
+    List<ModelProperty> getProperties();
+
+    /**
+     * Returns {@link ModelProperty} identified by the name parameter
+     */
+    ModelProperty getProperty(String name);
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/JavaFormModel.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/JavaFormModel.java
@@ -16,7 +16,7 @@
 
 package org.kie.workbench.common.forms.model;
 
-public interface JavaFormModel extends HasFormModelProperties {
+public interface JavaFormModel extends FormModel {
 
     String getType();
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/MetaDataEntry.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/MetaDataEntry.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.model;
+
+public interface MetaDataEntry<T> {
+
+    String getName();
+
+    T getValue();
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/ModelMetaData.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/ModelMetaData.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.model;
+
+import java.util.Collection;
+
+public interface ModelMetaData {
+
+    Collection<MetaDataEntry> getEntries();
+
+    MetaDataEntry getEntry(String name);
+
+    void addEntry(MetaDataEntry entry);
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/ModelProperty.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/ModelProperty.java
@@ -30,4 +30,6 @@ public interface ModelProperty {
      * Retrieves the info about the type of the property
      */
     TypeInfo getTypeInfo();
+
+    ModelMetaData getMetaData();
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/AbstractFormModel.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/AbstractFormModel.java
@@ -20,12 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kie.workbench.common.forms.model.FormModel;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.model.TypeKind;
 
-public abstract class AbstractFormModel implements FormModel,
-                                                   HasFormModelProperties {
+public abstract class AbstractFormModel implements FormModel {
 
     protected String name;
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/DefaultFormModel.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/DefaultFormModel.java
@@ -20,7 +20,7 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.forms.model.FormModel;
 
 @Portable
-public class DefaultFormModel implements FormModel {
+public class DefaultFormModel extends AbstractFormModel {
 
     @Override
     public String getName() {

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/ModelPropertyImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/ModelPropertyImpl.java
@@ -18,8 +18,10 @@ package org.kie.workbench.common.forms.model.impl;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.forms.model.ModelMetaData;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.model.TypeInfo;
+import org.kie.workbench.common.forms.model.impl.meta.ModelMetaDataImpl;
 
 @Portable
 public class ModelPropertyImpl implements ModelProperty {
@@ -28,10 +30,13 @@ public class ModelPropertyImpl implements ModelProperty {
 
     private TypeInfo typeInfo;
 
+    private ModelMetaData metaData;
+
     public ModelPropertyImpl(@MapsTo("name") String name,
                              @MapsTo("typeInfo") TypeInfo typeInfo) {
         this.name = name;
         this.typeInfo = typeInfo;
+        this.metaData = new ModelMetaDataImpl();
     }
 
     @Override
@@ -42,6 +47,11 @@ public class ModelPropertyImpl implements ModelProperty {
     @Override
     public TypeInfo getTypeInfo() {
         return typeInfo;
+    }
+
+    @Override
+    public ModelMetaData getMetaData() {
+        return metaData;
     }
 
     @Override
@@ -66,6 +76,8 @@ public class ModelPropertyImpl implements ModelProperty {
         int result = name.hashCode();
         result = ~~result;
         result = 31 * result + typeInfo.hashCode();
+        result = ~~result;
+        result = 31 * result + metaData.hashCode();
         result = ~~result;
         return result;
     }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/ModelMetaDataImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/ModelMetaDataImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.model.impl.meta;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.forms.model.MetaDataEntry;
+import org.kie.workbench.common.forms.model.ModelMetaData;
+
+@Portable
+public class ModelMetaDataImpl implements ModelMetaData {
+
+    private List<MetaDataEntry> entries = new ArrayList<>();
+
+    @Override
+    public Collection<MetaDataEntry> getEntries() {
+        return entries;
+    }
+
+    @Override
+    public MetaDataEntry getEntry(String name) {
+        return entries.stream()
+                .filter(entry -> entry.getName().equals(name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public void addEntry(MetaDataEntry entry) {
+        entries.add(entry);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ModelMetaDataImpl that = (ModelMetaDataImpl) o;
+
+        return entries.equals(that.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = entries.hashCode();
+        result = ~~result;
+        return result;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/AbstractMetaDataEntry.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/AbstractMetaDataEntry.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.model.impl.meta.entries;
+
+import org.kie.workbench.common.forms.model.MetaDataEntry;
+
+public abstract class AbstractMetaDataEntry<T> implements MetaDataEntry<T> {
+
+    protected String name;
+
+    protected T value;
+
+    protected AbstractMetaDataEntry(String name,
+                                    T value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public T getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractMetaDataEntry<?> that = (AbstractMetaDataEntry<?>) o;
+
+        if (!name.equals(that.name)) {
+            return false;
+        }
+        return value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = ~~result;
+        result = 31 * result + value.hashCode();
+        result = ~~result;
+        return result;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldLabelEntry.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldLabelEntry.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.model.impl.meta.entries;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class FieldLabelEntry extends AbstractMetaDataEntry<String> {
+
+    public static final String NAME = "field-label";
+
+    public FieldLabelEntry(@MapsTo("value") String value) {
+        super(NAME,
+              value);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldReadOnlyEntry.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldReadOnlyEntry.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.model.impl.meta.entries;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class FieldReadOnlyEntry extends AbstractMetaDataEntry<Boolean> {
+
+    public static final String NAME = "field-readOnly";
+
+    public FieldReadOnlyEntry(@MapsTo("value") Boolean value) {
+        super(NAME,
+              value);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldRequiredEntry.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldRequiredEntry.java
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.forms.model;
+package org.kie.workbench.common.forms.model.impl.meta.entries;
 
-import java.util.List;
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
 
-public interface HasFormModelProperties extends FormModel {
+@Portable
+public class FieldRequiredEntry extends AbstractMetaDataEntry<Boolean> {
 
-    public List<ModelProperty> getProperties();
+    public static final String NAME = "field-required";
 
-    public ModelProperty getProperty(String name);
+    public FieldRequiredEntry(@MapsTo("value") Boolean value) {
+        super(NAME,
+              value);
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldTypeEntry.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/impl/meta/entries/FieldTypeEntry.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.model.impl.meta.entries;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class FieldTypeEntry extends AbstractMetaDataEntry<String> {
+
+    public static final String NAME = "field-type";
+
+    public FieldTypeEntry(@MapsTo("value") String value) {
+        super(NAME,
+              value);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/util/formModel/FormModelPropertiesUtil.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/model/util/formModel/FormModelPropertiesUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.forms.model.util;
+package org.kie.workbench.common.forms.model.util.formModel;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class ModelPropertiesUtil {
+public class FormModelPropertiesUtil {
 
     private static final List<String> simplePropertyTypes = new ArrayList<>();
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/backend/util/ModelPropertiesGenerator.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/backend/util/ModelPropertiesGenerator.java
@@ -19,7 +19,7 @@ import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.model.TypeKind;
 import org.kie.workbench.common.forms.model.impl.ModelPropertyImpl;
 import org.kie.workbench.common.forms.model.impl.TypeInfoImpl;
-import org.kie.workbench.common.forms.model.util.ModelPropertiesUtil;
+import org.kie.workbench.common.forms.model.util.formModel.FormModelPropertiesUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public class ModelPropertiesGenerator {
                                                     String className,
                                                     ClassLoader classLoader) {
 
-        if (ModelPropertiesUtil.isListType(className)) {
+        if (FormModelPropertiesUtil.isListType(className)) {
             return createModelProperty(name,
                                        Object.class.getName(),
                                        true,
@@ -56,14 +56,14 @@ public class ModelPropertiesGenerator {
                                                     String className,
                                                     boolean isMultiple,
                                                     ClassLoader classLoader) {
-        if (ModelPropertiesUtil.isBaseType(className)) {
+        if (FormModelPropertiesUtil.isBaseType(className)) {
             // Dealing with basic type properties (String, Integer...)
             return new ModelPropertyImpl(name,
                                          new TypeInfoImpl(className,
                                                           isMultiple));
         } else {
             // Dealing with complex types.
-            if (ModelPropertiesUtil.isListType(className)) {
+            if (FormModelPropertiesUtil.isListType(className)) {
                 // If className is a List let's create a model for Object...
                 return createModelProperty(name,
                                            Object.class.getName(),

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/MetaDataEntryManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/MetaDataEntryManager.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.service.shared.meta.processing;
+
+import org.kie.workbench.common.forms.model.MetaDataEntry;
+
+public interface MetaDataEntryManager {
+
+    Class<? extends MetaDataEntry> getMetaDataEntryClass(String entryName);
+
+    MetaDataEntryProcessor getProcessorForEntry(MetaDataEntry entry);
+
+    MetaDataEntryProcessor getProcessorForEntry(String entryName);
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/MetaDataEntryProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/MetaDataEntryProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.service.shared.meta.processing;
+
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.MetaDataEntry;
+
+/**
+ * Processes the value of a specific type of {@link MetaDataEntry} and initalizes a {@link FieldDefinition} with it.
+ * @param <ENTRY> any type of {@link MetaDataEntry}
+ * @param <FIELD> any type of {@link FieldDefinition}
+ */
+public interface MetaDataEntryProcessor<ENTRY extends MetaDataEntry, FIELD> {
+
+    /**
+     * Returns the name of the {@link MetaDataEntry} supported by this processor
+     */
+    String getEntryName();
+
+    /**
+     * Returns the Class of the {@link MetaDataEntry} supported by this processor
+     * @return
+     */
+    Class<ENTRY> getEntryClass();
+
+    /**
+     * Processes the given entry and initializes the field with its value.
+     * @param entry any type of {@link MetaDataEntry}
+     * @param field any type of {@link FieldDefinition}
+     */
+    void process(ENTRY entry, FIELD field);
+
+    /**
+     * Determines if the processor supports the given {@link FieldDefinition}.
+     * @param fieldDefinition any type of {@link FieldDefinition}
+     * @return True if the processor supports it or false if not.
+     */
+    default boolean supports(FieldDefinition fieldDefinition) {
+        return true;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/AbstractMetaDataEntryManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/AbstractMetaDataEntryManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.service.shared.meta.processing.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.workbench.common.forms.model.MetaDataEntry;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryManager;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+
+public abstract class AbstractMetaDataEntryManager implements MetaDataEntryManager {
+
+    private Map<String, MetaDataEntryProcessor> processors = new HashMap<>();
+
+    protected void registerProcessor(MetaDataEntryProcessor processor) {
+        processors.put(processor.getEntryName(),
+                       processor);
+    }
+
+    @Override
+    public Class<? extends MetaDataEntry> getMetaDataEntryClass(String entryName) {
+        MetaDataEntryProcessor processor = getProcessorForEntry(entryName);
+
+        if (processor != null) {
+            return processor.getEntryClass();
+        }
+
+        return null;
+    }
+
+    @Override
+    public MetaDataEntryProcessor getProcessorForEntry(MetaDataEntry entry) {
+        return getProcessorForEntry(entry.getName());
+    }
+
+    @Override
+    public MetaDataEntryProcessor getProcessorForEntry(String entryName) {
+        return processors.get(entryName);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldLabelEntryProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldLabelEntryProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldLabelEntry;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+
+@Dependent
+public class FieldLabelEntryProcessor implements MetaDataEntryProcessor<FieldLabelEntry, FieldDefinition> {
+
+    @Override
+    public String getEntryName() {
+        return FieldLabelEntry.NAME;
+    }
+
+    @Override
+    public Class<FieldLabelEntry> getEntryClass() {
+        return FieldLabelEntry.class;
+    }
+
+    @Override
+    public void process(FieldLabelEntry entry, FieldDefinition fieldDefinition) {
+        fieldDefinition.setLabel(entry.getValue());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldReadOnlyEntryProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldReadOnlyEntryProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldReadOnlyEntry;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+
+@Dependent
+public class FieldReadOnlyEntryProcessor implements MetaDataEntryProcessor<FieldReadOnlyEntry, FieldDefinition> {
+
+    @Override
+    public String getEntryName() {
+        return FieldReadOnlyEntry.NAME;
+    }
+
+    @Override
+    public Class<FieldReadOnlyEntry> getEntryClass() {
+        return FieldReadOnlyEntry.class;
+    }
+
+    @Override
+    public void process(FieldReadOnlyEntry entry, FieldDefinition fieldDefinition) {
+        fieldDefinition.setReadOnly(entry.getValue());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldRequiredEntryProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldRequiredEntryProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldRequiredEntry;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+
+@Dependent
+public class FieldRequiredEntryProcessor implements MetaDataEntryProcessor<FieldRequiredEntry, FieldDefinition> {
+
+    @Override
+    public String getEntryName() {
+        return FieldRequiredEntry.NAME;
+    }
+
+    @Override
+    public Class<FieldRequiredEntry> getEntryClass() {
+        return FieldRequiredEntry.class;
+    }
+
+    @Override
+    public void process(FieldRequiredEntry entry, FieldDefinition fieldDefinition) {
+        fieldDefinition.setRequired(entry.getValue());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldTypeEntryProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/src/main/java/org/kie/workbench/common/forms/service/shared/meta/processing/impl/processors/FieldTypeEntryProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldTypeEntry;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+
+@Dependent
+public class FieldTypeEntryProcessor implements MetaDataEntryProcessor<FieldTypeEntry, FieldDefinition> {
+
+    @Override
+    public String getEntryName() {
+        return FieldTypeEntry.NAME;
+    }
+
+    @Override
+    public Class<FieldTypeEntry> getEntryClass() {
+        return FieldTypeEntry.class;
+    }
+
+    @Override
+    public boolean supports(FieldDefinition fieldDefinition) {
+        return false; // It shouldn't process anything
+    }
+
+    @Override
+    public void process(FieldTypeEntry entry, FieldDefinition fieldDefinition) {
+        // Does nothing
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
@@ -77,6 +77,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textArea/provider/TextAreaFieldProvider.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/textArea/provider/TextAreaFieldProvider.java
@@ -39,6 +39,7 @@ public class TextAreaFieldProvider extends BasicTypeFieldProvider<TextAreaFieldD
     @Override
     protected void doRegisterFields() {
         registerPropertyType(String.class);
+        registerPropertyType(Object.class);
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/model/meta/entries/FieldPlaceHolderEntry.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/model/meta/entries/FieldPlaceHolderEntry.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.model.meta.entries;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.forms.model.impl.meta.entries.AbstractMetaDataEntry;
+
+@Portable
+public class FieldPlaceHolderEntry extends AbstractMetaDataEntry<String> {
+
+    public static final String NAME = "field-placeHolder";
+
+    public FieldPlaceHolderEntry(@MapsTo("value") String value) {
+        super(NAME,
+              value);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/model/meta/entries/FieldPlaceHolderEntryProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/model/meta/entries/FieldPlaceHolderEntryProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.shared.model.meta.entries;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.HasPlaceHolder;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.service.shared.meta.processing.MetaDataEntryProcessor;
+
+@Dependent
+public class FieldPlaceHolderEntryProcessor implements MetaDataEntryProcessor<FieldPlaceHolderEntry, HasPlaceHolder> {
+
+    @Override
+    public String getEntryName() {
+        return FieldPlaceHolderEntry.NAME;
+    }
+
+    @Override
+    public Class<FieldPlaceHolderEntry> getEntryClass() {
+        return FieldPlaceHolderEntry.class;
+    }
+
+    @Override
+    public boolean supports(FieldDefinition fieldDefinition) {
+        return fieldDefinition instanceof HasPlaceHolder;
+    }
+
+    @Override
+    public void process(FieldPlaceHolderEntry entry, HasPlaceHolder hasPlaceHolder) {
+        hasPlaceHolder.setPlaceHolder(entry.getValue());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/test/TestFieldManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/test/TestFieldManager.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm
 public class TestFieldManager extends AbstractFieldManager {
 
     public TestFieldManager() {
+        super(new TestMetaDataEntryManager());
         registerFieldProvider(new TextBoxFieldProvider() {
             {
                 doRegisterFields();

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/test/TestMetaDataEntryManager.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/test/TestMetaDataEntryManager.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.fields.test;
+
+import org.kie.workbench.common.forms.fields.shared.model.meta.entries.FieldPlaceHolderEntryProcessor;
+import org.kie.workbench.common.forms.service.shared.meta.processing.impl.AbstractMetaDataEntryManager;
+import org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors.FieldLabelEntryProcessor;
+import org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors.FieldReadOnlyEntryProcessor;
+import org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors.FieldRequiredEntryProcessor;
+import org.kie.workbench.common.forms.service.shared.meta.processing.impl.processors.FieldTypeEntryProcessor;
+
+public class TestMetaDataEntryManager extends AbstractMetaDataEntryManager {
+
+    public TestMetaDataEntryManager() {
+        registerProcessor(new FieldLabelEntryProcessor());
+        registerProcessor(new FieldPlaceHolderEntryProcessor());
+        registerProcessor(new FieldPlaceHolderEntryProcessor());
+        registerProcessor(new FieldReadOnlyEntryProcessor());
+        registerProcessor(new FieldRequiredEntryProcessor());
+        registerProcessor(new FieldTypeEntryProcessor());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/src/main/java/org/kie/workbench/common/forms/editor/model/FormModelerContent.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/src/main/java/org/kie/workbench/common/forms/editor/model/FormModelerContent.java
@@ -15,15 +15,10 @@
  */
 package org.kie.workbench.common.forms.editor.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.forms.editor.service.shared.FormEditorRenderingContext;
-import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
-import org.kie.workbench.common.forms.model.ModelProperty;
 import org.uberfire.backend.vfs.Path;
 
 @Portable
@@ -33,8 +28,6 @@ public class FormModelerContent {
     private Overview overview;
     private FormDefinition definition;
     private FormModelSynchronizationResult synchronizationResult;
-    private List<ModelProperty> modelProperties = new ArrayList<>();
-    private List<FieldDefinition> availableFields = new ArrayList<>();
     private FormEditorRenderingContext renderingContext;
 
     public Path getPath() {
@@ -75,18 +68,6 @@ public class FormModelerContent {
 
     public void setSynchronizationResult(FormModelSynchronizationResult synchronizationResult) {
         this.synchronizationResult = synchronizationResult;
-    }
-
-    public void setAvailableFields(List<FieldDefinition> availableFields) {
-        this.availableFields = availableFields;
-    }
-
-    public List<FieldDefinition> getAvailableFields() {
-        return availableFields;
-    }
-
-    public List<ModelProperty> getModelProperties() {
-        return modelProperties;
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/src/main/java/org/kie/workbench/common/forms/editor/service/backend/FormModelHandler.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/src/main/java/org/kie/workbench/common/forms/editor/service/backend/FormModelHandler.java
@@ -21,14 +21,13 @@ import java.util.List;
 import org.kie.workbench.common.forms.editor.model.FormModelSynchronizationResult;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormModel;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.uberfire.backend.vfs.Path;
 
 /**
  * Handler class that is able to get {@link FieldDefinition} for a especific {@link FormModel}
  */
-public interface FormModelHandler<F extends HasFormModelProperties> {
+public interface FormModelHandler<F extends FormModel> {
 
     /**
      * Retrieves the supported {@link FormModel} type.
@@ -51,16 +50,6 @@ public interface FormModelHandler<F extends HasFormModelProperties> {
      */
     FormModelSynchronizationResult synchronizeFormModelProperties(F formModel,
                                                                   List<ModelProperty> newProperties);
-
-    /**
-     * Retrieves the available {@link FieldDefinition} for the {@link FormModel} which it's been initialized
-     */
-    List<FieldDefinition> getAllFormModelFields();
-
-    /**
-     * Creates a {@link FieldDefinition} for the given fieldName if the {@link FormModel} allows it.
-     */
-    FieldDefinition createFieldDefinition(ModelProperty property);
 
     /**
      * Creates a new {@link FormModelHandler} instance.

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/src/test/java/org/kie/workbench/common/forms/editor/service/shared/model/impl/FormModelSynchronizationUtilImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/src/test/java/org/kie/workbench/common/forms/editor/service/shared/model/impl/FormModelSynchronizationUtilImplTest.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
+import org.kie.workbench.common.forms.model.FormModel;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.model.impl.TypeInfoImpl;
 import org.kie.workbench.common.forms.service.backend.util.ModelPropertiesGenerator;
@@ -45,13 +45,13 @@ import static org.junit.Assert.*;
 @RunWith(MockitoJUnitRunner.class)
 public class FormModelSynchronizationUtilImplTest {
 
-    FormModelSynchronizationUtilImpl synchronizationUtil;
+    private FormModelSynchronizationUtilImpl synchronizationUtil;
 
-    FormDefinition form;
+    private FormDefinition form;
 
-    HasFormModelProperties formModel;
+    private FormModel formModel;
 
-    FormModelSynchronizationResultImpl formModelSynchronizationResult = new FormModelSynchronizationResultImpl();
+    private FormModelSynchronizationResultImpl formModelSynchronizationResult = new FormModelSynchronizationResultImpl();
 
     @Before
     public void init() {
@@ -59,7 +59,7 @@ public class FormModelSynchronizationUtilImplTest {
                                                                    new StaticFormLayoutTemplateGenerator());
         form = TestFormGenerator.getEmployeeForm();
 
-        formModel = (HasFormModelProperties) form.getModel();
+        formModel = form.getModel();
     }
 
     @Test

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/main/java/org/kie/workbench/common/forms/editor/backend/service/impl/AbstractFormModelHandler.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/main/java/org/kie/workbench/common/forms/editor/backend/service/impl/AbstractFormModelHandler.java
@@ -25,14 +25,14 @@ import org.kie.workbench.common.forms.editor.model.impl.FormModelSynchronization
 import org.kie.workbench.common.forms.editor.model.impl.TypeConflictImpl;
 import org.kie.workbench.common.forms.editor.service.backend.FormModelHandler;
 import org.kie.workbench.common.forms.model.FieldDefinition;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
+import org.kie.workbench.common.forms.model.FormModel;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.service.backend.util.ModelPropertiesGenerator;
 import org.kie.workbench.common.services.backend.project.ProjectClassLoaderHelper;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.uberfire.backend.vfs.Path;
 
-public abstract class AbstractFormModelHandler<F extends HasFormModelProperties> implements FormModelHandler<F> {
+public abstract class AbstractFormModelHandler<F extends FormModel> implements FormModelHandler<F> {
 
     protected F formModel;
     protected Path path;
@@ -59,18 +59,6 @@ public abstract class AbstractFormModelHandler<F extends HasFormModelProperties>
 
     protected void initClassLoader() {
         this.projectClassLoader = classLoaderHelper.getProjectClassLoader(projectService.resolveProject(path));
-    }
-
-    @Override
-    public List<FieldDefinition> getAllFormModelFields() {
-        checkInitialized();
-        return doGenerateModelFields();
-    }
-
-    @Override
-    public FieldDefinition createFieldDefinition(ModelProperty property) {
-        checkInitialized();
-        return doCreateFieldDefinition(property);
     }
 
     protected abstract void initialize();
@@ -138,10 +126,6 @@ public abstract class AbstractFormModelHandler<F extends HasFormModelProperties>
                                 Exception e);
 
     protected abstract List<ModelProperty> getCurrentModelProperties();
-
-    protected abstract List<FieldDefinition> doGenerateModelFields();
-
-    protected abstract FieldDefinition doCreateFieldDefinition(ModelProperty property);
 
     public void checkInitialized() {
         if (path == null || formModel == null || projectClassLoader == null) {

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/main/java/org/kie/workbench/common/forms/editor/backend/service/impl/FormEditorServiceImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/main/java/org/kie/workbench/common/forms/editor/backend/service/impl/FormEditorServiceImpl.java
@@ -38,7 +38,6 @@ import org.kie.workbench.common.forms.editor.service.shared.VFSFormFinderService
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
 import org.kie.workbench.common.forms.model.FormModel;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
 import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
 import org.kie.workbench.common.services.backend.service.KieService;
@@ -185,29 +184,26 @@ public class FormEditorServiceImpl extends KieService<FormModelerContent> implem
 
             formModelConent.setRenderingContext(context);
 
-            if (Optional.ofNullable(form.getModel()).isPresent() && form.getModel() instanceof HasFormModelProperties) {
+            if (Optional.ofNullable(form.getModel()).isPresent()) {
 
-                HasFormModelProperties formModel = (HasFormModelProperties) form.getModel();
+                FormModel formModel = form.getModel();
 
-                Optional<FormModelHandler> modelOptional = getHandlerForForm(form,
+                Optional<FormModelHandler> modelHandlerOptional = getHandlerForForm(form,
                                                                              path);
-                if (modelOptional.isPresent()) {
+                if (modelHandlerOptional.isPresent()) {
 
-                    FormModelHandler formModelHandler = modelOptional.get();
+                    FormModelHandler formModelHandler = modelHandlerOptional.get();
 
                     FormModelSynchronizationResult synchronizationResult = formModelHandler.synchronizeFormModel();
 
                     formModel.getProperties().forEach(property -> {
                         Optional<FieldDefinition> fieldOptional = Optional.ofNullable(form.getFieldByBinding(property.getName()));
                         if (!fieldOptional.isPresent()) {
-                            formModelConent.getAvailableFields().add(formModelHandler.createFieldDefinition(property));
                             synchronizationResult.resolveConflict(property.getName());
                         }
                     });
 
                     formModelConent.setSynchronizationResult(synchronizationResult);
-
-                    formModelConent.getModelProperties().addAll(formModel.getProperties());
                 }
             }
 
@@ -253,14 +249,10 @@ public class FormEditorServiceImpl extends KieService<FormModelerContent> implem
     protected Optional<FormModelHandler> getHandlerForForm(FormDefinition form,
                                                            Path path) {
 
-        if (!(form.getModel() instanceof HasFormModelProperties)) {
-            return Optional.empty();
-        }
-
         Optional<FormModelHandler> optional = Optional.ofNullable(modelHandlerManager.getFormModelHandler(form.getModel().getClass()));
 
         if (optional.isPresent()) {
-            optional.get().init((HasFormModelProperties) form.getModel(),
+            optional.get().init(form.getModel(),
                                 path);
         }
         return optional;

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/indexing/FormDefinitionIndexerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/indexing/FormDefinitionIndexerTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.editor.backend.indexing.query.FindFormDefinitionIdsQuery;
 import org.kie.workbench.common.forms.editor.type.FormResourceTypeDefinition;
+import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.model.FormModel;
 import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
 import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
@@ -87,9 +88,10 @@ public class FormDefinitionIndexerTest extends BaseIndexingTest<FormResourceType
         when(providersInstance.iterator()).thenReturn(providers.iterator());
 
         indexer = spy(new TestFormDefinitionIndexer(new FormResourceTypeDefinition(),
-                                                new FormDefinitionSerializerImpl(new FieldSerializer(),
-                                                                                 new FormModelSerializer()),
-                                                providersInstance));
+                                                    new FormDefinitionSerializerImpl(new FieldSerializer(),
+                                                                                     new FormModelSerializer(),
+                                                                                     new TestMetaDataEntryManager()),
+                                                    providersInstance));
 
         when(indexer.getProviderForModel(any())).thenReturn(provider);
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
@@ -41,7 +41,6 @@ import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FieldType;
 import org.kie.workbench.common.forms.model.FormDefinition;
 import org.kie.workbench.common.forms.model.FormModel;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
 import org.uberfire.commons.data.Pair;
 
@@ -106,7 +105,7 @@ public class FormEditorHelper {
                                               field));
             }
         }
-        addAvailableFields(content.getAvailableFields());
+        addAvailableFields();
     }
 
     public FormDefinition getFormDefinition() {
@@ -117,10 +116,15 @@ public class FormEditorHelper {
         return getFormDefinition().getModel();
     }
 
-    public void addAvailableFields(List<FieldDefinition> fields) {
-        for (FieldDefinition field : fields) {
-            addAvailableField(field);
-        }
+    public void addAvailableFields() {
+        FormModel model = getFormModel();
+        FormDefinition formDefinition = getFormDefinition();
+
+        model.getProperties().forEach(modelProperty -> {
+            if(formDefinition.getFieldByBinding(modelProperty.getName()) == null) {
+                addAvailableField(fieldManager.getDefinitionByModelProperty(modelProperty));
+            }
+        });
     }
 
     public void addAvailableField(FieldDefinition field) {
@@ -191,10 +195,7 @@ public class FormEditorHelper {
     public boolean modelContainsField(FieldDefinition fieldDefinition) {
         FormModel formModel = getFormModel();
 
-        if (formModel instanceof HasFormModelProperties) {
-            return ((HasFormModelProperties) formModel).getProperty(fieldDefinition.getBinding()) != null;
-        }
-        return false;
+        return formModel.getProperty(fieldDefinition.getBinding()) != null;
     }
 
     public List<String> getCompatibleModelFields(FieldDefinition field) {

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
@@ -40,7 +40,6 @@ import org.kie.workbench.common.forms.editor.service.shared.FormEditorService;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
 import org.kie.workbench.common.forms.model.FormModel;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
 import org.kie.workbench.common.services.refactoring.client.usages.ShowAssetUsagesDisplayer;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.kie.workbench.common.widgets.metadata.client.KieEditor;
@@ -277,9 +276,6 @@ public class FormEditorPresenter extends KieEditor {
 
     protected void loadAvailableFields() {
         FormModel model = editorHelper.getFormDefinition().getModel();
-        if (!(model instanceof HasFormModelProperties)) {
-            return;
-        }
 
         LayoutDragComponentGroup group = new LayoutDragComponentGroup(model.getName());
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayer.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -33,6 +35,7 @@ import org.kie.workbench.common.forms.editor.model.FormModelSynchronizationResul
 import org.kie.workbench.common.forms.editor.model.FormModelerContent;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormModel;
+import org.kie.workbench.common.forms.service.shared.FieldManager;
 import org.uberfire.commons.validation.PortablePreconditions;
 import org.uberfire.mvp.Command;
 
@@ -44,6 +47,8 @@ public class ChangesNotificationDisplayer implements ChangesNotificationDisplaye
     private NewPropertiesDisplayer newPropertiesDisplayer;
 
     private ConflictsDisplayer conflictsDisplayer;
+
+    private FieldManager fieldManager;
 
     private FormModelerContent content;
 
@@ -58,10 +63,12 @@ public class ChangesNotificationDisplayer implements ChangesNotificationDisplaye
     @Inject
     public ChangesNotificationDisplayer(ChangesNotificationDisplayerView view,
                                         ConflictsDisplayer conflictsDisplayer,
-                                        NewPropertiesDisplayer newPropertiesDisplayer) {
+                                        NewPropertiesDisplayer newPropertiesDisplayer,
+                                        FieldManager fieldManager) {
         this.view = view;
         this.newPropertiesDisplayer = newPropertiesDisplayer;
         this.conflictsDisplayer = conflictsDisplayer;
+        this.fieldManager = fieldManager;
         this.view.init(this);
     }
 
@@ -100,9 +107,11 @@ public class ChangesNotificationDisplayer implements ChangesNotificationDisplaye
         FormModelSynchronizationResult synchronizationResult = content.getSynchronizationResult();
 
         if (synchronizationResult != null && synchronizationResult.hasNewProperties()) {
-            Set<FieldDefinition> modelFields = new HashSet<>(content.getAvailableFields());
 
-            modelFields.removeIf(fieldDefinition -> !synchronizationResult.getNewProperties().stream().filter(property -> property.getName().equals(fieldDefinition.getBinding())).findAny().isPresent());
+            Set<FieldDefinition> modelFields = synchronizationResult.getNewProperties().stream()
+                    .filter(modelProperty -> content.getDefinition().getFieldByBinding(modelProperty.getName()) == null)
+                    .map(fieldManager::getDefinitionByModelProperty)
+                    .collect(Collectors.toSet());
 
             if (!modelFields.isEmpty()) {
                 this.canDisplay = true;

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelperTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelperTest.java
@@ -132,8 +132,6 @@ public class FormEditorHelperTest {
 
             content = new FormModelerContent();
 
-            content.getModelProperties().addAll(modelProperties);
-
             PortableJavaModel model = new PortableJavaModel("com.test.Employee");
 
             model.getProperties().addAll(modelProperties);
@@ -142,7 +140,6 @@ public class FormEditorHelperTest {
 
             content.setDefinition(form);
             content.setOverview(new Overview());
-            content.setAvailableFields(employeeFields);
 
             return content;
         });
@@ -213,11 +210,14 @@ public class FormEditorHelperTest {
 
     @Test
     public void testGetFormFieldAvailable() {
-        FieldDefinition resultField = formEditorHelper.getFormField(nameField.getId());
+        FieldDefinition resultField = formEditorHelper.getAvailableFields().values().stream().filter( fieldDefinition -> fieldDefinition.getBinding().equals(nameField.getBinding())).findFirst().get();
+
         formEditorHelper.saveFormField(nameField,
                                        resultField);
 
-        Assertions.assertThat(resultField).isNotNull().isEqualTo(nameField);
+        Assertions.assertThat(resultField)
+                .isNotNull()
+                .isEqualToComparingOnlyGivenFields(nameField, "name", "binding", "standaloneClassName");
 
         Assertions.assertThat(content.getDefinition().getFieldById(resultField.getId())).isNotNull();
 
@@ -260,17 +260,8 @@ public class FormEditorHelperTest {
         formEditorHelper.addAvailableField(employeeFields.get(0));
         Map<String, FieldDefinition> availableFields = formEditorHelper.getAvailableFields();
         assertEquals("The added field should be returned in available fields",
-                     availableFields.size(),
-                     employeeFields.size());
-    }
-
-    @Test
-    public void testAddAvailableFields() {
-        formEditorHelper.addAvailableFields(employeeFields);
-        Map<String, FieldDefinition> availableFields = formEditorHelper.getAvailableFields();
-        assertEquals("The added field should be returned in available fields",
-                     availableFields.size(),
-                     employeeFields.size());
+                     employeeFields.size() + 1,
+                     availableFields.size());
     }
 
     @Test
@@ -390,10 +381,9 @@ public class FormEditorHelperTest {
         FieldDefinition result = formEditorHelper.switchToField(originalField,
                                                                 expectedField.getBinding());
 
-        Assertions.assertThat(result.getId()).isEqualTo(expectedField.getId());
-        Assertions.assertThat(result.getName()).isEqualTo(expectedField.getName());
-        Assertions.assertThat(result.getBinding()).isEqualTo(expectedField.getBinding());
-        Assertions.assertThat(result.getStandaloneClassName()).isEqualTo(expectedField.getStandaloneClassName());
+        Assertions.assertThat(result)
+                .isNotNull()
+                .isEqualToComparingOnlyGivenFields(expectedField, "name", "binding", "standaloneClassName");
     }
 
     @Test
@@ -415,7 +405,7 @@ public class FormEditorHelperTest {
     private void initFields() {
         TextBoxFieldDefinition name = new TextBoxFieldDefinition();
         name.setId("name");
-        name.setName("employee_name");
+        name.setName("name");
         name.setLabel("Name");
         name.setPlaceHolder("Name");
         name.setBinding("name");
@@ -425,7 +415,7 @@ public class FormEditorHelperTest {
 
         TextBoxFieldDefinition lastName = new TextBoxFieldDefinition();
         lastName.setId("lastName");
-        lastName.setName("employee_lastName");
+        lastName.setName("lastName");
         lastName.setLabel("Last Name");
         lastName.setPlaceHolder("Last Name");
         lastName.setBinding("lastName");
@@ -434,14 +424,14 @@ public class FormEditorHelperTest {
 
         DatePickerFieldDefinition birthday = new DatePickerFieldDefinition();
         birthday.setId("birthday");
-        birthday.setName("employee_birthday");
+        birthday.setName("birthday");
         birthday.setLabel("Birthday");
         birthday.setBinding("birthday");
         birthday.setStandaloneClassName(Date.class.getName());
 
         CheckBoxFieldDefinition married = new CheckBoxFieldDefinition();
         married.setId("married");
-        married.setName("employee_married");
+        married.setName("married");
         married.setLabel("Married");
         married.setBinding("married");
         married.setStandaloneClassName(Boolean.class.getName());
@@ -449,14 +439,14 @@ public class FormEditorHelperTest {
 
         IntegerBoxFieldDefinition age = new IntegerBoxFieldDefinition();
         age.setId("age");
-        age.setName("employee_age");
+        age.setName("age");
         age.setLabel("Age");
         age.setBinding("age");
         ageField = age;
 
         DecimalBoxFieldDefinition weight = new DecimalBoxFieldDefinition();
         weight.setId("weight");
-        weight.setName("employee_weight");
+        weight.setName("weight");
         weight.setLabel("Weight");
         weight.setBinding("weight");
         weightField = weight;

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterAbstractTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterAbstractTest.java
@@ -147,6 +147,8 @@ public class FormEditorPresenterAbstractTest {
     @Mock
     protected AssetsUsageService assetsUsagService;
 
+    protected TestFieldManager fieldManager;
+
     protected List<Path> assetUsages = new ArrayList<>();
 
     protected ShowAssetUsagesDisplayer showAssetUsagesDisplayer;
@@ -158,9 +160,31 @@ public class FormEditorPresenterAbstractTest {
 
     protected FormModelSynchronizationResultImpl synchronizationResult = new FormModelSynchronizationResultImpl();
 
+    protected PortableJavaModel model;
+
+    protected FormDefinition form;
+
     @Before
     public void setUp() throws Exception {
-        initFields();
+        fieldManager = new TestFieldManager();
+
+        model = new PortableJavaModel("com.test.Employee");
+
+        model.addProperty("name", String.class.getName());
+        model.addProperty("lastName", String.class.getName());
+        model.addProperty("birthday", Date.class.getName());
+        model.addProperty("married", Boolean.class.getName());
+
+        form = new FormDefinition(model);
+
+        form.setName("EmployeeTestForm");
+        form.setId("_random_id");
+
+        //model.getProperties().stream().map(fieldManager::getDefinitionByModelProperty).forEach(fieldDefinition -> form.getFields().add(fieldDefinition));
+
+        modelProperties = new ArrayList<>(model.getProperties());
+
+        employeeFields = new ArrayList<>(form.getFields());
     }
 
     protected void loadContent() {
@@ -173,7 +197,7 @@ public class FormEditorPresenterAbstractTest {
 
         editorServiceCallerMock = new CallerMock<>(formEditorService);
 
-        editorHelper = spy(new TestFormEditorHelper(new TestFieldManager(),
+        editorHelper = spy(new TestFormEditorHelper(fieldManager,
                                                     editorFieldLayoutComponents));
 
         when(layoutEditorMock.getLayout()).thenReturn(new LayoutTemplate());
@@ -226,6 +250,13 @@ public class FormEditorPresenterAbstractTest {
                 deletePopUpPresenter = FormEditorPresenterAbstractTest.this.deletePopUpPresenter;
             }
 
+            @Override
+            public void doLoadContent(FormModelerContent content) {
+                super.doLoadContent(content);
+                employeeFields.addAll(editorHelper.getAvailableFields().values());
+            }
+
+            @Override
             protected void addSourcePage() {
             }
         };
@@ -237,69 +268,15 @@ public class FormEditorPresenterAbstractTest {
     }
 
     public FormModelerContent serviceLoad() {
-        FormDefinition form = new FormDefinition();
-        form.setName("EmployeeTestForm");
-        form.setId("_random_id");
 
         content = spy(new FormModelerContent());
-
-        PortableJavaModel model = new PortableJavaModel("com.test.Employee");
-
-        form.setModel(model);
 
         content.setDefinition(form);
         content.setOverview(new Overview());
         content.setPath(path);
-        content.setAvailableFields(employeeFields);
         content.setSynchronizationResult(synchronizationResult);
-        employeeFields.forEach(fieldDefinition -> {
-            model.addProperty(fieldDefinition.getBinding(),
-                              fieldDefinition.getStandaloneClassName());
-        });
-        content.getModelProperties().addAll(modelProperties);
+
         return content;
-    }
-
-    protected void initFields() {
-        TextBoxFieldDefinition name = new TextBoxFieldDefinition();
-        name.setId("name");
-        name.setName("employee_name");
-        name.setLabel("Name");
-        name.setPlaceHolder("Name");
-        name.setBinding("name");
-        name.setStandaloneClassName(String.class.getName());
-
-        TextBoxFieldDefinition lastName = new TextBoxFieldDefinition();
-        lastName.setId(LAST_NAME);
-        lastName.setName("employee_lastName");
-        lastName.setLabel("Last Name");
-        lastName.setPlaceHolder("Last Name");
-        lastName.setBinding("lastName");
-        lastName.setStandaloneClassName(String.class.getName());
-
-        DatePickerFieldDefinition birthday = new DatePickerFieldDefinition();
-        birthday.setId("birthday");
-        birthday.setName("employee_birthday");
-        birthday.setLabel("Birthday");
-        birthday.setBinding("birthday");
-        birthday.setStandaloneClassName(Date.class.getName());
-
-        CheckBoxFieldDefinition married = new CheckBoxFieldDefinition();
-        married.setId("married");
-        married.setName("employee_married");
-        married.setLabel("Married");
-        married.setBinding("married");
-        married.setStandaloneClassName(Boolean.class.getName());
-
-        employeeFields = new ArrayList<>();
-        employeeFields.add(name);
-        employeeFields.add(lastName);
-        employeeFields.add(birthday);
-        employeeFields.add(married);
-        modelProperties = new ArrayList<>();
-
-        employeeFields.forEach(fieldDefinition -> modelProperties.add(new ModelPropertyImpl(fieldDefinition.getBinding(),
-                                                                                            new TypeInfoImpl(fieldDefinition.getStandaloneClassName()))));
     }
 
     protected void loadAvailableFields() {

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterTest.java
@@ -160,7 +160,7 @@ public class FormEditorPresenterTest extends FormEditorPresenterAbstractTest {
 
         FormDefinition form = editorHelper.getFormDefinition();
 
-        addField(editorHelper.getAvailableFields().get(fieldId));
+        addField(editorHelper.getAvailableFields().values().stream().filter(fieldDefinition -> fieldDefinition.getBinding().equals(fieldId)).findFirst().get());
 
         checkExpectedFields(editorHelper.getAvailableFields().size(),
                             1,
@@ -357,8 +357,6 @@ public class FormEditorPresenterTest extends FormEditorPresenterAbstractTest {
     @Test
     public void testLoadAvailableFieldsNoContent() {
         loadContent();
-        when(content.getAvailableFields()).thenReturn(null);
-        FormEditorPresenter presenterSpy = spy(presenter);
 
         presenter.doLoadContent(content);
     }
@@ -366,7 +364,6 @@ public class FormEditorPresenterTest extends FormEditorPresenterAbstractTest {
     @Test
     public void testGetFormTemplate() {
         loadContent();
-        when(content.getAvailableFields()).thenReturn(null);
 
         presenter.getFormTemplate();
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayerTest.java
@@ -38,6 +38,9 @@ import org.kie.workbench.common.forms.editor.model.impl.FormModelSynchronization
 import org.kie.workbench.common.forms.editor.model.impl.TypeConflictImpl;
 import org.kie.workbench.common.forms.editor.service.shared.FormEditorRenderingContext;
 import org.kie.workbench.common.forms.editor.service.shared.model.FormModelSynchronizationUtil;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.EntityRelationField;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.definition.MultipleSubFormFieldDefinition;
+import org.kie.workbench.common.forms.fields.test.TestFieldManager;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
 import org.kie.workbench.common.forms.model.ModelProperty;
@@ -129,7 +132,8 @@ public class ChangesNotificationDisplayerTest {
 
         presenter = new ChangesNotificationDisplayer(view,
                                                      conflictsDisplayer,
-                                                     newPropertiesDisplayer) {
+                                                     newPropertiesDisplayer,
+                                                     new TestFieldManager()) {
             {
                 register(nestedFormsConflictHandler);
                 register(formModelConflictHandler);
@@ -149,7 +153,6 @@ public class ChangesNotificationDisplayerTest {
 
     @Test
     public void testShowNewFields() {
-        content.setAvailableFields(fields);
 
         synchronizationResult.getNewProperties().addAll(getModelProperties());
 
@@ -162,7 +165,7 @@ public class ChangesNotificationDisplayerTest {
         verify(formModelConflictHandler).checkConflicts(any(),
                                                         any());
 
-        verify(newPropertiesDisplayer).showAvailableFields(new HashSet<FieldDefinition>(fields));
+        verify(newPropertiesDisplayer).showAvailableFields(any());
 
         verify(conflictsDisplayer,
                never()).showConflict(any());
@@ -306,6 +309,6 @@ public class ChangesNotificationDisplayerTest {
 
     public List<ModelProperty> getModelProperties() {
         return fields.stream().map(fieldDefinition -> new ModelPropertyImpl(fieldDefinition.getBinding(),
-                                                                            new TypeInfoImpl(fieldDefinition.getStandaloneClassName()))).collect(Collectors.toList());
+                                                                            new TypeInfoImpl(fieldDefinition instanceof EntityRelationField ? TypeKind.OBJECT : TypeKind.BASE, fieldDefinition.getStandaloneClassName(), fieldDefinition instanceof MultipleSubFormFieldDefinition))).collect(Collectors.toList());
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponentTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponentTest.java
@@ -40,6 +40,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.def
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
+import org.kie.workbench.common.forms.model.FormModel;
 import org.kie.workbench.common.forms.model.TypeInfo;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
 import org.mockito.Mock;
@@ -96,6 +97,9 @@ public class EditorFieldLayoutComponentTest {
     @Mock
     private FormDefinition formDefinition;
 
+    @Mock
+    private FormModel formModel;
+
     private FieldDefinition fieldDefinition;
 
     private LayoutComponent layoutComponent = new LayoutComponent(EditorFieldLayoutComponent.class.getName());
@@ -128,6 +132,7 @@ public class EditorFieldLayoutComponentTest {
 
         when(formDefinition.getId()).thenReturn(EditorFieldLayoutComponent.FORM_ID);
         when(formDefinition.getFieldById(anyString())).thenReturn(fieldDefinition);
+        when(formDefinition.getModel()).thenReturn(formModel);
         when(context.getRootForm()).thenReturn(formDefinition);
 
         content = new FormModelerContent();

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/test/TestFormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/test/TestFormEditorHelper.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.forms.editor.client.editor.test;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -45,5 +46,9 @@ public class TestFormEditorHelper extends FormEditorHelper {
 
     public Collection<FieldType> getEditorFieldTypes() {
         return enabledPaletteFieldTypes;
+    }
+
+    public void addAvailableFields(List<FieldDefinition> availableFields) {
+        availableFields.forEach(this::addAvailableField);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/src/main/java/org/kie/workbench/common/forms/data/modeller/service/impl/DataObjectFormModelHandler.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/src/main/java/org/kie/workbench/common/forms/data/modeller/service/impl/DataObjectFormModelHandler.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.forms.data.modeller.service.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -28,9 +28,9 @@ import org.kie.workbench.common.forms.data.modeller.model.DataObjectFormModel;
 import org.kie.workbench.common.forms.data.modeller.service.DataObjectFinderService;
 import org.kie.workbench.common.forms.editor.backend.service.impl.AbstractFormModelHandler;
 import org.kie.workbench.common.forms.editor.service.backend.FormModelHandler;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.HasPlaceHolder;
-import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.model.meta.entries.FieldPlaceHolderEntry;
 import org.kie.workbench.common.forms.model.ModelProperty;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldLabelEntry;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
 import org.kie.workbench.common.screens.datamodeller.model.maindomain.MainDomainAnnotations;
 import org.kie.workbench.common.services.backend.project.ProjectClassLoaderHelper;
@@ -121,7 +121,12 @@ public class DataObjectFormModelHandler extends AbstractFormModelHandler<DataObj
                                                                        property.isMultiple());
 
                 if (optional.isPresent()) {
-                    properties.add(optional.get());
+                    ModelProperty modelProperty = optional.get();
+
+                    extractMetaData(property,
+                                    modelProperty);
+
+                    properties.add(modelProperty);
                 }
             }
         });
@@ -136,51 +141,14 @@ public class DataObjectFormModelHandler extends AbstractFormModelHandler<DataObj
                                               fieldManager);
     }
 
-    @Override
-    protected List<FieldDefinition> doGenerateModelFields() {
-        return formModel.getProperties().stream().map(this::doCreateFieldDefinition).collect(Collectors.toList());
-    }
-
-    @Override
-    protected FieldDefinition doCreateFieldDefinition(ModelProperty property) {
-
-        Optional<ObjectProperty> objectPropertyOptional = Optional.ofNullable(dataObject.getProperty(property.getName()));
-
-        if (!objectPropertyOptional.isPresent()) {
-            return null;
-        }
-
-        ObjectProperty objectProperty = objectPropertyOptional.get();
-
-        if (!isValidDataObjectProperty(objectProperty)) {
-            return null;
-        }
-
-        Optional<FieldDefinition> fieldOptional = Optional.ofNullable(fieldManager.getDefinitionByDataType(property.getTypeInfo()));
-
-        if (!fieldOptional.isPresent()) {
-            return null;
-        }
-
-        FieldDefinition field = fieldOptional.get();
-        field.setName(property.getName());
-        String label = getPropertyLabel(objectProperty);
-        field.setLabel(label);
-        field.setBinding(property.getName());
-
-        if (field instanceof HasPlaceHolder) {
-            ((HasPlaceHolder) field).setPlaceHolder(label);
-        }
-        return field;
-    }
-
-    private String getPropertyLabel(ObjectProperty property) {
+    private void extractMetaData(ObjectProperty property,
+                                 ModelProperty modelProperty) {
         Annotation labelAnnotation = property.getAnnotation(MainDomainAnnotations.LABEL_ANNOTATION);
         if (labelAnnotation != null) {
-            return labelAnnotation.getValue(MainDomainAnnotations.VALUE_PARAM).toString();
+            String label = labelAnnotation.getValue(MainDomainAnnotations.VALUE_PARAM).toString();
+            modelProperty.getMetaData().addEntry(new FieldLabelEntry(label));
+            modelProperty.getMetaData().addEntry(new FieldPlaceHolderEntry(label));
         }
-
-        return property.getName();
     }
 
     public static boolean isValidDataObjectProperty(ObjectProperty property) {

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/src/test/java/org/kie/workbench/common/forms/data/modeller/service/impl/DataObjectFormModelHandlerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/src/test/java/org/kie/workbench/common/forms/data/modeller/service/impl/DataObjectFormModelHandlerTest.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +62,7 @@ import org.kie.workbench.common.services.shared.project.KieProject;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import org.uberfire.backend.vfs.Path;
 
 import static org.junit.Assert.*;
@@ -99,11 +101,15 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
     @Mock
     private ProjectClassLoaderHelper projectClassLoaderHelper;
 
+    @Mock
+    private ClassLoader classLoader;
+
     @Before
     public void setUp() throws Exception {
 
         when(projectService.resolveProject(any())).thenReturn(project);
-        when(projectClassLoaderHelper.getProjectClassLoader(project)).thenReturn(this.getClass().getClassLoader());
+        when(projectClassLoaderHelper.getProjectClassLoader(project)).thenReturn(classLoader);
+        when(classLoader.loadClass(any())).thenAnswer((Answer<Class>) invocation -> String.class);
 
         createModel();
 
@@ -161,7 +167,9 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
         expectedFieldTypes.put(MultipleSubFormFieldDefinition.class.getSimpleName(),
                                Collections.singletonList(NESTED_CLASSNAME));
 
-        List<FieldDefinition> formModelFields = handler.getAllFormModelFields();
+        formModel = handler.createFormModel(dataObject, path);
+
+        List<FieldDefinition> formModelFields = formModel.getProperties().stream().map(fieldManager::getDefinitionByModelProperty).collect(Collectors.toList());
         formFieldsShouldNotBeGeneratedForPersistenceId(formModelFields);
         listsOfBasicDataTypesShouldBeExcludedFromTheFormFields(formModelFields);
 
@@ -218,12 +226,16 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
 
     @Test
     public void datePickerHasCorrectProperties() {
+        formModel = handler.createFormModel(dataObject, path);
+
         DatePickerFieldDefinition datePicker = (DatePickerFieldDefinition) checkCommonProperties("Date");
         assertTrue(datePicker.getShowTime());
     }
 
     @Test
     public void subformHasCorrectProperties() {
+        formModel = handler.createFormModel(dataObject, path);
+
         SubFormFieldDefinition subForm = (SubFormFieldDefinition) checkCommonProperties("address");
         assertEquals("",
                      subForm.getNestedForm());
@@ -231,6 +243,8 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
 
     @Test
     public void multipleSubformHasCorrectProperties() {
+        formModel = handler.createFormModel(dataObject, path);
+
         MultipleSubFormFieldDefinition multipleSubform = (MultipleSubFormFieldDefinition) checkCommonProperties("address_list");
         assertEquals("",
                      multipleSubform.getCreationForm());
@@ -241,8 +255,10 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
     }
 
     private FieldDefinition checkCommonProperties(String dataFieldName) {
+
         ObjectProperty dataField = dataObject.getProperty(dataFieldName);
-        FieldDefinition formField = handler.createFieldDefinition(formModel.getProperty(dataFieldName));
+
+        FieldDefinition formField = fieldManager.getDefinitionByModelProperty(formModel.getProperty(dataFieldName));
         String dataFieldClassName = dataField.getClassName();
         TypeInfo fieldTypeInfo = formField.getFieldTypeInfo();
 
@@ -253,8 +269,8 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
                         fieldTypeInfo.getType());
         assertEquals(dataField.isMultiple(),
                      fieldTypeInfo.isMultiple());
-        assertEquals(dataField.getName(),
-                     formField.getLabel());
+        assertEquals(dataField.getName().toLowerCase(),
+                     formField.getLabel().toLowerCase());
         assertEquals(dataField.getName(),
                      formField.getBinding());
         assertEquals(dataFieldClassName,
@@ -265,8 +281,8 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
 
         //test interface specific properties
         if (formField instanceof HasPlaceHolder) {
-            assertEquals(dataField.getName(),
-                         ((HasPlaceHolder) formField).getPlaceHolder());
+            assertEquals(dataField.getName().toLowerCase(),
+                         ((HasPlaceHolder) formField).getPlaceHolder().toLowerCase());
         }
         if (formField instanceof HasMaxLength) {
             long maxLength = ((HasMaxLength) formField).getMaxLength();

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/main/java/org/kie/workbench/common/forms/jbpm/model/authoring/document/provider/DocumentFieldProvider.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/main/java/org/kie/workbench/common/forms/jbpm/model/authoring/document/provider/DocumentFieldProvider.java
@@ -22,7 +22,6 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.BasicTypeFi
 import org.kie.workbench.common.forms.jbpm.model.authoring.document.definition.DocumentFieldDefinition;
 import org.kie.workbench.common.forms.jbpm.model.authoring.document.type.DocumentFieldType;
 import org.kie.workbench.common.forms.model.TypeInfo;
-import org.kie.workbench.common.forms.model.util.ModelPropertiesUtil;
 
 @Dependent
 public class DocumentFieldProvider extends BasicTypeFieldProvider<DocumentFieldDefinition> {

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/main/java/org/kie/workbench/common/forms/jbpm/service/bpmn/util/BPMNVariableUtils.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/main/java/org/kie/workbench/common/forms/jbpm/service/bpmn/util/BPMNVariableUtils.java
@@ -50,7 +50,7 @@ public class BPMNVariableUtils {
 
         if (!type.contains(".")) {
             if ("Object".equals(type)) {
-                return String.class.getName();
+                return Object.class.getName();
             }
             if ("String".equals(type)) {
                 return String.class.getName();

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/pom.xml
@@ -99,6 +99,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-layout-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>org.eclipse.bpmn2</artifactId>
     </dependency>
@@ -161,6 +166,16 @@
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-base</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-engine-api</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/FormsJBPMIntegrationBackendEntryPoint.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/FormsJBPMIntegrationBackendEntryPoint.java
@@ -19,7 +19,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.kie.workbench.common.forms.jbpm.model.authoring.document.type.DocumentFieldType;
-import org.kie.workbench.common.forms.model.util.ModelPropertiesUtil;
+import org.kie.workbench.common.forms.model.util.formModel.FormModelPropertiesUtil;
 import org.uberfire.commons.services.cdi.Startup;
 
 @ApplicationScoped
@@ -29,7 +29,7 @@ public class FormsJBPMIntegrationBackendEntryPoint {
     @PostConstruct
     public void init() {
         // registering Document Types to ModelPropertiesUtil
-        ModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_TYPE);
-        ModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_IMPL_TYPE);
+        FormModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_TYPE);
+        FormModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_IMPL_TYPE);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/authoring/BPMNVFSFormDefinitionGeneratorService.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/authoring/BPMNVFSFormDefinitionGeneratorService.java
@@ -18,12 +18,13 @@ package org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.a
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.guvnor.common.services.backend.util.CommentedOptionFactory;
-import org.kie.workbench.common.forms.commons.shared.layout.FormLayoutTemplateGenerator;
 import org.kie.workbench.common.forms.editor.model.FormModelSynchronizationResult;
 import org.kie.workbench.common.forms.editor.service.backend.FormModelHandler;
 import org.kie.workbench.common.forms.editor.service.backend.FormModelHandlerManager;
@@ -35,7 +36,6 @@ import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.Ab
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.GenerationContext;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.model.FormDefinition;
-import org.kie.workbench.common.forms.model.HasFormModelProperties;
 import org.kie.workbench.common.forms.model.JavaFormModel;
 import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
@@ -65,15 +65,13 @@ public class BPMNVFSFormDefinitionGeneratorService extends AbstractBPMNFormGener
 
     @Inject
     public BPMNVFSFormDefinitionGeneratorService(FieldManager fieldManager,
-                                                 FormLayoutTemplateGenerator layoutTemplateGenerator,
                                                  FormModelHandlerManager formModelHandlerManager,
                                                  VFSFormFinderService formFinderService,
                                                  FormDefinitionSerializer formSerializer,
                                                  @Named("ioStrategy") IOService ioService,
                                                  CommentedOptionFactory commentedOptionFactory,
                                                  FormModelSynchronizationUtil formModelSynchronizationUtil) {
-        super(fieldManager,
-              layoutTemplateGenerator);
+        super(fieldManager);
         this.formModelHandlerManager = formModelHandlerManager;
         this.formFinderService = formFinderService;
         this.formSerializer = formSerializer;
@@ -103,7 +101,7 @@ public class BPMNVFSFormDefinitionGeneratorService extends AbstractBPMNFormGener
                         kiePath);
 
             // If the form exists on the VFS let's synchronize form fields
-            FormModelSynchronizationResult synchronizationResult = modelHandler.synchronizeFormModelProperties((HasFormModelProperties) form.getModel(),
+            FormModelSynchronizationResult synchronizationResult = modelHandler.synchronizeFormModelProperties(form.getModel(),
                                                                                                                context.getFormModel().getProperties());
 
             formModelSynchronizationUtil.init(form,
@@ -121,7 +119,7 @@ public class BPMNVFSFormDefinitionGeneratorService extends AbstractBPMNFormGener
 
             if (synchronizationResult.hasNewProperties()) {
                 logger.warn("Process/Task has new variables. Adding them to form:");
-                formModelSynchronizationUtil.addNewFields(modelHandler::createFieldDefinition);
+                formModelSynchronizationUtil.addNewFields(fieldManager::getDefinitionByModelProperty);
             }
 
             form.setModel(context.getFormModel());
@@ -132,9 +130,7 @@ public class BPMNVFSFormDefinitionGeneratorService extends AbstractBPMNFormGener
 
             form.setName(context.getSource().getFileName());
 
-            form.getFields().addAll(modelHandler.getAllFormModelFields());
-
-            layoutTemplateGenerator.generateLayoutTemplate(form);
+            form.getFields().addAll(context.getFormModel().getProperties().stream().map(fieldManager::getDefinitionByModelProperty).collect(Collectors.toList()));
         }
 
         form.setModel(context.getFormModel());
@@ -162,16 +158,19 @@ public class BPMNVFSFormDefinitionGeneratorService extends AbstractBPMNFormGener
     protected List<FieldDefinition> extractModelFields(JavaFormModel formModel,
                                                        GenerationContext<Path> context) {
         FormModelHandler handler = formModelHandlerManager.getFormModelHandler(formModel.getClass());
+
         handler.init(formModel,
                      context.getSource());
         handler.synchronizeFormModel();
-        return handler.getAllFormModelFields();
+
+        return formModel.getProperties().stream().map(fieldManager::getDefinitionByModelProperty).collect(Collectors.toList());
     }
 
     @Override
     protected FormDefinition findFormDefinitionForModelType(String modelType,
                                                             GenerationContext<Path> context) {
-        FormDefinition form =  super.findFormDefinitionForModelType(modelType, context);
+        FormDefinition form = super.findFormDefinitionForModelType(modelType,
+                                                                   context);
 
         if (form != null) {
             return form;

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/runtime/BPMNRuntimeFormGeneratorService.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/runtime/BPMNRuntimeFormGeneratorService.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -30,7 +31,6 @@ import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
 import org.drools.workbench.models.datamodel.oracle.TypeSource;
-import org.kie.workbench.common.forms.commons.shared.layout.FormLayoutTemplateGenerator;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.HasPlaceHolder;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.AbstractBPMNFormGeneratorService;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.GenerationContext;
@@ -43,7 +43,7 @@ import org.kie.workbench.common.forms.model.TypeInfo;
 import org.kie.workbench.common.forms.model.TypeKind;
 import org.kie.workbench.common.forms.model.impl.ModelPropertyImpl;
 import org.kie.workbench.common.forms.model.impl.TypeInfoImpl;
-import org.kie.workbench.common.forms.model.util.ModelPropertiesUtil;
+import org.kie.workbench.common.forms.model.util.formModel.FormModelPropertiesUtil;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
 import org.kie.workbench.common.services.datamodel.backend.server.builder.projects.ClassFactBuilder;
 import org.kie.workbench.common.services.datamodel.backend.server.builder.projects.FactBuilder;
@@ -54,10 +54,8 @@ import org.kie.workbench.common.services.datamodel.backend.server.builder.projec
 public class BPMNRuntimeFormGeneratorService extends AbstractBPMNFormGeneratorService<ClassLoader> {
 
     @Inject
-    public BPMNRuntimeFormGeneratorService(FieldManager fieldManager,
-                                           FormLayoutTemplateGenerator layoutTemplateGenerator) {
-        super(fieldManager,
-              layoutTemplateGenerator);
+    public BPMNRuntimeFormGeneratorService(FieldManager fieldManager) {
+        super(fieldManager);
     }
 
     @Override
@@ -79,8 +77,6 @@ public class BPMNRuntimeFormGeneratorService extends AbstractBPMNFormGeneratorSe
                 form.getFields().add(field);
             }
         });
-
-        layoutTemplateGenerator.generateLayoutTemplate(form);
 
         return form;
     }
@@ -124,7 +120,7 @@ public class BPMNRuntimeFormGeneratorService extends AbstractBPMNFormGeneratorSe
                     fieldType = oracle.getProjectFieldParametersType().get(modelType + "#" + modelField.getName());
                 }
 
-                TypeKind typeKind = isEnunm ? TypeKind.ENUM : ModelPropertiesUtil.isBaseType(fieldType) ? TypeKind.BASE : TypeKind.OBJECT;
+                TypeKind typeKind = isEnunm ? TypeKind.ENUM : FormModelPropertiesUtil.isBaseType(fieldType) ? TypeKind.BASE : TypeKind.OBJECT;
 
                 TypeInfo info = new TypeInfoImpl(typeKind,
                                                  fieldType,
@@ -181,23 +177,11 @@ public class BPMNRuntimeFormGeneratorService extends AbstractBPMNFormGeneratorSe
 
     protected FieldDefinition generateFieldDefinition(ModelProperty property,
                                                       GenerationContext<ClassLoader> context) {
-        FieldDefinition field = fieldManager.getDefinitionByDataType(property.getTypeInfo());
+
+        FieldDefinition field = fieldManager.getDefinitionByModelProperty(property);
 
         if (field == null) {
             return null;
-        }
-
-        String fieldName = property.getName();
-
-        String label = fieldName.substring(0,
-                                           1).toUpperCase() + fieldName.substring(1);
-        field.setName(fieldName);
-        field.setLabel(label);
-        field.setStandaloneClassName(property.getTypeInfo().getClassName());
-        field.setBinding(fieldName);
-
-        if (field instanceof HasPlaceHolder) {
-            ((HasPlaceHolder) field).setPlaceHolder(label);
         }
 
         processFieldDefinition(field,

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/impl/AbstractJBPMFormModelHandler.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/impl/AbstractJBPMFormModelHandler.java
@@ -16,17 +16,9 @@
 
 package org.kie.workbench.common.forms.jbpm.server.service.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import org.apache.commons.lang3.StringUtils;
 import org.kie.workbench.common.forms.editor.backend.service.impl.AbstractFormModelHandler;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.HasPlaceHolder;
 import org.kie.workbench.common.forms.jbpm.model.authoring.JBPMFormModel;
 import org.kie.workbench.common.forms.jbpm.service.shared.BPMFinderService;
-import org.kie.workbench.common.forms.model.FieldDefinition;
-import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
 import org.kie.workbench.common.services.backend.project.ProjectClassLoaderHelper;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
@@ -50,48 +42,5 @@ public abstract class AbstractJBPMFormModelHandler<M extends JBPMFormModel> exte
     @Override
     protected void initialize() {
         super.checkInitialized();
-    }
-
-    @Override
-    protected List<FieldDefinition> doGenerateModelFields() {
-        List<FieldDefinition> fields = new ArrayList<>();
-
-        formModel.getProperties().forEach(property -> {
-            FieldDefinition field = fieldManager.getDefinitionByDataType(property.getTypeInfo());
-
-            if (field != null) {
-                initFieldDefinition(field,
-                                    property);
-                fields.add(field);
-            }
-        });
-
-        return fields;
-    }
-
-    @Override
-    protected FieldDefinition doCreateFieldDefinition(ModelProperty property) {
-        Optional<ModelProperty> optional = formModel.getProperties().stream().filter(modelProperty -> modelProperty.getName().equals(property.getName())).findFirst();
-
-        if (optional.isPresent()) {
-            FieldDefinition field = fieldManager.getDefinitionByDataType(property.getTypeInfo());
-            initFieldDefinition(field,
-                                property);
-            return field;
-        }
-
-        return null;
-    }
-
-    protected void initFieldDefinition(FieldDefinition field,
-                                       ModelProperty property) {
-        String label = StringUtils.capitalize(property.getName());
-        field.setId(property.getName());
-        field.setName(property.getName());
-        field.setLabel(label);
-        field.setBinding(property.getName());
-        if (field instanceof HasPlaceHolder) {
-            ((HasPlaceHolder) field).setPlaceHolder(label);
-        }
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMNFormModelGeneratorImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMNFormModelGeneratorImpl.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -39,12 +38,15 @@ import org.eclipse.bpmn2.Process;
 import org.eclipse.bpmn2.RootElement;
 import org.eclipse.bpmn2.UserTask;
 import org.jsoup.parser.Parser;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
 import org.kie.workbench.common.forms.jbpm.model.authoring.process.BusinessProcessFormModel;
 import org.kie.workbench.common.forms.jbpm.model.authoring.task.TaskFormModel;
 import org.kie.workbench.common.forms.jbpm.server.service.BPMNFormModelGenerator;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.util.BPMNVariableUtils;
 import org.kie.workbench.common.forms.model.ModelProperty;
-import org.kie.workbench.common.forms.model.util.ModelPropertiesUtil;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldReadOnlyEntry;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldTypeEntry;
+import org.kie.workbench.common.forms.model.util.formModel.FormModelPropertiesUtil;
 import org.kie.workbench.common.forms.service.backend.util.ModelPropertiesGenerator;
 import org.kie.workbench.common.services.backend.project.ProjectClassLoaderHelper;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
@@ -79,10 +81,14 @@ public class BPMNFormModelGeneratorImpl implements BPMNFormModelGenerator {
             List<ModelProperty> properties = process.getProperties().stream().map(property -> {
                 String varName = property.getId();
                 String varType = BPMNVariableUtils.getRealTypeForInput(property.getItemSubjectRef().getStructureRef());
-                return createModelProperty(varName,
-                                           varType,
+
+                Variable variable = new Variable(varName, varType);
+                variable.setInput(true);
+                variable.setOutput(true);
+
+                return createModelProperty(variable,
                                            projectClassLoader);
-            }).collect(Collectors.toList());
+            }).sorted((property1, property2) -> property1.getName().compareToIgnoreCase(property2.getName())).collect(Collectors.toList());
 
             return new BusinessProcessFormModel(process.getId(),
                                                 process.getName(),
@@ -108,20 +114,27 @@ public class BPMNFormModelGeneratorImpl implements BPMNFormModelGenerator {
                     return false;
                 }
                 return true;
-            }).map(taskFormVariables -> taskFormVariables.toFormModel((BiFunction<String, String, ModelProperty>) (name, type) -> createModelProperty(name,
-                                                                                                                                                      type,
-                                                                                                                                                      projectClassLoader))).collect(Collectors.toList());
+            }).map(taskFormVariables -> taskFormVariables.toFormModel(variable -> createModelProperty(variable,
+                                                                                                          projectClassLoader))).collect(Collectors.toList());
         }
         return Collections.emptyList();
     }
 
-    protected ModelProperty createModelProperty(String name,
-                                                String type,
+    protected ModelProperty createModelProperty(Variable variable,
                                                 ClassLoader classLoader) {
-        return ModelPropertiesGenerator.createModelProperty(name,
-                                                            type,
-                                                            ModelPropertiesUtil.isListType(type),
-                                                            classLoader);
+        ModelProperty property = ModelPropertiesGenerator.createModelProperty(variable.getName(),
+                                                                              variable.getType(),
+                                                                              FormModelPropertiesUtil.isListType(variable.getType()),
+                                                                              classLoader);
+
+
+        property.getMetaData().addEntry(new FieldReadOnlyEntry(variable.isInput() && !variable.isOutput()));
+
+        if(!property.getTypeInfo().isMultiple() && property.getTypeInfo().getClassName().equals(Object.class.getName())) {
+            property.getMetaData().addEntry(new FieldTypeEntry(TextAreaFieldDefinition.FIELD_TYPE.getTypeName()));
+        }
+
+        return property;
     }
 
     @Override
@@ -145,8 +158,7 @@ public class BPMNFormModelGeneratorImpl implements BPMNFormModelGenerator {
 
                 final ClassLoader projectClassLoader = projectClassLoaderHelper.getProjectClassLoader(projectService.resolveProject(path));
 
-                return formVariables.toFormModel((name, type) -> createModelProperty(name,
-                                                                                     type,
+                return formVariables.toFormModel(variable -> createModelProperty(variable,
                                                                                      projectClassLoader));
             }
         }
@@ -204,8 +216,12 @@ public class BPMNFormModelGeneratorImpl implements BPMNFormModelGenerator {
 
                         type = BPMNVariableUtils.getRealTypeForInput(type);
 
-                        formVariables.addVariable(name,
-                                                  type);
+                        Variable variable = new Variable(name, type);
+
+                        variable.setInput(true);
+
+                        formVariables.addVariable(variable);
+
                     } else if (BPMNVariableUtils.TASK_FORM_VARIABLE.equals(name)) {
                         List<Assignment> assignments = inputAssociation.getAssignment();
 
@@ -244,8 +260,11 @@ public class BPMNFormModelGeneratorImpl implements BPMNFormModelGenerator {
 
                     type = BPMNVariableUtils.getRealTypeForInput(type);
 
-                    formVariables.addVariable(name,
-                                              type);
+                    Variable variable = new Variable(name, type);
+
+                    variable.setOutput(true);
+
+                    formVariables.addVariable(variable);
                 }
             });
         }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/impl/Variable.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/impl/Variable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.jbpm.server.service.impl;
+
+public class Variable {
+
+    private String name;
+
+    private String type;
+
+    private boolean input = false;
+
+    private boolean output = false;
+
+    public Variable(String name,
+                    String type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public boolean isInput() {
+        return input;
+    }
+
+    public void setInput(boolean input) {
+        this.input = input;
+    }
+
+    public boolean isOutput() {
+        return output;
+    }
+
+    public void setOutput(boolean output) {
+        this.output = output;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/AbstractBPMNFormGeneratorServiceTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/AbstractBPMNFormGeneratorServiceTest.java
@@ -59,8 +59,6 @@ public abstract class AbstractBPMNFormGeneratorServiceTest<SERVICE extends Abstr
 
     protected FieldManager fieldManager = new TestFieldManager();
 
-    protected FormLayoutTemplateGenerator templateGenerator = new StaticFormLayoutTemplateGenerator();
-
     protected SERVICE service;
 
     protected SOURCE source;
@@ -119,8 +117,7 @@ public abstract class AbstractBPMNFormGeneratorServiceTest<SERVICE extends Abstr
         });
 
         assertNotNull(form.getLayoutTemplate());
-        assertEquals(form.getFields().size(),
-                     form.getLayoutTemplate().getRows().size());
+        assertFalse(form.getLayoutTemplate().getRows().isEmpty());
     }
 
     protected FormGenerationResult launchNestedFormsTest() {

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/authoring/BPMNVFSFormDefinitionGeneratorServiceTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/authoring/BPMNVFSFormDefinitionGeneratorServiceTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.forms.editor.service.backend.FormModelHandlerMan
 import org.kie.workbench.common.forms.editor.service.shared.VFSFormFinderService;
 import org.kie.workbench.common.forms.editor.service.shared.model.impl.FormModelSynchronizationUtilImpl;
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
+import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.AbstractBPMNFormGeneratorServiceTest;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.test.TestFormModelHandlerManager;
 import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
@@ -61,7 +62,8 @@ public abstract class BPMNVFSFormDefinitionGeneratorServiceTest extends Abstract
     protected DataObjectFinderService dataObjectFinderService;
     protected FormModelHandlerManager formModelHandlerManager;
     protected FormDefinitionSerializer formSerializer = new FormDefinitionSerializerImpl(new FieldSerializer(),
-                                                                                         new FormModelSerializer());
+                                                                                         new FormModelSerializer(),
+                                                                                         new TestMetaDataEntryManager());
     protected SimpleFileSystemProvider simpleFileSystemProvider = null;
     @Mock
     protected CommentedOptionFactory commentedOptionFactory;
@@ -97,7 +99,6 @@ public abstract class BPMNVFSFormDefinitionGeneratorServiceTest extends Abstract
                                                                   dataObjectFinderService);
 
         service = new BPMNVFSFormDefinitionGeneratorService(fieldManager,
-                                                            templateGenerator,
                                                             formModelHandlerManager,
                                                             formFinderService,
                                                             formSerializer,

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/runtime/BPMNRuntimeFormDefinitionGeneratorServiceTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/runtime/BPMNRuntimeFormDefinitionGeneratorServiceTest.java
@@ -28,7 +28,6 @@ public abstract class BPMNRuntimeFormDefinitionGeneratorServiceTest extends Abst
 
         source = mock(ClassLoader.class);
 
-        service = new BPMNRuntimeFormGeneratorService(fieldManager,
-                                                      templateGenerator);
+        service = new BPMNRuntimeFormGeneratorService(fieldManager);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMFinderServiceImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMFinderServiceImplTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.services.shared.project.KieProject;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.DirectoryStream;
@@ -60,29 +61,32 @@ public class BPMFinderServiceImplTest {
 
     private SimpleFileSystemProvider simpleFileSystemProvider = null;
 
-    Path rootPath;
+    private Path rootPath;
 
     @Mock
-    IOService ioService;
+    private IOService ioService;
 
     @Mock
-    KieProject project;
+    private KieProject project;
 
     @Mock
-    KieProjectService projectService;
+    private KieProjectService projectService;
 
     @Mock
-    ProjectClassLoaderHelper projectClassLoaderHelper;
-
-    BPMNFormModelGeneratorImpl bpmnFormModelGenerator;
-
-    BPMFinderServiceImpl finderService;
+    private ProjectClassLoaderHelper projectClassLoaderHelper;
 
     @Mock
-    org.uberfire.backend.vfs.Path testPath;
+    private ClassLoader classLoader;
+
+    private BPMNFormModelGeneratorImpl bpmnFormModelGenerator;
+
+    private BPMFinderServiceImpl finderService;
+
+    @Mock
+    private org.uberfire.backend.vfs.Path testPath;
 
     @Before
-    public void initialize() throws URISyntaxException {
+    public void initialize() throws URISyntaxException, ClassNotFoundException {
 
         when(ioService.newDirectoryStream(any(),
                                           any())).thenAnswer(invocationOnMock -> Files.newDirectoryStream((Path) invocationOnMock.getArguments()[0],
@@ -97,7 +101,9 @@ public class BPMFinderServiceImplTest {
         when(projectService.resolveProject(any())).thenReturn(project);
         when(project.getRootPath()).thenReturn(Paths.convert(rootPath));
 
-        when(projectClassLoaderHelper.getProjectClassLoader(any())).thenReturn(getClass().getClassLoader());
+        when(classLoader.loadClass(any())).thenAnswer((Answer<Class>) invocation -> String.class);
+
+        when(projectClassLoaderHelper.getProjectClassLoader(any())).thenReturn(classLoader);
 
         bpmnFormModelGenerator = new BPMNFormModelGeneratorImpl(projectService,
                                                                 projectClassLoaderHelper);

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMNFormGenerationTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMNFormGenerationTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.kie.workbench.common.forms.commons.shared.layout.impl.DynamicFormLayoutTemplateGenerator;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.EnumListBoxFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.definition.MultipleSubFormFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.definition.SubFormFieldDefinition;
@@ -63,8 +62,7 @@ public abstract class BPMNFormGenerationTest<MODEL extends JBPMFormModel> {
 
     @Before
     public void initTest() {
-        generatorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager(),
-                                                               new DynamicFormLayoutTemplateGenerator());
+        generatorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager());
 
         generator = new DynamicBPMNFormGeneratorImpl(generatorService);
     }

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMNFormModelGeneratorImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/test/java/org/kie/workbench/common/forms/jbpm/server/service/impl/BPMNFormModelGeneratorImplTest.java
@@ -69,7 +69,7 @@ public class BPMNFormModelGeneratorImplTest {
         put("_float",
             Float.class.getName());
         put("_object",
-            String.class.getName());
+            Object.class.getName());
         put("_dataObject",
             DATA_OBJECT_TYPE);
         put("_customType",
@@ -86,7 +86,7 @@ public class BPMNFormModelGeneratorImplTest {
         put("float_",
             Float.class.getName());
         put("object_",
-            String.class.getName());
+            Object.class.getName());
         put("dataObject_",
             DATA_OBJECT_TYPE);
         put("customType_",
@@ -161,7 +161,7 @@ public class BPMNFormModelGeneratorImplTest {
             put("float",
                 Float.class.getName());
             put("object",
-                String.class.getName());
+                Object.class.getName());
             put("dataObject",
                 DATA_OBJECT_TYPE);
             put("customType",
@@ -233,7 +233,7 @@ public class BPMNFormModelGeneratorImplTest {
             put("_float_",
                 Float.class.getName());
             put("_object_",
-                String.class.getName());
+                Object.class.getName());
             put("_dataObject_",
                 DATA_OBJECT_TYPE);
             put("_customType_",

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/FormsJBPMIntegrationEntryPoint.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/FormsJBPMIntegrationEntryPoint.java
@@ -21,7 +21,7 @@ import javax.annotation.PostConstruct;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
 import org.kie.workbench.common.forms.jbpm.model.authoring.document.type.DocumentFieldType;
-import org.kie.workbench.common.forms.model.util.ModelPropertiesUtil;
+import org.kie.workbench.common.forms.model.util.formModel.FormModelPropertiesUtil;
 
 @EntryPoint
 @Bundle("resources/i18n/Constants.properties")
@@ -30,7 +30,7 @@ public class FormsJBPMIntegrationEntryPoint {
     @PostConstruct
     public void init() {
         // registering Document Types to ModelPropertiesUtil
-        ModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_TYPE);
-        ModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_IMPL_TYPE);
+        FormModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_TYPE);
+        FormModelPropertiesUtil.registerBaseType(DocumentFieldType.DOCUMENT_IMPL_TYPE);
     }
 }


### PR DESCRIPTION
Copy of https://github.com/kiegroup/kie-wb-common/pull/1186

@jsoltes could you please take a look?

This is part of an ensemble, merge with:
https://github.com/kiegroup/kie-wb-common/pull/1187
https://github.com/kiegroup/jbpm-designer/pull/666
https://github.com/kiegroup/jbpm-wb/pull/904
