### PR TITLE
DROOLS-2230: Deadlock related to org.kie.workbench.common.services.backend.builder.core.LRUProjectDependenciesClassLoaderCache

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/cache/LRUDataModelOracleCache.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/cache/LRUDataModelOracleCache.java
@@ -15,9 +15,6 @@
 
 package org.kie.workbench.common.services.datamodel.backend.server.cache;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.StreamSupport.stream;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -49,8 +46,11 @@ import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.io.IOService;
-import org.uberfire.java.nio.file.DirectoryStream.Filter;
 import org.uberfire.java.nio.file.DirectoryStream;
+import org.uberfire.java.nio.file.DirectoryStream.Filter;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 
 /**
  * A simple LRU cache for Package DataModelOracles
@@ -98,7 +98,7 @@ public class LRUDataModelOracleCache extends LRUCache<Package, PackageDataModelO
         this.evaluator = evaluator;
     }
 
-    public synchronized void invalidatePackageCache(@Observes final InvalidateDMOPackageCacheEvent event) {
+    public void invalidatePackageCache(@Observes final InvalidateDMOPackageCacheEvent event) {
         PortablePreconditions.checkNotNull("event",
                                            event);
         final Path resourcePath = event.getResourcePath();
@@ -110,7 +110,7 @@ public class LRUDataModelOracleCache extends LRUCache<Package, PackageDataModelO
         }
     }
 
-    public synchronized void invalidateProjectPackagesCache(@Observes final InvalidateDMOProjectCacheEvent event) {
+    public void invalidateProjectPackagesCache(@Observes final InvalidateDMOProjectCacheEvent event) {
         PortablePreconditions.checkNotNull("event",
                                            event);
         final Path resourcePath = event.getResourcePath();
@@ -144,8 +144,8 @@ public class LRUDataModelOracleCache extends LRUCache<Package, PackageDataModelO
     }
 
     //Check the DataModelOracle for the Package has been created, otherwise create one!
-    public synchronized PackageDataModelOracle assertPackageDataModelOracle(final KieProject project,
-                                                                            final Package pkg) {
+    public PackageDataModelOracle assertPackageDataModelOracle(final KieProject project,
+                                                               final Package pkg) {
         PackageDataModelOracle oracle = getEntry(pkg);
         if (oracle == null) {
             oracle = makePackageDataModelOracle(project,

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/cache/LRUProjectDataModelOracleCache.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/cache/LRUProjectDataModelOracleCache.java
@@ -53,7 +53,7 @@ public class LRUProjectDataModelOracleCache
         this.buildInfoService = buildInfoService;
     }
 
-    public synchronized void invalidateProjectCache(@Observes final InvalidateDMOProjectCacheEvent event) {
+    public void invalidateProjectCache(@Observes final InvalidateDMOProjectCacheEvent event) {
         PortablePreconditions.checkNotNull("event",
                                            event);
         final Path resourcePath = event.getResourcePath();
@@ -66,7 +66,7 @@ public class LRUProjectDataModelOracleCache
     }
 
     //Check the ProjectOracle for the Project has been created, otherwise create one!
-    public synchronized ProjectDataModelOracle assertProjectDataModelOracle(final KieProject project) {
+    public ProjectDataModelOracle assertProjectDataModelOracle(final KieProject project) {
         ProjectDataModelOracle projectOracle = getEntry(project);
         if (projectOracle == null) {
             projectOracle = makeProjectOracle(project);

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
@@ -264,12 +264,9 @@ public class Builder implements Serializable {
             }
         }
 
-        //The KieModule has been built at this point so we do not need to check whether it's been built
-        final KieModule kieModule = ((InternalKieBuilder) kieBuilder).getKieModuleIgnoringErrors();
-        final KieModuleMetaData kieModuleMetaData = KieModuleMetaData.Factory.newKieModuleMetaData(kieModule,
+        //Store the project dependencies ClassLoader for optimization purposes.
+        final KieModuleMetaData kieModuleMetaData = KieModuleMetaData.Factory.newKieModuleMetaData(getKieModuleIgnoringErrors(),
                                                                                                    DependencyFilter.COMPILE_FILTER);
-
-        //store the project dependencies ClassLoader for optimization purposes.
         updateDependenciesClassLoader(project,
                                       kieModuleMetaData);
 
@@ -563,7 +560,9 @@ public class Builder implements Serializable {
         if (!isBuilt()) {
             build();
         }
-        return kieBuilder.getKieModule();
+        synchronized (kieFileSystem) {
+            return kieBuilder.getKieModule();
+        }
     }
 
     public KieModule getKieModuleIgnoringErrors() {
@@ -571,7 +570,9 @@ public class Builder implements Serializable {
         if (!isBuilt()) {
             build();
         }
-        return ((InternalKieBuilder) kieBuilder).getKieModuleIgnoringErrors();
+        synchronized (kieFileSystem) {
+            return ((InternalKieBuilder) kieBuilder).getKieModuleIgnoringErrors();
+        }
     }
 
     public KieModuleMetaData getKieModuleMetaDataIgnoringErrors() {

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
@@ -76,10 +76,12 @@ import org.uberfire.java.nio.file.Path;
 import org.uberfire.workbench.events.ResourceChange;
 import org.uberfire.workbench.events.ResourceChangeType;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.*;
-import static org.kie.workbench.common.services.backend.builder.core.BaseFileNameResolver.*;
-import static org.kie.workbench.common.services.backend.builder.core.BuildMessageBuilder.*;
-import static org.kie.workbench.common.services.backend.builder.core.MessageConverter.*;
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import static org.kie.workbench.common.services.backend.builder.core.BaseFileNameResolver.getBaseFileName;
+import static org.kie.workbench.common.services.backend.builder.core.BuildMessageBuilder.makeErrorMessage;
+import static org.kie.workbench.common.services.backend.builder.core.BuildMessageBuilder.makeWarningMessage;
+import static org.kie.workbench.common.services.backend.builder.core.MessageConverter.convertMessages;
+import static org.kie.workbench.common.services.backend.builder.core.MessageConverter.convertValidationMessages;
 
 public class Builder implements Serializable {
 
@@ -205,12 +207,12 @@ public class Builder implements Serializable {
     }
 
     public BuildResults build() {
+        final BuildResults results = new BuildResults(projectGAV);
         synchronized (kieFileSystem) {
             //KieBuilder is not re-usable for successive "full" builds
             kieBuilder = createKieBuilder(kieFileSystem);
 
             //Record RTEs from KieBuilder - that can fail if a rule uses an inaccessible class
-            final BuildResults results = new BuildResults(projectGAV);
             try {
                 final Results kieResults = ((InternalKieBuilder) kieBuilder).buildAll(classFilter).getResults();
                 results.addAllBuildMessages(convertMessages(kieResults.getMessages(),
@@ -232,64 +234,67 @@ public class Builder implements Serializable {
                                            pomModel);
                 }
             }
+        }
 
-            //Add validate messages from external helpers
-            for (Map.Entry<Path, BuildValidationHelper> e : nonKieResourceValidationHelpers.entrySet()) {
-                final org.uberfire.backend.vfs.Path vfsPath = Paths.convert(e.getKey());
-                final List<ValidationMessage> validationMessages = e.getValue().validate(vfsPath);
-                nonKieResourceValidationHelperMessages.put(e.getKey(),
-                                                           validationMessages);
-                results.addAllBuildMessages(convertValidationMessages(validationMessages));
-            }
+        //Add validate messages from external helpers
+        for (Map.Entry<Path, BuildValidationHelper> e : nonKieResourceValidationHelpers.entrySet()) {
+            final org.uberfire.backend.vfs.Path vfsPath = Paths.convert(e.getKey());
+            final List<ValidationMessage> validationMessages = e.getValue().validate(vfsPath);
+            nonKieResourceValidationHelperMessages.put(e.getKey(),
+                                                       validationMessages);
+            results.addAllBuildMessages(convertValidationMessages(validationMessages));
+        }
 
-            //Check external imports are available. These are loaded when a DMO is requested, but it's better to report them early
-            final Path nioExternalImportsPath = projectRoot.resolve("project.imports");
-            if (Files.exists(nioExternalImportsPath)) {
-                final org.uberfire.backend.vfs.Path externalImportsPath = Paths.convert(nioExternalImportsPath);
-                final ProjectImports projectImports = importsService.load(externalImportsPath);
-                final Imports imports = projectImports.getImports();
-                for (final Import item : imports.getImports()) {
-                    final String fullyQualifiedClassName = item.getType();
-                    try {
-                        Class clazz = this.getClass().getClassLoader().loadClass(item.getType());
-                    } catch (ClassNotFoundException cnfe) {
-                        logger.warn(cnfe.getMessage());
-                        final String msg = MessageFormat.format(ERROR_CLASS_NOT_FOUND,
-                                                                fullyQualifiedClassName);
-                        results.addBuildMessage(makeWarningMessage(msg));
-                    }
+        //Check external imports are available. These are loaded when a DMO is requested, but it's better to report them early
+        final Path nioExternalImportsPath = projectRoot.resolve("project.imports");
+        if (Files.exists(nioExternalImportsPath)) {
+            final org.uberfire.backend.vfs.Path externalImportsPath = Paths.convert(nioExternalImportsPath);
+            final ProjectImports projectImports = importsService.load(externalImportsPath);
+            final Imports imports = projectImports.getImports();
+            for (final Import item : imports.getImports()) {
+                final String fullyQualifiedClassName = item.getType();
+                try {
+                    Class clazz = this.getClass().getClassLoader().loadClass(item.getType());
+                } catch (ClassNotFoundException cnfe) {
+                    logger.warn(cnfe.getMessage());
+                    final String msg = MessageFormat.format(ERROR_CLASS_NOT_FOUND,
+                                                            fullyQualifiedClassName);
+                    results.addBuildMessage(makeWarningMessage(msg));
                 }
             }
-
-            //At the end we are interested to ensure that external .jar files referenced as dependencies don't have
-            // referential inconsistencies. We will at least provide a basic algorithm to ensure that if an external class
-            // X references another external class Y, Y is also accessible by the class loader.
-            final KieModuleMetaData kieModuleMetaData = getKieModuleMetaDataIgnoringErrors();
-
-            //store the project dependencies ClassLoader for optimization purposes.
-            updateDependenciesClassLoader(project,
-                                          kieModuleMetaData);
-
-            results.addAllBuildMessages(verifyClasses(kieModuleMetaData));
-
-            return results;
         }
+
+        //The KieModule has been built at this point so we do not need to check whether it's been built
+        final KieModule kieModule = ((InternalKieBuilder) kieBuilder).getKieModuleIgnoringErrors();
+        final KieModuleMetaData kieModuleMetaData = KieModuleMetaData.Factory.newKieModuleMetaData(kieModule,
+                                                                                                   DependencyFilter.COMPILE_FILTER);
+
+        //store the project dependencies ClassLoader for optimization purposes.
+        updateDependenciesClassLoader(project,
+                                      kieModuleMetaData);
+
+        results.addAllBuildMessages(verifyClasses(kieModuleMetaData));
+
+        return results;
     }
 
-    public BuildResults build(Path resource,
-                              InputStream inputStream) {
+    public BuildResults build(final Path resource,
+                              final InputStream inputStream) {
         synchronized (kieFileSystem) {
             final String destinationPath = destinationPath(resource);
             final Resource inputStreamResource = KieServices.Factory.get().getResources().newInputStreamResource(new BufferedInputStream(inputStream));
 
             kieFileSystem.write(destinationPath,
                                 inputStreamResource);
-
-            return build();
         }
+
+        return build();
     }
 
-    private List<BuildMessage> verifyClasses(KieModuleMetaData kieModuleMetaData) {
+    private List<BuildMessage> verifyClasses(final KieModuleMetaData kieModuleMetaData) {
+        //At the end we are interested to ensure that external .jar files referenced as dependencies don't have
+        // referential inconsistencies. We will at least provide a basic algorithm to ensure that if an external class
+        // X references another external class Y, Y is also accessible by the class loader.
         return new ClassVerifier(kieModuleMetaData,
                                  getTypeSourceResolver(kieModuleMetaData)).verify(getWhiteList(kieModuleMetaData));
     }
@@ -323,69 +328,41 @@ public class Builder implements Serializable {
                            ioService.newInputStream(resource));
     }
 
-    public IncrementalBuildResults deleteResource(final Path resource) {
-        synchronized (kieFileSystem) {
-            checkNotNull("resource",
-                         resource);
-
-            checkAFullBuildHasBeenPerformed();
-
-            //Resource Type might have been validated "externally" (i.e. it's not covered by Kie). Clear any errors.
-            final IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
-            final BuildValidationHelper validator = getBuildValidationHelper(resource);
-            if (validator != null) {
-                nonKieResourceValidationHelpers.remove(resource);
-                results.addAllRemovedMessages(convertValidationMessages(nonKieResourceValidationHelperMessages.remove(resource)));
-            }
-
-            removeResource(resource);
-            buildIncrementally(results,
-                               destinationPath(resource));
-
-            return results;
-        }
-    }
-
-    private void removeResource(final Path resource) {
-        kieFileSystem.delete(destinationPath(resource));
-        removeJavaClass(resource);
-    }
-
     private IncrementalBuildResults addResource(final Path resource,
                                                 final InputStream inputStream) {
+        checkNotNull("resource",
+                     resource);
+
+        //Only files can be processed
+        if (!Files.isRegularFile(resource)) {
+            return new IncrementalBuildResults(projectGAV);
+        }
+
+        checkAFullBuildHasBeenPerformed();
+
+        //Resource Type might require "external" validation (i.e. it's not covered by Kie)
+        final IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
+        final BuildValidationHelper validator = getBuildValidationHelper(resource);
+        if (validator != null) {
+            final List<ValidationMessage> addedValidationMessages = validator.validate(Paths.convert(resource));
+
+            results.addAllAddedMessages(convertValidationMessages(addedValidationMessages));
+            results.addAllRemovedMessages(convertValidationMessages(nonKieResourceValidationHelperMessages.remove(resource)));
+
+            nonKieResourceValidationHelpers.put(resource,
+                                                validator);
+            nonKieResourceValidationHelperMessages.put(resource,
+                                                       addedValidationMessages);
+        }
+
         synchronized (kieFileSystem) {
-            checkNotNull("resource",
-                         resource);
-
-            //Only files can be processed
-            if (!Files.isRegularFile(resource)) {
-                return new IncrementalBuildResults(projectGAV);
-            }
-
-            checkAFullBuildHasBeenPerformed();
-
-            //Resource Type might require "external" validation (i.e. it's not covered by Kie)
-            final IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
-            final BuildValidationHelper validator = getBuildValidationHelper(resource);
-            if (validator != null) {
-                final List<ValidationMessage> addedValidationMessages = validator.validate(Paths.convert(resource));
-
-                results.addAllAddedMessages(convertValidationMessages(addedValidationMessages));
-                results.addAllRemovedMessages(convertValidationMessages(nonKieResourceValidationHelperMessages.remove(resource)));
-
-                nonKieResourceValidationHelpers.put(resource,
-                                                    validator);
-                nonKieResourceValidationHelperMessages.put(resource,
-                                                           addedValidationMessages);
-            }
-
             addNewResource(resource,
                            inputStream);
             buildIncrementally(results,
                                destinationPath(resource));
-
-            return results;
         }
+
+        return results;
     }
 
     private void addNewResource(final Path path,
@@ -400,36 +377,61 @@ public class Builder implements Serializable {
         addJavaClass(path);
     }
 
+    public IncrementalBuildResults deleteResource(final Path resource) {
+        checkNotNull("resource",
+                     resource);
+
+        checkAFullBuildHasBeenPerformed();
+
+        //Resource Type might have been validated "externally" (i.e. it's not covered by Kie). Clear any errors.
+        final IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
+        final BuildValidationHelper validator = getBuildValidationHelper(resource);
+        if (validator != null) {
+            nonKieResourceValidationHelpers.remove(resource);
+            results.addAllRemovedMessages(convertValidationMessages(nonKieResourceValidationHelperMessages.remove(resource)));
+        }
+
+        synchronized (kieFileSystem) {
+            removeResource(resource);
+            buildIncrementally(results,
+                               destinationPath(resource));
+        }
+
+        return results;
+    }
+
+    private void removeResource(final Path resource) {
+        kieFileSystem.delete(destinationPath(resource));
+        removeJavaClass(resource);
+    }
+
     private String destinationPath(final Path resource) {
         return resource.toUri().toString().substring(projectPrefix.length() + 1);
     }
 
     public IncrementalBuildResults updateResource(final Path resource) {
-        synchronized (kieFileSystem) {
-            return addResource(resource);
-        }
+        return addResource(resource);
     }
 
     public IncrementalBuildResults updateResource(final Path resource,
-                                                  InputStream inputStream) {
-        synchronized (kieFileSystem) {
-            return addResource(resource,
-                               inputStream);
-        }
+                                                  final InputStream inputStream) {
+        return addResource(resource,
+                           inputStream);
     }
 
     public IncrementalBuildResults applyBatchResourceChanges(final Map<org.uberfire.backend.vfs.Path, Collection<ResourceChange>> changes) {
+        checkNotNull("changes",
+                     changes);
+
+        checkAFullBuildHasBeenPerformed();
+
+        //Add all changes to KieFileSystem before executing the build
+        final List<String> changedFilesKieBuilderPaths = new ArrayList<String>();
+        final List<ValidationMessage> nonKieResourceValidatorAddedMessages = new ArrayList<ValidationMessage>();
+        final List<ValidationMessage> nonKieResourceValidatorRemovedMessages = new ArrayList<ValidationMessage>();
+        final IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
+
         synchronized (kieFileSystem) {
-            checkNotNull("changes",
-                         changes);
-
-            checkAFullBuildHasBeenPerformed();
-
-            //Add all changes to KieFileSystem before executing the build
-            final List<String> changedFilesKieBuilderPaths = new ArrayList<String>();
-            final List<ValidationMessage> nonKieResourceValidatorAddedMessages = new ArrayList<ValidationMessage>();
-            final List<ValidationMessage> nonKieResourceValidatorRemovedMessages = new ArrayList<ValidationMessage>();
-
             for (final Map.Entry<org.uberfire.backend.vfs.Path, Collection<ResourceChange>> pathCollectionEntry : changes.entrySet()) {
                 for (final ResourceChange change : pathCollectionEntry.getValue()) {
                     final ResourceChangeType type = change.getType();
@@ -452,29 +454,26 @@ public class Builder implements Serializable {
 
                             update(nonKieResourceValidatorAddedMessages,
                                    nonKieResourceValidatorRemovedMessages,
-                                   resource,
-                                   destinationPath);
+                                   resource);
 
                             break;
                         case DELETE:
                             delete(nonKieResourceValidatorRemovedMessages,
-                                   resource,
-                                   destinationPath);
+                                   resource);
                     }
                 }
             }
 
             //Perform the Incremental build and get messages from incremental build
-            final IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
             buildIncrementally(results,
                                toArray(changedFilesKieBuilderPaths));
-
-            //Copy in BuildMessages for non-KIE resources
-            results.addAllAddedMessages(convertValidationMessages(nonKieResourceValidatorAddedMessages));
-            results.addAllRemovedMessages(convertValidationMessages(nonKieResourceValidatorRemovedMessages));
-
-            return results;
         }
+
+        //Copy in BuildMessages for non-KIE resources
+        results.addAllAddedMessages(convertValidationMessages(nonKieResourceValidatorAddedMessages));
+        results.addAllRemovedMessages(convertValidationMessages(nonKieResourceValidatorRemovedMessages));
+
+        return results;
     }
 
     private String[] toArray(List<String> stringList) {
@@ -483,27 +482,9 @@ public class Builder implements Serializable {
         return stringArray;
     }
 
-    private void delete(final List<ValidationMessage> nonKieResourceValidatorRemovedMessages,
-                        final Path resource,
-                        final String destinationPath) {
-        //Resource Type might have been validated "externally" (i.e. it's not covered by Kie). Clear any errors.
-        nonKieResourceValidationHelpers.remove(resource);
-        final List<ValidationMessage> removedValidationMessages = nonKieResourceValidationHelperMessages.remove(resource);
-        if (!(removedValidationMessages == null || removedValidationMessages.isEmpty())) {
-            for (ValidationMessage validationMessage : removedValidationMessages) {
-                nonKieResourceValidatorRemovedMessages.add(validationMessage);
-            }
-        }
-
-        //The file has already been deleted so we can't check if the Path is a file or folder :(
-        kieFileSystem.delete(destinationPath);
-        removeJavaClass(resource);
-    }
-
     private void update(final List<ValidationMessage> nonKieResourceValidatorAddedMessages,
                         final List<ValidationMessage> nonKieResourceValidatorRemovedMessages,
-                        final Path resource,
-                        final String destinationPath) {
+                        final Path resource) {
         //Resource Type might require "external" validation (i.e. it's not covered by Kie)
         final BuildValidationHelper validator = getBuildValidationHelper(resource);
         if (validator != null) {
@@ -527,14 +508,22 @@ public class Builder implements Serializable {
                                                        addedValidationMessages);
         }
 
-        //Add new resource
-        final InputStream is = ioService.newInputStream(resource);
-        final BufferedInputStream bis = new BufferedInputStream(is);
-        kieFileSystem.write(destinationPath,
-                            KieServices.Factory.get().getResources().newInputStreamResource(bis));
-        addJavaClass(resource);
-        handles.put(getBaseFileName(destinationPath),
-                    Paths.convert(resource));
+        addNewResource(resource,
+                       ioService.newInputStream(resource));
+    }
+
+    private void delete(final List<ValidationMessage> nonKieResourceValidatorRemovedMessages,
+                        final Path resource) {
+        //Resource Type might have been validated "externally" (i.e. it's not covered by Kie). Clear any errors.
+        nonKieResourceValidationHelpers.remove(resource);
+        final List<ValidationMessage> removedValidationMessages = nonKieResourceValidationHelperMessages.remove(resource);
+        if (!(removedValidationMessages == null || removedValidationMessages.isEmpty())) {
+            for (ValidationMessage validationMessage : removedValidationMessages) {
+                nonKieResourceValidatorRemovedMessages.add(validationMessage);
+            }
+        }
+
+        removeResource(resource);
     }
 
     private void buildIncrementally(final IncrementalBuildResults results,
@@ -574,9 +563,7 @@ public class Builder implements Serializable {
         if (!isBuilt()) {
             build();
         }
-        synchronized (kieFileSystem) {
-            return kieBuilder.getKieModule();
-        }
+        return kieBuilder.getKieModule();
     }
 
     public KieModule getKieModuleIgnoringErrors() {
@@ -584,9 +571,7 @@ public class Builder implements Serializable {
         if (!isBuilt()) {
             build();
         }
-        synchronized (kieFileSystem) {
-            return ((InternalKieBuilder) kieBuilder).getKieModuleIgnoringErrors();
-        }
+        return ((InternalKieBuilder) kieBuilder).getKieModuleIgnoringErrors();
     }
 
     public KieModuleMetaData getKieModuleMetaDataIgnoringErrors() {
@@ -630,9 +615,7 @@ public class Builder implements Serializable {
     }
 
     public boolean isBuilt() {
-        synchronized (kieFileSystem) {
-            return kieBuilder != null;
-        }
+        return kieBuilder != null;
     }
 
     private void visitPaths(final DirectoryStream<Path> directoryStream) {

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/LRUBuilderCache.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/LRUBuilderCache.java
@@ -107,7 +107,7 @@ public class LRUBuilderCache extends LRUCache<Project, Builder> {
         classFilters.forEach(filter -> classFilterBeans.destroy(filter));
     }
 
-    public synchronized void invalidateProjectCache(@Observes final InvalidateDMOProjectCacheEvent event) {
+    public void invalidateProjectCache(@Observes final InvalidateDMOProjectCacheEvent event) {
         PortablePreconditions.checkNotNull("event",
                                            event);
         final Project project = event.getProject();
@@ -118,7 +118,7 @@ public class LRUBuilderCache extends LRUCache<Project, Builder> {
         }
     }
 
-    public synchronized Builder assertBuilder(POM pom)
+    public Builder assertBuilder(POM pom)
             throws NoBuilderFoundException {
         for (Project project : getKeys()) {
             if (project.getPom().getGav().equals(pom.getGav())) {
@@ -128,11 +128,11 @@ public class LRUBuilderCache extends LRUCache<Project, Builder> {
         throw new NoBuilderFoundException();
     }
 
-    public synchronized Builder assertBuilder(final Project project) {
+    public Builder assertBuilder(final Project project) {
         return makeBuilder(project);
     }
 
-    public synchronized Builder getBuilder(final Project project) {
+    public Builder getBuilder(final Project project) {
         return getEntry(project);
     }
 

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/LRUPomModelCache.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/LRUPomModelCache.java
@@ -45,7 +45,7 @@ public class LRUPomModelCache extends LRUCache<Project, PomModel> {
         this.projectService = projectService;
     }
 
-    public synchronized void invalidateProjectCache(@Observes final InvalidateDMOProjectCacheEvent event) {
+    public void invalidateProjectCache(@Observes final InvalidateDMOProjectCacheEvent event) {
         PortablePreconditions.checkNotNull("event",
                                            event);
         final Path resourcePath = event.getResourcePath();

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/LRUProjectDependenciesClassLoaderCache.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/LRUProjectDependenciesClassLoaderCache.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.services.backend.builder.core;
 
 import java.net.URLClassLoader;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -33,19 +34,19 @@ public class LRUProjectDependenciesClassLoaderCache extends LRUCache<KieProject,
 
     private BuildInfoService buildInfoService;
 
-    public LRUProjectDependenciesClassLoaderCache( ) {
+    public LRUProjectDependenciesClassLoaderCache() {
     }
 
     @Inject
-    public LRUProjectDependenciesClassLoaderCache( BuildInfoService buildInfoService ) {
+    public LRUProjectDependenciesClassLoaderCache(BuildInfoService buildInfoService) {
         this.buildInfoService = buildInfoService;
     }
 
-    protected void setBuildInfoService( final BuildInfoService buildInfoService ) {
+    protected void setBuildInfoService(final BuildInfoService buildInfoService) {
         this.buildInfoService = buildInfoService;
     }
 
-    public synchronized ClassLoader assertDependenciesClassLoader(final KieProject project) {
+    public ClassLoader assertDependenciesClassLoader(final KieProject project) {
         ClassLoader classLoader = getEntry(project);
         if (classLoader == null) {
             classLoader = buildClassLoader(project);
@@ -55,8 +56,8 @@ public class LRUProjectDependenciesClassLoaderCache extends LRUCache<KieProject,
         return classLoader;
     }
 
-    public synchronized void setDependenciesClassLoader(final KieProject project,
-                                                        ClassLoader classLoader) {
+    public void setDependenciesClassLoader(final KieProject project,
+                                           ClassLoader classLoader) {
         setEntry(project,
                  classLoader);
     }
@@ -87,7 +88,7 @@ public class LRUProjectDependenciesClassLoaderCache extends LRUCache<KieProject,
         } else {
             //this case should never happen. But if ProjectClassLoader calculation for KieModuleMetadata changes at
             //the error will be notified for implementation review.
-            throw new RuntimeException("It was not posible to calculate project dependencies class loader for project: "
+            throw new RuntimeException("It was not possible to calculate project dependencies class loader for project: "
                                                + project.getKModuleXMLPath());
         }
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2230

QE had dead-locks in failing Selenium tests. 

The changes in this PR resolve the issues as verified by @tomasdavidorg 

```Builder``` had the most extensive changes; whereby synchronised blocks were changed to safe-guard the smallest area possible. ```LRUCache``` implementations synchronised removed from public methods as the underlying ```Collection``` used by the cache is thread-safe in itself. 