### PR TITLE
Stunner - Fixing start and intermediate SVG icons declaration

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/icons/event/event-intermediate.svg
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/icons/event/event-intermediate.svg
@@ -26,7 +26,7 @@
 	<g transform="translate(3.7,3.7) scale(0.05,0.05)" style="opacity:1">
 		<use xlink:href="event-signal.svg#eventSignal"/>
 	</g>
-        <g stunner:layout="CENTER" transform="translate(4,4) scale(0.05,0.05)" style="opacity:1">
+	<g transform="translate(4,4) scale(0.05,0.05)" style="opacity:1">
     	  <use xlink:href="event-message.svg#eventMessage"/>
         </g>
 	<g style="opacity:1">

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/icons/event/event-start.svg
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/icons/event/event-start.svg
@@ -23,7 +23,7 @@
   <g transform="translate(4,4) scale(0.05,0.05)" style="opacity:1">
     <use xlink:href="event-timer.svg#eventTimer"/>
   </g>
-  <g stunner:layout="CENTER" transform="translate(4,4) scale(0.05,0.05)" style="opacity:1">
+  <g transform="translate(4,4) scale(0.05,0.05)" style="opacity:1">
     <use xlink:href="event-message.svg#eventMessage"/>
   </g>
   <g style="opacity:1">


### PR DESCRIPTION
Hey @alepintus @wmedvede @hasys 

Actually the icons for start and intermediate events are not being displayed, neither in the morph menu on the canvas shapes neither when dragging those icons from the palette. Here is the fix for it, it was due a few invalid declarations in the SVG files.

Thanks!