### PR TITLE
RHBRMS-3022: Cannot disable "Delete" button for Analyst role in business central

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
@@ -603,26 +603,34 @@ public class ProjectScreenPresenter
         init();
     }
 
-    private void makeMenuBar() {
+    void makeMenuBar() {
+
+        final String namespace = getClass().getName();
+
         menus = MenuFactory
                 .newTopLevelMenu( CommonConstants.INSTANCE.Save() )
                 .withRoles( kieACL.getGrantedRoles( F_PROJECT_AUTHORING_SAVE ) )
+                .withNamespace( namespace )
                 .respondsWith( getSaveCommand( DeploymentMode.VALIDATED ) )
                 .endMenu()
                 .newTopLevelMenu( CommonConstants.INSTANCE.Delete() )
                 .withRoles( kieACL.getGrantedRoles( F_PROJECT_AUTHORING_DELETE ) )
+                .withNamespace( namespace )
                 .respondsWith( getDeleteCommand() )
                 .endMenu()
                 .newTopLevelMenu( CommonConstants.INSTANCE.Rename() )
                 .withRoles( kieACL.getGrantedRoles( F_PROJECT_AUTHORING_RENAME ) )
+                .withNamespace( namespace )
                 .respondsWith( getRenameCommand() )
                 .endMenu()
                 .newTopLevelMenu( CommonConstants.INSTANCE.Copy() )
                 .withRoles( kieACL.getGrantedRoles( F_PROJECT_AUTHORING_COPY ) )
+                .withNamespace( namespace )
                 .respondsWith( getCopyCommand() )
                 .endMenu()
                 .newTopLevelMenu( CommonConstants.INSTANCE.Reimport() )
                 .withRoles( kieACL.getGrantedRoles( F_PROJECT_AUTHORING_SAVE ) )
+                .withNamespace( namespace )
                 .respondsWith( getReImportCommand() )
                 .endMenu()
                 .newTopLevelCustomMenu( new MenuFactory.CustomMenuBuilder() {

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.screens.projecteditor.client.editor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import com.google.gwtmockito.GwtMock;
@@ -55,6 +54,8 @@ import org.uberfire.mocks.CallerMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
+import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.Menus;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyBoolean;
@@ -541,6 +542,44 @@ public class ProjectScreenPresenterTest
         spiedPresenter.getBuildCommand( DeploymentMode.VALIDATED ).execute();
 
         verify( spiedPresenter ).buildAndDeploy( DeploymentMode.VALIDATED );
+    }
+
+    @Test
+    public void testMakeMenuBar() {
+
+        spiedPresenter.makeMenuBar();
+
+        final Menus menus = spiedPresenter.getMenus();
+        final List<MenuItem> items = menus.getItems();
+
+        final MenuItem saveMenuItem = items.get( 0 );
+        final MenuItem deleteMenuItem = items.get( 1 );
+        final MenuItem renameMenuItem = items.get( 2 );
+        final MenuItem copyMenuItem = items.get( 3 );
+        final MenuItem reImportMenuItem = items.get( 4 );
+
+        assertEquals( "Save", saveMenuItem.getCaption() );
+        assertSignatureId( saveMenuItem );
+
+        assertEquals( "Delete", deleteMenuItem.getCaption() );
+        assertSignatureId( deleteMenuItem );
+
+        assertEquals( "Rename", renameMenuItem.getCaption() );
+        assertSignatureId( renameMenuItem );
+
+        assertEquals( "Copy", copyMenuItem.getCaption() );
+        assertSignatureId( copyMenuItem );
+
+        assertEquals( "Reimport", reImportMenuItem.getCaption() );
+        assertSignatureId( reImportMenuItem );
+    }
+
+    private void assertSignatureId( final MenuItem menuItem ) {
+
+        final String signatureId = menuItem.getSignatureId();
+        final String namespace = getClass().getName();
+
+        assertTrue( signatureId.contains( namespace ) );
     }
 
     private void verifyBusyShowHideAnyString( int show,


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-3022

Before:
![before](https://user-images.githubusercontent.com/1079279/32587825-d0201672-c4f1-11e7-9d41-34a258a5e3d5.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/32587824-cd99e338-c4f1-11e7-9db2-cf0f28e49eac.gif)

---

Menus from other editors were interfering with permissions to enable/disable delete (and other buttons) in the Project Editor.

---

Part of an ensemble:
- https://github.com/AppFormer/uberfire/pull/903
- https://github.com/kiegroup/kie-wb-common/pull/1284

