### PR TITLE
[7.3.x] AF-615: Items in the logout menu duplicated every time navigation tree is changed

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/menu/DefaultWorkbenchFeaturesMenusHelper.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/menu/DefaultWorkbenchFeaturesMenusHelper.java
@@ -224,6 +224,8 @@ public class DefaultWorkbenchFeaturesMenusHelper {
     }
 
     public void addUserMenuItems() {
+        userMenu.clear();
+
         final Menus userMenus = MenuFactory
                 .newTopLevelMenu(constants.LogOut())
                 .respondsWith(new LogoutCommand())

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/menu/DefaultWorkbenchFeaturesMenusHelperTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/menu/DefaultWorkbenchFeaturesMenusHelperTest.java
@@ -313,6 +313,7 @@ public class DefaultWorkbenchFeaturesMenusHelperTest {
     public void addUserMenuItemTest() {
         menusHelper.addUserMenuItems();
 
+        verify(userMenu).clear();
         ArgumentCaptor<Menus> menusCaptor = ArgumentCaptor.forClass(Menus.class);
         verify(userMenu,
                times(1)).addMenus(menusCaptor.capture());


### PR DESCRIPTION
Cherry-picked from [master](https://github.com/kiegroup/kie-wb-common/pull/1174)