### PR TITLE
[7.3.x] GUVNOR-3394: [DMN Editor] Literal Expression: Line breaks for multiple line expressions

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.Text;
+import com.ait.lienzo.client.core.shape.TextBoundsWrap;
 import com.ait.lienzo.client.core.shape.wires.LayoutContainer;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.shared.core.types.ColorName;
@@ -36,10 +37,10 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewHandler
 /**
  * A helper class for handling the wires shapes' text primitive
  * that is used to display the shape's name.
- * <p>
+ * <p/>
  * It handles common logic for ShapeViews that implement <code>HasText</code>
  * type, can be reused for shapes or connectors.
- * <p>
+ * <p/>
  */
 public class WiresTextDecorator {
 
@@ -50,6 +51,7 @@ public class WiresTextDecorator {
     private ViewHandler<TextClickEvent> textClickEventViewHandler;
     private ViewHandler<TextDoubleClickEvent> textDblClickEventViewHandler;
     private Text text;
+    private TextBoundsWrap textWrapper;
     private LayoutContainer.Layout currentTextLayout;
 
     public WiresTextDecorator(final ViewEventHandlerManager eventHandlerManager) {
@@ -81,6 +83,12 @@ public class WiresTextDecorator {
                 .setDraggable(false)
                 .setAlpha(0)
                 .setTextAlign(TextAlign.CENTER);
+        this.textWrapper = new TextBoundsWrap(text,
+                                              new BoundingBox(0,
+                                                              0,
+                                                              100,
+                                                              100));
+        this.text.setWrapper(textWrapper);
         this.currentTextLayout = LayoutContainer.Layout.CENTER;
         textContainer.add(text);
         // Ensure path bounds are available on the selection context.
@@ -183,7 +191,7 @@ public class WiresTextDecorator {
         }
         final boolean changed = !currentTextLayout.equals(layout);
         this.currentTextLayout = layout;
-        setTextBoundaries(text.getWrapBoundaries());
+        setTextBoundaries(textWrapper.getWrapBoundaries());
         return changed;
     }
 
@@ -262,19 +270,19 @@ public class WiresTextDecorator {
         switch (getLayout()) {
             case LEFT:
                 if (null != boundaries) {
-                    text.setWrapBoundaries(new BoundingBox(boundaries.getMinY(),
-                                                           boundaries.getMaxX(),
-                                                           boundaries.getMaxY(),
-                                                           boundaries.getMaxX()));
+                    textWrapper.setWrapBoundaries(new BoundingBox(boundaries.getMinY(),
+                                                                  boundaries.getMaxX(),
+                                                                  boundaries.getMaxY(),
+                                                                  boundaries.getMaxX()));
                 }
                 break;
 
             case RIGHT:
                 if (null != boundaries) {
-                    text.setWrapBoundaries(new BoundingBox(boundaries.getMinY(),
-                                                           boundaries.getMaxX(),
-                                                           boundaries.getMaxY(),
-                                                           boundaries.getMaxX()));
+                    textWrapper.setWrapBoundaries(new BoundingBox(boundaries.getMinY(),
+                                                                  boundaries.getMaxX(),
+                                                                  boundaries.getMaxY(),
+                                                                  boundaries.getMaxX()));
                 }
                 break;
 
@@ -282,7 +290,7 @@ public class WiresTextDecorator {
             case CENTER:
             case BOTTOM:
             default:
-                text.setWrapBoundaries(boundaries);
+                textWrapper.setWrapBoundaries(boundaries);
                 break;
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorViewTest.java
@@ -28,6 +28,7 @@ import com.ait.lienzo.client.core.shape.wires.MagnetManager;
 import com.ait.lienzo.client.core.shape.wires.WiresConnection;
 import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorControl;
+import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.shared.core.types.IColor;
@@ -90,6 +91,10 @@ public class WiresConnectorViewTest {
         when(tailDecorator.getPath()).thenReturn(tailPath);
         when(headPath.asNode()).thenReturn(headPathNode);
         when(tailPath.asNode()).thenReturn(tailPathNode);
+        when(headPath.getBoundingBox()).thenReturn(new BoundingBox(0,
+                                                                   0,
+                                                                   10,
+                                                                   10));
         this.tested = new WiresConnectorView(line,
                                              headDecorator,
                                              tailDecorator);


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3394

This is the corollary of https://github.com/kiegroup/kie-wb-common/pull/1074 for 7.3.x.

(cherry picked from commit ed62be08a4488b0a4f469b35918ce6e0292d35aa)

Please note 7.3.x does not have the DMN Editor and hence the changes here are only for Stunner.