### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/pom.xml
@@ -96,11 +96,6 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-social-activities-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
@@ -123,10 +123,6 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
     <!-- drools -->
     <dependency>
       <groupId>org.drools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.kie.soup</groupId>
-        <artifactId>kie-soup-bom</artifactId>
-        <version>${version.org.kie}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-bom</artifactId>
         <version>${version.org.dashbuilder}</version>


### PR DESCRIPTION
@psiroky could you please check and merge? Now that maven 3.5.2 highlights those warnings with colors, it's kinda harder to ignore :-)

Fixing the following warnings. Those dependencies are already declared in those poms, just removing all the duplicates found by 
`mvn dependency:analyze-duplicate`

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie.workbench.widgets:kie-wb-common-widgets:pom:7.5.0-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-bom:pom -> duplicate declaration of version ${version.org.kie} @ org.kie.workbench:kie-wb-common:[unknown-version], /home/hrk/Devel/github.com/jhrcek/kie-wb-common/pom.xml, line 83, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie.workbench.screens:kie-wb-common-library-client:jar:7.5.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.uberfire:uberfire-social-activities-api:jar -> duplicate declaration of version (?) @ org.kie.workbench.screens:kie-wb-common-library-client:[unknown-version], /home/hrk/Devel/github.com/jhrcek/kie-wb-common/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/pom.xml, line 97, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie.workbench.services:kie-wb-common-refactoring-backend:jar:7.5.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-commons:jar -> duplicate declaration of version (?) @ org.kie.workbench.services:kie-wb-common-refactoring-backend:[unknown-version], /home/hrk/Devel/github.com/jhrcek/kie-wb-common/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml, line 126, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie.workbench:kie-wb-common:pom:7.5.0-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-bom:pom -> duplicate declaration of version ${version.org.kie} @ org.kie.workbench:kie-wb-common:[unknown-version], /home/hrk/Devel/github.com/jhrcek/kie-wb-common/pom.xml, line 83, column 19
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```