### PR TITLE
GUVNOR-3524: Do not expose unsupported features by UI (e.g. scorecards, decision trees)

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/EditorIds.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/EditorIds.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.workbench.client;
+
+public interface EditorIds {
+
+    String GUIDED_DECISION_TREE = "GuidedDecisionTreeEditorPresenter";
+    String GUIDED_SCORE_CARD = "GuidedScoreCardEditor";
+    String XLS_SCORE_CARD = "ScoreCardXLSEditor";
+    String STUNNER_DESIGNER = "BPMNDiagramEditor";
+}

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/authz/PermissionTreeSetup.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/authz/PermissionTreeSetup.java
@@ -24,8 +24,13 @@ import org.guvnor.common.services.project.client.security.ProjectTreeProvider;
 import org.guvnor.structure.client.security.OrganizationalUnitTreeProvider;
 import org.guvnor.structure.client.security.RepositoryTreeProvider;
 import org.kie.workbench.common.workbench.client.resources.i18n.DefaultWorkbenchConstants;
+import org.uberfire.client.authz.EditorTreeProvider;
 import org.uberfire.client.authz.PerspectiveTreeProvider;
 
+import static org.kie.workbench.common.workbench.client.EditorIds.GUIDED_DECISION_TREE;
+import static org.kie.workbench.common.workbench.client.EditorIds.GUIDED_SCORE_CARD;
+import static org.kie.workbench.common.workbench.client.EditorIds.STUNNER_DESIGNER;
+import static org.kie.workbench.common.workbench.client.EditorIds.XLS_SCORE_CARD;
 import static org.kie.workbench.common.workbench.client.PerspectiveIds.ADMIN;
 import static org.kie.workbench.common.workbench.client.PerspectiveIds.ADMINISTRATION;
 import static org.kie.workbench.common.workbench.client.PerspectiveIds.APPS;
