### PR TITLE
DROOLS-2270: [DMN Editor] Replace 'Return to DRG' button with Link

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
@@ -15,8 +15,8 @@
   -->
 
 <div class="kie-dmn-container">
-    <div class="exit-button">
-        <button class="btn btn-danger" type="button" data-field="exitButton" data-i18n-key="exitButton"></button>
+    <div class="return-to-DRG">
+        <i class="fa fa-angle-double-left" aria-hidden="true"></i><a href="#" data-field="returnToDRG"></a>
     </div>
     <div class="control-buttons">
         <div data-field="editorControls"></div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import com.ait.lienzo.client.core.types.Transform;
 import com.google.gwt.event.dom.client.ClickEvent;
 import org.jboss.errai.common.client.api.IsElement;
+import org.jboss.errai.common.client.dom.Anchor;
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.Document;
@@ -36,6 +37,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
+import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BoundaryTransformMediator;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
@@ -57,8 +59,8 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
     private ExpressionEditorView.Presenter presenter;
 
-    @DataField("exitButton")
-    private Div exitButton;
+    @DataField("returnToDRG")
+    private Anchor returnToDRG;
 
     @DataField("editorControls")
     private Div expressionEditorControls;
@@ -79,7 +81,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     }
 
     @Inject
-    public ExpressionEditorViewImpl(final Div exitButton,
+    public ExpressionEditorViewImpl(final Anchor returnToDRG,
                                     final Div expressionEditorControls,
                                     final Document document,
                                     final TranslationService translationService,
@@ -88,7 +90,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                     final @DMNEditor RestrictedMousePanMediator mousePanMediator,
                                     final SessionManager sessionManager,
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager) {
-        this.exitButton = exitButton;
+        this.returnToDRG = returnToDRG;
         this.expressionEditorControls = expressionEditorControls;
         this.document = document;
         this.translationService = translationService;
@@ -159,6 +161,9 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         gridPanel.updatePanelSize();
         gridLayer.batch();
 
+        hasName.ifPresent(name -> returnToDRG.setTextContent(translationService.format(DMNEditorConstants.ExpressionEditor_ReturnToDRG,
+                                                                                       name.getName().getValue())));
+
         onExpressionEditorSelected(oEditor);
     }
 
@@ -184,8 +189,8 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     }
 
     @SuppressWarnings("unused")
-    @EventHandler("exitButton")
-    void onClickExitButton(final ClickEvent event) {
+    @EventHandler("returnToDRG")
+    void onClickReturnToDRG(final ClickEvent event) {
         presenter.exit();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.less
@@ -21,9 +21,14 @@
   height: 100%;
 }
 
-.exit-button {
+.return-to-DRG {
   height: 32px;
   display: block;
+}
+
+.return-to-DRG i {
+  //This duplicates Bootstraps spacing for breadcrumbs
+  padding: 0 9px 0 7px;
 }
 
 .control-buttons {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/resources/i18n/DMNEditorConstants.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/resources/i18n/DMNEditorConstants.java
@@ -20,6 +20,9 @@ import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
 public class DMNEditorConstants {
 
     @TranslationKey(defaultValue = "")
+    public static final String ExpressionEditor_ReturnToDRG = "ExpressionEditor.ReturnToDRG";
+
+    @TranslationKey(defaultValue = "")
     public static final String ExpressionEditor_UndefinedExpressionType = "ExpressionEditor.UndefinedExpressionType";
 
     @TranslationKey(defaultValue = "")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+ExpressionEditor.ReturnToDRG=Back to "{0}"
 ExpressionEditor.UndefinedExpressionType=Undefined
 ExpressionEditor.LiteralExpressionType=Literal expression
 ExpressionEditor.ContextExpressionType=Context expression
 ExpressionEditor.DecisionTableExpressionType=Decision Table expression
-ExpressionEditorViewImpl.exitButton=Return to DRG
 ContextGridControlsImpl.addContextEntry=Add Context Entry
 DecisionTableGridControlsImpl.addInputClause=Add Input Clause
 DecisionTableGridControlsImpl.addOutputClause=Add Output Clause

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -219,17 +220,9 @@ public class ExpressionEditorViewImplTest {
     public void testSetEditorDoesUpdateReturnToDRGTextWhenHasNameIsNotEmpty() {
         final String NAME = "NAME";
         final Name name = new Name(NAME);
-        final Optional<HasName> hasName = Optional.of(new HasName() {
-            @Override
-            public Name getName() {
-                return name;
-            }
-
-            @Override
-            public void setName(final Name name) {
-                //Not required for this test
-            }
-        });
+        final HasName hasNameMock = mock(HasName.class);
+        doReturn(name).when(hasNameMock).getName();
+        final Optional<HasName> hasName = Optional.of(hasNameMock);
         final Optional<Expression> expression = Optional.empty();
 
         view.setEditor(editorDefinition,


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2270

@jomarko Due to [this](https://issues.jboss.org/browse/DROOLS-1937) the name of the node shown in the "back link" in the UI is always "My name" however you can see from the Unit Test that it does use the value extracted from the ```HasName``` instance. I also stepped through the code in the browser and the ```HasName``` passed is identical to the node selected in the graph.