### PR TITLE
[7.5.x] DROOLS-2250: Align Engine hints in Decision Table column wizard with BAPL-708

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/resources/org/kie/workbench/common/screens/datamodeller/client/resources/i18n/Constants.properties
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/resources/org/kie/workbench/common/screens/datamodeller/client/resources/i18n/Constants.properties
@@ -123,7 +123,7 @@ objectEditor_descriptionLabel=Description
 objectEditor_packageLabel=Package
 objectEditor_superclassLabel=Superclass
 objectEditor_roleLabel=Role
-objectEditor_roleHelp=A field that is being annotated with the Event value, indicates that the corresponding fact type will be treated by the rules engine as an event (See Drools Fusion)
+objectEditor_roleHelp=A field that is being annotated with the Event value, indicates that the corresponding fact type will be treated by the decision engine as an event (See Drools Fusion)
 objectEditor_typeSafeLabel=TypeSafe
 objectEditor_typeSafeHelp=Sets the type safe behaviour for a type. \
 If set, enables (true) or disables (false) the type safe behaviour. \


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2250

This is the corollary of https://github.com/kiegroup/kie-wb-common/pull/1370 for 7.5.x

(cherry picked from commit 979908f61defd37e288582ebdb7f563e00756566)