### PR TITLE
JBPM-5568 Cannot open Diagrams that contain "unsupported" Definitions 

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
 import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
@@ -77,7 +78,8 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final ProjectDiagramEditorMenuItemsBuilder menuItemsBuilder,
                             final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                             final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
-                            final ProjectMessagesListener projectMessagesListener) {
+                            final ProjectMessagesListener projectMessagesListener,
+                            final DiagramClientErrorHandler diagramClientErrorHandler) {
         super(view,
               placeManager,
               errorPopupPresenter,
@@ -91,7 +93,8 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
               menuItemsBuilder,
               onDiagramFocusEvent,
               onDiagramLostFocusEvent,
-              projectMessagesListener);
+              projectMessagesListener,
+              diagramClientErrorHandler);
     }
 
     @OnStartup

--- a/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/DiagramLookupServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/DiagramLookupServiceImpl.java
@@ -30,6 +30,8 @@ import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.lookup.criteria.AbstractCriteriaLookupManager;
 import org.kie.workbench.common.stunner.core.lookup.diagram.DiagramLookupRequest;
+import org.kie.workbench.common.stunner.core.lookup.diagram.DiagramRepresentation;
+import org.kie.workbench.common.stunner.core.service.DiagramService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Paths;
@@ -42,6 +44,8 @@ public class DiagramLookupServiceImpl
 
     private static final Logger LOG = LoggerFactory.getLogger(DiagramLookupServiceImpl.class.getName());
 
+    private DiagramService diagramService;
+
     protected DiagramLookupServiceImpl() {
         this(null,
              null);
@@ -52,6 +56,7 @@ public class DiagramLookupServiceImpl
                                     final DiagramServiceImpl diagramService) {
         super(ioService,
               diagramService);
+        this.diagramService = diagramService;
     }
 
     protected org.uberfire.java.nio.file.Path parseCriteriaPath(final DiagramLookupRequest request) {
@@ -80,6 +85,12 @@ public class DiagramLookupServiceImpl
         String m = "Criteria [" + criteria + "] not supported.";
         LOG.error(m);
         throw new IllegalArgumentException(m);
+    }
+
+    @Override
+    public LookupResponse<DiagramRepresentation> lookup(DiagramLookupRequest request) {
+        diagramService.registryDiagrams();
+        return super.lookup(request);
     }
 
     private DiagramServiceImpl getServiceImpl() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/DiagramServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/DiagramServiceImpl.java
@@ -97,6 +97,10 @@ public class DiagramServiceImpl
         initFileSystem();
         // Register packaged diagrams into VFS.
         registerAppDefinitions();
