### PR TITLE
JBPM-6419 - When opening more than one Diagram the Palette is not rendered on all of them

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactory.java
@@ -18,21 +18,22 @@ package org.kie.workbench.common.dmn.client.components.palette.factory;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Categories;
-import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.dmn.client.components.palette.widget.DMNPaletteWidget;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.BindablePaletteDefinitionFactory;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPaletteBuilder;
 
 @Dependent
-public class DMNPaletteDefinitionFactory extends BindablePaletteDefinitionFactory<DefinitionsPaletteBuilder, DefinitionsPalette, BS3PaletteWidget<DefinitionsPalette>> {
+public class DMNPaletteDefinitionFactory extends BindablePaletteDefinitionFactory<DefinitionsPaletteBuilder, DefinitionsPalette, DMNPaletteWidget> {
 
     @Inject
     public DMNPaletteDefinitionFactory(final ShapeManager shapeManager,
                                        final DefinitionsPaletteBuilder paletteBuilder,
-                                       final BS3PaletteWidget<DefinitionsPalette> palette) {
+                                       final ManagedInstance<DMNPaletteWidget> palette) {
         super(shapeManager,
               paletteBuilder,
               palette);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/factory/DMNPaletteDefinitionFactoryTest.java
@@ -15,20 +15,20 @@
  */
 package org.kie.workbench.common.dmn.client.components.palette.factory;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Categories;
-import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.dmn.client.components.palette.widget.DMNPaletteWidget;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
-import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPaletteBuilder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DMNPaletteDefinitionFactoryTest {
@@ -40,7 +40,7 @@ public class DMNPaletteDefinitionFactoryTest {
     private DefinitionsPaletteBuilder paletteBuilder;
 
     @Mock
-    private BS3PaletteWidget<DefinitionsPalette> palette;
+    private ManagedInstance<DMNPaletteWidget> palette;
 
     private DMNPaletteDefinitionFactory factory;
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicFormRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicFormRenderer.java
@@ -209,7 +209,7 @@ public class DynamicFormRenderer implements IsWidget, IsFormView {
     }
 
     public boolean isValid() {
-        return formHandler.validate();
+        return isInitialized() && formHandler.validate();
     }
 
     public void forceModelSynchronization() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/DefaultDefSetPaletteDefinitionFactoryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/DefaultDefSetPaletteDefinitionFactoryImpl.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.client.widgets.palette;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.AbstractPaletteDefinitionFactory;
 import org.kie.workbench.common.stunner.core.client.components.palette.factory.DefaultDefSetPaletteDefinitionFactory;
@@ -35,7 +36,7 @@ public class DefaultDefSetPaletteDefinitionFactoryImpl extends AbstractPaletteDe
     @Inject
     public DefaultDefSetPaletteDefinitionFactoryImpl(final ShapeManager shapeManager,
                                                      final DefinitionSetPaletteBuilder paletteBuilder,
-                                                     final BS3PaletteWidget<DefinitionSetPalette> palette) {
+                                                     final ManagedInstance<BS3PaletteWidget<DefinitionSetPalette>> palette) {
         super(shapeManager,
               paletteBuilder,
               palette);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/SelectionControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/SelectionControlImpl.java
@@ -280,7 +280,7 @@ public final class SelectionControlImpl<H extends AbstractCanvasHandler>
     }
 
     private Canvas getCanvas() {
-        return canvasHandler.getCanvas();
+        return canvasHandler != null ? canvasHandler.getCanvas() : null;
     }
 
     private String getRootUUID() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/AbstractPaletteDefinitionFactory.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
@@ -26,11 +27,11 @@ public abstract class AbstractPaletteDefinitionFactory<B extends PaletteDefiniti
 
     protected ShapeManager shapeManager;
     protected B paletteBuilder;
-    protected P palette;
+    protected ManagedInstance<P> palette;
 
     public AbstractPaletteDefinitionFactory(final ShapeManager shapeManager,
                                             final B paletteBuilder,
-                                            final P palette) {
+                                            ManagedInstance<P> palette) {
         this.shapeManager = shapeManager;
         this.paletteBuilder = paletteBuilder;
         this.palette = palette;
@@ -43,6 +44,7 @@ public abstract class AbstractPaletteDefinitionFactory<B extends PaletteDefiniti
 
     @Override
     public P newPalette() {
-        return palette;
+        //get a NEW instance from the CDI Bean Manager Context every time this method is called
+        return palette.get();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindableDefSetPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindableDefSetPaletteDefinitionFactory.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
+import javax.enterprise.inject.Instance;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
@@ -28,7 +31,7 @@ public abstract class BindableDefSetPaletteDefinitionFactory<I extends HasPalett
 
     public BindableDefSetPaletteDefinitionFactory(final ShapeManager shapeManager,
                                                   final DefinitionSetPaletteBuilder paletteBuilder,
-                                                  final P palette) {
+                                                  final ManagedInstance<P> palette) {
         super(shapeManager,
               paletteBuilder,
               palette);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindablePaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/factory/BindablePaletteDefinitionFactory.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.components.palette.factory;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.HasPaletteItems;
@@ -27,7 +28,7 @@ public abstract class BindablePaletteDefinitionFactory<B extends PaletteDefiniti
 
     public BindablePaletteDefinitionFactory(final ShapeManager shapeManager,
                                             final B paletteBuilder,
-                                            final P palette) {
+                                            final ManagedInstance<P> palette) {
         super(shapeManager,
               paletteBuilder,
               palette);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-basicset/kie-wb-common-stunner-basicset-client/src/main/java/org/kie/workbench/common/stunner/basicset/client/components/palette/factory/BasicSetPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-basicset/kie-wb-common-stunner-basicset-client/src/main/java/org/kie/workbench/common/stunner/basicset/client/components/palette/factory/BasicSetPaletteDefinitionFactory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.basicset.BasicSet;
 import org.kie.workbench.common.stunner.basicset.definition.BasicConnector;
 import org.kie.workbench.common.stunner.basicset.definition.Categories;
@@ -56,7 +57,7 @@ public class BasicSetPaletteDefinitionFactory extends BindableDefSetPaletteDefin
     @Inject
     public BasicSetPaletteDefinitionFactory(final ShapeManager shapeManager,
                                             final DefinitionSetPaletteBuilder paletteBuilder,
-                                            final BS3PaletteWidget<DefinitionSetPalette> palette) {
+                                            final ManagedInstance<BS3PaletteWidget<DefinitionSetPalette>> palette) {
         super(shapeManager,
               paletteBuilder,
               palette);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/factory/BPMNPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/factory/BPMNPaletteDefinitionFactory.java
@@ -23,6 +23,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BaseEndEvent;
@@ -85,7 +86,7 @@ public class BPMNPaletteDefinitionFactory extends BindableDefSetPaletteDefinitio
   public BPMNPaletteDefinitionFactory(final ShapeManager shapeManager,
                                       final DefinitionSetPaletteBuilder paletteBuilder,
                                       final AbstractTranslationService translationService,
-                                      final BS3PaletteWidget<DefinitionSetPalette> palette) {
+                                      final ManagedInstance<BS3PaletteWidget<DefinitionSetPalette>> palette) {
     super(shapeManager,
           paletteBuilder,
           palette);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.bpmn.definition.AdHocSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
 import org.kie.workbench.common.stunner.bpmn.definition.Categories;
@@ -65,7 +66,7 @@ public class CaseManagementPaletteDefinitionFactory extends BindableDefSetPalett
     @Inject
     public CaseManagementPaletteDefinitionFactory(final ShapeManager shapeManager,
                                                   final @CaseManagementEditor DefinitionSetPaletteBuilder paletteBuilder,
-                                                  final BS3PaletteWidget<DefinitionSetPalette> palette) {
+                                                  final ManagedInstance<BS3PaletteWidget<DefinitionSetPalette>> palette) {
         super(shapeManager,
               paletteBuilder,
               palette);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementDefinitionSetPaletteBuilderImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementDefinitionSetPaletteBuilderImplTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -114,7 +115,7 @@ public class CaseManagementDefinitionSetPaletteBuilderImplTest {
     private ShapeManager shapeManager;
 
     @Mock
-    private BS3PaletteWidget palette;
+    private ManagedInstance<BS3PaletteWidget<DefinitionSetPalette>> palette;
 
     @Mock
     private DefinitionManager definitionManager;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.stunner.cm.client.palette;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +34,7 @@ import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
 import org.kie.workbench.common.stunner.cm.CaseManagementDefinitionSet;
 import org.kie.workbench.common.stunner.cm.definition.CaseManagementDiagram;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPaletteBuilder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -50,7 +52,7 @@ public class CaseManagementPaletteDefinitionFactoryTest {
     private DefinitionSetPaletteBuilder paletteBuilder;
 
     @Mock
-    private BS3PaletteWidget palette;
+    private ManagedInstance<BS3PaletteWidget<DefinitionSetPalette>> palette;
 
     private CaseManagementPaletteDefinitionFactory factory;
 


### PR DESCRIPTION
Now if more than one diagram is opened the palette is displayed on all of them.
The problem was basically the `AbstractPaletteDefinitionFactory.newPalette` was returning always the same instance instead of creating a new instance on each method call, in this way there was only one instance of the palette. Now, every method call `AbstractPaletteDefinitionFactory.newPalette` a new instance is returned.
This issue was affecting **BPMN** and **DMN**.

**Important**: there was a bug inserted on the master branch on this line https://github.com/kiegroup/kie-wb-common/blob/2b2ff376755db5d918fbc7e032c160e5be91f34d/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidget.java#L258 probably on this commit https://github.com/kiegroup/kie-wb-common/commit/cdf85d73afb77946d87d20f273a37cc795c6b4c5, the main problem is that the form is trying to be validated without any element/diagram previwous selected, on the project showcase this not happens because the `ProjectDiagramPropertiesScreen` is loaded after the diagram is selected, and on the standalone showcase and dmn the `SessionPropertiesScreen` is loaded before any selection, and then try to validate. To solve this I've inserted a check on the `DynamicFormRenderer` to check whether it is initialized AND valid, avoiding the NullPointerException, this solves the bug returning false in case it is not initialized.

@romartin 
@manstis 
@hasys 