### PR TITLE
JBPM-6503 - Missing Dependency when building webapp Showcases

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
@@ -674,6 +674,18 @@
       <artifactId>kie-soup-project-datamodel-api</artifactId>
     </dependency>
 
+    <!-- Necessary to inject MVELEvaluator dependency -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-cdi</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.drools</groupId>
+          <artifactId>drools-compiler</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-bpmn2</artifactId>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -892,6 +892,18 @@
       <artifactId>kie-soup-project-datamodel-api</artifactId>
     </dependency>
 
+    <!-- Necessary to inject MVELEvaluator dependency -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-cdi</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.drools</groupId>
+          <artifactId>drools-compiler</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-default-editor-api</artifactId>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -665,6 +665,18 @@
       <artifactId>kie-soup-project-datamodel-commons</artifactId>
     </dependency>
 
+    <!-- Necessary to inject MVELEvaluator dependency -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-cdi</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.drools</groupId>
+          <artifactId>drools-compiler</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-bpmn2</artifactId>


### PR DESCRIPTION
Adding dependency to fix building GWT on Stunner and DMN webapp showcases.
Basically it was an inection of `MVELEvaluator` instance that was missing on the CDI.
Drools implements it on `SafeMVELEvaluator` and it is instantiated on the CDI on https://github.com/kiegroup/drools/blob/master/drools-cdi/src/main/java/org/drools/cdi/CDIProducer.java.
Thanks @manstis to give me the clue.
Can you check if is it alright, I've tested all webapps and they are running fine now.

@romartin 
@wmedvede 
@alepintus 