### PR TITLE
DROOLS-2260: [DMN Designer] Background Color change throws an Exception

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/background/BgColour.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/background/BgColour.java
@@ -33,6 +33,8 @@ import org.kie.workbench.common.stunner.core.definition.property.type.ColorType;
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class BgColour implements DMNProperty {
 
+    private static final String DEFAULT = "#ffffff";
+
     @Type
     public static final PropertyType type = new ColorType();
 
@@ -41,6 +43,7 @@ public class BgColour implements DMNProperty {
     private String value;
 
     public BgColour() {
+        this(DEFAULT);
     }
 
     public BgColour(final String value) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/background/BorderColour.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/background/BorderColour.java
@@ -33,6 +33,8 @@ import org.kie.workbench.common.stunner.core.definition.property.type.ColorType;
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class BorderColour implements DMNProperty {
 
+    private static final String DEFAULT = "#000000";
+
     @Type
     public static final PropertyType type = new ColorType();
 
@@ -41,6 +43,7 @@ public class BorderColour implements DMNProperty {
     private String value;
 
     public BorderColour() {
+        this(DEFAULT);
     }
 
     public BorderColour(final String value) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/font/FontColour.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/font/FontColour.java
@@ -33,6 +33,8 @@ import org.kie.workbench.common.stunner.core.definition.property.type.ColorType;
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class FontColour implements DMNProperty {
 
+    private static final String DEFAULT = "#000000";
+
     @Type
     public static final PropertyType type = new ColorType();
 
@@ -41,6 +43,7 @@ public class FontColour implements DMNProperty {
     private String value;
 
     public FontColour() {
+        this(DEFAULT);
     }
 
     public FontColour(final String value) {


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2260

This PR is probably impacted by #1362 however I'm happy to keep this PR pending (merge of #1362) and fix accordingly (the mentioned PR removes ```defaultValue``` but I'll move to static literals instead). 