### PR TITLE
DROOLS-2155: Table editor should use full canvas area available

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -165,6 +165,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
     </dependency>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditor.java
@@ -80,6 +80,11 @@ public class ExpressionEditor implements ExpressionEditorView.Presenter {
     }
 
     @Override
+    public ExpressionEditorView getView() {
+        return view;
+    }
+
+    @Override
     public void init(final SessionPresenter<AbstractClientFullSession, ?, Diagram> presenter) {
         this.toolbarCommandStateHandler = new ToolbarCommandStateHandler((EditorToolbar) presenter.getToolbar());
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorView.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions;
 
 import java.util.Optional;
 
+import com.google.gwt.user.client.ui.ProvidesResize;
 import org.jboss.errai.common.client.api.IsElement;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
@@ -24,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.events.ExpressionEditorSelectedEvent;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.RequiresResize;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -31,7 +33,9 @@ import org.uberfire.client.mvp.UberElement;
 import org.uberfire.mvp.Command;
 
 public interface ExpressionEditorView extends org.jboss.errai.ui.client.local.api.IsElement,
-                                              UberElement<ExpressionEditorView.Presenter> {
+                                              UberElement<ExpressionEditorView.Presenter>,
+                                              RequiresResize,
+                                              ProvidesResize {
 
     interface Presenter extends IsElement {
 
@@ -46,6 +50,8 @@ public interface ExpressionEditorView extends org.jboss.errai.ui.client.local.ap
         void onExpressionEditorSelected(final ExpressionEditorSelectedEvent event);
 
         void setExitCommand(final Command exitCommand);
+
+        ExpressionEditorView getView();
 
         void exit();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
@@ -14,50 +14,14 @@
   ~ limitations under the License.
   -->
 
-<div>
-    <style scoped>
-        /*
-        This is the same width as the canvas. It's used to stop the Toolbar
-        from repositioning when the Expression Editor is opened/closed
-        */
-        .kie-dmn-container {
-            width: 1415px;
-            height: 600px;
-            position: relative;
-            top: 0;
-            overflow: hidden;
-        }
-
-        .expression-editor {
-            position: absolute;
-            z-index: 1;
-        }
-
-        .control-buttons {
-            position: absolute;
-            top: 475px;
-            z-index: 1000;
-        }
-
-        .exit-button {
-            position: absolute;
-            top: 508px;
-            z-index: 1000;
-        }
-
-    </style>
-
-    <div class="kie-dmn-container">
-        <div class="expression-editor">
-            <div data-field="dmn-table"></div>
-        </div>
-
-        <div class="control-buttons">
-            <div data-field="editorControls"></div>
-        </div>
-
-        <div class="exit-button">
-            <button class="btn btn-danger" type="button" data-field="exitButton" data-i18n-key="exitButton"></button>
-        </div>
+<div class="kie-dmn-container">
+    <div class="exit-button">
+        <button class="btn btn-danger" type="button" data-field="exitButton" data-i18n-key="exitButton"></button>
+    </div>
+    <div class="control-buttons">
+        <div data-field="editorControls"></div>
+    </div>
+    <div class="expression-editor">
+        <div data-field="dmn-table"></div>
     </div>
 </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -65,7 +65,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
     private Document document;
 
-    private TranslationService ts;
+    private TranslationService translationService;
     private DMNGridPanel gridPanel;
     private DMNGridLayer gridLayer;
     private RestrictedMousePanMediator mousePanMediator;
@@ -82,7 +82,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     public ExpressionEditorViewImpl(final Div exitButton,
                                     final Div expressionEditorControls,
                                     final Document document,
-                                    final TranslationService ts,
+                                    final TranslationService translationService,
                                     final @DMNEditor DMNGridPanel gridPanel,
                                     final @DMNEditor DMNGridLayer gridLayer,
                                     final @DMNEditor RestrictedMousePanMediator mousePanMediator,
@@ -91,7 +91,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         this.exitButton = exitButton;
         this.expressionEditorControls = expressionEditorControls;
         this.document = document;
-        this.ts = ts;
+        this.translationService = translationService;
         this.gridPanel = gridPanel;
         this.gridLayer = gridLayer;
         this.mousePanMediator = mousePanMediator;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -53,7 +53,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.Restri
 @Dependent
 public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
-    private static final double VP_SCALE = 1.0;
+    static final double VP_SCALE = 1.0;
 
     private ExpressionEditorView.Presenter presenter;
 
@@ -179,5 +179,10 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     @EventHandler("exitButton")
     void onClickExitButton(final ClickEvent event) {
         presenter.exit();
+    }
+
+    @Override
+    public void onResize() {
+        gridPanel.onResize();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.less
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.kie-dmn-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.exit-button {
+  height: 32px;
+  display: block;
+}
+
+.control-buttons {
+  height: 32px;
+  display: block;
+}
+
+.expression-editor {
+  display: flex;
+  width: 100%;
+  height: ~"calc(100% - 32px)";
+  top: 32px;
+}
+

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
@@ -51,7 +51,7 @@ public class UndefinedExpressionEditorDefinition implements ExpressionEditorDefi
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
     private Event<ExpressionEditorSelectedEvent> editorSelectedEvent;
-    private TranslationService ts;
+    private TranslationService translationService;
 
     public UndefinedExpressionEditorDefinition() {
         //CDI proxy
@@ -64,14 +64,14 @@ public class UndefinedExpressionEditorDefinition implements ExpressionEditorDefi
                                                final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                                final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
                                                final Event<ExpressionEditorSelectedEvent> editorSelectedEvent,
-                                               final TranslationService ts) {
+                                               final TranslationService translationService) {
         this.gridPanel = gridPanel;
         this.gridLayer = gridLayer;
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
         this.editorSelectedEvent = editorSelectedEvent;
-        this.ts = ts;
+        this.translationService = translationService;
     }
 
     @Override
@@ -81,7 +81,7 @@ public class UndefinedExpressionEditorDefinition implements ExpressionEditorDefi
 
     @Override
     public String getName() {
-        return ts.getTranslation(DMNEditorConstants.ExpressionEditor_UndefinedExpressionType);
+        return translationService.getTranslation(DMNEditorConstants.ExpressionEditor_UndefinedExpressionType);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -24,6 +24,7 @@ import javax.enterprise.event.Event;
 
 import com.ait.lienzo.client.core.event.INodeXYEvent;
 import com.ait.lienzo.client.core.event.NodeMouseDoubleClickHandler;
+import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.Viewport;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
@@ -195,6 +196,18 @@ public abstract class BaseExpressionGrid<E extends Expression, M extends BaseUIM
             viewport = gridLayer.getViewport();
         }
         return viewport;
+    }
+
+    @Override
+    public Layer getLayer() {
+        // A GridWidget's Layer may not have been set IF the grid has not been attached to a Layer.
+        // This is possible when a nested Expression Editor is on a newly created non-visible row as the
+        // GridRenderer ignores rows/cells outside of the Layer's visible extents.
+        Layer layer = super.getLayer();
+        if (layer == null) {
+            layer = gridLayer;
+        }
+        return layer;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanel.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.widgets.panel;
 
 import com.ait.lienzo.client.core.types.Transform;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.dom.client.MouseWheelHandler;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -58,12 +59,20 @@ public class DMNGridPanel extends GridLienzoPanel {
     }
 
     @Override
-    public void updatePanelSize() {
-        super.updatePanelSize();
-        final TransformMediator restriction = mousePanMediator.getTransformMediator();
-        final Transform transform = restriction.adjust(gridLayer.getViewport().getTransform(),
-                                                       gridLayer.getVisibleBounds());
-        gridLayer.getViewport().setTransform(transform);
-        gridLayer.batch();
+    public void onResize() {
+        doResize(() -> {
+            updatePanelSize();
+            refreshScrollPosition();
+
+            final TransformMediator restriction = mousePanMediator.getTransformMediator();
+            final Transform transform = restriction.adjust(gridLayer.getViewport().getTransform(),
+                                                           gridLayer.getVisibleBounds());
+            gridLayer.getViewport().setTransform(transform);
+            gridLayer.batch();
+        });
+    }
+
+    void doResize(final Scheduler.ScheduledCommand command) {
+        Scheduler.get().scheduleDeferred(command);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigationCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigationCommandTest.java
@@ -34,10 +34,12 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientSession;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.mockito.Mock;
+import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +47,9 @@ public abstract class BaseNavigationCommandTest {
 
     @Mock
     protected ExpressionEditorView.Presenter editor;
+
+    @Mock
+    protected ResizeFlowPanel editorContainerForErrai1090;
 
     @Mock
     protected AbstractSessionPresenter sessionPresenter;
@@ -101,8 +106,7 @@ public abstract class BaseNavigationCommandTest {
         this.command = spy(getCommand());
 
         doNothing().when(command).hidePaletteWidget(any(Boolean.class));
-        doNothing().when(command).addDRGEditorToCanvasWidget();
-        doNothing().when(command).addExpressionEditorToCanvasWidget();
+        doReturn(editorContainerForErrai1090).when(command).wrapElementForErrai1090();
     }
 
     protected abstract BaseNavigateCommand getCommand();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
@@ -22,6 +22,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 
 import static org.junit.Assert.assertEquals;
@@ -53,6 +54,8 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
         verify(session).resume();
         verify(command).hidePaletteWidget(eq(false));
         verify(command).addDRGEditorToCanvasWidget();
+        verify(sessionPresenterView).setCanvasWidget(view);
+        verify(sessionPresenterView).setContentScrollType(eq(SessionPresenter.View.ScrollType.AUTO));
     }
 
     @Test
@@ -65,6 +68,8 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
         verify(session).pause();
         verify(command).hidePaletteWidget(eq(true));
         verify(command).addExpressionEditorToCanvasWidget();
+        verify(sessionPresenterView).setCanvasWidget(editorContainerForErrai1090);
+        verify(sessionPresenterView).setContentScrollType(eq(SessionPresenter.View.ScrollType.CUSTOM));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommandTest.java
@@ -22,6 +22,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 
 import static org.junit.Assert.assertEquals;
@@ -53,6 +54,8 @@ public class NavigateToExpressionEditorCommandTest extends BaseNavigationCommand
         verify(session).pause();
         verify(command).hidePaletteWidget(eq(true));
         verify(command).addExpressionEditorToCanvasWidget();
+        verify(sessionPresenterView).setCanvasWidget(editorContainerForErrai1090);
+        verify(sessionPresenterView).setContentScrollType(eq(SessionPresenter.View.ScrollType.CUSTOM));
     }
 
     @Test
@@ -65,6 +68,8 @@ public class NavigateToExpressionEditorCommandTest extends BaseNavigationCommand
         verify(session).resume();
         verify(command).hidePaletteWidget(eq(false));
         verify(command).addDRGEditorToCanvasWidget();
+        verify(sessionPresenterView).setCanvasWidget(view);
+        verify(sessionPresenterView).setContentScrollType(eq(SessionPresenter.View.ScrollType.AUTO));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions;
+
+import com.ait.lienzo.client.core.mediator.Mediators;
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Element;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.Document;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class ExpressionEditorViewImplTest {
+
+    @Mock
+    private Div exitButton;
+
+    @Mock
+    private Div expressionEditorControls;
+
+    @Mock
+    private Document document;
+
+    @Mock
+    private TranslationService ts;
+
+    @Mock
+    private DMNGridPanel gridPanel;
+
+    @Mock
+    private DMNGridLayer gridLayer;
+
+    @Mock
+    private RestrictedMousePanMediator mousePanMediator;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private Viewport viewport;
+
+    @Mock
+    private Element gridPanelElement;
+
+    @Mock
+    private Mediators viewportMediators;
+
+    @Captor
+    private ArgumentCaptor<Transform> transformArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<GridWidget> expressionContainerArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<TransformMediator> transformMediatorArgumentCaptor;
+
+    private ExpressionEditorViewImpl view;
+
+    @Before
+    public void setup() {
+        doReturn(viewport).when(gridPanel).getViewport();
+        doReturn(viewportMediators).when(viewport).getMediators();
+        doReturn(gridPanelElement).when(gridPanel).getElement();
+
+        this.view = new ExpressionEditorViewImpl(exitButton,
+                                                 expressionEditorControls,
+                                                 document,
+                                                 ts,
+                                                 gridPanel,
+                                                 gridLayer,
+                                                 mousePanMediator,
+                                                 sessionManager,
+                                                 sessionCommandManager);
+    }
+
+    @Test
+    public void testSetupGridPanel() {
+        verify(viewport).setTransform(transformArgumentCaptor.capture());
+        final Transform transform = transformArgumentCaptor.getValue();
+
+        assertEquals(ExpressionEditorViewImpl.VP_SCALE,
+                     transform.getScaleX(),
+                     0.0);
+        assertEquals(ExpressionEditorViewImpl.VP_SCALE,
+                     transform.getScaleY(),
+                     0.0);
+
+        verify(gridPanel).add(gridLayer);
+    }
+
+    @Test
+    public void testSetupGridWidget() {
+        verify(gridLayer).removeAll();
+        verify(gridLayer).add(expressionContainerArgumentCaptor.capture());
+
+        final GridWidget expressionContainer = expressionContainerArgumentCaptor.getValue();
+
+        verify(gridLayer).select(eq(expressionContainer));
+        verify(gridLayer).enterPinnedMode(eq(expressionContainer),
+                                          any(Command.class));
+    }
+
+    @Test
+    public void testSetupGridWidgetPanControl() {
+        verify(mousePanMediator).setTransformMediator(transformMediatorArgumentCaptor.capture());
+
+        final TransformMediator transformMediator = transformMediatorArgumentCaptor.getValue();
+
+        verify(mousePanMediator).setBatchDraw(true);
+        verify(gridLayer).setDefaultTransformMediator(eq(transformMediator));
+        verify(viewportMediators).push(eq(mousePanMediator));
+    }
+
+    @Test
+    public void testOnResize() {
+        view.onResize();
+
+        verify(gridPanel).onResize();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -59,7 +59,7 @@ public class ExpressionEditorViewImplTest {
     private Document document;
 
     @Mock
-    private TranslationService ts;
+    private TranslationService translationService;
 
     @Mock
     private DMNGridPanel gridPanel;
@@ -105,7 +105,7 @@ public class ExpressionEditorViewImplTest {
         this.view = new ExpressionEditorViewImpl(exitButton,
                                                  expressionEditorControls,
                                                  document,
-                                                 ts,
+                                                 translationService,
                                                  gridPanel,
                                                  gridLayer,
                                                  mousePanMediator,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
@@ -19,6 +19,8 @@ package org.kie.workbench.common.dmn.client.widgets.grid;
 import java.util.Arrays;
 import java.util.Optional;
 
+import com.ait.lienzo.client.core.shape.Node;
+import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.common.client.api.IsElement;
 import org.junit.Before;
@@ -43,6 +45,7 @@ import org.uberfire.mocks.EventSourceMock;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BaseExpressionGridTest {
@@ -57,6 +60,9 @@ public class BaseExpressionGridTest {
     private DMNGridLayer gridLayer;
 
     @Mock
+    private Viewport viewport;
+
+    @Mock
     private SessionManager sessionManager;
 
     @Mock
@@ -68,6 +74,9 @@ public class BaseExpressionGridTest {
     @Mock
     private BaseUIModelMapper mapper;
 
+    @Mock
+    private Node gridParent;
+
     private BaseExpressionGrid grid;
 
     @Before
@@ -78,16 +87,16 @@ public class BaseExpressionGridTest {
         final Optional<LiteralExpression> expression = Optional.of(mock(LiteralExpression.class));
         final Optional<HasName> hasName = Optional.of(mock(HasName.class));
 
-        this.grid = new BaseExpressionGrid(parent,
-                                           hasExpression,
-                                           expression,
-                                           hasName,
-                                           gridPanel,
-                                           gridLayer,
-                                           renderer,
-                                           sessionManager,
-                                           sessionCommandManager,
-                                           editorSelectedEvent) {
+        this.grid = spy(new BaseExpressionGrid(parent,
+                                               hasExpression,
+                                               expression,
+                                               hasName,
+                                               gridPanel,
+                                               gridLayer,
+                                               renderer,
+                                               sessionManager,
+                                               sessionCommandManager,
+                                               editorSelectedEvent) {
             @Override
             protected BaseUIModelMapper makeUiModelMapper() {
                 return mapper;
@@ -107,7 +116,9 @@ public class BaseExpressionGridTest {
             public Optional<IsElement> getEditorControls() {
                 return Optional.empty();
             }
-        };
+        });
+
+        doReturn(viewport).when(gridLayer).getViewport();
     }
 
     @Test
@@ -145,6 +156,36 @@ public class BaseExpressionGridTest {
                            new MockColumnData(COL_0_ACTUAL, 25.0),
                            new MockColumnData(COL_1_ACTUAL, 35.0),
                            new MockColumnData(225.0, COL_2_MIN));
+    }
+
+    @Test
+    public void testGetViewportGridAttachedToLayer() {
+        doReturn(gridParent).when(grid).getParent();
+        doReturn(viewport).when(gridParent).getViewport();
+
+        assertEquals(viewport,
+                     grid.getViewport());
+    }
+
+    @Test
+    public void testGetViewportGridNotAttachedToLayer() {
+        assertEquals(viewport,
+                     grid.getViewport());
+    }
+
+    @Test
+    public void testGetLayerGridAttachedToLayer() {
+        doReturn(gridParent).when(grid).getParent();
+        doReturn(gridLayer).when(gridParent).getLayer();
+
+        assertEquals(gridLayer,
+                     grid.getLayer());
+    }
+
+    @Test
+    public void testGetLayerGridNotAttachedToLayer() {
+        assertEquals(gridLayer,
+                     grid.getLayer());
     }
 
     private void assertMinimumWidth(final double expectedMinimumWidth,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.panel;
+
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.core.client.Scheduler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DMNGridPanelTest {
+
+    @Mock
+    private DMNGridLayer gridLayer;
+
+    @Mock
+    private RestrictedMousePanMediator mousePanMediator;
+
+    @Mock
+    private TransformMediator transformMediator;
+
+    @Mock
+    private Transform transform;
+
+    @Mock
+    private Transform newTransform;
+
+    @Mock
+    private Viewport viewport;
+
+    private DMNGridPanel gridPanel;
+
+    @Before
+    public void setup() {
+        this.gridPanel = spy(new DMNGridPanel(gridLayer,
+                                              mousePanMediator));
+        doAnswer((o) -> {
+            ((Scheduler.ScheduledCommand) o.getArguments()[0]).execute();
+            return null;
+        }).when(gridPanel).doResize(any(Scheduler.ScheduledCommand.class));
+
+        doNothing().when(gridPanel).updatePanelSize();
+        doNothing().when(gridPanel).refreshScrollPosition();
+
+        doReturn(viewport).when(gridLayer).getViewport();
+        doReturn(transform).when(viewport).getTransform();
+        doReturn(transformMediator).when(mousePanMediator).getTransformMediator();
+        doReturn(newTransform).when(transformMediator).adjust(eq(transform),
+                                                              any(Bounds.class));
+    }
+
+    @Test
+    public void testOnResize() {
+        gridPanel.onResize();
+
+        verify(gridPanel).updatePanelSize();
+        verify(gridPanel).refreshScrollPosition();
+        verify(viewport).setTransform(eq(newTransform));
+        verify(gridLayer).batch();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/view/BootstrapNavigatorView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/view/BootstrapNavigatorView.java
@@ -32,6 +32,7 @@ import org.gwtbootstrap3.client.ui.constants.ColumnSize;
 import org.kie.workbench.common.stunner.client.widgets.explorer.navigator.NavigatorItem;
 import org.kie.workbench.common.stunner.client.widgets.explorer.navigator.NavigatorItemView;
 import org.kie.workbench.common.stunner.client.widgets.explorer.navigator.NavigatorView;
+import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
 @Dependent
 public class BootstrapNavigatorView
@@ -45,7 +46,7 @@ public class BootstrapNavigatorView
     private static ViewBinder uiBinder = GWT.create(ViewBinder.class);
 
     @UiField
-    FlowPanel mainPanel;
+    ResizeFlowPanel mainPanel;
 
     @UiField
     FlowPanel loadingPanel;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/view/BootstrapNavigatorView.ui.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/navigator/view/BootstrapNavigatorView.ui.xml
@@ -18,6 +18,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
              xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
+             xmlns:af="urn:import:org.uberfire.client.workbench.widgets.listbar"
              xmlns:g="urn:import:com.google.gwt.user.client.ui">
 
   <ui:style>
@@ -31,7 +32,7 @@
     }
   </ui:style>
 
-  <g:FlowPanel ui:field="mainPanel" addStyleNames="{style.panel}">
+  <af:ResizeFlowPanel ui:field="mainPanel" addStyleNames="{style.panel}">
 
     <g:FlowPanel ui:field="loadingPanel" addStyleNames="{style.panel} {style.loadingPanel}">
 
@@ -51,6 +52,6 @@
 
     <b:Container ui:field="container" fluid="true" addStyleNames="{style.panel}"/>
 
-  </g:FlowPanel>
+  </af:ResizeFlowPanel>
 
 </ui:UiBinder>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/SessionPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/SessionPresenter.java
@@ -19,6 +19,8 @@ package org.kie.workbench.common.stunner.client.widgets.presenters.session;
 import java.util.function.Predicate;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.ProvidesResize;
+import com.google.gwt.user.client.ui.RequiresResize;
 import org.kie.workbench.common.stunner.client.widgets.notification.Notification;
 import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
@@ -31,7 +33,7 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 
 /**
  * A session's presenter type for generic client session instances.
- * <p>
+ * <p/>
  * A session presenter is a client side component that has same goals as a SessionViewer/Editor, so displaying a diagram
  * and handling the different controls for either viewing or authoring purposes, but it provides some additional
  * features:
@@ -58,7 +60,9 @@ public interface SessionPresenter<S extends ClientSession, H extends CanvasHandl
         void afterSessionOpened();
     }
 
-    interface View extends IsWidget {
+    interface View extends IsWidget,
+                           RequiresResize,
+                           ProvidesResize {
 
         IsWidget getCanvasWidget();
 
@@ -66,11 +70,15 @@ public interface SessionPresenter<S extends ClientSession, H extends CanvasHandl
 
         IsWidget getPaletteWidget();
 
+        ScrollType getContentScrollType();
+
         View setCanvasWidget(final IsWidget widget);
 
         View setToolbarWidget(final IsWidget widget);
 
         View setPaletteWidget(final PaletteWidget<PaletteDefinition> paletteWidget);
+
+        void setContentScrollType(final ScrollType handler);
 
         View showLoading(final boolean loading);
 
@@ -81,6 +89,11 @@ public interface SessionPresenter<S extends ClientSession, H extends CanvasHandl
         View showError(final String message);
 
         void destroy();
+
+        enum ScrollType {
+            AUTO,
+            CUSTOM
+        }
     }
 
     SessionPresenter<S, H, D> withToolbar(final boolean hasToolbar);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionContainer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionContainer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.presenters.session.impl;
+
+import com.google.gwt.safehtml.shared.annotations.IsSafeHtml;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.HasHTML;
+import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
+
+/**
+ * This provides a Panel that is compatible with RequiresResize and errai-ui @Templated Views
+ * This is the outer most container of the SessionPresenterView that needs to support RequiresResize
+ * to propagate RequiresResize to child elements. In order for errai-ui to correctly substitute
+ * the remainder of the HTML template the Panel needs to implement HasHTML.
+ */
+public class SessionContainer extends ResizeFlowPanel implements HasHTML {
+
+    private final HTML container = new HTML();
+
+    public SessionContainer() {
+        add(container);
+    }
+
+    @Override
+    public String getHTML() {
+        return container.getHTML();
+    }
+
+    @Override
+    public void setHTML(final @IsSafeHtml String html) {
+        container.setHTML(html);
+    }
+
+    @Override
+    public String getText() {
+        return container.getText();
+    }
+
+    @Override
+    public void setText(final String text) {
+        container.setText(text);
+    }
+
+    @Override
+    public void onResize() {
+        super.onResize();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.html
@@ -12,42 +12,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<!--
-<table style="background-color:#D3D3D3;">
-    <tr>
-        <td>
-            <span data-field="loadingPanel" class="label label-danger" style="margin: 5px; position: absolute; padding: 5px;">Loading</span>
-        </td>
-        <td>
-            <div data-field="toolbarPanel" style=" width: 100%; margin: 5px; text-align: center;"></div>
-        </td>
-    </tr>
-    <tr>
-        <td style="vertical-align: top; padding-top: 15px;">
-            <div data-field="palettePanel" style="width: 100%;"></div>
-        </td>
-        <td style="padding-right: 10px;padding-top: 5px;padding-bottom: 10px;">
-            <div data-field="canvasPanel" style="width: 100%;"></div>
-        </td>
-    </tr>
-</table>
-
--->
 <div>
-    <div class="session-container" data-field="sessionContainer">
-        <div>
-            <span data-field="loadingPanel" class="label label-danger loading-panel">Loading</span>
-        </div>
-
-        <div data-field="toolbarPanel" class="toolbar-panel">
-        </div>
-
-        <div class="diagram-container">
-
-            <div data-field="palettePanel" class="palette-panel"></div>
-
-            <div data-field="canvasPanel" class="canvas-panel"></div>
-        </div>
+  <!-- The outer <div> is important - for some reason - to receive browser events in sessionContainer -->
+  <div class="session-container" data-field="sessionContainer">
+    <div>
+      <span data-field="loadingPanel" class="label label-danger loading-panel">Loading</span>
     </div>
+
+    <div data-field="toolbarPanel" class="toolbar-panel"></div>
+
+    <div data-field="diagramContainer" class="diagram-container">
+      <div data-field="palettePanel" class="palette-panel"></div>
+      <div data-field="canvasPanel" class="canvas-panel"></div>
+    </div>
+  </div>
 </div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
@@ -33,7 +33,6 @@ import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.gwtbootstrap3.extras.notify.client.constants.NotifyType;
 import org.gwtbootstrap3.extras.notify.client.ui.Notify;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
-import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
@@ -42,6 +41,7 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
+import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
 // TODO: i18n.
 @Dependent
@@ -62,7 +62,7 @@ public class SessionPresenterView extends Composite
 
     @Inject
     @DataField
-    private FlowPanel canvasPanel;
+    private ResizeFlowPanel canvasPanel;
 
     @Inject
     @DataField
@@ -70,9 +70,11 @@ public class SessionPresenterView extends Composite
 
     @Inject
     @DataField
-    private Div sessionContainer;
+    private SessionContainer sessionContainer;
 
     private final NotifySettings settings = NotifySettings.newSettings();
+
+    private ScrollType scrollType = ScrollType.AUTO;
 
     private double paletteInitialTop;
 
@@ -122,6 +124,11 @@ public class SessionPresenterView extends Composite
     }
 
     @Override
+    public ScrollType getContentScrollType() {
+        return scrollType;
+    }
+
+    @Override
     public SessionPresenterView setToolbarWidget(final IsWidget widget) {
         setWidgetForPanel(toolbarPanel,
                           widget);
@@ -133,6 +140,25 @@ public class SessionPresenterView extends Composite
         setWidgetForPanel(palettePanel,
                           ElementWrapperWidget.getWidget(paletteWidget.getElement()));
         return this;
+    }
+
+    @Override
+    public SessionPresenterView setCanvasWidget(final IsWidget widget) {
+        setWidgetForPanel(canvasPanel,
+                          widget);
+        return this;
+    }
+
+    @Override
+    public void setContentScrollType(final ScrollType type) {
+        final Style style = sessionContainer.getElement().getStyle();
+        switch (type) {
+            case AUTO:
+                style.setOverflow(Style.Overflow.AUTO);
+                break;
+            case CUSTOM:
+                style.setOverflow(Style.Overflow.HIDDEN);
+        }
     }
 
     @Override
@@ -172,16 +198,14 @@ public class SessionPresenterView extends Composite
     }
 
     @Override
-    public SessionPresenterView setCanvasWidget(final IsWidget widget) {
-        setWidgetForPanel(canvasPanel,
-                          widget);
+    public SessionPresenterView showLoading(final boolean loading) {
+        loadingPanel.setVisible(loading);
         return this;
     }
 
     @Override
-    public SessionPresenterView showLoading(final boolean loading) {
-        loadingPanel.setVisible(loading);
-        return this;
+    public void onResize() {
+        canvasPanel.onResize();
     }
 
     protected void setWidgetForPanel(final Panel panel,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.less
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.less
@@ -7,6 +7,10 @@
 
 .diagram-container {
     display: flex;
+    width: 100%;
+    /* Height is 100% - toolbar-panel.height - (2 * toolbar-panel.margin) */
+    /* See https://github.com/less/less.js/issues/974 for explanation of syntax */
+    height: ~"calc( 100% - 48px - 10px)";
 }
 
 .loading-panel {
@@ -48,6 +52,7 @@
     float: right;
     z-index: 0;
     left: 0;
-    padding-right: 10px;
-    padding-bottom: 10px;
+    display: flex;
+    width: 100%;
+    height: 100%;
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/ScreenPanelViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/ScreenPanelViewImpl.java
@@ -18,14 +18,14 @@ package org.kie.workbench.common.stunner.client.widgets.views.session;
 
 import javax.enterprise.context.Dependent;
 
-import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
+import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
 @Dependent
 public class ScreenPanelViewImpl implements ScreenPanelView {
 
-    private final FlowPanel panel = new FlowPanel();
+    private final ResizeFlowPanel panel = new ResizeFlowPanel();
 
     @Override
     public ScreenPanelView setWidget(final IsWidget widget) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
@@ -31,11 +31,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.widgets.presenters.AbstractCanvasHandlerViewerTest;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,6 +63,15 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
 
     @Mock
     private FlowPanel palettePanel;
+
+    @Mock
+    private SessionContainer sessionContainer;
+
+    @Mock
+    private com.google.gwt.user.client.Element sessionContainerElement;
+
+    @Mock
+    private Style sessionContainerElementStyle;
 
     private ContextMenuHandler handler;
 
@@ -95,6 +106,14 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
             return null;
         })).when(tested).onScroll(scrollEvent);
 
+        doAnswer((invocation -> {
+            setFinal(tested,
+                     SessionPresenterView.class.getDeclaredField("sessionContainer"),
+                     sessionContainer);
+            invocation.callRealMethod();
+            return null;
+        })).when(tested).setContentScrollType(any(SessionPresenter.View.ScrollType.class));
+
         when(tested.addDomHandler(any(),
                                   any())).thenAnswer((invocation -> {
             handler = invocation.getArgumentAt(0,
@@ -105,6 +124,9 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
         when(scrollEvent.getRelativeElement()).thenReturn(element);
         when(palettePanel.getElement()).thenReturn(paletteElement);
         when(paletteElement.getStyle()).thenReturn(paletteStyle);
+
+        doReturn(sessionContainerElement).when(sessionContainer).getElement();
+        doReturn(sessionContainerElementStyle).when(sessionContainerElement).getStyle();
 
         tested.init();
     }
@@ -135,7 +157,7 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
     }
 
     @Test
-    public void testOnScroll(){
+    public void testOnScroll() {
         reset(element);
 
         when(element.getScrollTop()).thenReturn(100);
@@ -145,5 +167,19 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
 
         verify(paletteStyle, times(1)).setTop(100, Style.Unit.PX);
         verify(paletteStyle, times(1)).setLeft(200, Style.Unit.PX);
+    }
+
+    @Test
+    public void testSetContentScrollTypeAuto() {
+        tested.setContentScrollType(SessionPresenter.View.ScrollType.AUTO);
+
+        verify(sessionContainerElementStyle).setOverflow(Style.Overflow.AUTO);
+    }
+
+    @Test
+    public void testSetContentScrollTypeCustom() {
+        tested.setContentScrollType(SessionPresenter.View.ScrollType.CUSTOM);
+
+        verify(sessionContainerElementStyle).setOverflow(Style.Overflow.HIDDEN);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2155

@romartin This introduces some small changes to Stunner. A continuous "inheritance path" is required from the (Lienzo) ```Layer``` used to hold the DMN grids to the outer most Stunner ```SessionPresenterView``` that supports ```RequiresResize``` so the DMN grid layer can resize and adjust its virtual scrollbars. Therefore I've had to make a few ```FlowPanel``` into ```ResizableFlowPanel``` in Stunner.

I also added the ability for the ```SessionPresenterView``` to have set whether it's main ```DIV``` controls scrollbars on the content (as you have now, a large (Lienzo) ```Panel``` in a small ```DIV``` with ```overflow: auto``` or whether the content provides its own scrollbars (as is the case with the DMN grid layer).

I've tested with DMN standalone, Stunner standalone and ```kie-drools-wb```.. The "new Process designer" looks to work entirely as it used to before this PR.. so all should be good.

The changes in here will be of use when you move Stunner to use the "virtual scrollbar" stuff @karreiro did originally for Decision Tables, now re-used by the DMN grid editor and to be used for Stunner as we've previously discussed (I think there is a JIRA for it somewhere).