### PR TITLE
JBPM-6705 [Stunner] Multi-selection copy/cut and paste

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/selection/CanvasSelectionEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/selection/CanvasSelectionEvent.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.event.selection;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -30,15 +31,13 @@ public final class CanvasSelectionEvent
     public CanvasSelectionEvent(final CanvasHandler canvasHandler,
                                 final Collection<String> identifiers) {
         super(canvasHandler);
-        this.identifiers = identifiers;
+        this.identifiers = new LinkedList<>(identifiers);
     }
 
     public CanvasSelectionEvent(final CanvasHandler canvasHandler,
                                 final String uuid) {
         super(canvasHandler);
-        this.identifiers = new LinkedList<String>() {{
-            add(uuid);
-        }};
+        this.identifiers = new LinkedList<>(Arrays.asList(uuid));
     }
 
     public Collection<String> getIdentifiers() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
@@ -96,5 +96,7 @@ public interface CanvasCommandFactory<H extends CanvasHandler> {
 
     CanvasCommand<H> clearCanvas();
 
-    CanvasCommand<H> cloneNode(Node candidate, String parentUuid, Point2D cloneLocation, Consumer<Node> cloneNodeCallback);
+    CanvasCommand<H> cloneNode(Node candidate, String parentUuid, Point2D cloneLocation, Consumer<Node> callback);
+
+    CanvasCommand<H> cloneConnector(Edge candidate, String sourceUUID, String targetUUID, String shapeSetId, Consumer<Edge> callback);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/util/Counter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/util/Counter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.util;
+
+import java.util.Objects;
+
+public class Counter {
+
+    private int counter;
+
+    public Counter() {
+        this(0);
+    }
+
+    public Counter(int value) {
+        this.counter = value;
+    }
+
+    public int get() {
+        return counter;
+    }
+
+    public int increment() {
+        return ++counter;
+    }
+
+    public int decrement() {
+        return --counter;
+    }
+
+    public boolean equalsToValue(int value) {
+        return counter == value;
+    }
+
+    public String toString(){
+        return String.valueOf(counter);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Counter counter1 = (Counter) o;
+        return counter == counter1.counter;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(counter);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/util/CounterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/util/CounterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CounterTest {
+
+    private Counter counter;
+    private static final int INIT_VALUE = 10;
+
+    @Before
+    public void setUp() throws Exception {
+        counter = new Counter(INIT_VALUE);
+    }
+
+    @Test
+    public void get() {
+        assertEquals(counter.get(), INIT_VALUE);
+        counter = new Counter();
+        assertEquals(counter.get(), 0);
+    }
+
+    @Test
+    public void increment() {
+        assertEquals(counter.increment(), INIT_VALUE + 1);
+        assertEquals(counter.increment(), INIT_VALUE + 2);
+    }
+
+    @Test
+    public void decrement() {
+        assertEquals(counter.decrement(), INIT_VALUE - 1);
+        assertEquals(counter.decrement(), INIT_VALUE - 2);
+    }
+
+    @Test
+    public void equalsToValue() {
+        assertTrue(counter.equalsToValue(INIT_VALUE));
+        assertFalse(counter.equalsToValue(INIT_VALUE + 1));
+
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneConnectorCommand.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.command;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+public class CloneConnectorCommand extends AbstractCanvasGraphCommand {
+
+    private final String sourceUUID;
+    private final String targetUUID;
+    private final Edge candidate;
+    private final String shapeSetId;
+    private final Optional<Consumer<Edge>> callback;
+    private transient CompositeCommand<AbstractCanvasHandler, CanvasViolation> command;
+
+    public CloneConnectorCommand(final Edge candidate,
+                                 final String sourceUUID,
+                                 final String targetUUID,
+                                 final String shapeSetId,
+                                 final Consumer<Edge> callback) {
+        this.candidate = candidate;
+        this.sourceUUID = sourceUUID;
+        this.targetUUID = targetUUID;
+        this.shapeSetId = shapeSetId;
+        this.callback = Optional.ofNullable(callback);
+        this.command = buildCommand();
+    }
+
+    private CompositeCommand<AbstractCanvasHandler, CanvasViolation> buildCommand() {
+        return new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
+                .reverse()
+                .build();
+    }
+
+    @Override
+    protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
+        return new org.kie.workbench.common.stunner.core.graph.command.impl.CloneConnectorCommand(candidate, sourceUUID, targetUUID, getCloneCallback());
+    }
+
+    protected Consumer<Edge> getCloneCallback() {
+        return edge -> {
+            //check if not a redo operation, in case size == 1 it was set before
+            if (!command.isEmpty()) {
+                command = buildCommand();
+            }
+            command.addCommand(new AddCanvasConnectorCommand(edge, shapeSetId));
+            command.addCommand(new SetCanvasConnectionCommand(edge));
+            callback.ifPresent(c -> c.accept(edge));
+        };
+    }
+
+    @Override
+    protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
+        return command;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneNodeCommand.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -80,7 +79,7 @@ public class CloneNodeCommand extends AbstractCanvasGraphCommand {
     private Consumer<Node> cloneNodeCallback(AbstractCanvasHandler context) {
         return clone -> {
             //check if not a redo operation, in case size == 1 it was set before
-            if (!Objects.equals(command.size(), 0)) {
+            if (!command.isEmpty()) {
                 command = buildCommand();
             }
             command.addCommand(getCloneCanvasNodeCommand(GraphUtils.getParent(clone).asNode(), clone, context.getDiagram().getMetadata().getShapeSetId()));
@@ -97,5 +96,9 @@ public class CloneNodeCommand extends AbstractCanvasGraphCommand {
 
     public ManagedInstance<ChildrenTraverseProcessor> getChildrenTraverseProcessor() {
         return childrenTraverseProcessor;
+    }
+
+    public Node getCandidate() {
+        return candidate;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
@@ -210,6 +210,11 @@ public class DefaultCanvasCommandFactory implements CanvasCommandFactory<Abstrac
         return new CloneNodeCommand(candidate, parentUuid, cloneLocation, cloneNodeCallback, childrenTraverseProcessors);
     }
 
+    @Override
+    public CanvasCommand<AbstractCanvasHandler> cloneConnector(Edge candidate, String sourceUUID, String targetUUID, String shapeSetId, Consumer<Edge> callback) {
+        return new CloneConnectorCommand(candidate, sourceUUID, targetUUID, shapeSetId, callback);
+    }
+
     protected ChildrenTraverseProcessor newChildrenTraverseProcessor() {
         return childrenTraverseProcessors.get();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/clipboard/LocalClipboardControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/clipboard/LocalClipboardControl.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanv
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 
 @ApplicationScoped
@@ -54,7 +55,7 @@ public class LocalClipboardControl extends AbstractCanvasControl<AbstractCanvas>
     public ClipboardControl<Element, AbstractCanvas, ClientSession> set(Element... element) {
         clear();
         elements.addAll(Arrays.stream(element).collect(Collectors.toSet()));
-        elementsParent.putAll(elements.stream().collect(Collectors.toMap(Element::getUUID, e -> GraphUtils.getParent(e.asNode()).getUUID())));
+        elementsParent.putAll(elements.stream().filter(e -> e instanceof Node).collect(Collectors.toMap(Element::getUUID, e -> GraphUtils.getParent(e.asNode()).getUUID())));
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
@@ -71,18 +71,9 @@ public class CopySelectionSessionCommand extends AbstractClientSessionCommand<Cl
                 //for now just copy Nodes not Edges
                 final SelectionControl<AbstractCanvasHandler, Element> selectionControl = getSession().getSelectionControl();
 
-                //for now throw error in case trying to copy not Node elements
-                if (selectionControl.getSelectedItems().stream()
-                        .map(this::getElement)
-                        .anyMatch(element -> !(element instanceof Node))) {
-                    clipboardControl.clear();
-                    throw new RuntimeException("Copy node only is allowed");
-                }
-
                 //for now just copy Nodes not Edges
                 clipboardControl.set(selectionControl.getSelectedItems().stream()
                                              .map(this::getElement)
-                                             .filter(element -> element instanceof Node)
                                              .toArray(Element[]::new));
 
                 callback.onSuccess();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
@@ -16,14 +16,18 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.Collections;
+import java.util.DoubleSummaryStatistics;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -34,6 +38,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.controls.clipboard.ClipboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent.Key;
@@ -50,6 +55,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.util.Counter;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher.doKeysMatch;
@@ -66,9 +72,10 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     private final Event<CanvasSelectionEvent> selectionEvent;
-    private final List<String> clonedElements;
+    private final Map<String, String> clonedElements;
     private ClipboardControl<Element, AbstractCanvas, ClientSession> clipboardControl;
     private final CopySelectionSessionCommand copySelectionSessionCommand;
+    private transient DoubleSummaryStatistics yPositionStatistics;
 
     protected PasteSelectionSessionCommand() {
         this(null, null, null, null);
@@ -83,7 +90,7 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
         this.sessionCommandManager = sessionCommandManager;
         this.canvasCommandFactory = canvasCommandFactory;
         this.selectionEvent = selectionEvent;
-        this.clonedElements = new ArrayList<>();
+        this.clonedElements = new HashMap<>();
         this.copySelectionSessionCommand = sessionCommandFactory.newCopySelectionCommand();
     }
 
@@ -117,39 +124,41 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
                      callback);
 
         if (clipboardControl.hasElements()) {
-            final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder = new CompositeCommand.Builder<>();
+            final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> nodesCommandBuilder = createCommandBuilder();
 
-            //for now just pasting Nodes not Edges
-            commandBuilder.addCommands(clipboardControl.getElements().stream()
-                                               .filter(element -> element instanceof Node)
-                                               .map(Element::asNode)
-                                               .filter(Objects::nonNull)
-                                               .map(node -> (Node<View<?>, Edge>) node)
-                                               .map(node -> {
-                                                   String newParentUUID = getNewParentUUID(node);
-                                                   return canvasCommandFactory.cloneNode(node, newParentUUID, calculateNewLocation(node, newParentUUID), cloneNodeCallback());
-                                               })
-                                               .collect(Collectors.toList()));
+            Counter processedNodesCountdown = new Counter((int) clipboardControl.getElements().stream()
+                    .filter(element -> element instanceof Node).count());
 
-            // Execute the command.
-            if (Objects.equals(commandBuilder.size(), 0)) {
+            //first processing nodes
+            nodesCommandBuilder.addCommands(clipboardControl.getElements().stream()
+                                                    .filter(element -> element instanceof Node)
+                                                    .filter(Objects::nonNull)
+                                                    .map(node -> (Node<View<?>, Edge>) node)
+                                                    .map(node -> {
+                                                        String newParentUUID = getNewParentUUID(node);
+                                                        return canvasCommandFactory.cloneNode(node, newParentUUID, calculateNewLocation(node, newParentUUID), cloneNodeCallback(node, processedNodesCountdown));
+                                                    })
+                                                    .collect(Collectors.toList()));
+
+            if (Objects.equals(nodesCommandBuilder.size(), 0)) {
                 return;
             }
 
-            final CommandResult<CanvasViolation> result;
+            // Execute the command for cloning nodes
+            CommandResult<CanvasViolation> finalResult;
             if (wasNodesDeletedFromGraph()) {
                 //in case of a cut command the source elements were deleted from graph, so first undo the command to take node back into canvas
                 clipboardControl.getRollbackCommands().forEach(command -> command.undo(getCanvasHandler()));
-                result = sessionCommandManager.execute(getCanvasHandler(), commandBuilder.build());
+                finalResult = executeCommands(nodesCommandBuilder, processedNodesCountdown);
                 //after the clone execution than delete source elements again
                 clipboardControl.getRollbackCommands().forEach(command -> command.execute(getCanvasHandler()));
             } else {
                 //if elements are still on the graph, in case copy command, just execute the clone commands
-                result = sessionCommandManager.execute(getCanvasHandler(), commandBuilder.build());
+                finalResult = executeCommands(nodesCommandBuilder, processedNodesCountdown);
             }
 
-            if (CommandUtils.isError(result)) {
-                LOGGER.severe("Error on paste selection." + getCanvasViolations(result));
+            if (CommandUtils.isError(finalResult)) {
+                LOGGER.severe("Error pasting selection." + getCanvasViolations(finalResult));
                 return;
             }
 
@@ -162,6 +171,57 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
         }
     }
 
+    private CommandResult<CanvasViolation> executeCommands(CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder, Counter processedNodesCountdown) {
+        CommandResult<CanvasViolation> nodesResult = sessionCommandManager.execute(getCanvasHandler(), commandBuilder.build());
+        if (CommandUtils.isError(nodesResult)) {
+            return nodesResult;
+        }
+
+        // Processing connectors: after all nodes has been cloned
+        CommandResult<CanvasViolation> connectorsResult = processConnectors(processedNodesCountdown);
+        return new CanvasCommandResultBuilder()
+                .setType(nodesResult.getType())
+                .addViolations((Objects.nonNull(nodesResult.getViolations()) ?
+                        StreamSupport.stream(nodesResult.getViolations().spliterator(), false).collect(Collectors.toList()) :
+                        Collections.emptyList()))
+                .addViolations((Objects.nonNull(connectorsResult.getViolations()) ?
+                        StreamSupport.stream(connectorsResult.getViolations().spliterator(), false).collect(Collectors.toList()) :
+                        Collections.emptyList()))
+                .build();
+    }
+
+    private CommandResult<CanvasViolation> processConnectors(Counter processedNodesCountdown) {
+        if (processedNodesCountdown.equalsToValue(0)) {
+            final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder = createCommandBuilder();
+            commandBuilder.addCommands(clipboardControl.getElements().stream()
+                                               .filter(element -> element instanceof Edge)
+                                               .filter(Objects::nonNull)
+                                               .map(edge -> (Edge) edge)
+                                               .filter(edge -> Objects.nonNull(edge.getSourceNode()) &&
+                                                       Objects.nonNull(clonedElements.get(edge.getSourceNode().getUUID())) &&
+                                                       Objects.nonNull(edge.getTargetNode()) &&
+                                                       Objects.nonNull(clonedElements.get(edge.getTargetNode().getUUID())))
+                                               .map(edge -> canvasCommandFactory.cloneConnector(edge,
+                                                                                                clonedElements.get(edge.getSourceNode().getUUID()),
+                                                                                                clonedElements.get(edge.getTargetNode().getUUID()),
+                                                                                                getCanvasHandler().getDiagram().getMetadata().getShapeSetId(),
+                                                                                                cloneEdgeCallback(edge)))
+                                               .collect(Collectors.toList()));
+
+            return sessionCommandManager.execute(getCanvasHandler(), commandBuilder.build());
+        }
+
+        return new CanvasCommandResultBuilder().build();
+    }
+
+    private CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> createCommandBuilder() {
+        return new CompositeCommand.Builder<>();
+    }
+
+    private Consumer<Edge> cloneEdgeCallback(Edge candidate) {
+        return clone -> clonedElements.put(candidate.getUUID(), clone.getUUID());
+    }
+
     public boolean wasNodesDeletedFromGraph() {
         return clipboardControl.getElements().stream().allMatch(element -> Objects.isNull(getElement(element.getUUID())));
     }
@@ -169,6 +229,7 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
     public void clear() {
         clipboardControl.clear();
         clonedElements.clear();
+        yPositionStatistics = null;
     }
 
     public String getCanvasViolations(CommandResult<CanvasViolation> result) {
@@ -178,24 +239,29 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
         return "";
     }
 
-    private Consumer<Node> cloneNodeCallback() {
-        return clone -> clonedElements.add(clone.getUUID());
+    private Consumer<Node> cloneNodeCallback(Node candidate, Counter processedNodesCountdown) {
+        return clone -> {
+            clonedElements.put(candidate.getUUID(), clone.getUUID());
+            processedNodesCountdown.decrement();
+        };
     }
 
     private void fireSelectedElementEvent() {
-        clonedElements.stream().forEach(uuid -> selectionEvent.fire(new CanvasSelectionEvent(getCanvasHandler(), uuid)));
+        selectionEvent.fire(new CanvasSelectionEvent(getCanvasHandler(), clonedElements.values()));
     }
 
     private String getNewParentUUID(Node node) {
         //getting parent if selected
-        Optional<Element> selectedParent = getSelectedParentElement();
+        Optional<Element> selectedParent = getSelectedParentElement(node.getUUID());
         if (selectedParent.isPresent() && !Objects.equals(selectedParent.get().getUUID(), node.getUUID()) && checkIfExistsOnCanvas(selectedParent.get().getUUID())) {
             return selectedParent.get().getUUID();
         }
 
         //getting node parent if no different parent is selected
         String nodeParentUUID = clipboardControl.getParent(node.getUUID());
-        if (selectedParent.isPresent() && Objects.equals(selectedParent.get().getUUID(), node.getUUID()) && Objects.nonNull(nodeParentUUID) && checkIfExistsOnCanvas(nodeParentUUID)) {
+        if (selectedParent.isPresent() &&
+                Objects.equals(selectedParent.get().getUUID(), node.getUUID()) &&
+                Objects.nonNull(nodeParentUUID) && checkIfExistsOnCanvas(nodeParentUUID)) {
             return nodeParentUUID;
         }
 
@@ -211,12 +277,17 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
         return getCanvasHandler().getDiagram().getMetadata().getCanvasRootUUID();
     }
 
-    private Optional<Element> getSelectedParentElement() {
+    private Optional<Element> getSelectedParentElement(String nodeUUID) {
         if (null != getSession().getSelectionControl()) {
             Collection<String> selectedItems = getSession().getSelectionControl().getSelectedItems();
             if (Objects.nonNull(selectedItems) && !selectedItems.isEmpty()) {
-                String selectedUUID = selectedItems.stream().filter(Objects::nonNull).findFirst().orElse(null);
-                return Optional.ofNullable(getElement(selectedUUID));
+                Optional<String> selectedParent = selectedItems.stream()
+                        .filter(Objects::nonNull)
+                        .filter(item -> Objects.equals(item, nodeUUID))
+                        .findFirst();
+                return (selectedParent.isPresent() ?
+                        selectedParent : selectedItems.stream().filter(Objects::nonNull).findFirst())
+                        .map(this::getElement);
             }
         }
         return Optional.empty();
@@ -232,11 +303,26 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
 
         //node is still on canvas (not deleted)
         if (existsOnCanvas(node)) {
-            return new Point2D(position.getX() + DEFAULT_PADDING, position.getY() + DEFAULT_PADDING);
+            double x = position.getX();
+            double max = getYPositionStatistics().getMax();
+            double min = getYPositionStatistics().getMin();
+            double y = max + (position.getY() - min) + DEFAULT_PADDING;
+            return new Point2D(x, y);
         }
 
         //default or node was deleted
         return position;
+    }
+
+    private DoubleSummaryStatistics getYPositionStatistics() {
+        if (Objects.isNull(yPositionStatistics)) {
+            yPositionStatistics = Stream.concat(clipboardControl.getElements().stream()
+                                                        .filter(element -> element instanceof Node)
+                                                        .map(element -> ((View) element.getContent()).getBounds().getLowerRight()),
+                                                clipboardControl.getElements().stream().filter(element -> element instanceof Node)
+                                                        .map(element -> ((View) element.getContent()).getBounds().getUpperLeft())).mapToDouble(bound -> bound.getY()).summaryStatistics();
+        }
+        return yPositionStatistics;
     }
 
     private boolean hasParentChanged(Node<? extends View<?>, Edge> node, String newParentUUID) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneConnectorCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneConnectorCommandTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.command;
+
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.core.util.UUID;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloneConnectorCommandTest {
+
+    private CloneConnectorCommand cloneConnectorCommand;
+
+    @Mock
+    private Edge candidate;
+
+    @Mock
+    private Edge clone;
+
+    @Mock
+    private AbstractCanvasHandler context;
+
+    private static final String SOURCE_UUID = UUID.uuid();
+    private static final String TARGET_UUID = UUID.uuid();
+    private static final String SHAPE_SET_UUID = UUID.uuid();
+
+    @Before
+    public void setUp() {
+        cloneConnectorCommand = new CloneConnectorCommand(candidate, SOURCE_UUID, TARGET_UUID, SHAPE_SET_UUID, null);
+    }
+
+    @Test
+    public void newGraphCommand() {
+        Command<GraphCommandExecutionContext, RuleViolation> command = cloneConnectorCommand.newGraphCommand(context);
+        assertTrue(command instanceof org.kie.workbench.common.stunner.core.graph.command.impl.CloneConnectorCommand);
+    }
+
+    @Test
+    public void newCanvasCommand() {
+        Command<AbstractCanvasHandler, CanvasViolation> command = cloneConnectorCommand.newCanvasCommand(context);
+        assertTrue(command instanceof CompositeCommand);
+
+        Consumer<Edge> cloneCallback = cloneConnectorCommand.getCloneCallback();
+        cloneCallback.accept(clone);
+
+        CompositeCommand compositeCommand = (CompositeCommand) command;
+        assertTrue(compositeCommand.getCommands().stream().anyMatch(c -> c instanceof AddCanvasConnectorCommand));
+        assertEquals(((AddCanvasConnectorCommand) compositeCommand.getCommands().stream()
+                .filter(c -> c instanceof AddCanvasConnectorCommand)
+                .findFirst()
+                .get()).getCandidate(), clone);
+        assertTrue(compositeCommand.getCommands().stream().anyMatch(c -> c instanceof SetCanvasConnectionCommand));
+        assertEquals(((SetCanvasConnectionCommand) compositeCommand.getCommands().stream()
+                .filter(c -> c instanceof SetCanvasConnectionCommand)
+                .findFirst()
+                .get()).getEdge(), clone);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
@@ -36,9 +36,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -98,6 +96,18 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardT
         when(selectionControl.getSelectedItems()).thenThrow(new RuntimeException());
         copySelectionSessionCommand.execute(callback);
         verify(callback, never()).onSuccess();
+    }
+
+    @Test
+    public void testExecuteMultiSelection() {
+        copySelectionSessionCommand.bind(session);
+
+        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(graphInstance.startNode.getUUID(),
+                                                                           graphInstance.edge1.getUUID(),
+                                                                           graphInstance.intermNode.getUUID()));
+        copySelectionSessionCommand.execute(callback);
+        verify(clipboardControl, times(1))
+                .set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -30,6 +32,7 @@ import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.CloneConnectorCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.CloneNodeCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.clipboard.ClipboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.clipboard.LocalClipboardControl;
@@ -40,8 +43,10 @@ import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
@@ -56,6 +61,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand.DEFAULT_PADDING;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -67,12 +73,20 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboardTest {
 
+    public static final double NODE_SIZE = 10d;
+
+    public static final double X = 20d;
+
+    public static final double Y = 20d;
+
     private PasteSelectionSessionCommand pasteSelectionSessionCommand;
 
     @Mock
     private AbstractCanvasHandler canvasHandler;
 
     private Node node;
+
+    private Node node2;
 
     private TestingGraphInstanceBuilder.TestGraph2 graphInstance;
 
@@ -106,18 +120,37 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
     @Mock
     private CommandResult commandResult;
 
+    @Mock
+    private CommandResult commandResultConnector;
+
     private static final String CANVAS_UUID = UUID.uuid();
 
     @Mock
     private Node clone;
 
     @Mock
+    private Node clone2;
+
+    @Mock
+    private Edge cloneEdge;
+
+    private Map<Node, Node> cloneMap;
+
+    @Mock
     private CloneNodeCommand cloneNodeCommand;
+
+    @Mock
+    private CloneNodeCommand cloneNodeCommand2;
+
+    @Mock
+    private CloneConnectorCommand cloneConnectorCommand;
 
     @Mock
     private CopySelectionSessionCommand copySelectionSessionCommand;
 
     private static final String CLONE_UUID = UUID.uuid();
+
+    private static final String CLONE2_UUID = UUID.uuid();
 
     @Before
     public void setUp() throws Exception {
@@ -127,17 +160,27 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
         this.graphInstance = TestingGraphInstanceBuilder.newGraph2(graphMockHandler);
         node = graphInstance.startNode;
         node.setContent(view);
+        node2 = graphInstance.intermNode;
+        node2.setContent(view);
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(canvasHandler.getGraphIndex()).thenReturn(graphMockHandler.graphIndex);
-        when(view.getBounds()).thenReturn(new BoundsImpl(new BoundImpl(20d, 20d), new BoundImpl(30d, 30d)));
+        when(view.getBounds()).thenReturn(new BoundsImpl(new BoundImpl(X, Y), new BoundImpl(X + NODE_SIZE, Y + NODE_SIZE)));
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(diagram.getMetadata()).thenReturn(metadata);
         when(metadata.getCanvasRootUUID()).thenReturn(CANVAS_UUID);
         when(sessionCommandManager.execute(eq(canvasHandler), any())).thenReturn(commandResult);
+        when(sessionCommandManager.execute(canvasHandler, cloneConnectorCommand)).thenReturn(commandResultConnector);
         when(commandResult.getType()).thenReturn(CommandResult.Type.INFO);
+        when(commandResultConnector.getType()).thenReturn(CommandResult.Type.INFO);
         when(clone.getUUID()).thenReturn(CLONE_UUID);
+        when(clone2.getUUID()).thenReturn(CLONE2_UUID);
         when(session.getClipboardControl()).thenReturn(clipboardControl);
         when(sessionCommandFactory.newCopySelectionCommand()).thenReturn(copySelectionSessionCommand);
+
+        cloneMap = new HashMap() {{
+            put(node, clone);
+            put(node2, clone2);
+        }};
 
         super.setup();
         this.pasteSelectionSessionCommand = getCommand();
@@ -161,7 +204,7 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(node.getUUID()));
         pasteSelectionSessionCommand.execute(callback);
         verify(canvasCommandFactory, times(1))
-                .cloneNode(eq(node), eq(graphInstance.parentNode.getUUID()), eq(new Point2D(35d, 35d)), any());
+                .cloneNode(eq(node), eq(graphInstance.parentNode.getUUID()), eq(new Point2D(X, DEFAULT_PADDING + Y + NODE_SIZE)), any());
 
         //different parent
         clipboardControl.set(graphInstance.startNode);
@@ -194,6 +237,54 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
                 .cloneNode(eq(node), eq(CANVAS_UUID), eq(new Point2D(DEFAULT_PADDING, DEFAULT_PADDING)), any());
         verify(callback, never()).onSuccess();
         verify(selectionEvent, never()).fire(canvasElementSelectedEventArgumentCaptor.capture());
+    }
+
+    @Test
+    public void executeWithMultiSelection() throws Exception {
+        pasteSelectionSessionCommand.bind(session);
+
+        //Mock the callback of CloneNodeCommand
+        ArgumentCaptor<Consumer> consumerNode = ArgumentCaptor.forClass(Consumer.class);
+        ArgumentCaptor<Consumer> consumerNode2 = ArgumentCaptor.forClass(Consumer.class);
+        when(cloneNodeCommand.getCandidate()).thenReturn(node);
+        when(cloneNodeCommand2.getCandidate()).thenReturn(node2);
+        when(canvasCommandFactory.cloneNode(eq(node), any(), any(), consumerNode.capture())).thenReturn(cloneNodeCommand);
+        when(canvasCommandFactory.cloneNode(eq(node2), any(), any(), consumerNode2.capture())).thenReturn(cloneNodeCommand2);
+        Map<Node, ArgumentCaptor<Consumer>> consumerMap = new HashMap() {{
+            put(node, consumerNode);
+            put(node2, consumerNode2);
+        }};
+
+        //Mock the callback of CloneConnectorCommand
+        ArgumentCaptor<Consumer> consumerEdge = ArgumentCaptor.forClass(Consumer.class);
+        when(canvasCommandFactory.cloneConnector(any(), anyString(), anyString(), anyString(), consumerEdge.capture())).thenReturn(cloneConnectorCommand);
+
+        //apply callbacks mocks
+        when(sessionCommandManager.execute(eq(canvasHandler), any())).thenAnswer(param -> {
+            CompositeCommand argument = param.getArgumentAt(1, CompositeCommand.class);
+            //callback to nodes
+            argument.getCommands().stream().filter(c -> c instanceof CloneNodeCommand).forEach(c -> {
+                CloneNodeCommand cloneNodeCommand = (CloneNodeCommand) c;
+                Node candidate = cloneNodeCommand.getCandidate();
+                consumerMap.get(candidate).getValue().accept(cloneMap.get(candidate));
+            });
+
+            //callback to connectors
+            argument.getCommands().stream().filter(c -> c instanceof CloneConnectorCommand).forEach(c ->
+                                                                                                            consumerEdge.getValue().accept(cloneEdge)
+            );
+            return commandResult;
+        });
+
+        //Executing the command
+        clipboardControl.set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
+        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(graphInstance.startNode.getUUID(), graphInstance.edge1.getUUID(), graphInstance.intermNode.getUUID()));
+        pasteSelectionSessionCommand.execute(callback);
+        verify(canvasCommandFactory, times(1))
+                .cloneNode(eq(graphInstance.startNode), eq(graphInstance.parentNode.getUUID()), eq(new Point2D(X, DEFAULT_PADDING + Y + NODE_SIZE)), any());
+
+        verify(canvasCommandFactory, times(1))
+                .cloneConnector(eq(graphInstance.edge1), anyString(), anyString(), anyString(), any());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/AbstractCompositeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/AbstractCompositeCommand.java
@@ -111,6 +111,10 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
         return commands.size();
     }
 
+    public boolean isEmpty() {
+        return commands.isEmpty();
+    }
+
     public List<Command<T, V>> getCommands() {
         return commands;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphMockHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphMockHandler.java
@@ -209,9 +209,14 @@ public class TestingGraphMockHandler {
                         final Optional<Set<String>> labels) {
         final Object definition = newDef(id,
                                          labels);
+        return newEdge(uuid, definition);
+    }
+
+    private Edge newEdge(String uuid, Object definition) {
         final Edge<Definition<Object>, Node> edge = edgeFactory.build(uuid,
                                                                       definition);
         when(graphIndex.getEdge(eq(uuid))).thenReturn(edge);
+        when(graphIndex.get(eq(uuid))).thenReturn(edge);
         return edge;
     }
 
@@ -221,10 +226,9 @@ public class TestingGraphMockHandler {
                 def.get() :
                 newDef("def-" + uuid,
                        Optional.empty());
-        final Edge<Definition<Object>, Node> edge = edgeFactory.build(uuid,
-                                                                      definition);
-        when(graphIndex.getEdge(eq(uuid))).thenReturn(edge);
-        return edge;
+
+
+        return newEdge(uuid, definition);
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/command/CaseManagementCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/command/CaseManagementCanvasCommandFactory.java
@@ -96,7 +96,7 @@ public class CaseManagementCanvasCommandFactory extends DefaultCanvasCommandFact
     }
 
     @Override
-    public CanvasCommand<AbstractCanvasHandler> cloneNode(Node candidate, String parentUuid, Point2D cloneLocation, Consumer<Node> cloneNodeCallback) {
-        return new CaseManagementCloneNodeCommand(candidate, parentUuid, cloneLocation, cloneNodeCallback, getChildrenTraverseProcessors());
+    public CanvasCommand<AbstractCanvasHandler> cloneNode(Node candidate, String parentUuid, Point2D cloneLocation, Consumer<Node> callback) {
+        return new CaseManagementCloneNodeCommand(candidate, parentUuid, cloneLocation, callback, getChildrenTraverseProcessors());
     }
 }


### PR DESCRIPTION
Now it is possible to copy/cut and paste multiple selection of elements on diagrams.
The position of pasting was changed to avoid overlapping elements, now it is considered the max Y position considering all the elements on the selection.

@romartin @hasys  can you please help to review the PR.
Thanks.