### PR TITLE
JBPM-6543: Execution Servers: Deleting container throws Runtime Exc…

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
@@ -122,5 +122,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDI.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDI.java
@@ -16,9 +16,10 @@
 
 package org.kie.workbench.common.screens.server.management.backend.service;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -44,28 +45,28 @@ public class RuntimeManagementServiceCDI extends RuntimeManagementServiceImpl
 
     @Inject
     @Override
-    public void setKieServerInstanceManager( KieServerInstanceManager kieServerInstanceManager ) {
-        super.setKieServerInstanceManager( kieServerInstanceManager );
+    public void setKieServerInstanceManager(KieServerInstanceManager kieServerInstanceManager) {
+        super.setKieServerInstanceManager(kieServerInstanceManager);
     }
 
     @Inject
     @Override
-    public void setTemplateStorage( KieServerTemplateStorage templateStorage ) {
-        super.setTemplateStorage( templateStorage );
+    public void setTemplateStorage(KieServerTemplateStorage templateStorage) {
+        super.setTemplateStorage(templateStorage);
     }
 
     @Override
-    public Collection<Container> getContainersByServerInstance( final String serverTemplateId,
-                                                                final String serverInstanceId ) {
-        final ServerTemplate serverTemplate = getTemplateStorage().load( serverTemplateId );   // best to pass both serverTemplateId and serverInstanceId
-        if ( serverTemplate == null ) {
-            throw new RuntimeException( "No server template found for server instance id " + serverInstanceId );
+    public Collection<Container> getContainersByServerInstance(final String serverTemplateId,
+                                                               final String serverInstanceId) {
+        final ServerTemplate serverTemplate = getTemplateStorage().load(serverTemplateId);   // best to pass both serverTemplateId and serverInstanceId
+        if (serverTemplate == null) {
+            throw new RuntimeException("No server template found for server instance id " + serverInstanceId);
         }
 
-        for ( final ServerInstanceKey serverInstance : serverTemplate.getServerInstanceKeys() ) {
+        for (final ServerInstanceKey serverInstance : serverTemplate.getServerInstanceKeys()) {
 
-            if ( serverInstance.getServerInstanceId().equals( serverInstanceId ) ) {
-                return getContainers( serverInstance );
+            if (serverInstance.getServerInstanceId().equals(serverInstanceId)) {
+                return getContainers(serverInstance);
             }
         }
 
@@ -73,22 +74,17 @@ public class RuntimeManagementServiceCDI extends RuntimeManagementServiceImpl
     }
 
     @Override
-    public ContainerSpecData getContainersByContainerSpec( final String serverTemplateId,
-                                                           final String containerSpecId ) {
-        final Collection<Container> containers = new ArrayList<Container>();
-
-        final ServerTemplate serverTemplate = getTemplateStorage().load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new RuntimeException( "No server template found for container spec " + containerSpecId );
+    public ContainerSpecData getContainersByContainerSpec(final String serverTemplateId,
+                                                          final String containerSpecId) {
+        final ServerTemplate serverTemplate = getTemplateStorage().load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new RuntimeException("No server template found for container spec " + containerSpecId);
         }
 
-        ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecId );
+        ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
 
-        getKieServerInstanceManager().getContainers(serverTemplate, containerSpec);
+        List<Container> containers = getKieServerInstanceManager().getContainers(serverTemplate, containerSpec);
 
-        return new ContainerSpecData( serverTemplate.getContainerSpec( containerSpecId ),
-                                      containers );
-
+        return new ContainerSpecData(containerSpec, containers);
     }
-
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDI.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDI.java
@@ -68,15 +68,15 @@ public class RuntimeManagementServiceCDI extends RuntimeManagementServiceImpl
     public ContainerSpecData getContainersByContainerSpec(final String serverTemplateId, final String containerSpecId) {
         final ServerTemplate serverTemplate = loadServerTemplate(serverTemplateId);
 
-        ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
+        final ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
 
-        List<Container> containers = getKieServerInstanceManager().getContainers(serverTemplate, containerSpec);
+        final List<Container> containers = getKieServerInstanceManager().getContainers(serverTemplate, containerSpec);
 
         return new ContainerSpecData(containerSpec, containers);
     }
 
     private ServerTemplate loadServerTemplate(String serverTemplateId) {
-        ServerTemplate template = getTemplateStorage().load(serverTemplateId);
+        final ServerTemplate template = getTemplateStorage().load(serverTemplateId);
         if (template == null) {
             throw new RuntimeException("No server template found for id " + serverTemplateId);
         }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDITest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDITest.java
@@ -98,12 +98,9 @@ public class RuntimeManagementServiceCDITest {
         );
         final List<Container> containersInServerInstance = Arrays.asList(new Container(), new Container());
 
-        //Template storage has one Template, which has 1 server instance
-        KieServerTemplateStorage templateStorageMock = mock(KieServerTemplateStorage.class);
-        when(templateStorageMock.load(eq(templateId)))
-                .thenReturn(serverTemplate);
+        KieServerTemplateStorage templateStorageMock = createMockStorageWithOneTemplate(serverTemplate);
 
-        // Instance has 2 dummy containers
+        // Instance with 2 dummy containers
         KieServerInstanceManager instanceMangerMock = mock(KieServerInstanceManager.class);
         when(instanceMangerMock.getContainers(eq(serverInstanceKey)))
                 .thenReturn(containersInServerInstance);
@@ -162,15 +159,13 @@ public class RuntimeManagementServiceCDITest {
                 templateName,
                 Collections.emptyList(),
                 Collections.emptyMap(),
-                Arrays.asList(containerSpec)
+                Collections.singletonList(containerSpec)
         );
 
         final List<Container> containersInServerInstance = Collections.singletonList(container);
 
         // Setup mocks
-        KieServerTemplateStorage templateStorageMock = mock(KieServerTemplateStorage.class);
-        when(templateStorageMock.load(eq(templateId)))
-                .thenReturn(serverTemplate);
+        KieServerTemplateStorage templateStorageMock = createMockStorageWithOneTemplate(serverTemplate);
 
         KieServerInstanceManager instanceMangerMock = mock(KieServerInstanceManager.class);
         when(instanceMangerMock.getContainers(eq(serverTemplate), eq(containerSpec)))
@@ -186,5 +181,12 @@ public class RuntimeManagementServiceCDITest {
 
         assertThat(containerSpecData.getContainers()).contains(container);
         assertThat(containerSpecData.getContainerSpec()).isEqualTo(containerSpec);
+    }
+
+    private KieServerTemplateStorage createMockStorageWithOneTemplate(ServerTemplate serverTemplate) {
+        KieServerTemplateStorage templateStorageMock = mock(KieServerTemplateStorage.class);
+        when(templateStorageMock.load(eq(serverTemplate.getId())))
+                .thenReturn(serverTemplate);
+        return templateStorageMock;
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDITest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDITest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.server.management.backend.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.kie.server.controller.api.storage.KieServerTemplateStorage;
+import org.kie.server.controller.impl.KieServerInstanceManager;
+import org.kie.workbench.common.screens.server.management.model.ContainerSpecData;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RuntimeManagementServiceCDITest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void getContainersByServerInstance_throwsRuntimeException_whenServerTemplateNotFound() {
+        final String templateId = "this_template_does_NOT_exist";
+
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage(containsString("No server template found for id " + templateId));
+
+        RuntimeManagementServiceCDI testedService = new RuntimeManagementServiceCDI();
+        //Tested method
+        testedService.getContainersByServerInstance(templateId, "dummy_container_spec_id");
+    }
+
+    @Test
+    public void getContainersByServerInstance_returnsEmptyList_whenInstanceWithIdDoesntExistInTemplate() {
+        final String
+                templateId = "templateId",
+                serverInstanceId = "serverInstanceId";
+
+        KieServerTemplateStorage templateStorageMock = mock(KieServerTemplateStorage.class);
+        when(templateStorageMock.load(eq(templateId)))
+                .thenReturn(new ServerTemplate(null, null, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList(), Collections.emptyList()));
+
+        // Setup tested service
+        RuntimeManagementServiceCDI testedService = new RuntimeManagementServiceCDI();
+        testedService.setTemplateStorage(templateStorageMock);
+
+        // Tested method
+        Collection<Container> containers = testedService.getContainersByServerInstance(templateId, serverInstanceId);
+        assertThat(containers)
+                .as("List of containers should be empty, when Server template doesn't contain server instance id")
+                .isEmpty();
+    }
+
+    @Test
+    public void getContainersByServerInstance_returnsListOfContainers_whenInstanceWithIdExists() {
+        final String
+                templateId = "templateId",
+                templateName = "templateName",
+                serverInstanceId = "serverInstanceId";
+        ServerInstanceKey serverInstanceKey = new ServerInstanceKey(templateId, templateName, serverInstanceId, "dummyUrl");
+        ServerTemplate serverTemplate = new ServerTemplate(
+                templateId,
+                templateName,
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.singletonList(serverInstanceKey)
+        );
+        final List<Container> containersInServerInstance = Arrays.asList(new Container(), new Container());
+
+        //Template storage has one Template, which has 1 server instance
+        KieServerTemplateStorage templateStorageMock = mock(KieServerTemplateStorage.class);
+        when(templateStorageMock.load(eq(templateId)))
+                .thenReturn(serverTemplate);
+
+        // Instance has 2 dummy containers
+        KieServerInstanceManager instanceMangerMock = mock(KieServerInstanceManager.class);
+        when(instanceMangerMock.getContainers(eq(serverInstanceKey)))
+                .thenReturn(containersInServerInstance);
+
+        RuntimeManagementServiceCDI testedService = new RuntimeManagementServiceCDI();
+        testedService.setTemplateStorage(templateStorageMock);
+        testedService.setKieServerInstanceManager(instanceMangerMock);
+
+        Collection<Container> containers = testedService.getContainersByServerInstance(templateId, serverInstanceId);
+
+        assertThat(containers)
+                .as("Should return list of containers from server instance id")
+                .hasSameSizeAs(containersInServerInstance);
+    }
+
+    @Test
+    public void getContainersByContainerSpec_throwsRuntimeException_whenServerTemplateNotFound() {
+        final String templateId = "this_template_does_NOT_exist";
+
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage(containsString("No server template found for id " + templateId));
+
+        RuntimeManagementServiceCDI testedService = new RuntimeManagementServiceCDI();
+        testedService.getContainersByContainerSpec(templateId, "dummy_container_spec_id");
+    }
+
+    @Test
+    public void getContainersByContainerSpec_returnsContainerSpecData() {
+        final String
+                templateId = "templateId",
+                templateName = "templateName",
+                serverInstanceId = "serverInstanceId",
+                containerName = "containerName1",
+                group = "g1",
+                artifact = "a1",
+                version = "1",
+                containerSpecId = String.join(":", group, artifact, version);
+
+        final ReleaseId releaseId = new ReleaseId(group, artifact, version);
+
+        ServerInstanceKey serverInstanceKey = new ServerInstanceKey(templateId, null, serverInstanceId, null);
+
+        Container container = new Container(containerSpecId, containerName, serverInstanceKey, Collections.emptyList(), releaseId, null);
+
+        ContainerSpec containerSpec = new ContainerSpec(
+                containerSpecId,
+                containerName,
+                new ServerTemplateKey(templateId, templateName),
+                releaseId,
+                KieContainerStatus.STARTED,
+                Collections.emptyMap()
+        );
+
+        ServerTemplate serverTemplate = new ServerTemplate(
+                templateId,
+                templateName,
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                Arrays.asList(containerSpec)
+        );
+
+        final List<Container> containersInServerInstance = Collections.singletonList(container);
+
+        // Setup mocks
+        KieServerTemplateStorage templateStorageMock = mock(KieServerTemplateStorage.class);
+        when(templateStorageMock.load(eq(templateId)))
+                .thenReturn(serverTemplate);
+
+        KieServerInstanceManager instanceMangerMock = mock(KieServerInstanceManager.class);
+        when(instanceMangerMock.getContainers(eq(serverTemplate), eq(containerSpec)))
+                .thenReturn(containersInServerInstance);
+
+        // Setup tested object
+        RuntimeManagementServiceCDI testedService = new RuntimeManagementServiceCDI();
+        testedService.setTemplateStorage(templateStorageMock);
+        testedService.setKieServerInstanceManager(instanceMangerMock);
+
+        //Tested method
+        ContainerSpecData containerSpecData = testedService.getContainersByContainerSpec(templateId, containerSpecId);
+
+        assertThat(containerSpecData.getContainers()).contains(container);
+        assertThat(containerSpecData.getContainerSpec()).isEqualTo(containerSpec);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
@@ -143,16 +143,10 @@ public class ContainerPresenter {
     }
 
     public void load(final ContainerSpecKey containerSpecKey) {
-        checkNotNull("containerSpecKey",
-                     containerSpecKey);
-        runtimeManagementService.call(new RemoteCallback<ContainerSpecData>() {
-            @Override
-            public void callback(final ContainerSpecData content) {
-                checkNotNull("content",
-                             content);
-                setup(content.getContainerSpec(),
-                      content.getContainers());
-            }
+        checkNotNull("containerSpecKey", containerSpecKey);
+        runtimeManagementService.call((RemoteCallback<ContainerSpecData>) content -> {
+            checkNotNull("content", content);
+            loadContainers(content);
         }).getContainersByContainerSpec(containerSpecKey.getServerTemplateKey().getId(),
                                         containerSpecKey.getId());
     }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+
 import javax.enterprise.event.Event;
 
 import org.jboss.errai.common.client.api.Caller;
@@ -34,6 +35,7 @@ import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
 import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerConfig;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ContainerSpecKey;
 import org.kie.server.controller.api.model.spec.ProcessConfig;
 import org.kie.server.controller.api.model.spec.RuleConfig;
 import org.kie.server.controller.api.model.spec.ServerTemplateKey;
@@ -398,5 +400,17 @@ public class ContainerPresenterTest {
                                                         NotificationEvent.NotificationType.ERROR));
         verify(serverTemplateSelectedEvent,
                times(2)).fire(new ServerTemplateSelected(containerSpec.getServerTemplateKey()));
+    }
+
+    @Test //Reproducer for GUVNOR-3579
+    public void loadContainerSpecDataWithNullContainerSpec_doesntCauseNpe() {
+        ContainerSpecData badData = new ContainerSpecData(null, null);
+        when(runtimeManagementService.getContainersByContainerSpec(anyObject(), anyObject())).thenReturn(badData);
+
+        ContainerSpecKey lookupKey = new ContainerSpecKey("dummyId", "dummyName", new ServerTemplateKey("keyId", "keyName"));
+
+        presenter.load(lookupKey); // Doesn't throw NPE when ContainerSpecData contain nulls
+
+        verify(view, never()).setContainerName(anyString());
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
@@ -16,6 +16,20 @@
 
 package org.kie.workbench.common.screens.server.management.client.container;
 
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -62,10 +76,6 @@ import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.events.NotificationEvent;
-
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerPresenterTest {
@@ -402,8 +412,8 @@ public class ContainerPresenterTest {
                times(2)).fire(new ServerTemplateSelected(containerSpec.getServerTemplateKey()));
     }
 
-    @Test //Reproducer for GUVNOR-3579
-    public void loadContainerSpecDataWithNullContainerSpec_doesntCauseNpe() {
+    @Test //Test fix for GUVNOR-3579
+    public void testLoadWhenRuntimeManagementServiceReturnsInvalidData() {
         ContainerSpecData badData = new ContainerSpecData(null, null);
         when(runtimeManagementService.getContainersByContainerSpec(anyObject(), anyObject())).thenReturn(badData);
 


### PR DESCRIPTION
…eption

@karreiro Please review. This fixes 2 issues related to [GUVNOR-3579](https://issues.jboss.org/browse/GUVNOR-3579):

1) NPE in GUI modal when removing container from template
The problem was that [getContainerSpec()](https://github.com/kiegroup/kie-wb-common/blob/master/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java#L153) was returning null. This null is there, because after you click Remove button (to remove container from template) the container spec is [removed from the template](https://github.com/kiegroup/kie-wb-common/blob/master/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java#L256-L257) and then since the container spec is no longer in the template [this code](https://github.com/kiegroup/kie-wb-common/blob/master/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDI.java#L85-L90) sets it to null and that is propagated back to UI by tangle of "refresh gui" code :P

Fixing that lead to accidental discovery of another related issue, which I also fixed

2.  [This method](https://github.com/kiegroup/kie-wb-common/blob/master/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/RuntimeManagementServiceCDI.java#L76-L92)'s implementation is buggy:
      1. It creates empty array list, which it passes to ContainerSpecData constructor without adding anything
      2. It queries `getKieServerInstanceManager().getContainers(serverTemplate, containerSpec);` but doesn't save the result anywhere
   -> Fixed by saving the query result to the list.

Is that NPE fix acceptable (I tested in kie-wb war locally and checked that it doesn't break other things)?

TODO: I still need to add coverage for the RuntimeManagementServiceCDI, because there are not tests for that one.