### PR TITLE
GUVNOR-3531: Workbench navigation - An error popup appears, if unsaved data, when navigating to the Projects screen

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspective.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspective.java
@@ -68,7 +68,11 @@ public class LibraryPerspective {
     public void onOpen() {
         Command callback = null;
         if (refresh) {
-            callback = () -> libraryPlaces.goToLibrary();
+            callback = () -> {
+                if (getRootPanel() != null) {
+                    libraryPlaces.goToLibrary();
+                }
+            };
         }
         libraryPlaces.refresh(callback);
     }
@@ -79,6 +83,10 @@ public class LibraryPerspective {
     }
 
     public PanelDefinition getRootPanel() {
+        if (perspectiveDefinition == null) {
+            return null;
+        }
+
         return perspectiveDefinition.getRoot();
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/perspective/LibraryPerspectiveTest.java
@@ -20,7 +20,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+import org.uberfire.workbench.model.PanelDefinition;
 
 import static org.mockito.Mockito.*;
 
@@ -30,18 +34,41 @@ public class LibraryPerspectiveTest {
     @Mock
     private LibraryPlaces libraryPlaces;
 
+    @Captor
+    private ArgumentCaptor<Command> commandCaptor;
+
     private LibraryPerspective perspective;
 
     @Before
     public void setup() {
-        perspective = new LibraryPerspective(libraryPlaces);
+        perspective = spy(new LibraryPerspective(libraryPlaces));
     }
 
     @Test
-    public void libraryRefreshesPlacesOnStartupTest() {
+    public void libraryRefreshesPlacesOnOpenWithRootPanelTest() {
+        doReturn(mock(PanelDefinition.class)).when(perspective).getRootPanel();
+
         perspective.onOpen();
 
-        verify(libraryPlaces).refresh(any());
+        verify(libraryPlaces).refresh(commandCaptor.capture());
+
+        commandCaptor.getValue().execute();
+
+        verify(libraryPlaces).goToLibrary();
+    }
+
+    @Test
+    public void libraryDoesNotLoadOnOpenWithoutRootPanelTest() {
+        doReturn(null).when(perspective).getRootPanel();
+
+        perspective.onOpen();
+
+        verify(libraryPlaces).refresh(commandCaptor.capture());
+
+        commandCaptor.getValue().execute();
+
+        verify(libraryPlaces,
+               never()).goToLibrary();
     }
 
     @Test


### PR DESCRIPTION
RHBPMS-4895: [Library] Javascript error when canceling navigation to Library perspective