### PR TITLE
DROOLS-2256: [DMN Designer] Scrollbars in full screen mode

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
@@ -25,6 +25,7 @@ import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
+import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.AbstractSessionPresenter;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -44,6 +45,8 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
 public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
+
+    public static final PaletteWidget.PaletteVisibility HIDDEN = () -> false;
 
     static final NoOperationGraphCommand NOP_GRAPH_COMMAND = new NoOperationGraphCommand();
 
@@ -142,7 +145,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
     }
 
     protected void hidePaletteWidget(final boolean hidden) {
-        presenter.getPalette().setVisible(!hidden);
+        presenter.getPalette().setVisible(hidden ? HIDDEN : PaletteWidget.VISIBLE);
     }
 
     private CanvasHandler getCanvasHandler() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidget.java
@@ -24,11 +24,15 @@ import javax.inject.Inject;
 import org.jboss.errai.common.client.api.IsElement;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.client.commands.general.BaseNavigateCommand;
 import org.kie.workbench.common.stunner.client.widgets.palette.BS3PaletteWidget;
+import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteViewFactory;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.AbstractPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMinimizedEvent;
 import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
@@ -49,6 +53,7 @@ public class DMNPaletteWidget extends AbstractPalette<DefinitionsPalette>
     protected ItemDragUpdateCallback itemDragUpdateCallback;
 
     private ManagedInstance<DMNPaletteItemWidget> paletteItemWidgets;
+    private PaletteVisibility visibility = PaletteWidget.VISIBLE;
 
     private BS3PaletteViewFactory viewFactory;
 
@@ -209,7 +214,24 @@ public class DMNPaletteWidget extends AbstractPalette<DefinitionsPalette>
     }
 
     @Override
