### PR TITLE
[7.3.x] AF-619: [Library] Null exception appears in Project Explorer when switching views

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/ProjectExplorerContentResolver.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/ProjectExplorerContentResolver.java
@@ -397,7 +397,7 @@ public class ProjectExplorerContentResolver {
                                                                    userContent ) );
                     content.setSelectedBranch( loadBranch( content.getSelectedOrganizationalUnit(),
                                                            content.getSelectedRepository(),
-                                                           lastContent.getLastPackage().getBranch() ) );
+                                                           lastContent.getLastFolderItem().getBranch() ) );
                     content.setSelectedProject( loadProject( content.getSelectedOrganizationalUnit(),
                                                              content.getSelectedRepository(),
                                                              lastContent.getLastFolderItem().getProject(),

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/HelperWrapper.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/HelperWrapper.java
@@ -21,6 +21,7 @@ import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.repositories.Repository;
 import org.kie.workbench.common.screens.explorer.model.FolderListing;
 import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
+import org.kie.workbench.common.screens.explorer.service.Option;
 import org.mockito.ArgumentCaptor;
 
 import static org.mockito.Matchers.*;
@@ -35,6 +36,7 @@ public class HelperWrapper {
     private ArgumentCaptor<Project> projectArgumentCaptor;
     private ArgumentCaptor<FolderListing> folderListingArgumentCaptor;
     private ArgumentCaptor<Package> packageArgumentCaptor;
+    private ArgumentCaptor<ActiveOptions> activeOptionsArgumentCaptor;
     private ExplorerServiceHelper helper;
     private boolean includePackage = true;
 
@@ -49,6 +51,10 @@ public class HelperWrapper {
 
     public UserExplorerLastData getUserExplorerLastData() {
         UserExplorerLastData userExplorerLastData = new UserExplorerLastData();
+
+        if (activeOptionsArgumentCaptor != null) {
+            userExplorerLastData.setOptions(activeOptionsArgumentCaptor.getValue());
+        }
 
         if (packageArgumentCaptor == null) {
             return userExplorerLastData;
@@ -91,6 +97,7 @@ public class HelperWrapper {
         projectArgumentCaptor = ArgumentCaptor.forClass(Project.class);
         folderListingArgumentCaptor = ArgumentCaptor.forClass(FolderListing.class);
         packageArgumentCaptor = ArgumentCaptor.forClass(Package.class);
+        activeOptionsArgumentCaptor = ArgumentCaptor.forClass(ActiveOptions.class);
 
         verify(
                 helper,
@@ -101,7 +108,7 @@ public class HelperWrapper {
                 projectArgumentCaptor.capture(),
                 folderListingArgumentCaptor.capture(),
                 packageArgumentCaptor.capture(),
-                any( ActiveOptions.class));
+                activeOptionsArgumentCaptor.capture());
 
     }
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ProjectExplorerContentResolverTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ProjectExplorerContentResolverTest.java
@@ -280,6 +280,20 @@ public class ProjectExplorerContentResolverTest {
         assertNull( content.getSelectedPackage() );
     }
 
+    @Test
+    public void testChangeFromBusinessToTechnicalView() {
+        resolver.resolve( getContentQuery( "master", createProject( "master", "project 1" ), Option.BUSINESS_CONTENT ) );
+        helperWrapper.reset();
+
+        Content content = resolver.setupSelectedItems( getContentQuery( "master", createProject( "master", "project 1" ), Option.TECHNICAL_CONTENT, null, getFileItem() ) );
+
+        assertEquals( "demo", content.getSelectedOrganizationalUnit().getName() );
+        assertEquals( "master", content.getSelectedBranch() );
+        assertEquals( "master@project 1", content.getSelectedProject().getRootPath().toURI() );
+        assertNull( content.getSelectedItem() );
+        assertNull( content.getSelectedPackage() );
+    }
+
     private Project createProject( final String branch,
                                    final String projectName ) {
         return new Project( createMockPath( branch, projectName ), createMockPath( branch, projectName ), projectName );


### PR DESCRIPTION
Cherry-picked from [master](https://github.com/kiegroup/kie-wb-common/pull/1181).