@@ -56,24 +61,32 @@ import static org.kie.workbench.common.workbench.client.PerspectiveIds.TASKS_ADM
 @ApplicationScoped
 public class PermissionTreeSetup {
 
-    @Inject
     private WorkbenchTreeProvider workbenchTreeProvider;
-
-    @Inject
     private PerspectiveTreeProvider perspectiveTreeProvider;
-
-    @Inject
+    private EditorTreeProvider editorTreeProvider;
     private Instance<OrganizationalUnitTreeProvider> orgUnitTreeProvider;
-
-    @Inject
     private Instance<RepositoryTreeProvider> repositoryTreeProvider;
-
-    @Inject
     private Instance<ProjectTreeProvider> projectTreeProvider;
 
     private DefaultWorkbenchConstants i18n = DefaultWorkbenchConstants.INSTANCE;
 
     public PermissionTreeSetup() {
+        //CDI proxy
+    }
+
+    @Inject
+    public PermissionTreeSetup(final WorkbenchTreeProvider workbenchTreeProvider,
+                               final PerspectiveTreeProvider perspectiveTreeProvider,
+                               final EditorTreeProvider editorTreeProvider,
+                               final Instance<OrganizationalUnitTreeProvider> orgUnitTreeProvider,
+                               final Instance<RepositoryTreeProvider> repositoryTreeProvider,
+                               final Instance<ProjectTreeProvider> projectTreeProvider) {
+        this.workbenchTreeProvider = workbenchTreeProvider;
+        this.perspectiveTreeProvider = perspectiveTreeProvider;
+        this.editorTreeProvider = editorTreeProvider;
+        this.orgUnitTreeProvider = orgUnitTreeProvider;
+        this.repositoryTreeProvider = repositoryTreeProvider;
+        this.projectTreeProvider = projectTreeProvider;
     }
 
     public void configureTree() {
@@ -129,19 +142,29 @@ public class PermissionTreeSetup {
         perspectiveTreeProvider.excludePerspectiveId(SOCIAL_HOME); /* uberfire */
         perspectiveTreeProvider.excludePerspectiveId(SOCIAL_USER_HOME); /* uberfire */
         perspectiveTreeProvider.excludePerspectiveId("Asset Management"); /* guvnor */
-        perspectiveTreeProvider.excludePerspectiveId(SOCIAL_USER_HOME); /* uberfire */
+
+        // Include optional editors
+        editorTreeProvider.registerEditor(GUIDED_DECISION_TREE,
+                                          i18n.GuidedDecisionTree());
+        editorTreeProvider.registerEditor(GUIDED_SCORE_CARD,
+                                          i18n.GuidedScoreCard());
+        editorTreeProvider.registerEditor(XLS_SCORE_CARD,
+                                          i18n.XLSScoreCard());
+        editorTreeProvider.registerEditor(STUNNER_DESIGNER,
+                                          i18n.StunnerDesigner());
 
         // Set the desired display order
         workbenchTreeProvider.setRootNodePosition(0);
         perspectiveTreeProvider.setRootNodePosition(1);
-        if(orgUnitTreeProvider.isUnsatisfied() == false) {
-            orgUnitTreeProvider.get().setRootNodePosition(2);
+        editorTreeProvider.setRootNodePosition(2);
+        if (!orgUnitTreeProvider.isUnsatisfied()) {
+            orgUnitTreeProvider.get().setRootNodePosition(3);
         }
-        if(repositoryTreeProvider.isUnsatisfied() == false) {
-            repositoryTreeProvider.get().setRootNodePosition(3);
+        if (!repositoryTreeProvider.isUnsatisfied()) {
+            repositoryTreeProvider.get().setRootNodePosition(4);
         }
-        if(projectTreeProvider.isUnsatisfied() == false) {
-            projectTreeProvider.get().setRootNodePosition(4);
+        if (!projectTreeProvider.isUnsatisfied()) {
+            projectTreeProvider.get().setRootNodePosition(5);
         }
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.java
@@ -152,4 +152,12 @@ public interface DefaultWorkbenchConstants
     String Languages();
 
     String Tasks_Admin();
+
+    String GuidedDecisionTree();
+
+    String GuidedScoreCard();
+
+    String XLSScoreCard();
+
+    String StunnerDesigner();
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.properties
@@ -78,3 +78,7 @@ GuidedDecisionTableEditColumns=Edit Guided Decision Table columns
 GuidedDecisionTableEditColumnsHelp=Enables the edition of Guided Decision Table columns.
 Languages=Languages
 Tasks_Admin=Tasks Administration
+GuidedDecisionTree=Guided Decision Tree Editor
+GuidedScoreCard=Guided Score Card Editor
+XLSScoreCard=XLS Score Card Editor
+StunnerDesigner=(New) jBPM Designer Editor

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/authz/PermissionTreeSetupTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/authz/PermissionTreeSetupTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.workbench.client.authz;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.client.security.ProjectTreeProvider;
+import org.guvnor.structure.client.security.OrganizationalUnitTreeProvider;
+import org.guvnor.structure.client.security.RepositoryTreeProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.client.authz.EditorTreeProvider;
+import org.uberfire.client.authz.PerspectiveTreeProvider;
+import org.uberfire.mocks.MockInstanceImpl;
+
+import static org.kie.workbench.common.workbench.client.EditorIds.GUIDED_DECISION_TREE;
+import static org.kie.workbench.common.workbench.client.EditorIds.GUIDED_SCORE_CARD;
+import static org.kie.workbench.common.workbench.client.EditorIds.STUNNER_DESIGNER;
+import static org.kie.workbench.common.workbench.client.EditorIds.XLS_SCORE_CARD;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.ADMIN;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.ADMINISTRATION;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.APPS;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.AUTHORING;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.BUSINESS_DASHBOARDS;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.DATASET_AUTHORING;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.DATASOURCE_MANAGEMENT;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.DEPLOYMENTS;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.EXECUTION_ERRORS;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.GUVNOR_M2REPO;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.HOME;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.JOBS;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.LIBRARY;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.PLUGIN_AUTHORING;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.PROCESS_DASHBOARD;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.PROCESS_DEFINITIONS;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.PROCESS_INSTANCES;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.SECURITY_MANAGEMENT;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.SERVER_MANAGEMENT;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.SOCIAL_HOME;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.SOCIAL_USER_HOME;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.TASKS;
+import static org.kie.workbench.common.workbench.client.PerspectiveIds.TASKS_ADMIN;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class PermissionTreeSetupTest {
+
+    @Mock
+    private WorkbenchTreeProvider workbenchTreeProvider;
+
+    @Mock
+    private PerspectiveTreeProvider perspectiveTreeProvider;
+
+    @Mock
+    private EditorTreeProvider editorTreeProvider;
+
+    @Mock
+    private MockInstanceImpl<OrganizationalUnitTreeProvider> orgUnitTreeProvider;
+
+    @Mock
+    private MockInstanceImpl<RepositoryTreeProvider> repositoryTreeProvider;
+
+    @Mock
+    private MockInstanceImpl<ProjectTreeProvider> projectTreeProvider;
+
+    private PermissionTreeSetup tree;
+
+    @Before
+    public void setup() {
+        when(orgUnitTreeProvider.isUnsatisfied()).thenReturn(true);
+        when(repositoryTreeProvider.isUnsatisfied()).thenReturn(true);
+        when(projectTreeProvider.isUnsatisfied()).thenReturn(true);
+
+        this.tree = new PermissionTreeSetup(workbenchTreeProvider,
+                                            perspectiveTreeProvider,
+                                            editorTreeProvider,
+                                            orgUnitTreeProvider,
+                                            repositoryTreeProvider,
+                                            projectTreeProvider);
+    }
+
+    @Test
+    public void testConfigureTree_Perspectives() {
+        tree.configureTree();
+
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(HOME),
+                                                           eq("HomePage"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(ADMIN),
+                                                           eq("Admin"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(SECURITY_MANAGEMENT),
+                                                           eq("SecurityManagement"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(GUVNOR_M2REPO),
+                                                           eq("ArtifactRepository"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(DATASET_AUTHORING),
+                                                           eq("DataSets"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(DATASOURCE_MANAGEMENT),
+                                                           eq("DataSources"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(LIBRARY),
+                                                           eq("ProjectAuthoring"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(BUSINESS_DASHBOARDS),
+                                                           eq("Business_Dashboards"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(DEPLOYMENTS),
+                                                           eq("Process_Deployments"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(SERVER_MANAGEMENT),
+                                                           eq("Rule_Deployments"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(PROCESS_DEFINITIONS),
+                                                           eq("ProcessDefinitions"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(PROCESS_INSTANCES),
+                                                           eq("ProcessInstances"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(TASKS_ADMIN),
+                                                           eq("Tasks_Admin"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(JOBS),
+                                                           eq("Jobs"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(EXECUTION_ERRORS),
+                                                           eq("ExecutionErrors"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(TASKS),
+                                                           eq("Tasks"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(PROCESS_DASHBOARD),
+                                                           eq("Process_Dashboard"));
+        verify(perspectiveTreeProvider).setPerspectiveName(eq(APPS),
+                                                           eq("Apps"));
+    }
+
+    @Test
+    public void testConfigureTree_ExcludedPerspectives() {
+        tree.configureTree();
+
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq(AUTHORING));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("AuthoringPerspectiveNoContext"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("FormDisplayPerspective"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("Drools Tasks"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("Experimental Paging"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("StandaloneEditorPerspective"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("WiresTreesPerspective"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("WiresGridsDemoPerspective"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("PreferencesCentralPerspective"));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq(ADMINISTRATION));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq(PLUGIN_AUTHORING));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq(SOCIAL_HOME));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq(SOCIAL_USER_HOME));
+        verify(perspectiveTreeProvider).excludePerspectiveId(eq("Asset Management"));
+    }
+
+    @Test
+    public void testConfigureTree_RegisteredEditors() {
+        tree.configureTree();
+
+        verify(editorTreeProvider).registerEditor(eq(GUIDED_DECISION_TREE),
+                                                  eq("GuidedDecisionTree"));
+        verify(editorTreeProvider).registerEditor(eq(GUIDED_SCORE_CARD),
+                                                  eq("GuidedScoreCard"));
+        verify(editorTreeProvider).registerEditor(eq(XLS_SCORE_CARD),
+                                                  eq("XLSScoreCard"));
+        verify(editorTreeProvider).registerEditor(eq(STUNNER_DESIGNER),
+                                                  eq("StunnerDesigner"));
+    }
+
+    @Test
+    public void testConfigureTree_ProviderOrders() {
+        final OrganizationalUnitTreeProvider orgUnitTree = mock(OrganizationalUnitTreeProvider.class);
+        final RepositoryTreeProvider repositoryTree = mock(RepositoryTreeProvider.class);
+        final ProjectTreeProvider projectTree = mock(ProjectTreeProvider.class);
+        when(orgUnitTreeProvider.isUnsatisfied()).thenReturn(false);
+        when(repositoryTreeProvider.isUnsatisfied()).thenReturn(false);
+        when(projectTreeProvider.isUnsatisfied()).thenReturn(false);
+        when(orgUnitTreeProvider.get()).thenReturn(orgUnitTree);
+        when(repositoryTreeProvider.get()).thenReturn(repositoryTree);
+        when(projectTreeProvider.get()).thenReturn(projectTree);
+
+        tree.configureTree();
+
+        verify(workbenchTreeProvider).setRootNodePosition(eq(0));
+        verify(perspectiveTreeProvider).setRootNodePosition(eq(1));
+        verify(editorTreeProvider).setRootNodePosition(eq(2));
+        verify(orgUnitTree).setRootNodePosition(eq(3));
+        verify(repositoryTree).setRootNodePosition(eq(4));
+        verify(projectTree).setRootNodePosition(eq(5));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/pom.xml
@@ -133,6 +133,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-properties-editor-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -180,6 +185,11 @@
       <artifactId>errai-data-binding</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
     <!-- Test scope. -->
 
     <dependency>
@@ -206,8 +216,6 @@
       <scope>test</scope>
     </dependency>
 
-
   </dependencies>
-
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/handlers/BPMNDiagramNewResourceHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/handlers/BPMNDiagramNewResourceHandler.java
@@ -26,12 +26,21 @@ import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.project.client.handlers.AbstractProjectDiagramNewResourceHandler;
 import org.kie.workbench.common.stunner.project.client.service.ClientProjectDiagramService;
 import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.rpc.SessionInfo;
+import org.uberfire.security.authz.AuthorizationManager;
 
 @ApplicationScoped
 public class BPMNDiagramNewResourceHandler extends AbstractProjectDiagramNewResourceHandler<BPMNDiagramResourceType> {
 
+    static final String PERMISSION = "editor.read." + BPMNDiagramEditor.EDITOR_ID;
+
+    private final AuthorizationManager authorizationManager;
+    private final SessionInfo sessionInfo;
+
     protected BPMNDiagramNewResourceHandler() {
         this(null,
+             null,
+             null,
              null,
              null,
              null);
@@ -41,11 +50,15 @@ public class BPMNDiagramNewResourceHandler extends AbstractProjectDiagramNewReso
     public BPMNDiagramNewResourceHandler(final DefinitionManager definitionManager,
                                          final ClientProjectDiagramService projectDiagramServices,
                                          final BusyIndicatorView indicatorView,
-                                         final BPMNDiagramResourceType projectDiagramResourceType) {
+                                         final BPMNDiagramResourceType projectDiagramResourceType,
+                                         final AuthorizationManager authorizationManager,
+                                         final SessionInfo sessionInfo) {
         super(definitionManager,
               projectDiagramServices,
               indicatorView,
               projectDiagramResourceType);
+        this.authorizationManager = authorizationManager;
+        this.sessionInfo = sessionInfo;
     }
 
     @Override
@@ -66,6 +79,12 @@ public class BPMNDiagramNewResourceHandler extends AbstractProjectDiagramNewReso
     @Override
     public IsWidget getIcon() {
         return getBPMNDiagramResourceType().getIcon();
+    }
+
+    @Override
+    public boolean canCreate() {
+        return authorizationManager.authorize(PERMISSION,
+                                              sessionInfo.getIdentity());
     }
 
     private BPMNDiagramResourceType getBPMNDiagramResourceType() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/handlers/BPMNDiagramNewResourceHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/handlers/BPMNDiagramNewResourceHandler.java
@@ -27,12 +27,13 @@ import org.kie.workbench.common.stunner.project.client.handlers.AbstractProjectD
 import org.kie.workbench.common.stunner.project.client.service.ClientProjectDiagramService;
 import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
 import org.uberfire.rpc.SessionInfo;
+import org.uberfire.security.ResourceAction;
+import org.uberfire.security.ResourceRef;
 import org.uberfire.security.authz.AuthorizationManager;
+import org.uberfire.workbench.model.ActivityResourceType;
 
 @ApplicationScoped
 public class BPMNDiagramNewResourceHandler extends AbstractProjectDiagramNewResourceHandler<BPMNDiagramResourceType> {
-
-    static final String PERMISSION = "editor.read." + BPMNDiagramEditor.EDITOR_ID;
 
     private final AuthorizationManager authorizationManager;
     private final SessionInfo sessionInfo;
@@ -83,7 +84,9 @@ public class BPMNDiagramNewResourceHandler extends AbstractProjectDiagramNewReso
 
     @Override
     public boolean canCreate() {
-        return authorizationManager.authorize(PERMISSION,
+        return authorizationManager.authorize(new ResourceRef(BPMNDiagramEditor.EDITOR_ID,
+                                                              ActivityResourceType.EDITOR),
+                                              ResourceAction.READ,
                                               sessionInfo.getIdentity());
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/handlers/BPMNDiagramNewResourceHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/handlers/BPMNDiagramNewResourceHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.bpmn.project.client.handlers;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.project.client.type.BPMNDiagramResourceType;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.project.client.service.ClientProjectDiagramService;
+import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.rpc.SessionInfo;
+import org.uberfire.security.authz.AuthorizationManager;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class BPMNDiagramNewResourceHandlerTest {
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private ClientProjectDiagramService projectDiagramServices;
+
+    @Mock
+    private BusyIndicatorView indicatorView;
+
+    @Mock
+    private BPMNDiagramResourceType projectDiagramResourceType;
+
+    @Mock
+    private AuthorizationManager authorizationManager;
+
+    @Mock
+    private SessionInfo sessionInfo;
+
+    @Mock
+    private User user;
+
+    private BPMNDiagramNewResourceHandler handler;
+
+    @Before
+    public void setup() {
+        this.handler = new BPMNDiagramNewResourceHandler(definitionManager,
+                                                         projectDiagramServices,
+                                                         indicatorView,
+                                                         projectDiagramResourceType,
+                                                         authorizationManager,
+                                                         sessionInfo);
+        when(sessionInfo.getIdentity()).thenReturn(user);
+    }
+
+    @Test
+    public void checkCanCreateWhenFeatureDisabled() {
+        when(authorizationManager.authorize(eq(BPMNDiagramNewResourceHandler.PERMISSION),
+                                            eq(user))).thenReturn(false);
+        assertFalse(handler.canCreate());
+    }
+
+    @Test
+    public void checkCanCreateWhenFeatureEnabled() {
+        when(authorizationManager.authorize(eq(BPMNDiagramNewResourceHandler.PERMISSION),
+                                            eq(user))).thenReturn(true);
+        assertTrue(handler.canCreate());
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3524

This PR sets up the ```PermissionTreeSetup``` to include the editors we need to restrict access to; and adjusts Stunner's ```NewResourceHandler``` to prevent creation of new assets if permission is denied. Plus a bunch of tests. 