### PR TITLE
[UF-510] detect session timeout and show nicer modal

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallback.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallback.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.workbench.client.error;
 
+import com.google.gwt.user.client.Window;
 import org.dashbuilder.dataset.exception.*;
+import org.jboss.errai.bus.client.api.InvalidBusContentException;
 import org.jboss.errai.bus.client.api.messaging.Message;
 import org.kie.server.api.exception.KieServicesHttpException;
 import org.kie.workbench.common.workbench.client.resources.i18n.DefaultWorkbenchConstants;
 import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
+import org.uberfire.ext.widgets.common.client.common.popups.YesNoCancelPopup;
 import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.ext.widgets.common.client.resources.i18n.CommonConstants;
 
@@ -50,10 +53,23 @@ public class DefaultWorkbenchErrorCallback extends DefaultErrorCallback {
         return false;
     }
 
+    public static boolean isInvalidBusContentException(final Throwable throwable) {
+        return throwable instanceof InvalidBusContentException;
+    }
+
     @Override
     public boolean error(final Message message,
                          final Throwable throwable) {
-        if (isKieServerForbiddenException(throwable)) {
+        if (isInvalidBusContentException(throwable)) {
+            final YesNoCancelPopup result = YesNoCancelPopup.newYesNoCancelPopup(DefaultWorkbenchConstants.INSTANCE.SessionTimeout(),
+                                                                                 DefaultWorkbenchConstants.INSTANCE.InvalidBusResponseProbablySessionTimeout(),
+                                                                                 Window.Location::reload,
+                                                                                 null,
+                                                                                 () -> {});
+            result.clearScrollHeight();
+            result.show();
+            return false;
+        } else if (isKieServerForbiddenException(throwable)) {
             ErrorPopup.showMessage(DefaultWorkbenchConstants.INSTANCE.KieServerError403());
             return false;
         } else if (isKieServerUnauthorizedException(throwable)) {
@@ -68,4 +84,5 @@ public class DefaultWorkbenchErrorCallback extends DefaultErrorCallback {
                                throwable);
         }
     }
+
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.java
@@ -160,4 +160,9 @@ public interface DefaultWorkbenchConstants
     String XLSScoreCard();
 
     String StunnerDesigner();
+
+    String InvalidBusResponseProbablySessionTimeout();
+
+    String SessionTimeout();
+
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.properties
@@ -82,3 +82,5 @@ GuidedDecisionTree=Guided Decision Tree Editor
 GuidedScoreCard=Guided Score Card Editor
 XLSScoreCard=XLS Score Card Editor
 StunnerDesigner=(New) jBPM Designer Editor
+SessionTimeout=Session timeout
+InvalidBusResponseProbablySessionTimeout=Invalid response received from the server. This very likely means that you have been logged out due to inactivity. Do you want to log in again?

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallbackTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallbackTest.java
@@ -17,10 +17,12 @@
 package org.kie.workbench.common.workbench.client.error;
 
 import org.dashbuilder.dataset.exception.*;
+import org.jboss.errai.bus.client.api.InvalidBusContentException;
 import org.junit.Test;
 import org.kie.server.api.exception.KieServicesHttpException;
 
 import static org.junit.Assert.*;
+import static org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback.isInvalidBusContentException;
 import static org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback.isKieServerForbiddenException;
 import static org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback.isKieServerUnauthorizedException;
 
@@ -62,5 +64,12 @@ public class DefaultWorkbenchErrorCallbackTest {
                                                                                 null,
                                                                                 new Exception("Unexpected HTTP response code when requesting URI ''! Error code: 403, message: <html><head><title>Error</title></head><body>Forbidden</body></html>"))));
         assertFalse(isKieServerUnauthorizedException(new Exception("Some Unexpected HTTP response code when requesting URI")));
+    }
+
+    @Test
+    public void testInvalidBusContentException() {
+        assertTrue(isInvalidBusContentException(new InvalidBusContentException("text/html", "content")));
+
+        assertFalse(isInvalidBusContentException(new RuntimeException()));
     }
 }


### PR DESCRIPTION
The previous modal showed just a cryptic error saying JSON could not
parsed, which was quite confusing.

The modal shows a `Yes`, `No` and `Cancel` options (with `No` and `Cancel` doing the same -- nothing, just closing the modal). Does that make sense? Is there a use case where user would not want to login again directly and remain on the page (even though it can be used anymore)?

@manstis or @porcelli could you please take a look?