### PR TITLE
DROOLS-1946: Change implementation of moving rows. Fixes.

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
@@ -46,8 +46,19 @@ public class CommandUtils {
         });
     }
 
-    public static <T> void moveRows(final List<T> allRows, final List<T> rowsToMove, final int index) {
+    public static <T> void moveRows(final List<T> allRows,
+                                    final List<T> rowsToMove,
+                                    final int index) {
+        final int oldBlockStart = allRows.indexOf(rowsToMove.get(0));
+
         allRows.removeAll(rowsToMove);
-        allRows.addAll(index, rowsToMove);
+
+        if (index < oldBlockStart) {
+            allRows.addAll(index,
+                           rowsToMove);
+        } else if (index > oldBlockStart) {
+            allRows.addAll(index - rowsToMove.size() + 1,
+                           rowsToMove);
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveRowsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveRowsCommandTest.java
@@ -151,7 +151,7 @@ public class MoveRowsCommandTest {
 
     @Test
     public void moveMultipleRowsDown() throws Exception {
-        moveRowsToPositionCommand(rowsUnderTest.subList(0, 2), 1);
+        moveRowsToPositionCommand(rowsUnderTest.subList(0, 2), 2);
 
         graphCommand.execute(graphCommandExecutionContext);
         canvasCommand.execute(canvasHandler);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
@@ -91,7 +91,7 @@ public class CommandUtilsTest {
 
     @Test
     public void testMoveTwoRowsDown() throws Exception {
-        CommandUtils.moveRows(allRows, Arrays.asList(decisionRuleOne, decisionRuleTwo), 1);
+        CommandUtils.moveRows(allRows, Arrays.asList(decisionRuleOne, decisionRuleTwo), 2);
 
         Assertions.assertThat(allRows).containsSequence(decisionRuleThree, decisionRuleOne, decisionRuleTwo);
     }


### PR DESCRIPTION
Fixes following https://github.com/kiegroup/kie-wb-common/pull/1339