-    public void setVisible(boolean visible) {
-        view.showEmptyView(!visible);
+    public void setVisible(final PaletteVisibility visibility) {
+        this.visibility = visibility;
+        view.showEmptyView(!visibility.isVisible());
+    }
+
+    @Override
+    public void onScreenMaximized(final ScreenMaximizedEvent event) {
+        if (visibility.equals(BaseNavigateCommand.HIDDEN)) {
+            return;
+        }
+        setVisible(event.isDiagramScreen() ? PaletteWidget.VISIBLE : PaletteWidget.HIDDEN);
+    }
+
+    @Override
+    public void onScreenMinimized(final ScreenMinimizedEvent event) {
+        if (visibility.equals(BaseNavigateCommand.HIDDEN)) {
+            return;
+        }
+        setVisible(PaletteWidget.VISIBLE);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/widget/DMNPaletteWidgetTest.java
@@ -22,6 +22,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.commands.general.BaseNavigateCommand;
 import org.kie.workbench.common.stunner.client.widgets.palette.PaletteWidget;
 import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteViewFactory;
 import org.kie.workbench.common.stunner.core.client.ShapeSet;
@@ -30,6 +31,8 @@ import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteItem;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionsPalette;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMinimizedEvent;
 import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
@@ -291,5 +294,66 @@ public class DMNPaletteWidgetTest {
         verify(paletteItemWidgets).destroyAll();
         verify(viewFactory).destroy();
         verify(view).destroy();
+    }
+
+    @Test
+    public void checkOnScreenMaximisedDiagramEditor() {
+        final ScreenMaximizedEvent event = new ScreenMaximizedEvent(true);
+        widget.onScreenMaximized(event);
+
+        verify(view).showEmptyView(false);
+    }
+
+    @Test
+    public void checkOnScreenMaximisedDiagramEditorShowingExpressionEditor() {
+        widget.setVisible(BaseNavigateCommand.HIDDEN);
+
+        //reset view to ensure we're only verifying the effect of the ScreenMaximizedEvent
+        reset(view);
+
+        final ScreenMaximizedEvent event = new ScreenMaximizedEvent(true);
+        widget.onScreenMaximized(event);
+
+        verify(view, never()).showEmptyView(anyBoolean());
+    }
+
+    @Test
+    public void checkOnScreenMaximisedNotDiagramEditor() {
+        //showEmptyView(true) is called in the palette.init() method so reset for this test
+        reset(view);
+
+        final ScreenMaximizedEvent event = new ScreenMaximizedEvent(false);
+        widget.onScreenMaximized(event);
+
+        verify(view).showEmptyView(true);
+    }
+
+    @Test
+    public void checkOnScreenMinimisedDiagramEditor() {
+        final ScreenMinimizedEvent event = new ScreenMinimizedEvent(true);
+        widget.onScreenMinimized(event);
+
+        verify(view).showEmptyView(false);
+    }
+
+    @Test
+    public void checkOnScreenMinimisedDiagramEditorShowingExpressionEditor() {
+        widget.setVisible(BaseNavigateCommand.HIDDEN);
+
+        //reset view to ensure we're only verifying the effect of the ScreenMinimizedEvent
+        reset(view);
+
+        final ScreenMinimizedEvent event = new ScreenMinimizedEvent(true);
+        widget.onScreenMinimized(event);
+
+        verify(view, never()).showEmptyView(anyBoolean());
+    }
+
+    @Test
+    public void checkOnScreenMinimisedNotDiagramEditor() {
+        final ScreenMinimizedEvent event = new ScreenMinimizedEvent(false);
+        widget.onScreenMinimized(event);
+
+        verify(view).showEmptyView(false);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImpl.java
@@ -36,6 +36,8 @@ import org.kie.workbench.common.stunner.core.client.components.glyph.ShapeGlyphD
 import org.kie.workbench.common.stunner.core.client.components.palette.AbstractPalette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionPaletteCategory;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.definition.DefinitionSetPalette;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMinimizedEvent;
 import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
@@ -152,8 +154,18 @@ public class BS3PaletteWidgetImpl extends AbstractPalette<DefinitionSetPalette>
     }
 
     @Override
-    public void setVisible(boolean visible) {
-        view.showEmptyView(!visible);
+    public void setVisible(final PaletteVisibility visibility) {
+        view.showEmptyView(!visibility.isVisible());
+    }
+
+    @Override
+    public void onScreenMaximized(final ScreenMaximizedEvent event) {
+        setVisible(event.isDiagramScreen() ? PaletteWidget.VISIBLE : PaletteWidget.HIDDEN);
+    }
+
+    @Override
+    public void onScreenMinimized(final ScreenMinimizedEvent event) {
+        setVisible(PaletteWidget.VISIBLE);
     }
 
     protected ShapeFactory getShapeFactory() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/PaletteWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/palette/PaletteWidget.java
@@ -19,6 +19,8 @@ package org.kie.workbench.common.stunner.client.widgets.palette;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.kie.workbench.common.stunner.core.client.components.palette.Palette;
 import org.kie.workbench.common.stunner.core.client.components.palette.model.PaletteDefinition;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMinimizedEvent;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
 
@@ -49,6 +51,15 @@ public interface PaletteWidget<D extends PaletteDefinition>
                               final double y);
     }
 
+    interface PaletteVisibility {
+
+        boolean isVisible();
+    }
+
+    PaletteVisibility VISIBLE = () -> true;
+
+    PaletteVisibility HIDDEN = () -> false;
+
     PaletteWidget<D> onItemDrop(final ItemDropCallback callback);
 
     PaletteWidget<D> onItemDragStart(final ItemDragStartCallback callback);
@@ -57,7 +68,11 @@ public interface PaletteWidget<D extends PaletteDefinition>
 
     void unbind();
 
-    void setVisible(boolean visible);
+    void setVisible(PaletteVisibility visibility);
+
+    void onScreenMaximized(ScreenMaximizedEvent event);
+
+    void onScreenMinimized(ScreenMinimizedEvent event);
 
     HTMLElement getElement();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenter.java
@@ -39,9 +39,9 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 
 /**
  * A generic session's presenter instance for authoring purposes.
- * <p>
+ * <p/>
  * It provides support for an editor Toolbar and a BS3 Palette widget.
- * <p>
+ * <p/>
  * It aggregates a custom session viewer type which provides binds the editors's diagram instance and the
  * different editors' controls with the diagram and controls for the given session.
  * @see <a>org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorImpl</a>
@@ -78,11 +78,11 @@ public class SessionEditorPresenter<S extends AbstractClientFullSession, H exten
     }
 
     private void onScreenMaximized(ScreenMaximizedEvent event) {
-        getPalette().setVisible(event.isDiagramScreen());
+        getPalette().onScreenMaximized(event);
     }
 
     private void onScreenMinimized(ScreenMinimizedEvent event) {
-        getPalette().setVisible(true);
+        getPalette().onScreenMinimized(event);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/palette/BS3PaletteWidgetImplTest.java
@@ -23,10 +23,13 @@ import org.kie.workbench.common.stunner.client.widgets.palette.categories.Defini
 import org.kie.workbench.common.stunner.client.widgets.palette.factory.BS3PaletteViewFactory;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.components.glyph.ShapeGlyphDragHandler;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMaximizedEvent;
+import org.kie.workbench.common.stunner.core.client.event.screen.ScreenMinimizedEvent;
 import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -70,5 +73,40 @@ public class BS3PaletteWidgetImplTest {
         verify(categoryWidgetInstance).destroyAll();
         verify(viewFactory).destroy();
         verify(view).destroy();
+    }
+
+    @Test
+    public void checkOnScreenMaximisedDiagramEditor() {
+        final ScreenMaximizedEvent event = new ScreenMaximizedEvent(true);
+        palette.onScreenMaximized(event);
+
+        verify(view).showEmptyView(false);
+    }
+
+    @Test
+    public void checkOnScreenMaximisedNotDiagramEditor() {
+        //showEmptyView(true) is called in the palette.init() method so reset for this test
+        reset(view);
+
+        final ScreenMaximizedEvent event = new ScreenMaximizedEvent(false);
+        palette.onScreenMaximized(event);
+
+        verify(view).showEmptyView(true);
+    }
+
+    @Test
+    public void checkOnScreenMinimisedDiagramEditor() {
+        final ScreenMinimizedEvent event = new ScreenMinimizedEvent(true);
+        palette.onScreenMinimized(event);
+
+        verify(view).showEmptyView(false);
+    }
+
+    @Test
+    public void checkOnScreenMinimisedNotDiagramEditor() {
+        final ScreenMinimizedEvent event = new ScreenMinimizedEvent(false);
+        palette.onScreenMinimized(event);
+
+        verify(view).showEmptyView(false);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenterTest.java
@@ -41,11 +41,15 @@ import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientF
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.inOrder;
@@ -104,6 +108,12 @@ public class SessionEditorPresenterTest {
     @Mock
     private Diagram diagram;
 
+    @Captor
+    private ArgumentCaptor<ScreenMaximizedEvent> screenMaximizedEventArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<ScreenMinimizedEvent> screenMinimizedEventArgumentCaptor;
+
     @Before
     public void init() throws Exception {
 
@@ -144,9 +154,12 @@ public class SessionEditorPresenterTest {
         screenResizeEventObserver.onEventReceived(new ScreenMinimizedEvent(false));
 
         InOrder inOrder = inOrder(paletteWidget);
-        inOrder.verify(paletteWidget).setVisible(true);
-        inOrder.verify(paletteWidget).setVisible(false);
-        inOrder.verify(paletteWidget,
-                       times(2)).setVisible(true);
+        inOrder.verify(paletteWidget, times(2)).onScreenMaximized(screenMaximizedEventArgumentCaptor.capture());
+        inOrder.verify(paletteWidget, times(2)).onScreenMinimized(screenMinimizedEventArgumentCaptor.capture());
+
+        assertTrue(screenMaximizedEventArgumentCaptor.getAllValues().get(0).isDiagramScreen());
+        assertFalse(screenMaximizedEventArgumentCaptor.getAllValues().get(1).isDiagramScreen());
+        assertTrue(screenMinimizedEventArgumentCaptor.getAllValues().get(0).isDiagramScreen());
+        assertFalse(screenMinimizedEventArgumentCaptor.getAllValues().get(1).isDiagramScreen());
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2256

@tiagobento the changes you made for https://issues.jboss.org/browse/GUVNOR-3357 forces the Palette to show (for a ```@DiagramEditor``` widget) when a workbench Panel is maximised or minimised. This breaks the DMN Editor that has two modes of operation: (1) The normal "Stunner" graph grid display, (2) A sub-view when the User chooses to edit the detail of a node (the sub-view is still part of the ```@DiagramEditor``` "main" view). In the second scenario we hide the Palette as it is not needed; however maximising/minimising a Panel caused the Palette to reappear.

The change in this PR allows me to prevent this undesirable behaviour by only showing the Palette if it has not been hidden "on purpose" by the User editing the node detail.