### PR TITLE
JBPM-6617 Fix for missing drools constants on keyStoreHelper

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/DroolsSystemPropertiesInitializer.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/DroolsSystemPropertiesInitializer.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.drools.core.util.KeyStoreHelper;
+import org.drools.core.util.KeyStoreConstants;
 import org.guvnor.common.services.backend.preferences.SystemPropertiesInitializer;
 import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 
@@ -28,30 +28,30 @@ import org.kie.workbench.common.services.shared.preferences.ApplicationPreferenc
 public class DroolsSystemPropertiesInitializer implements SystemPropertiesInitializer {
 
     @Override
-    public void setSystemProperties( final Map<String, String> preferences ) {
-        setSystemProperty( preferences,
-                           ApplicationPreferences.DATE_FORMAT );
-        setSystemProperty( preferences,
-                           ApplicationPreferences.DATE_TIME_FORMAT );
-        setSystemProperty( preferences,
-                           ApplicationPreferences.DEFAULT_LANGUAGE );
-        setSystemProperty( preferences,
-                           ApplicationPreferences.DEFAULT_COUNTRY );
+    public void setSystemProperties(final Map<String, String> preferences) {
+        setSystemProperty(preferences,
+                          ApplicationPreferences.DATE_FORMAT);
+        setSystemProperty(preferences,
+                          ApplicationPreferences.DATE_TIME_FORMAT);
+        setSystemProperty(preferences,
+                          ApplicationPreferences.DEFAULT_LANGUAGE);
+        setSystemProperty(preferences,
+                          ApplicationPreferences.DEFAULT_COUNTRY);
 
-        setSystemProperty( preferences,
-                           KeyStoreHelper.PROP_SIGN );
-        setSystemProperty( preferences,
-                           KeyStoreHelper.PROP_PVT_KS_URL );
-        setSystemProperty( preferences,
-                           KeyStoreHelper.PROP_PVT_KS_PWD );
-        setSystemProperty( preferences,
-                           KeyStoreHelper.PROP_PVT_ALIAS );
-        setSystemProperty( preferences,
-                           KeyStoreHelper.PROP_PVT_PWD );
-        setSystemProperty( preferences,
-                           KeyStoreHelper.PROP_PUB_KS_URL );
-        setSystemProperty( preferences,
-                           KeyStoreHelper.PROP_PUB_KS_PWD );
+        setSystemProperty(preferences,
+                          KeyStoreConstants.PROP_SIGN);
+        setSystemProperty(preferences,
+                          KeyStoreConstants.PROP_PVT_KS_URL);
+        setSystemProperty(preferences,
+                          KeyStoreConstants.PROP_PVT_KS_PWD);
+        setSystemProperty(preferences,
+                          KeyStoreConstants.PROP_PVT_ALIAS);
+        setSystemProperty(preferences,
+                          KeyStoreConstants.PROP_PVT_PWD);
+        setSystemProperty(preferences,
+                          KeyStoreConstants.PROP_PUB_KS_URL);
+        setSystemProperty(preferences,
+                          KeyStoreConstants.PROP_PUB_KS_PWD);
     }
 
     private void setSystemProperty( final Map<String, String> preferences,


### PR DESCRIPTION
Inserting the import to `org.drools.core.util.KeyStoreConstants` the class the constants were moved to.

Can you review this, it is a fix to the master branch that is broken.
@romartin 
@manstis 