### PR TITLE
JBPM-6513 Stunner - Dropping / clicking palette items displays an error message

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
@@ -31,6 +31,7 @@ import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.MouseMoveEvent;
 import com.google.gwt.event.dom.client.MouseUpEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.RootPanel;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.components.drag.DragProxy;
@@ -111,8 +112,16 @@ public class ShapeGlyphDragHandlerImpl implements ShapeGlyphDragHandler<Abstract
 
         //MouseMoveEvents
         addMouseMoveEvents(floatingPanel, callback, style);
+
         //MouseUpEvent
-        addMouseUpEvent(floatingPanel, callback);
+        //delay to attach the MouseUpEvent handler, to avoid "clicking" to drop item.
+        new Timer() {
+            @Override
+            public void run() {
+                addMouseUpEvent(floatingPanel, callback);
+                this.cancel();
+            }
+        }.schedule(200);
     }
 
     private void addMouseMoveEvents(LienzoPanel floatingPanel, DragProxyCallback callback, Style style) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImplTest.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.components.glyph;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
@@ -72,12 +75,17 @@ public class ShapeGlyphDragHandlerImplTest {
 
     @Test
     public void testShow() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
 
         DragProxyCallback callback = mock(DragProxyCallback.class);
         shapeGlyphDragHandler.show(item, 0, 0, callback);
 
         //asserting handlers registrations
-        assertEquals(shapeGlyphDragHandler.handlerRegistrations.size(), 3);
+        assertEquals(shapeGlyphDragHandler.handlerRegistrations.size(), 2);
+        //delay timeout to add MouseUp handler
+        latch.await(201, TimeUnit.MILLISECONDS);
+        assertEquals(shapeGlyphDragHandler.handlerRegistrations.size(), 2);
+
         assertNotNull(shapeGlyphDragHandler.dragProxyPanel);
 
         verify(glyphLienzoGlyphRenderer).render(item.getShape(),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/exceptions/ElementOutOfBoundsException.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/exceptions/ElementOutOfBoundsException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.exceptions;
+
+public class ElementOutOfBoundsException extends RuntimeException{
+
+    public ElementOutOfBoundsException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
- Now when clicking on a palette item it starts the drag and when clicking again it drops, it works for the default item on the palette and when selecting a sub-item.

- Now if an item is dropped outside the canvas area, the item is not placed on canvas and no error message will appear to the user, only the error log about trying to drop outside canvas area.

@romartin 
@hasys 