### PR TITLE
DROOLS-2109: Show Extension labels in the new resource dialogue

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/handler/NewFormDefinitionlHandler.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/handler/NewFormDefinitionlHandler.java
@@ -75,8 +75,8 @@ public class NewFormDefinitionlHandler extends DefaultNewResourceHandler {
 
     @PostConstruct
     private void setupExtensions() {
-        extensions.add(new Pair<String, IsWidget>(translationService.getTranslation(FormEditorConstants.NewFormDefinitionlHandlerSelectFormUse),
-                                                  formModelsPresenter));
+        extensions.add(Pair.newPair("", // not needed FormModelsPresenter describes the extension itself
+                                    formModelsPresenter));
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploader.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploader.java
@@ -69,8 +69,8 @@ public class NewFileUploader
 
     @PostConstruct
     private void setupExtensions() {
-        extensions.add(new Pair<String, DefaultEditorNewFileUpload>(GuvnorDefaultEditorConstants.INSTANCE.Options(),
-                                                                    options));
+        extensions.add(Pair.newPair("", // not needed DefaultEditorNewFileUpload describes the extension itself
+                                    options));
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/resources/i18n/GuvnorDefaultEditorConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/resources/i18n/GuvnorDefaultEditorConstants.java
@@ -34,8 +34,6 @@ public interface GuvnorDefaultEditorConstants
 
     String NewFileDescription();
 
-    String Options();
-
     String Uploading();
 
 }

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/resources/org/kie/workbench/common/screens/defaulteditor/client/editor/resources/i18n/GuvnorDefaultEditorConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/resources/org/kie/workbench/common/screens/defaulteditor/client/editor/resources/i18n/GuvnorDefaultEditorConstants.properties
@@ -16,5 +16,4 @@
 MetaFileEditor=Meta File Editor [ {0} ]
 TextEditor=Text Editor [ {0} ]
 NewFileDescription=Uploaded file
-Options=Options
 Uploading=Uploading...

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceViewImpl.java
@@ -17,10 +17,12 @@
 package org.kie.workbench.common.widgets.client.handlers;
 
 import java.util.List;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style;
@@ -140,6 +142,11 @@ public class NewResourceViewImpl implements NewResourceView,
         handlerExtensionsGroup.getStyle().setDisplay(showExtensions ? Style.Display.BLOCK : Style.Display.NONE);
         if (showExtensions) {
             extensions.forEach(pair -> {
+                if (pair.getK1() != null && !pair.getK1().isEmpty()) {
+                    final FormLabel extensionLabel = GWT.create(FormLabel.class);
+                    extensionLabel.setText(pair.getK1());
+                    handlerExtensions.add(extensionLabel);
+                }
                 handlerExtensions.add(pair.getK2());
             });
         }


### PR DESCRIPTION
This is part of an ensemble:
- #1278 
- kiegroup/drools-wb#815
- kiegroup/jbpm-designer#748