### PR TITLE
[7.3.x] JBPM-6470: Password displayed in clear text while creating datasource in kie-workbench.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/editor/datasource/DataSourceDefMainPanelViewImpl.html
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/editor/datasource/DataSourceDefMainPanelViewImpl.html
@@ -36,7 +36,7 @@
 
     <div class="form-group" data-field="password-form-group">
       <label class="control-label" data-i18n-key="password"></label>
-      <input class="form-control" data-field="password"/>
+      <input class="form-control" data-field="password" type="password"/>
       <span data-field="password-help" class="help-block" style="visibility: hidden;"></span>
     </div>
 


### PR DESCRIPTION
(cherry picked from commit f794ea9dca3775ac3afd4a2dca4ae631aa2ca542)