### PR TITLE
JBPM-6584: SelectorDataProvider generates two blank options

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/CharacterListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/CharacterListBoxFieldRenderer.java
@@ -17,14 +17,21 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
 import org.jboss.errai.databinding.client.api.Converter;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.CharacterSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.CharacterListBoxFieldDefinition;
 
 @Dependent
 public class CharacterListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<CharacterListBoxFieldDefinition, CharacterSelectorOption, Character> {
+
+    @Inject
+    public CharacterListBoxFieldRenderer(TranslationService translationService) {
+        super(translationService);
+    }
 
     @Override
     public Class<CharacterListBoxFieldDefinition> getSupportedFieldDefinition() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/DecimalListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/DecimalListBoxFieldRenderer.java
@@ -17,13 +17,20 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.DecimalSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.DecimalListBoxFieldDefinition;
 
 @Dependent
 public class DecimalListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<DecimalListBoxFieldDefinition, DecimalSelectorOption, Double> {
+
+    @Inject
+    public DecimalListBoxFieldRenderer(TranslationService translationService) {
+        super(translationService);
+    }
 
     @Override
     public Class<DecimalListBoxFieldDefinition> getSupportedFieldDefinition() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/EnumListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/EnumListBoxFieldRenderer.java
@@ -17,13 +17,20 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.EnumSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.EnumListBoxFieldDefinition;
 
 @Dependent
 public class EnumListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<EnumListBoxFieldDefinition, EnumSelectorOption, Enum> {
+
+    @Inject
+    public EnumListBoxFieldRenderer(TranslationService translationService) {
+        super(translationService);
+    }
 
     @Override
     public Class<EnumListBoxFieldDefinition> getSupportedFieldDefinition() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/IntegerListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/IntegerListBoxFieldRenderer.java
@@ -17,13 +17,20 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.IntegerSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.IntegerListBoxFieldDefinition;
 
 @Dependent
 public class IntegerListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<IntegerListBoxFieldDefinition, IntegerSelectorOption, Long> {
+
+    @Inject
+    public IntegerListBoxFieldRenderer(TranslationService translationService) {
+        super(translationService);
+    }
 
     @Override
     public Class<IntegerListBoxFieldDefinition> getSupportedFieldDefinition() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/StringListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/StringListBoxFieldRenderer.java
@@ -17,13 +17,20 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.StringListBoxFieldDefinition;
 
 @Dependent
 public class StringListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<StringListBoxFieldDefinition, StringSelectorOption, String> {
+
+    @Inject
+    public StringListBoxFieldRenderer(TranslationService translationService) {
+        super(translationService);
+    }
 
     @Override
     public Class<StringListBoxFieldDefinition> getSupportedFieldDefinition() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/resources/i18n/FormRenderingConstants.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/resources/i18n/FormRenderingConstants.java
@@ -40,4 +40,7 @@ public interface FormRenderingConstants {
 
     @TranslationKey(defaultValue = "")
     String SubFormWrongForm = "SubForm.wrongForm";
+
+    @TranslationKey(defaultValue = "")
+    String ListBoxFieldRendererEmptyOptionText = "ListBoxFieldRenderer.emptyOptionText";
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/resources/org/kie/workbench/common/forms/dynamic/client/resources/i18n/FormRenderingConstants.properties
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/resources/org/kie/workbench/common/forms/dynamic/client/resources/i18n/FormRenderingConstants.properties
@@ -16,7 +16,8 @@ FieldProperties.validateOnChange=Validate on change field value
 FieldProperties.maxLength=Max. Length
 FieldProperties.placeHolder=PlaceHolder
 FieldProperties.defaultValue=Default Value
-FieldProperties.rows=Visible rows:
+FieldProperties.rows=Visible rows
+FieldProperties.addEmptyOption=Add default empty option
 
 FieldProperties.showTime=Show Time
 
@@ -42,3 +43,5 @@ FieldProperties.multipleSubform.editionForm=Edition Form
 FieldProperties.multipleSubform.columns=Table Columns
 FieldProperties.multipleSubform.columns.label=Caption
 FieldProperties.multipleSubform.columns.property=Property
+
+ListBoxFieldRenderer.emptyOptionText=-- Select a value --

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/AbstractListBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/AbstractListBoxFieldRendererTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMock;
+import org.gwtbootstrap3.client.ui.ValueListBox;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.util.DefaultValueListBoxRenderer;
+import org.kie.workbench.common.forms.dynamic.client.resources.i18n.FormRenderingConstants;
+import org.kie.workbench.common.forms.dynamic.service.shared.BackendSelectorDataProviderService;
+import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
+import org.kie.workbench.common.forms.dynamic.service.shared.SelectorDataProviderManager;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorOption;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.ListBoxBaseDefinition;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.uberfire.mocks.CallerMock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractListBoxFieldRendererTest<RENDERER extends AbstractListBoxFieldRenderer<FIELD, OPTION, TYPE>, FIELD extends ListBoxBaseDefinition<OPTION, TYPE>, OPTION extends SelectorOption<TYPE>, TYPE> {
+
+    @GwtMock
+    protected ValueListBox<TYPE> valueListBox;
+
+    @Mock
+    protected SelectorDataProviderManager clientProviderManager;
+
+    @Mock
+    protected CallerMock<BackendSelectorDataProviderService> backendSelectorDataProviderService;
+
+    @Spy
+    protected DefaultValueListBoxRenderer<TYPE> optionsRenderer = new DefaultValueListBoxRenderer<>();
+
+    @Mock
+    protected TranslationService translationService;
+
+    @Mock
+    protected FIELD field;
+
+    @Mock
+    protected FormRenderingContext context;
+
+    protected RENDERER renderer;
+
+    protected Map<TYPE, String> options = new HashMap<>();
+
+    @Before
+    public void init() {
+        renderer = getRenderer(translationService,
+                               clientProviderManager,
+                               backendSelectorDataProviderService,
+                               optionsRenderer);
+
+        renderer.init(context,
+                      field);
+
+        fillOptions(options);
+    }
+
+    @Test
+    public void testRefreshInputDontAddNullOption() {
+        when(field.getAddEmptyOption()).thenReturn(false);
+
+        renderer.refreshInput(options,
+                              null);
+
+        verify(field).getAddEmptyOption();
+
+        verify(translationService,
+               never()).getTranslation(FormRenderingConstants.ListBoxFieldRendererEmptyOptionText);
+
+        assertFalse(options.containsValue(null));
+
+        verify(optionsRenderer).setValues(options);
+
+        verify(valueListBox).setAcceptableValues(any());
+    }
+
+    @Test
+    public void testRefreshInputAddNullOption() {
+        when(field.getAddEmptyOption()).thenReturn(true);
+
+        renderer.refreshInput(options,
+                              null);
+
+        verify(field).getAddEmptyOption();
+
+        verify(translationService).getTranslation(FormRenderingConstants.ListBoxFieldRendererEmptyOptionText);
+
+        assertTrue(options.containsValue(null));
+
+        verify(optionsRenderer).setValues(options);
+
+        verify(valueListBox).setAcceptableValues(any());
+    }
+
+    @Test
+    public void testRefreshInputAddExistingNullOption() {
+        when(field.getAddEmptyOption()).thenReturn(true);
+
+        options.put(null,
+                    "null");
+
+        renderer.refreshInput(options,
+                              null);
+
+        verify(field).getAddEmptyOption();
+
+        verify(translationService,
+               never()).getTranslation(FormRenderingConstants.ListBoxFieldRendererEmptyOptionText);
+
+        verify(optionsRenderer).setValues(options);
+
+        verify(valueListBox).setAcceptableValues(any());
+    }
+
+    protected abstract RENDERER getRenderer(TranslationService translationServiceParam,
+                                            SelectorDataProviderManager clientProviderManagerParam,
+                                            CallerMock<BackendSelectorDataProviderService> backendSelectorDataProviderServiceParam,
+                                            DefaultValueListBoxRenderer<TYPE> optionsRendererParam);
+
+    protected abstract void fillOptions(Map<TYPE, String> options);
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/CharacterListBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/CharacterListBoxFieldRendererTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
+
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.ValueListBox;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.util.DefaultValueListBoxRenderer;
+import org.kie.workbench.common.forms.dynamic.service.shared.BackendSelectorDataProviderService;
+import org.kie.workbench.common.forms.dynamic.service.shared.SelectorDataProviderManager;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.CharacterSelectorOption;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.CharacterListBoxFieldDefinition;
+import org.uberfire.mocks.CallerMock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class CharacterListBoxFieldRendererTest extends AbstractListBoxFieldRendererTest<CharacterListBoxFieldRenderer, CharacterListBoxFieldDefinition, CharacterSelectorOption, Character> {
+
+    @Override
+    protected CharacterListBoxFieldRenderer getRenderer(final TranslationService translationService,
+                                                        final SelectorDataProviderManager clientProviderManagerParam,
+                                                        final CallerMock<BackendSelectorDataProviderService> backendSelectorDataProviderServiceParam,
+                                                        final DefaultValueListBoxRenderer<Character> optionsRendererParam) {
+        return new CharacterListBoxFieldRenderer(translationService) {
+            {
+                clientProviderManager = clientProviderManagerParam;
+                backendSelectorDataProviderService = backendSelectorDataProviderServiceParam;
+                optionsRenderer = optionsRendererParam;
+            }
+
+            @Override
+            protected ValueListBox<Character> getListWidget() {
+                return valueListBox;
+            }
+        };
+    }
+
+    @Override
+    protected void fillOptions(Map<Character, String> options) {
+        options.put('A',
+                    "A");
+        options.put('B',
+                    "B");
+        options.put('C',
+                    "C");
+        options.put('D',
+                    "D");
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/DecimalListBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/DecimalListBoxFieldRendererTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
+
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.ValueListBox;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.util.DefaultValueListBoxRenderer;
+import org.kie.workbench.common.forms.dynamic.service.shared.BackendSelectorDataProviderService;
+import org.kie.workbench.common.forms.dynamic.service.shared.SelectorDataProviderManager;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.DecimalSelectorOption;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.DecimalListBoxFieldDefinition;
+import org.uberfire.mocks.CallerMock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DecimalListBoxFieldRendererTest extends AbstractListBoxFieldRendererTest<DecimalListBoxFieldRenderer, DecimalListBoxFieldDefinition, DecimalSelectorOption, Double> {
+
+    @Override
+    protected DecimalListBoxFieldRenderer getRenderer(final TranslationService translationService,
+                                                      final SelectorDataProviderManager clientProviderManagerParam,
+                                                      final CallerMock<BackendSelectorDataProviderService> backendSelectorDataProviderServiceParam,
+                                                      final DefaultValueListBoxRenderer<Double> optionsRendererParam) {
+        return new DecimalListBoxFieldRenderer(translationService) {
+            {
+                clientProviderManager = clientProviderManagerParam;
+                backendSelectorDataProviderService = backendSelectorDataProviderServiceParam;
+                optionsRenderer = optionsRendererParam;
+            }
+
+            @Override
+            protected ValueListBox<Double> getListWidget() {
+                return valueListBox;
+            }
+        };
+    }
+
+    @Override
+    protected void fillOptions(Map<Double, String> options) {
+        options.put(0.0,
+                    "0.0");
+        options.put(1.0,
+                    "1.0");
+        options.put(2.0,
+                    "2.0");
+        options.put(3.0,
+                    "3.0");
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/EnumListBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/EnumListBoxFieldRendererTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
+
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.ValueListBox;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.util.DefaultValueListBoxRenderer;
+import org.kie.workbench.common.forms.dynamic.service.shared.BackendSelectorDataProviderService;
+import org.kie.workbench.common.forms.dynamic.service.shared.SelectorDataProviderManager;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.EnumSelectorOption;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.EnumListBoxFieldDefinition;
+import org.uberfire.mocks.CallerMock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class EnumListBoxFieldRendererTest extends AbstractListBoxFieldRendererTest<EnumListBoxFieldRenderer, EnumListBoxFieldDefinition, EnumSelectorOption, Enum> {
+
+    @Override
+    protected EnumListBoxFieldRenderer getRenderer(final TranslationService translationService,
+                                                   final SelectorDataProviderManager clientProviderManagerParam,
+                                                   final CallerMock<BackendSelectorDataProviderService> backendSelectorDataProviderServiceParam,
+                                                   final DefaultValueListBoxRenderer<Enum> optionsRendererParam) {
+        return new EnumListBoxFieldRenderer(translationService) {
+            {
+                clientProviderManager = clientProviderManagerParam;
+                backendSelectorDataProviderService = backendSelectorDataProviderServiceParam;
+                optionsRenderer = optionsRendererParam;
+            }
+
+            @Override
+            protected ValueListBox<Enum> getListWidget() {
+                return valueListBox;
+            }
+        };
+    }
+
+    @Override
+    protected void fillOptions(Map<Enum, String> options) {
+        options.put(EnumModel.VAL1,
+                    EnumModel.VAL1.name());
+        options.put(EnumModel.VAL2,
+                    EnumModel.VAL2.name());
+        options.put(EnumModel.VAL3,
+                    EnumModel.VAL3.name());
+        options.put(EnumModel.VAL4,
+                    EnumModel.VAL4.name());
+    }
+
+    public enum EnumModel {
+        VAL1,
+        VAL2,
+        VAL3,
+        VAL4
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/IntegerListBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/IntegerListBoxFieldRendererTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
+
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.ValueListBox;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.util.DefaultValueListBoxRenderer;
+import org.kie.workbench.common.forms.dynamic.service.shared.BackendSelectorDataProviderService;
+import org.kie.workbench.common.forms.dynamic.service.shared.SelectorDataProviderManager;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.IntegerSelectorOption;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.IntegerListBoxFieldDefinition;
+import org.uberfire.mocks.CallerMock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class IntegerListBoxFieldRendererTest extends AbstractListBoxFieldRendererTest<IntegerListBoxFieldRenderer, IntegerListBoxFieldDefinition, IntegerSelectorOption, Long> {
+
+    @Override
+    protected IntegerListBoxFieldRenderer getRenderer(final TranslationService translationService,
+                                                      final SelectorDataProviderManager clientProviderManagerParam,
+                                                      final CallerMock<BackendSelectorDataProviderService> backendSelectorDataProviderServiceParam,
+                                                      final DefaultValueListBoxRenderer<Long> optionsRendererParam) {
+        return new IntegerListBoxFieldRenderer(translationService) {
+            {
+                clientProviderManager = clientProviderManagerParam;
+                backendSelectorDataProviderService = backendSelectorDataProviderServiceParam;
+                optionsRenderer = optionsRendererParam;
+            }
+
+            @Override
+            protected ValueListBox<Long> getListWidget() {
+                return valueListBox;
+            }
+        };
+    }
+
+    @Override
+    protected void fillOptions(Map<Long, String> options) {
+        options.put(0l,
+                    "0");
+        options.put(1l,
+                    "1");
+        options.put(2l,
+                    "2");
+        options.put(3l,
+                    "3");
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/StringListBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/StringListBoxFieldRendererTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox;
+
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.ValueListBox;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.util.DefaultValueListBoxRenderer;
+import org.kie.workbench.common.forms.dynamic.service.shared.BackendSelectorDataProviderService;
+import org.kie.workbench.common.forms.dynamic.service.shared.SelectorDataProviderManager;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.StringListBoxFieldDefinition;
+import org.uberfire.mocks.CallerMock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class StringListBoxFieldRendererTest extends AbstractListBoxFieldRendererTest<StringListBoxFieldRenderer, StringListBoxFieldDefinition, StringSelectorOption, String> {
+
+    @Override
+    protected StringListBoxFieldRenderer getRenderer(final TranslationService translationService,
+                                                     final SelectorDataProviderManager clientProviderManagerParam,
+                                                     final CallerMock<BackendSelectorDataProviderService> backendSelectorDataProviderServiceParam,
+                                                     final DefaultValueListBoxRenderer<String> optionsRendererParam) {
+        return new StringListBoxFieldRenderer(translationService) {
+            {
+                clientProviderManager = clientProviderManagerParam;
+                backendSelectorDataProviderService = backendSelectorDataProviderServiceParam;
+                optionsRenderer = optionsRendererParam;
+            }
+
+            @Override
+            protected ValueListBox<String> getListWidget() {
+                return valueListBox;
+            }
+        };
+    }
+
+    @Override
+    protected void fillOptions(Map<String, String> options) {
+        options.put("A",
+                    "A");
+        options.put("B",
+                    "B");
+        options.put("C",
+                    "C");
+        options.put("D",
+                    "D");
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/widgets/util/DefaultValueListBoxRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/main/java/org/kie/workbench/common/forms/common/rendering/client/widgets/util/DefaultValueListBoxRenderer.java
@@ -23,6 +23,8 @@ import com.google.gwt.text.shared.Renderer;
 
 public class DefaultValueListBoxRenderer<T> implements Renderer<T> {
 
+    public static final String NULL_STR = "null";
+
     private Map<T, String> values;
 
     public void setValues(Map<T, String> values) {
@@ -31,11 +33,9 @@ public class DefaultValueListBoxRenderer<T> implements Renderer<T> {
 
     @Override
     public String render(T value) {
-        if (value == null) {
-            return "";
-        }
-        if (values == null || !values.containsKey(value)) {
-            return "";
+
+        if(values == null || !values.containsKey(value)) {
+            return NULL_STR;
         }
 
         return values.get(value);

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/test/java/org/kie/workbench/common/forms/common/rendering/client/widgets/util/DefaultValueListBoxRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/src/test/java/org/kie/workbench/common/forms/common/rendering/client/widgets/util/DefaultValueListBoxRendererTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.common.rendering.client.widgets.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultValueListBoxRendererTest {
+
+    private static final String VAL_1 = "val1";
+    private static final String VAL_2 = "val2";
+    private static final String VAL_3 = "val3";
+    private static final String VAL_4 = "val4";
+
+    private static final String NON_EXISTING_OPTION = "val5";
+
+    @Mock
+    private Appendable appendable;
+
+    @Spy
+    private DefaultValueListBoxRenderer<String> renderer = new DefaultValueListBoxRenderer<>();
+
+    @Test
+    public void testRenderWithoutOptions() throws Exception {
+        renderer.render(NON_EXISTING_OPTION,
+                        appendable);
+        verify(renderer,
+               times(1)).render(NON_EXISTING_OPTION);
+        verify(appendable,
+               times(1)).append(DefaultValueListBoxRenderer.NULL_STR);
+    }
+
+    @Test
+    public void testRenderNullWithoutOptions() throws Exception {
+        renderer.render(null,
+                        appendable);
+        verify(renderer,
+               times(1)).render(null);
+        verify(appendable,
+               times(1)).append(DefaultValueListBoxRenderer.NULL_STR);
+    }
+
+    @Test
+    public void testRendererWithOptions() throws Exception {
+        Map<String, String> values = new HashMap<>();
+        values.put(VAL_1,
+                   VAL_1);
+        values.put(VAL_2,
+                   VAL_2);
+        values.put(VAL_3,
+                   VAL_3);
+        values.put(VAL_4,
+                   VAL_4);
+
+        renderer.setValues(values);
+
+        renderer.render(VAL_1,
+                        appendable);
+        verify(renderer,
+               times(1)).render(VAL_1);
+        verify(appendable,
+               times(1)).append(VAL_1);
+
+        renderer.render(VAL_2,
+                        appendable);
+        verify(renderer,
+               times(1)).render(VAL_2);
+        verify(appendable,
+               times(1)).append(VAL_2);
+
+        renderer.render(VAL_3,
+                        appendable);
+        verify(renderer,
+               times(1)).render(VAL_3);
+        verify(appendable,
+               times(1)).append(VAL_3);
+
+        renderer.render(VAL_4,
+                        appendable);
+        verify(renderer,
+               times(1)).render(VAL_4);
+        verify(appendable,
+               times(1)).append(VAL_4);
+
+        renderer.render(NON_EXISTING_OPTION,
+                        appendable);
+        verify(appendable,
+               times(1)).append(DefaultValueListBoxRenderer.NULL_STR);
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/main/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/selectors/ListBoxFieldInitializer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/main/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/selectors/ListBoxFieldInitializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.selectors;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.FormGenerationContext;
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.FieldInitializer;
+import org.kie.workbench.common.forms.adf.service.definitions.elements.FieldElement;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.ListBoxBaseDefinition;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+
+@Dependent
+public class ListBoxFieldInitializer implements FieldInitializer<ListBoxBaseDefinition> {
+
+    @Override
+    public boolean supports(FieldDefinition fieldDefinition) {
+        return fieldDefinition instanceof ListBoxBaseDefinition;
+    }
+
+    @Override
+    public void initialize(ListBoxBaseDefinition listBoxBaseDefinition,
+                           FieldElement fieldElement,
+                           FormGenerationContext context) {
+
+        String addEmptyOption = fieldElement.getParams().get("addEmptyOption");
+
+        if (addEmptyOption != null) {
+            listBoxBaseDefinition.setAddEmptyOption(Boolean.valueOf(addEmptyOption));
+        }
+
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/test/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/selectors/ListBoxFieldInitilizerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/src/test/java/org/kie/workbench/common/forms/adf/engine/shared/formGeneration/processing/fields/fieldInitializers/selectors/ListBoxFieldInitilizerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.selectors;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.adf.definitions.annotations.field.selector.SelectorDataProvider;
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.FormGenerationContext;
+import org.kie.workbench.common.forms.adf.service.definitions.elements.FieldElement;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorFieldBaseDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.ListBoxBaseDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.StringListBoxFieldDefinition;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListBoxFieldInitilizerTest {
+
+    private static final String ADD_EMPTY_OPTION = "addEmptyOption";
+
+    private ListBoxFieldInitializer initializer;
+
+    private ListBoxBaseDefinition field;
+
+    @Mock
+    private FieldElement fieldElement;
+
+    @Mock
+    private FormGenerationContext context;
+
+    private Map<String, String> fieldElementParams = new HashMap<>();
+
+    @Before
+    public void init() {
+        initializer = new ListBoxFieldInitializer();
+        field = spy(new StringListBoxFieldDefinition());
+        when(fieldElement.getParams()).thenReturn(fieldElementParams);
+    }
+
+    @Test
+    public void testInitializeTrueValue() {
+
+        fieldElementParams.put(ADD_EMPTY_OPTION,
+                               "true");
+
+        initializer.initialize(field,
+                               fieldElement,
+                               context);
+
+        verify(field).setAddEmptyOption(true);
+        assertTrue(field.getAddEmptyOption());
+    }
+
+    @Test
+    public void testInitializeFalseValue() {
+
+        fieldElementParams.put(ADD_EMPTY_OPTION,
+                               "false");
+
+        initializer.initialize(field,
+                               fieldElement,
+                               context);
+
+        verify(field).setAddEmptyOption(false);
+        assertFalse(field.getAddEmptyOption());
+    }
+
+    @Test
+    public void testInitializeNullValue() {
+        initializer.initialize(field,
+                               fieldElement,
+                               context);
+
+        verify(field, never()).setAddEmptyOption(anyBoolean());
+        assertTrue(field.getAddEmptyOption());
+    }
+
+    @Test
+    public void testInitializeWrongValue() {
+
+        fieldElementParams.put(ADD_EMPTY_OPTION,
+                               "");
+
+        initializer.initialize(field,
+                               fieldElement,
+                               context);
+
+        verify(field).setAddEmptyOption(false);
+        assertFalse(field.getAddEmptyOption());
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/ListBoxBaseDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/basic/selectors/listBox/definition/ListBoxBaseDefinition.java
@@ -16,13 +16,21 @@
 
 package org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition;
 
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorFieldBaseDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
+import org.kie.workbench.common.forms.model.FieldDefinition;
 
 public abstract class ListBoxBaseDefinition<OPTIONS extends SelectorOption<TYPE>, TYPE> extends SelectorFieldBaseDefinition<OPTIONS, TYPE> {
 
     public static final ListBoxFieldType FIELD_TYPE = new ListBoxFieldType();
+
+    @FormField(
+            labelKey = "addEmptyOption",
+            afterElement = "label"
+    )
+    private Boolean addEmptyOption = Boolean.TRUE;
 
     public ListBoxBaseDefinition(String className) {
         super(className);
@@ -31,5 +39,25 @@ public abstract class ListBoxBaseDefinition<OPTIONS extends SelectorOption<TYPE>
     @Override
     public ListBoxFieldType getFieldType() {
         return FIELD_TYPE;
+    }
+
+    public Boolean getAddEmptyOption() {
+        return addEmptyOption;
+    }
+
+    public void setAddEmptyOption(Boolean addEmptyOption) {
+        this.addEmptyOption = addEmptyOption;
+    }
+
+    @Override
+    protected void doCopyFrom(FieldDefinition other) {
+        super.doCopyFrom(other);
+        if(other instanceof ListBoxBaseDefinition) {
+            ListBoxBaseDefinition otherListBox = (ListBoxBaseDefinition) other;
+            if(getStandaloneClassName().equals(otherListBox.getStandaloneClassName())) {
+                setDefaultValue((TYPE) otherListBox.getDefaultValue());
+            }
+            setAddEmptyOption(otherListBox.addEmptyOption);
+        }
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/multipleSubform/definition/MultipleSubFormFieldDefinition.java
@@ -52,7 +52,7 @@ public class MultipleSubFormFieldDefinition extends AbstractFieldDefinition impl
     @SelectorDataProvider(
             type = SelectorDataProvider.ProviderType.REMOTE,
             className = "org.kie.workbench.common.forms.editor.backend.dataProviders.VFSSelectorFormProvider")
-    protected String creationForm = "";
+    protected String creationForm = null;
 
     @FormField(
             labelKey = "multipleSubform.editionForm",
@@ -62,7 +62,7 @@ public class MultipleSubFormFieldDefinition extends AbstractFieldDefinition impl
     @SelectorDataProvider(
             type = SelectorDataProvider.ProviderType.REMOTE,
             className = "org.kie.workbench.common.forms.editor.backend.dataProviders.VFSSelectorFormProvider")
-    protected String editionForm = "";
+    protected String editionForm = null;
 
     @FormField(
             labelKey = "multipleSubform.columns",

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/subForm/definition/SubFormFieldDefinition.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/main/java/org/kie/workbench/common/forms/fields/shared/fieldTypes/relations/subForm/definition/SubFormFieldDefinition.java
@@ -48,7 +48,7 @@ public class SubFormFieldDefinition extends AbstractFieldDefinition implements H
     @SelectorDataProvider(
             type = SelectorDataProvider.ProviderType.REMOTE,
             className = "org.kie.workbench.common.forms.editor.backend.dataProviders.VFSSelectorFormProvider")
-    protected String nestedForm = "";
+    protected String nestedForm = null;
 
     public SubFormFieldDefinition() {
         super(Object.class.getName());

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/FieldManagerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/src/test/java/org/kie/workbench/common/forms/fields/FieldManagerTest.java
@@ -21,7 +21,6 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Date;
 
-import junit.framework.TestCase;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/src/test/java/org/kie/workbench/common/forms/data/modeller/service/impl/DataObjectFormModelHandlerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/src/test/java/org/kie/workbench/common/forms/data/modeller/service/impl/DataObjectFormModelHandlerTest.java
@@ -241,7 +241,7 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
         formModel = handler.createFormModel(dataObject, path);
 
         SubFormFieldDefinition subForm = (SubFormFieldDefinition) checkCommonProperties("address");
-        assertEquals("",
+        assertEquals(null,
                      subForm.getNestedForm());
     }
 
@@ -250,9 +250,9 @@ public class DataObjectFormModelHandlerTest extends AbstractDataObjectTest {
         formModel = handler.createFormModel(dataObject, path);
 
         MultipleSubFormFieldDefinition multipleSubform = (MultipleSubFormFieldDefinition) checkCommonProperties("address_list");
-        assertEquals("",
+        assertEquals(null,
                      multipleSubform.getCreationForm());
-        assertEquals("",
+        assertEquals(null,
                      multipleSubform.getEditionForm());
         assertEquals(Collections.emptyList(),
                      multipleSubform.getColumnMetas());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
@@ -84,7 +84,7 @@ public class EmbeddedSubprocess extends BaseSubprocess implements DataIOModel {
                     new SimulationSet(),
                     new OnEntryAction(""),
                     new OnExitAction(""),
-                    new ScriptLanguage(""),
+                    new ScriptLanguage(),
                     new IsAsync(),
                     new ProcessData());
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/assignee/Actors.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/assignee/Actors.java
@@ -63,7 +63,7 @@ public class Actors implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value = defaultValue;
+    private String value;
 
     public Actors() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/connectors/ConditionExpressionLanguage.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/connectors/ConditionExpressionLanguage.java
@@ -62,7 +62,7 @@ public class ConditionExpressionLanguage implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value = defaultValue;
+    private String value;
 
     public ConditionExpressionLanguage() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/connectors/SequenceFlowExecutionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/connectors/SequenceFlowExecutionSet.java
@@ -77,7 +77,7 @@ public class SequenceFlowExecutionSet implements BPMNPropertySet {
     public SequenceFlowExecutionSet() {
         this(new Priority(""),
              new ConditionExpression(""),
-             new ConditionExpressionLanguage("")
+             new ConditionExpressionLanguage()
         );
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalScope.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalScope.java
@@ -62,7 +62,7 @@ public class SignalScope implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value = defaultValue;
+    private String value;
 
     public SignalScope() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/gateway/DefaultRoute.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/gateway/DefaultRoute.java
@@ -63,7 +63,7 @@ public class DefaultRoute implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value = defaultValue;
+    private String value;
 
     public DefaultRoute() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/BusinessRuleTaskExecutionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/BusinessRuleTaskExecutionSet.java
@@ -98,10 +98,10 @@ public class BusinessRuleTaskExecutionSet implements BPMNPropertySet {
     private AdHocAutostart adHocAutostart;
 
     public BusinessRuleTaskExecutionSet() {
-        this(new RuleFlowGroup(""),
+        this(new RuleFlowGroup(),
              new OnEntryAction(""),
              new OnExitAction(""),
-             new ScriptLanguage(""),
+             new ScriptLanguage(),
              new IsAsync(),
              new AdHocAutostart());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/CalledElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/CalledElement.java
@@ -62,7 +62,7 @@ public class CalledElement implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value = defaultValue;
+    private String value;
 
     public CalledElement() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/RuleFlowGroup.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/RuleFlowGroup.java
@@ -62,7 +62,7 @@ public class RuleFlowGroup implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value = defaultValue;
+    private String value;
 
     public RuleFlowGroup() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ScriptLanguage.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ScriptLanguage.java
@@ -62,7 +62,7 @@ public class ScriptLanguage implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value = defaultValue;
+    private String value;
 
     public ScriptLanguage() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ScriptTaskExecutionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ScriptTaskExecutionSet.java
@@ -72,8 +72,8 @@ public class ScriptTaskExecutionSet implements BPMNPropertySet {
     private IsAsync isAsync;
 
     public ScriptTaskExecutionSet() {
-        this(new Script(""),
-             new ScriptLanguage(""),
+        this(new Script(),
+             new ScriptLanguage(),
              new IsAsync());
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/UserTaskExecutionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/UserTaskExecutionSet.java
@@ -180,7 +180,7 @@ public class UserTaskExecutionSet implements BPMNPropertySet {
              new AdHocAutostart(),
              new OnEntryAction(""),
              new OnExitAction(""),
-             new ScriptLanguage(""));
+             new ScriptLanguage());
     }
 
     public UserTaskExecutionSet(final @MapsTo("taskName") TaskName taskName,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/dataproviders/TimeCycleLanguageProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/dataproviders/TimeCycleLanguageProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.kie.workbench.common.stunner.bpmn.backend.dataproviders;
 
 import java.util.Map;


### PR DESCRIPTION
This commit fixes the dropdowns with two blank options issue. The issue was that the ValueList widget was adding new options when the widget was binded to a value that doesn't exist on the configured options. In the case of stunner all the model properties binded to listboxes were initialized with "" (empty String), so when the value was set to the widget it was adding the extra blank option.

From now the forms engine will add a null option with text "-- Select a value --" (is possible to configure the field to add or not this option on the field settings). All extra options added on the dropdown when option is not present will be displayed with the "null" text to warn the user that the value is incorrect.

@wmedvede @romartin @jsoltes could you please take a look?

@romartin as we alredy talked yesterday I modified the models in stunner to initialize the LB properties as null and also changed some builders to call the default constructors. All tests are passing and stunner seems to work well but please take a look since it might be some collateral issues that I cannot predict.