+
+    }
+
+    public void registryDiagrams() {
         // Load vfs diagrams and put into the parent registry.
         final Collection<Diagram<Graph, Metadata>> diagrams = getAllDiagrams();
         if (null != diagrams) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/exception/DefinitionNotFoundException.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/exception/DefinitionNotFoundException.java
@@ -14,17 +14,24 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.service;
+package org.kie.workbench.common.stunner.core.definition.exception;
 
-import org.jboss.errai.bus.server.annotations.Remote;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.jboss.errai.common.client.api.annotations.Portable;
 
-/**
- * Default Stunner's diagram service implementation.
- */
-@Remote
-public interface DiagramService extends BaseDiagramService<Metadata, Diagram<Graph, Metadata>> {
-    void registryDiagrams();
+@Portable
+public class DefinitionNotFoundException extends RuntimeException {
+
+    private String definitionId;
+
+    public DefinitionNotFoundException() {
+    }
+
+    public DefinitionNotFoundException(String message, String definitionId) {
+        super(message);
+        this.definitionId = definitionId;
+    }
+
+    public String getDefinitionId() {
+        return definitionId;
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/error/ClientErrorHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/error/ClientErrorHandler.java
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.service;
+package org.kie.workbench.common.stunner.core.client.error;
 
-import org.jboss.errai.bus.server.annotations.Remote;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
+import java.util.function.Consumer;
 
-/**
- * Default Stunner's diagram service implementation.
- */
-@Remote
-public interface DiagramService extends BaseDiagramService<Metadata, Diagram<Graph, Metadata>> {
-    void registryDiagrams();
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+
+public abstract class ClientErrorHandler {
+
+    protected ClientTranslationService translationService;
+
+    public ClientErrorHandler(ClientTranslationService translationService) {
+        this.translationService = translationService;
+    }
+
+    public abstract void handleError(ClientRuntimeError error, Consumer<String> showError);
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/error/DiagramClientErrorHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/error/DiagramClientErrorHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.error;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.definition.exception.DefinitionNotFoundException;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+
+public class DiagramClientErrorHandler extends ClientErrorHandler {
+
+    @Inject
+    public DiagramClientErrorHandler(ClientTranslationService translationService) {
+        super(translationService);
+    }
+
+    public void handleError(ClientRuntimeError error, Consumer<String> showError) {
+        if (Objects.isNull(error)) {
+            throw new RuntimeException("Error cannot be null");
+        }
+
+        String message = null;
+        if (error.getThrowable() instanceof DefinitionNotFoundException) {
+            message = translationService.getKeyValue(CoreTranslationMessages.DIAGRAM_LOAD_FAIL_UNSUPPORTED_ELEMENTS,
+                                                     ((DefinitionNotFoundException) error.getThrowable()).getDefinitionId());
+        }
+
+        showError.accept(Objects.nonNull(message) ? message : error.toString());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/i18n/ClientTranslationService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/i18n/ClientTranslationService.java
@@ -40,7 +40,7 @@ public class ClientTranslationService extends AbstractTranslationService {
     }
 
     @Override
-    protected String getKeyValue(final String key,
+    public String getKeyValue(final String key,
                                  final Object... args) {
         return erraiTranslationService.format(key,
                                               args);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/error/DiagramClientErrorHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/error/DiagramClientErrorHandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.error;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.definition.exception.DefinitionNotFoundException;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiagramClientErrorHandlerTest {
+
+    private DiagramClientErrorHandler diagramClientErrorHandler;
+
+    @Mock
+    private ClientTranslationService clientTranslationService;
+
+    @Mock
+    private ClientRuntimeError clientRuntimeError;
+
+    private static final String ERROR_MESSAGE = "Error on the response";
+    private static final String DEFINITION_ID = "testId";
+
+    @Before
+    public void setUp() {
+        diagramClientErrorHandler = new DiagramClientErrorHandler(clientTranslationService);
+        when(clientTranslationService.getKeyValue(CoreTranslationMessages.DIAGRAM_LOAD_FAIL_UNSUPPORTED_ELEMENTS,
+                                                  DEFINITION_ID)).thenReturn(ERROR_MESSAGE);
+    }
+
+    @Test
+    public void handleErrorTest() {
+        reset(clientRuntimeError);
+
+        when(clientRuntimeError.getThrowable()).thenReturn(new DefinitionNotFoundException("Error", DEFINITION_ID));
+        diagramClientErrorHandler.handleError(clientRuntimeError, message -> Assert.assertEquals(ERROR_MESSAGE, message));
+
+        when(clientRuntimeError.getThrowable()).thenReturn(new RuntimeException());
+        when(clientRuntimeError.toString()).thenReturn("runtime");
+        diagramClientErrorHandler.handleError(clientRuntimeError, message -> Assert.assertEquals("runtime", message));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessages.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessages.java
@@ -46,4 +46,6 @@ public class CoreTranslationMessages {
     public static final String VALIDATION_SUCCESS = RULE_PREF + "success";
 
     public static final String VALIDATION_FAILED = RULE_PREF + "fail";
+
+    public static final String DIAGRAM_LOAD_FAIL_UNSUPPORTED_ELEMENTS = "org.kie.workbench.common.stunner.core.client.diagram.load.fail.unsupported";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/resources/i18n/StunnerCoreConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/resources/i18n/StunnerCoreConstants.properties
@@ -50,3 +50,8 @@ org.kie.workbench.common.stunner.core.rule.violations.EmptyConnectionViolation=B
 org.kie.workbench.common.stunner.core.client.toolbox.createNewConnector=Create
 org.kie.workbench.common.stunner.core.client.toolbox.createNewNode=Create
 org.kie.workbench.common.stunner.core.client.toolbox.morphInto=Convert into
+
+########################
+#ClientDiagramService
+########################
+org.kie.workbench.common.stunner.core.client.diagram.load.fail.unsupported=Diagram cannot be loaded. There are unsupported elements: '{0}'

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearStatesSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteSelectionSessionCommand;
@@ -83,11 +84,15 @@ public class AbstractProjectDiagramEditorTest {
 
     @Mock
     protected SessionCommandFactory sessionCommandFactory;
+
     @Mock
     private ProjectMessagesListener projectMessagesListener;
 
     @Mock
     private ClientResourceTypeMock resourceType;
+
+    @Mock
+    private DiagramClientErrorHandler diagramClientErrorHandler;
 
     abstract class ClientResourceTypeMock implements ClientResourceType {
 
@@ -122,7 +127,8 @@ public class AbstractProjectDiagramEditorTest {
                                                                              mock(ProjectDiagramEditorMenuItemsBuilder.class),
                                                                              new EventSourceMock<>(),
                                                                              new EventSourceMock<>(),
-                                                                             projectMessagesListener) {
+                                                                             projectMessagesListener,
+                                                                             diagramClientErrorHandler) {
             {
                 fileMenuBuilder = AbstractProjectDiagramEditorTest.this.fileMenuBuilder;
                 workbenchContext = AbstractProjectDiagramEditorTest.this.workbenchContext;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorStub.java
@@ -20,6 +20,7 @@ import javax.enterprise.event.Event;
 
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
@@ -51,7 +52,8 @@ class ProjectDiagramEditorStub extends AbstractProjectDiagramEditor<ClientResour
                                     ProjectDiagramEditorMenuItemsBuilder menuItemsBuilder,
                                     Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                                     Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
-                                    ProjectMessagesListener projectMessagesListener) {
+                                    ProjectMessagesListener projectMessagesListener,
+                                    DiagramClientErrorHandler diagramClientErrorHandler) {
         super(view,
               placeManager,
               errorPopupPresenter,
@@ -65,7 +67,8 @@ class ProjectDiagramEditorStub extends AbstractProjectDiagramEditor<ClientResour
               menuItemsBuilder,
               onDiagramFocusEvent,
               onDiagramLostFocusEvent,
-              projectMessagesListener);
+              projectMessagesListener,
+              diagramClientErrorHandler);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
@@ -24,6 +24,7 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.session.Sessio
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
 import org.kie.workbench.common.stunner.core.client.api.AbstractClientSessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
 import org.kie.workbench.common.stunner.core.client.session.ClientSessionFactory;
@@ -151,6 +152,8 @@ public class ProjectDiagramEditorTest {
     EventSourceMock<OnDiagramLoseFocusEvent> onDiagramLostFocusEven;
     @Mock
     ProjectMessagesListener projectMessagesListener;
+    @Mock
+    DiagramClientErrorHandler diagramClientErrorHandler;
 
     private ProjectDiagramEditorStub tested;
 
@@ -197,7 +200,8 @@ public class ProjectDiagramEditorTest {
                                                    menuItemsBuilder,
                                                    onDiagramFocusEvent,
                                                    onDiagramLostFocusEven,
-                                                   projectMessagesListener
+                                                   projectMessagesListener,
+                                                   diagramClientErrorHandler
         ) {
             {
                 overviewWidget = overviewWidgetMock;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/builder/BPMNGraphObjectBuilderFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/builder/BPMNGraphObjectBuilderFactory.java
@@ -24,6 +24,7 @@ import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.backend.definition.adapter.annotation.RuntimeDefinitionAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.BindableMorphAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.MorphAdapter;
+import org.kie.workbench.common.stunner.core.definition.exception.DefinitionNotFoundException;
 import org.kie.workbench.common.stunner.core.definition.morph.BindablePropertyMorphDefinition;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.factory.graph.EdgeFactory;
@@ -88,7 +89,7 @@ public class BPMNGraphObjectBuilderFactory implements GraphObjectBuilderFactory 
                 }
             }
         }
-        throw new RuntimeException("No definition found for oryx stencil with id [" + oryxId + "]");
+        throw new DefinitionNotFoundException("No definition found for oryx stencil with id [" + oryxId + "]", oryxId);
     }
 
     private static boolean isNodeFactory(final Class<? extends ElementFactory> elementFactory) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.bpmn.project.client.type.BPMNDiagramReso
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenterFactory;
 import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
@@ -77,7 +78,8 @@ public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramR
                              final ProjectDiagramEditorMenuItemsBuilder menuItemsBuilder,
                              final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                              final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
-                             final ProjectMessagesListener projectMessagesListener) {
+                             final ProjectMessagesListener projectMessagesListener,
+                             final DiagramClientErrorHandler diagramClientErrorHandler) {
         super(view,
               placeManager,
               errorPopupPresenter,
@@ -91,7 +93,8 @@ public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramR
               menuItemsBuilder,
               onDiagramFocusEvent,
               onDiagramLostFocusEvent,
-              projectMessagesListener);
+              projectMessagesListener,
+              diagramClientErrorHandler);
     }
 
     @OnStartup

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.session.Sessio
 import org.kie.workbench.common.stunner.cm.project.client.type.CaseManagementDiagramResourceType;
 import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
@@ -78,7 +79,8 @@ public class CaseManagementDiagramEditor extends AbstractProjectDiagramEditor<Ca
                                        final ProjectDiagramEditorMenuItemsBuilder menuItemsBuilder,
                                        final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                                        final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
-                                       final ProjectMessagesListener projectMessagesListener) {
+                                       final ProjectMessagesListener projectMessagesListener,
+                                       final DiagramClientErrorHandler diagramClientErrorHandler) {
         super(view,
               placeManager,
               errorPopupPresenter,
@@ -92,7 +94,8 @@ public class CaseManagementDiagramEditor extends AbstractProjectDiagramEditor<Ca
               menuItemsBuilder,
               onDiagramFocusEvent,
               onDiagramLostFocusEvent,
-              projectMessagesListener);
+              projectMessagesListener,
+              diagramClientErrorHandler);
     }
 
     @OnStartup


### PR DESCRIPTION
When loading a diagram that contains unsupported definitions on Stunner, than an error message is displayed.
It was created `DiagramClientErrorHandler ` to handle the error generating a message based on the `ClientTranslationService` using the bundle properties that contains the message template on `StunnerCoreConstants.properties`.

@romartin 
@hasys 
@manstis 