### PR TITLE
[AF-549-elastic]: Added new indexing backend to add elasticsearch support

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
@@ -87,6 +87,17 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta-regexp</groupId>
+          <artifactId>jakarta-regexp</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-commons-io</artifactId>
     </dependency>
 
@@ -536,7 +547,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-backend</artifactId>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.kie.workbench</groupId>
       <artifactId>kie-wb-common-dmn-api</artifactId>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/backend/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/backend/DefaultLuceneConfigProducer.java
@@ -28,9 +28,9 @@ import org.kie.workbench.common.services.refactoring.backend.server.indexing.Low
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
+import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 
 /**
  * This class contains the default Lucene configuration, and can be
@@ -39,12 +39,12 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 @ApplicationScoped
 public class DefaultLuceneConfigProducer {
 
-    private LuceneConfig config;
+    private MetadataConfig config;
 
     @PostConstruct
     public void setup() {
         final Map<String, Analyzer> analyzers = getAnalyzers();
-        this.config = new LuceneConfigBuilder().withInMemoryMetaModelStore()
+        this.config = new MetadataConfigBuilder().withInMemoryMetaModelStore()
                 .usingAnalyzers(analyzers)
                 .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
                 .useDirectoryBasedIndex()
@@ -54,7 +54,7 @@ public class DefaultLuceneConfigProducer {
 
     @Produces
     @Named("luceneConfig")
-    public LuceneConfig configProducer() {
+    public MetadataConfig configProducer() {
         return this.config;
     }
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/main/java/org/kie/workbench/common/screens/datasource/management/backend/integration/wildfly/WildflyDeploymentClient.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/main/java/org/kie/workbench/common/screens/datasource/management/backend/integration/wildfly/WildflyDeploymentClient.java
@@ -17,10 +17,8 @@
 package org.kie.workbench.common.screens.datasource.management.backend.integration.wildfly;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-import org.apache.regexp.RE;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.dmr.ModelNode;
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/BaseLibraryIndexingTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/BaseLibraryIndexingTest.java
@@ -57,12 +57,12 @@ import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.commons.async.DescriptiveThreadFactory;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
+import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
 import org.uberfire.ext.metadata.io.IOServiceIndexedImpl;
 import org.uberfire.ext.metadata.io.IndexersFactory;
+import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
 
@@ -76,7 +76,7 @@ public abstract class BaseLibraryIndexingTest {
 
     private static final List<File> tempFiles = new ArrayList<>();
 
-    private static LuceneConfig config;
+    private static MetadataConfig config;
     protected int seed = new Random(10L).nextInt();
     protected boolean created = false;
     protected Path basePath;
@@ -212,7 +212,7 @@ public abstract class BaseLibraryIndexingTest {
     protected IOService ioService() {
         if (ioService == null) {
             final Map<String, Analyzer> analyzers = getAnalyzers();
-            LuceneConfigBuilder configBuilder = new LuceneConfigBuilder()
+            MetadataConfigBuilder configBuilder = new MetadataConfigBuilder()
                     .withInMemoryMetaModelStore()
                     .usingAnalyzers(analyzers)
                     .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsSortedQueryTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/FindAllLibraryAssetsSortedQueryTest.java
@@ -34,10 +34,9 @@ import org.mockito.stubbing.Answer;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.paging.PageResponse;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class FindAllLibraryAssetsSortedQueryTest
         extends BaseLibraryIndexingTest {

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
@@ -66,6 +66,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
       <exclusions>
         <exclusion>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultApplicationScopedProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultApplicationScopedProducer.java
@@ -34,7 +34,7 @@ import org.uberfire.backend.server.IOWatchServiceNonDotImpl;
 import org.uberfire.commons.concurrent.Unmanaged;
 import org.uberfire.commons.services.cdi.Startup;
 import org.uberfire.commons.services.cdi.StartupType;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
+import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.io.IOSearchServiceImpl;
 import org.uberfire.ext.metadata.io.IOServiceIndexedImpl;
 import org.uberfire.ext.metadata.search.IOSearchService;
@@ -52,7 +52,7 @@ public class DefaultApplicationScopedProducer implements ApplicationScopedProduc
 
     private IOService ioService;
     private IOSearchService ioSearchService;
-    private LuceneConfig config;
+    private MetadataConfig config;
     private IOWatchServiceNonDotImpl watchService;
     private AuthenticationService authenticationService;
     private DefaultIndexEngineObserver defaultIndexEngineObserver;
@@ -71,7 +71,7 @@ public class DefaultApplicationScopedProducer implements ApplicationScopedProduc
     }
 
     @Inject
-    public DefaultApplicationScopedProducer(@Named("luceneConfig") LuceneConfig config,
+    public DefaultApplicationScopedProducer(@Named("luceneConfig") MetadataConfig config,
                                             IOWatchServiceNonDotImpl watchService,
                                             AuthenticationService authenticationService,
                                             DefaultIndexEngineObserver defaultIndexEngineObserver,

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
@@ -30,10 +30,10 @@ import org.kie.workbench.common.services.refactoring.backend.server.indexing.Imp
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.LowerCaseOnlyAnalyzer;
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
+import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
+import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 
 /**
  * This class contains the default Lucene configuration, and can be
@@ -42,12 +42,12 @@ import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
 @ApplicationScoped
 public class DefaultLuceneConfigProducer {
 
-    private LuceneConfig config;
+    private MetadataConfig config;
 
     @PostConstruct
     public void setup() {
         final Map<String, Analyzer> analyzers = getAnalyzers();
-        this.config = new LuceneConfigBuilder().withInMemoryMetaModelStore()
+        this.config = new MetadataConfigBuilder().withInMemoryMetaModelStore()
                 .usingAnalyzers(analyzers)
                 .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
                 .useDirectoryBasedIndex()
@@ -57,7 +57,7 @@ public class DefaultLuceneConfigProducer {
 
     @Produces
     @Named("luceneConfig")
-    public LuceneConfig configProducer() {
+    public MetadataConfig configProducer() {
         return this.config;
     }
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
@@ -16,7 +16,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.kie.workbench.services</groupId>
@@ -74,6 +74,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
     </dependency>
     <dependency>
@@ -115,6 +119,10 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
     <!-- drools -->
     <dependency>
       <groupId>org.drools</groupId>
@@ -175,7 +183,7 @@
       <artifactId>reflections</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>simple-jndi</groupId>
       <artifactId>simple-jndi</artifactId>

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlInvalidDrl.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlInvalidDrl.java
@@ -16,17 +16,16 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -41,12 +40,12 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Appender;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.*;
 
 public class IndexDrlInvalidDrl extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
@@ -65,7 +64,7 @@ public class IndexDrlInvalidDrl extends BaseIndexingTest<TestDrlFileTypeDefiniti
 
         Thread.sleep(5000);
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant", ResourceType.JAVA ) ).build();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField1Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField1Test.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -30,7 +32,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeExpressionField1Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -45,7 +47,7 @@ public class IndexDrlLHSTypeExpressionField1Test extends BaseIndexingTest<TestDr
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant", ResourceType.JAVA ) ).build();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField2Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField2Test.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -30,7 +32,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeExpressionField2Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -45,7 +47,7 @@ public class IndexDrlLHSTypeExpressionField2Test extends BaseIndexingTest<TestDr
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant", ResourceType.JAVA ) ).build();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField3Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField3Test.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -30,7 +32,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeExpressionField3Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -45,7 +47,7 @@ public class IndexDrlLHSTypeExpressionField3Test extends BaseIndexingTest<TestDr
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant", ResourceType.JAVA ) ).build();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField4Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField4Test.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -30,7 +32,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeExpressionField4Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -45,7 +47,7 @@ public class IndexDrlLHSTypeExpressionField4Test extends BaseIndexingTest<TestDr
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Bank", ResourceType.JAVA ) ).build();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldCombinedTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldCombinedTest.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -28,7 +30,7 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.query.builder.SingleTermQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValuePartReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.PartType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeExpressionFieldCombinedTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -53,7 +55,7 @@ public class IndexDrlLHSTypeExpressionFieldCombinedTest extends BaseIndexingTest
 
         Thread.sleep( 7000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValuePartReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Mortgage", "applicant", PartType.FIELD ) ).build();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldTypeTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldTypeTest.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -28,7 +30,7 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.query.builder.SingleTermQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeExpressionFieldTypeTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -43,7 +45,7 @@ public class IndexDrlLHSTypeExpressionFieldTypeTest extends BaseIndexingTest<Tes
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Mortgage", ResourceType.JAVA ) ).build();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeFieldTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeFieldTest.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -28,7 +30,7 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.query.builder.SingleTermQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValuePartReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.PartType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeFieldTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -49,7 +51,7 @@ public class IndexDrlLHSTypeFieldTest extends BaseIndexingTest<TestDrlFileTypeDe
 
         Thread.sleep( 7000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         {
             final Query query = new SingleTermQueryBuilder( new ValuePartReferenceIndexTerm( "org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant", "age", PartType.FIELD ) )

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeTest.java
@@ -17,7 +17,9 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -29,7 +31,7 @@ import org.kie.workbench.common.services.refactoring.backend.server.query.builde
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm.TermSearchType;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
-import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
 public class IndexDrlLHSTypeTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
@@ -52,9 +54,9 @@ public class IndexDrlLHSTypeTest extends BaseIndexingTest<TestDrlFileTypeDefinit
                            drl3 );
         ioService().endBatch();
 
-        Thread.sleep( 7000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep( 12000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         //Check type extraction (with wildcards)
         {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/TestDrlFileIndexer.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/TestDrlFileIndexer.java
@@ -16,7 +16,6 @@
 package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.util.HashMap;
-
 import javax.enterprise.context.ApplicationScoped;
 
 import org.kie.soup.project.datamodel.commons.oracle.ProjectDataModelOracleImpl;

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/TestPackageNameDrlFileIndexer.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/TestPackageNameDrlFileIndexer.java
@@ -17,7 +17,6 @@ package org.kie.workbench.common.services.refactoring.backend.server.drl;
 
 import java.util.HashMap;
 import java.util.List;
-
 import javax.enterprise.context.ApplicationScoped;
 
 import org.drools.compiler.compiler.DrlParser;

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/impact/PackageDescrIndexVisitorIndexingTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/impact/PackageDescrIndexVisitorIndexingTest.java
@@ -15,18 +15,10 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.impact;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import javax.enterprise.inject.Instance;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -45,6 +37,8 @@ import org.kie.workbench.common.services.refactoring.model.query.RefactoringPage
 import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.kie.workbench.common.services.refactoring.service.impact.QueryOperationRequest;
 import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
 
 /**
  * This test is focused on making sure that the {@link PackageDescrIndexVisitor} is able to find and collect the data that it needs to.

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/indexing/PackageDescrIndexVisitorLogicTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/indexing/PackageDescrIndexVisitorLogicTest.java
@@ -15,11 +15,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.indexing;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -30,6 +25,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+import javassist.Modifier;
 import org.drools.compiler.compiler.ReturnValueDescr;
 import org.drools.compiler.lang.descr.BaseDescr;
 import org.drools.compiler.lang.descr.CompositePackageDescr;
@@ -39,7 +37,6 @@ import org.drools.compiler.lang.descr.PatternSourceDescr;
 import org.drools.compiler.lang.descr.ProcessDescr;
 import org.drools.compiler.lang.descr.RestrictionDescr;
 import org.junit.Test;
-import org.kie.workbench.common.services.refactoring.backend.server.impact.ResourceReferenceCollector;
 import org.mvel2.asm.ClassReader;
 import org.mvel2.asm.ClassVisitor;
 import org.mvel2.asm.MethodVisitor;
@@ -51,10 +48,7 @@ import org.reflections.util.ClasspathHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
-
-import javassist.Modifier;
+import static org.junit.Assert.*;
 
 /**
  * This test is focused on reflection-based code that inspects the {@link PackageDescrIndexVisitor} logic for inconsistencies.

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/RefactoringQueryServiceImplGeneralTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/RefactoringQueryServiceImplGeneralTest.java
@@ -15,22 +15,13 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.enterprise.inject.Instance;
-
 import org.apache.lucene.analysis.Analyzer;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -39,6 +30,8 @@ import org.kie.workbench.common.services.refactoring.backend.server.drl.TestDrlF
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.DefaultResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindResourceReferencesQuery;
+
+import static org.junit.Assert.*;
 
 public class RefactoringQueryServiceImplGeneralTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryInvalidIndexTermsTest.java
@@ -15,9 +15,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findresourcepartreferences;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -35,6 +32,8 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
+
+import static org.junit.Assert.*;
 
 public class FindResourcePartReferencesQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryValidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryValidIndexTermsTest.java
@@ -15,10 +15,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findresourcepartreferences;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,6 +36,8 @@ import org.kie.workbench.common.services.refactoring.model.query.RefactoringPage
 import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.paging.PageResponse;
+
+import static org.junit.Assert.*;
 
 public class FindResourcePartReferencesQueryValidIndexTermsTest
         extends BaseIndexingTest<TestDrlFileTypeDefinition> {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourceparts/FindResourcePartsQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourceparts/FindResourcePartsQueryInvalidIndexTermsTest.java
@@ -15,9 +15,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findresourceparts;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,6 +33,8 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
+
+import static org.junit.Assert.*;
 
 public class FindResourcePartsQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryInvalidIndexTermsTest.java
@@ -15,9 +15,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findresourcereferences;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -33,6 +30,8 @@ import org.kie.workbench.common.services.refactoring.backend.server.query.respon
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindResourceReferencesQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
+
+import static org.junit.Assert.*;
 
 public class FindResourceReferencesQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryValidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryValidIndexTermsTest.java
@@ -15,10 +15,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findresourcereferences;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -41,6 +37,8 @@ import org.kie.workbench.common.services.refactoring.model.query.RefactoringPage
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.paging.PageResponse;
+
+import static org.junit.Assert.*;
 
 public class FindResourceReferencesQueryValidIndexTermsTest
         extends BaseIndexingTest<TestDrlFileTypeDefinition> {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryInvalidIndexTermsTest.java
@@ -15,16 +15,9 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findresources;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-
-import javax.enterprise.inject.Instance;
 
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
@@ -40,6 +33,8 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueResourceIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
+
+import static org.junit.Assert.*;
 
 public class FindResourcesQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryValidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryValidIndexTermsTest.java
@@ -15,10 +15,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findresources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,6 +36,8 @@ import org.kie.workbench.common.services.refactoring.model.query.RefactoringPage
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.paging.PageResponse;
+
+import static org.junit.Assert.*;
 
 public class FindResourcesQueryValidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findrules/FindRulesByProjectQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findrules/FindRulesByProjectQueryInvalidIndexTermsTest.java
@@ -15,16 +15,9 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.query.findrules;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-
-import javax.enterprise.inject.Instance;
 
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
@@ -37,10 +30,9 @@ import org.kie.workbench.common.services.refactoring.backend.server.query.respon
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindRulesByProjectQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValuePackageNameIndexTerm;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueProjectRootPathIndexTerm;
-import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueReferenceIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
-import org.kie.workbench.common.services.refactoring.service.ResourceType;
+
+import static org.junit.Assert.*;
 
 public class FindRulesByProjectQueryInvalidIndexTermsTest
         extends BaseIndexingTest<TestDrlFileTypeDefinition> {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexAddedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexAddedResourcesTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -32,30 +32,32 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
-import org.uberfire.ext.metadata.engine.Index;
 import org.uberfire.ext.metadata.io.KObjectUtil;
+
+import static org.mockito.Mockito.*;
 
 public class IndexAddedResourcesTest extends BaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test
     public void testIndexingAddedResources() throws IOException, InterruptedException {
         //Add test files
-        loadProperties( "file1.properties",
-                        basePath );
-        loadProperties( "file2.properties",
-                        basePath );
-        loadProperties( "file3.properties",
-                        basePath );
-        loadProperties( "file4.properties",
-                        basePath );
+        loadProperties("file1.properties",
+                       basePath);
+        loadProperties("file2.properties",
+                       basePath);
+        loadProperties("file3.properties",
+                       basePath);
+        loadProperties("file4.properties",
+                       basePath);
 
-        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> indices = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
-        searchFor(index,
-                 (Query) new TermQuery( new Term( "title", "lucene" ) ),
-                 2);
+        searchFor(indices,
+                  (Query) new TermQuery(new Term("title",
+                                                 "lucene")),
+                  2);
     }
 
     @Override
@@ -80,7 +82,6 @@ public class IndexAddedResourcesTest extends BaseIndexingTest<TestPropertiesFile
 
     @Override
     protected KieProjectService getProjectService() {
-        return mock( KieProjectService.class );
+        return mock(KieProjectService.class);
     }
-
 }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexCopiedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexCopiedResourcesTest.java
@@ -16,10 +16,10 @@ s* Copyright 2016 Red Hat, Inc. and/or its affiliates.
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -31,39 +31,42 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
-import org.uberfire.ext.metadata.engine.Index;
 import org.uberfire.ext.metadata.io.KObjectUtil;
+
+import static org.mockito.Mockito.*;
 
 public class IndexCopiedResourcesTest extends BaseIndexingTest {
 
     @Test
     public void testIndexingCopiedResources() throws IOException, InterruptedException {
         //Add test files
-        loadProperties( "file1.properties",
-                        basePath );
-        loadProperties( "file2.properties",
-                        basePath );
-        loadProperties( "file3.properties",
-                        basePath );
-        loadProperties( "file4.properties",
-                        basePath );
+        loadProperties("file1.properties",
+                       basePath);
+        loadProperties("file2.properties",
+                       basePath);
+        loadProperties("file3.properties",
+                       basePath);
+        loadProperties("file4.properties",
+                       basePath);
 
-        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         searchFor(index,
-                  new TermQuery( new Term( "title", "lucene" ) ),
+                  new TermQuery(new Term("title",
+                                         "lucene")),
                   2);
 
         //Copy one of the files returned by the previous search
-        ioService().copy( basePath.resolve( "file1.properties" ),
-                          basePath.resolve( "file5.properties" ) );
+        ioService().copy(basePath.resolve("file1.properties"),
+                         basePath.resolve("file5.properties"));
 
-        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
         searchFor(index,
-                  new TermQuery( new Term( "title", "lucene" ) ),
+                  new TermQuery(new Term("title",
+                                         "lucene")),
                   3);
     }
 
@@ -89,7 +92,6 @@ public class IndexCopiedResourcesTest extends BaseIndexingTest {
 
     @Override
     protected KieProjectService getProjectService() {
-        return mock( KieProjectService.class );
+        return mock(KieProjectService.class);
     }
-
 }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexDeletedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexDeletedResourcesTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -31,8 +31,9 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
-import org.uberfire.ext.metadata.engine.Index;
 import org.uberfire.ext.metadata.io.KObjectUtil;
+
+import static org.mockito.Mockito.*;
 
 public class IndexDeletedResourcesTest extends BaseIndexingTest {
 
@@ -50,7 +51,7 @@ public class IndexDeletedResourcesTest extends BaseIndexingTest {
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         searchFor(index,
                   new TermQuery( new Term( "title", "lucene" ) ),

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexFullTextTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexFullTextTest.java
@@ -16,11 +16,10 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-import static org.uberfire.ext.metadata.engine.MetaIndexEngine.FULL_TEXT_FIELD;
-
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -32,8 +31,10 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
-import org.uberfire.ext.metadata.engine.Index;
 import org.uberfire.ext.metadata.io.KObjectUtil;
+
+import static org.mockito.Mockito.*;
+import static org.uberfire.ext.metadata.engine.MetaIndexEngine.FULL_TEXT_FIELD;
 
 public class IndexFullTextTest extends BaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
@@ -47,7 +48,7 @@ public class IndexFullTextTest extends BaseIndexingTest<TestPropertiesFileTypeDe
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         searchFor(index,
                   new WildcardQuery( new Term( FULL_TEXT_FIELD, "*file*" ) ),

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexUpdatedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexUpdatedResourcesTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -32,8 +32,9 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
-import org.uberfire.ext.metadata.engine.Index;
 import org.uberfire.ext.metadata.io.KObjectUtil;
+
+import static org.mockito.Mockito.*;
 
 public class IndexUpdatedResourcesTest extends BaseIndexingTest {
 
@@ -51,7 +52,7 @@ public class IndexUpdatedResourcesTest extends BaseIndexingTest {
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        List<String> index = Arrays.asList(KObjectUtil.toKCluster(basePath.getFileSystem()).getClusterId());
 
         searchFor(index,
                   new TermQuery( new Term( "title", "lucene" ) ),

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryAddedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryAddedResourcesTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -32,6 +30,8 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestProperti
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 
+import static org.mockito.Mockito.*;
+
 public class MultipleRepositoryAddedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test
@@ -44,6 +44,7 @@ public class MultipleRepositoryAddedResourcesTest extends MultipleRepositoryBase
                         getBasePath( this.getClass().getSimpleName() + "_2" ) );
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+
 
         searchFor( new TermQuery( new Term( "title", "lucene" ) ), 2);
     }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryCopiedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryCopiedResourcesTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -31,6 +29,8 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
+
+import static org.mockito.Mockito.*;
 
 public class MultipleRepositoryCopiedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryDeletedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryDeletedResourcesTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -31,6 +29,8 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
+
+import static org.mockito.Mockito.*;
 
 public class MultipleRepositoryDeletedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryUpdatedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryUpdatedResourcesTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.services.refactoring.backend.server.resources;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -32,6 +30,8 @@ import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.TestPropertiesFileTypeDefinition;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
+
+import static org.mockito.Mockito.*;
 
 public class MultipleRepositoryUpdatedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -116,6 +116,17 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta-regexp</groupId>
+          <artifactId>jakarta-regexp</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-commons-io</artifactId>
     </dependency>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -88,6 +88,17 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta-regexp</groupId>
+          <artifactId>jakarta-regexp</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-commons-io</artifactId>
     </dependency>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/backend/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/backend/DefaultLuceneConfigProducer.java
@@ -30,9 +30,9 @@ import org.kie.workbench.common.services.refactoring.backend.server.indexing.Low
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
+import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 
 /**
  * This class contains the default Lucene configuration, and can be
@@ -41,12 +41,12 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 @ApplicationScoped
 public class DefaultLuceneConfigProducer {
 
-    private LuceneConfig config;
+    private MetadataConfig config;
 
     @PostConstruct
     public void setup() {
         final Map<String, Analyzer> analyzers = getAnalyzers();
-        this.config = new LuceneConfigBuilder().withInMemoryMetaModelStore()
+        this.config = new MetadataConfigBuilder().withInMemoryMetaModelStore()
                 .usingAnalyzers(analyzers)
                 .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
                 .useDirectoryBasedIndex()
@@ -56,7 +56,7 @@ public class DefaultLuceneConfigProducer {
 
     @Produces
     @Named("luceneConfig")
-    public LuceneConfig configProducer() {
+    public MetadataConfig configProducer() {
         return this.config;
     }
 


### PR DESCRIPTION
A new Metadata index had been added. Its intention is to have an alternative to Lucene backend so you can use it, for instance in Openshift or on premise without zookeeper/helix to replicate those assets.

The idea is to maintain the same Lucene API but to transform it to Elasticsearch compatible messages. There is no need to change any Lucene Query to make it work. There is a class called **LuceneIndexEngine** that is not **public** anymore because it was very coupled to Lucene FS implementation so now it's behind a new Interface called **IndexProvider**. It tries to generate an abstraction for indexing a querying an index engine using domain objects and not lucene documents anymore.


The default indexing engine is Lucene but you can change it with a System Property:

- org.appformer.ext.metadata.index=elastic

There are some other properties to configure elasticsearch:

- org.appformer.ext.metadata.elastic.port
- org.appformer.ext.metadata.elastic.host
- org.appformer.ext.metadata.elastic.username
- org.appformer.ext.metadata.elastic.password
- org.appformer.ext.metadata.elastic.cluster

Related issues:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/581
https://github.com/AppFormer/uberfire/pull/882
https://github.com/kiegroup/kie-wb-common/pull/1254
https://github.com/kiegroup/jbpm-wb/pull/924
https://github.com/kiegroup/drools-wb/pull/666
https://github.com/kiegroup/optaplanner-wb/pull/228
https://github.com/kiegroup/jbpm-form-modeler/pull/150
https://github.com/kiegroup/kie-wb-distributions/pull/642