### PR TITLE
[7.5.x] GUVNOR-3486: [Guided Decision Table Graph] Refresh after removal of table

### DIFF
--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditor.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditor.java
@@ -106,7 +106,7 @@ public abstract class KieMultipleDocumentEditor<D extends KieDocument> implement
 
     protected Menus menus;
 
-    private D activeDocument = null;
+    protected D activeDocument = null;
     protected final Set<D> documents = new HashSet<>();
 
     //Handler for MayClose requests


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3486

This is the corollary of https://github.com/kiegroup/kie-wb-common/pull/1316 for 7.5.x

(cherry picked from commit 2a38bfed0f546b386ee3a35b894c9c320ad604b3)