### PR TITLE
JBPM-6589: Field Settings lost after moving on layout

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
@@ -348,9 +348,14 @@ public class FormEditorPresenter extends KieEditor {
 
         if (editorHelper.getFormDefinition().getId().equals(formId)) {
             String fieldId = event.getLayoutComponent().getProperties().get(FieldLayoutComponent.FIELD_ID);
-            editorHelper.removeField(fieldId,
-                                     true);
-            onSyncPalette(formId);
+
+            // If the event is caused by a element move we must hold the field on the form.
+            // If not it means that it should be removed.
+            if(!event.getFromMove()) {
+                editorHelper.removeField(fieldId,
+                                         true);
+                onSyncPalette(formId);
+            }
         }
     }
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterTest.java
@@ -233,7 +233,8 @@ public class FormEditorPresenterTest extends FormEditorPresenterAbstractTest {
                                                                 FieldDefinition field) {
 
         return new ComponentRemovedEvent(createLayoutComponent(form,
-                                                               field));
+                                                               field),
+                                         false);
     }
 
     protected LayoutComponent createLayoutComponent(FormDefinition form,
@@ -300,7 +301,8 @@ public class FormEditorPresenterTest extends FormEditorPresenterAbstractTest {
 
         Collection<FieldDefinition> availableFieldsValues = editorHelper.getAvailableFields().values();
 
-        verify(translationService, atLeastOnce())
+        verify(translationService,
+               atLeastOnce())
                 .getTranslation(FormEditorConstants.FormEditorPresenterModelFields);
         verify(presenterSpy,
                count).removeAllDraggableGroupComponent(presenter.getFormDefinition().getFields());
@@ -364,7 +366,8 @@ public class FormEditorPresenterTest extends FormEditorPresenterAbstractTest {
         FieldDefinition field = editorHelper.getFormDefinition().getFields().get(0);
 
         ComponentRemovedEvent event = new ComponentRemovedEvent(createLayoutComponent(presenter.getFormDefinition(),
-                                                                                      field));
+                                                                                      field),
+                                                                false);
         presenterSpy.onRemoveComponent(event);
 
         verify(presenterSpy,
@@ -384,6 +387,30 @@ public class FormEditorPresenterTest extends FormEditorPresenterAbstractTest {
 
         ComponentRemovedEvent event = new ComponentRemovedEvent(null);
         presenterSpy.onRemoveComponent(event);
+
+        verify(presenterSpy,
+               never()).onSyncPalette(anyString());
+        verify(editorHelper,
+               never()).removeField(anyString(),
+                                    anyBoolean());
+    }
+
+    @Test
+    public void testRemoveEventWhenMovingFieldOnLayout() {
+        loadContent();
+        loadAvailableFields();
+        addAllFields();
+
+        FormEditorPresenter presenterSpy = spy(presenter);
+
+        FieldDefinition field = editorHelper.getFormDefinition().getFields().get(0);
+
+        ComponentRemovedEvent event = new ComponentRemovedEvent(createLayoutComponent(presenter.getFormDefinition(),
+                                                                                      field),
+                                                                true);
+        presenterSpy.onRemoveComponent(event);
+
+        assertNotNull(editorHelper.getFormDefinition().getFieldById(field.getId()));
 
         verify(presenterSpy,
                never()).onSyncPalette(anyString());


### PR DESCRIPTION
@jsoltes Could you please take a look?

This PR is a part of an ensemble, please merge with:
https://github.com/AppFormer/uberfire/pull/907
https://github.com/kiegroup/kie-wb-common/pull/1287