### PR TITLE
fix equals, hashcode in core

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionImpl.java
@@ -41,13 +41,14 @@ public class DefinitionImpl<T> implements Definition<T> {
 
     @Override
     public int hashCode() {
-        return HashUtil.combineHashCodes(definition.hashCode());
+        return HashUtil.combineHashCodes(definition == null ? 0 : definition.hashCode());
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof Definition) {
-            return ((Definition) obj).getDefinition().equals(definition);
+            Object d = ((Definition) obj).getDefinition();
+            return this.definition == null ? d == null : this.definition.equals(d);
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionImpl.java
@@ -41,13 +41,13 @@ public class DefinitionImpl<T> implements Definition<T> {
 
     @Override
     public int hashCode() {
-        return definition.hashCode();
+        return HashUtil.combineHashCodes(definition.hashCode());
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof Definition) {
-            return ((Definition)obj).getDefinition().equals(definition);
+            return ((Definition) obj).getDefinition().equals(definition);
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionImpl.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.core.graph.content.definition;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 public class DefinitionImpl<T> implements Definition<T> {
@@ -36,5 +37,18 @@ public class DefinitionImpl<T> implements Definition<T> {
     @Override
     public void setDefinition(final T definition) {
         this.definition = definition;
+    }
+
+    @Override
+    public int hashCode() {
+        return definition.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Definition) {
+            return ((Definition)obj).getDefinition().equals(definition);
+        }
+        return false;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetImpl.java
@@ -19,6 +19,8 @@ package org.kie.workbench.common.stunner.core.graph.content.definition;
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 public class DefinitionSetImpl implements DefinitionSet {
@@ -53,5 +55,21 @@ public class DefinitionSetImpl implements DefinitionSet {
     @Override
     public void setBounds(final Bounds bounds) {
         this.bounds = bounds;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.combineHashCodes(id.hashCode(),
+                                         bounds.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof DefinitionSet) {
+            ViewConnector other = (ViewConnector) o;
+            return id.equals(other.getDefinition()) &&
+                    bounds.equals(other.getBounds());
+        }
+        return false;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetImpl.java
@@ -59,16 +59,16 @@ public class DefinitionSetImpl implements DefinitionSet {
 
     @Override
     public int hashCode() {
-        return HashUtil.combineHashCodes(id.hashCode(),
-                                         bounds.hashCode());
+        return HashUtil.combineHashCodes(id == null ? 0 : id.hashCode(),
+                                         bounds == null ? 0 : bounds.hashCode());
     }
 
     @Override
     public boolean equals(Object o) {
         if (o instanceof DefinitionSet) {
             ViewConnector other = (ViewConnector) o;
-            return id.equals(other.getDefinition()) &&
-                    bounds.equals(other.getBounds());
+            return (id == null ? other.getDefinition() == null : id.equals(other.getDefinition())) &&
+                    (bounds == null ? other.getBounds() == null : bounds.equals(other.getBounds()));
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetImpl.java
@@ -66,7 +66,7 @@ public class DefinitionSetImpl implements DefinitionSet {
     @Override
     public boolean equals(Object o) {
         if (o instanceof DefinitionSet) {
-            ViewConnector other = (ViewConnector) o;
+            DefinitionSet other = (DefinitionSet) o;
             return (id == null ? other.getDefinition() == null : id.equals(other.getDefinition())) &&
                     (bounds == null ? other.getBounds() == null : bounds.equals(other.getBounds()));
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
@@ -63,8 +63,8 @@ public final class ViewImpl<W> implements View<W> {
     public boolean equals(Object o) {
         if (o instanceof View) {
             View other = (View) o;
-            return definition.equals(other.getDefinition()) &&
-                    bounds.equals(other.getBounds());
+            return (definition == null ? other.getDefinition() == null : definition.equals(other.getDefinition())) &&
+                    (bounds == null ? other.getBounds() == null : bounds.equals(other.getBounds()));
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.graph.content.view;
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 public final class ViewImpl<W> implements View<W> {
@@ -50,5 +51,21 @@ public final class ViewImpl<W> implements View<W> {
     @Override
     public void setBounds(final Bounds bounds) {
         this.bounds = bounds;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.combineHashCodes(definition.hashCode(),
+                                         bounds.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof View) {
+            View other = (View) o;
+            return definition.equals(other.getDefinition()) &&
+                    bounds.equals(other.getBounds());
+        }
+        return false;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
@@ -55,8 +55,8 @@ public final class ViewImpl<W> implements View<W> {
 
     @Override
     public int hashCode() {
-        return HashUtil.combineHashCodes(definition.hashCode(),
-                                         bounds.hashCode());
+        return HashUtil.combineHashCodes(definition == null ? 0 : definition.hashCode(),
+                                         bounds == null ? 0 : bounds.hashCode());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElement.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 public abstract class AbstractElement<C>
         implements Element<C> {
@@ -63,12 +64,15 @@ public abstract class AbstractElement<C>
             return false;
         }
         AbstractElement that = (AbstractElement) o;
-        return uuid.equals(that.uuid);
+        return uuid.equals(that.uuid) &&
+                labels.equals(that.labels) &&
+                content.equals(that.content);
     }
 
     @Override
     public int hashCode() {
-        return uuid == null ? 0 : ~~uuid.hashCode();
+        return HashUtil.combineHashCodes(
+                uuid.hashCode(), labels.hashCode(), content.hashCode());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElement.java
@@ -64,15 +64,17 @@ public abstract class AbstractElement<C>
             return false;
         }
         AbstractElement that = (AbstractElement) o;
-        return uuid.equals(that.uuid) &&
-                labels.equals(that.labels) &&
-                content.equals(that.content);
+        return uuid.equals(that.getUUID()) &&
+                labels.equals(that.getLabels()) &&
+                content == null ? that.getContent() == null : content.equals(that.getContent());
     }
 
     @Override
     public int hashCode() {
         return HashUtil.combineHashCodes(
-                uuid.hashCode(), labels.hashCode(), content.hashCode());
+                uuid.hashCode(),
+                labels.hashCode(),
+                content == null ? 0 : content.hashCode());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/GraphImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/GraphImpl.java
@@ -22,11 +22,6 @@ import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
-import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
-import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.AbstractTreeTraverseCallback;
-import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessor;
-import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessorImpl;
 import org.kie.workbench.common.stunner.core.graph.store.GraphNodeStore;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -79,45 +74,16 @@ public class GraphImpl<C> extends AbstractElement<C> implements Graph<C, Node> {
 
     @Override
     public int hashCode() {
-        int[] hashArr = {0};//dirty trick to allow inner class to modify variable
-        final TreeWalkTraverseProcessor treeWalkTraverseProcessor = new TreeWalkTraverseProcessorImpl();
-
-        treeWalkTraverseProcessor
-                .traverse(this,
-                          new AbstractTreeTraverseCallback<Graph, Node, Edge>() {
-                              int[] myHashArr = hashArr;
-
-                              @Override
-                              public boolean startEdgeTraversal(final Edge edge) {
-                                  super.startEdgeTraversal(edge);
-                                  final Object content = edge.getContent();
-                                  myHashArr[0] = HashUtil.combineHashCodes(myHashArr[0],
-                                                                           content.hashCode());
-                                  return true;
-                              }
-
-                              @Override
-                              public boolean startNodeTraversal(final Node node) {
-                                  super.startNodeTraversal(node);
-                                  myHashArr[0] = HashUtil.combineHashCodes(myHashArr[0],
-                                                                           node.hashCode());
-                                  if (!(node.getContent() instanceof DefinitionSet) &&
-                                          node.getContent() instanceof Definition) {
-                                      Object def = ((Definition) (node.getContent())).getDefinition();
-                                      myHashArr[0] = HashUtil.combineHashCodes(myHashArr[0],
-                                                                               def.hashCode());
-                                  }
-                                  return true;
-                              }
-                          });
-        return hashArr[0];//Get the hash from the graph traversal
+        return HashUtil.combineHashCodes(
+                getUUID().hashCode(), this.nodeStore.hashCode());
     }
 
     @Override
     public boolean equals(Object o) {
         if (o instanceof GraphImpl) {
             GraphImpl g = (GraphImpl) o;
-            return this.hashCode() == g.hashCode();
+            return this.getUUID().equals(g.getUUID())
+                    && this.nodeStore.equals(g.nodeStore);
         } else {
             return false;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/GraphImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/GraphImpl.java
@@ -75,15 +75,15 @@ public class GraphImpl<C> extends AbstractElement<C> implements Graph<C, Node> {
     @Override
     public int hashCode() {
         return HashUtil.combineHashCodes(
-                getUUID().hashCode(), this.nodeStore.hashCode());
+                super.hashCode(), this.nodeStore.hashCode());
     }
 
     @Override
     public boolean equals(Object o) {
         if (o instanceof GraphImpl) {
             GraphImpl g = (GraphImpl) o;
-            return this.getUUID().equals(g.getUUID())
-                    && this.nodeStore.equals(g.nodeStore);
+            return super.equals(o) &&
+                    this.nodeStore.equals(g.nodeStore);
         } else {
             return false;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/GraphImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/GraphImpl.java
@@ -75,15 +75,15 @@ public class GraphImpl<C> extends AbstractElement<C> implements Graph<C, Node> {
     @Override
     public int hashCode() {
         return HashUtil.combineHashCodes(
-                super.hashCode(), this.nodeStore.hashCode());
+                super.hashCode(), this.nodes().hashCode());
     }
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof GraphImpl) {
-            GraphImpl g = (GraphImpl) o;
+        if (o instanceof Graph) {
+            Graph g = (Graph) o;
             return super.equals(o) &&
-                    this.nodeStore.equals(g.nodeStore);
+                    this.nodes().equals(g.nodes());
         } else {
             return false;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/store/GraphNodeStoreImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/store/GraphNodeStoreImpl.java
@@ -58,4 +58,14 @@ public class GraphNodeStoreImpl implements GraphNodeStore<Node> {
     public Iterator<Node> iterator() {
         return nodes.values().iterator();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof GraphNodeStoreImpl && nodes.equals(((GraphNodeStoreImpl) obj).nodes);
+    }
+
+    @Override
+    public int hashCode() {
+        return nodes.hashCode();
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionHashCodeAndEqualityTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.content.definition;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(JUnit4.class)
+public class DefinitionHashCodeAndEqualityTest {
+
+    @Test
+    public void testDefinitionEquals() {
+        DefinitionImpl<String> a = new DefinitionImpl<>("a");
+        DefinitionImpl<String> b = new DefinitionImpl<>("a");
+        assertEquals(a,
+                     b);
+
+        b.setDefinition("b");
+        assertNotEquals(a,
+                        b);
+
+        b.setDefinition("a");
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testDefinitionHashCode() {
+        DefinitionImpl<String> a = new DefinitionImpl<>("a");
+        DefinitionImpl<String> b = new DefinitionImpl<>("a");
+        assertEquals(a.hashCode(),
+                     b.hashCode());
+
+        b.setDefinition("b");
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+
+        b.setDefinition("a");
+        assertEquals(a.hashCode(), b.hashCode());
+
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionHashCodeAndEqualityTest.java
@@ -37,6 +37,10 @@ public class DefinitionHashCodeAndEqualityTest {
         assertEquals(a,
                      b);
 
+        b.setDefinition(null);
+        assertNotEquals(a,
+                        b);
+
         b.setDefinition("b");
         assertNotEquals(a,
                         b);
@@ -55,6 +59,10 @@ public class DefinitionHashCodeAndEqualityTest {
         b.setDefinition("b");
         assertNotEquals(a.hashCode(),
                         b.hashCode());
+
+        b.setDefinition(null);
+        assertNotEquals(a,
+                        b);
 
         b.setDefinition("a");
         assertEquals(a.hashCode(), b.hashCode());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetHashCodeAndEqualityTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.content.definition;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(JUnit4.class)
+public class DefinitionSetHashCodeAndEqualityTest {
+
+    @Test
+    public void testDefinitionSetEquals() {
+        DefinitionSet a = new DefinitionSetImpl("a");
+        DefinitionSetImpl b = new DefinitionSetImpl("a");
+        assertEquals(a,
+                     b);
+
+        b.setDefinition("b");
+        assertNotEquals(a,
+                        b);
+
+        b.setDefinition("a");
+        b.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(5.0,
+                                                 5.0)));
+        assertNotEquals(a,
+                        b);
+        a.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(5.0,
+                                                 5.0)));
+
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testDefinitionSetHashCode() {
+        DefinitionSetImpl a = new DefinitionSetImpl("a");
+        DefinitionSetImpl b = new DefinitionSetImpl("a");
+        assertEquals(a.hashCode(),
+                     b.hashCode());
+
+        b.setDefinition("b");
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+
+        b.setDefinition("a");
+        b.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(5.0,
+                                                 5.0)));
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+        a.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(5.0,
+                                                 5.0)));
+
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/definition/DefinitionSetHashCodeAndEqualityTest.java
@@ -47,6 +47,11 @@ public class DefinitionSetHashCodeAndEqualityTest {
                                                  5.0)));
         assertNotEquals(a,
                         b);
+
+        a.setBounds(null);
+        assertNotEquals(a,
+                        b);
+
         a.setBounds(new BoundsImpl(new BoundImpl(0.0,
                                                  0.0),
                                    new BoundImpl(5.0,
@@ -73,6 +78,11 @@ public class DefinitionSetHashCodeAndEqualityTest {
                                                  5.0)));
         assertNotEquals(a.hashCode(),
                         b.hashCode());
+
+        a.setBounds(null);
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+
         a.setBounds(new BoundsImpl(new BoundImpl(0.0,
                                                  0.0),
                                    new BoundImpl(5.0,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewHashCodeAndEqualityTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.content.view;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(JUnit4.class)
+public class ViewHashCodeAndEqualityTest {
+
+    @Test
+    public void testViewEquals() {
+        ViewImpl<String> a = new ViewImpl<>("a",
+                                            new BoundsImpl(new BoundImpl(0.0,
+                                                                         0.0),
+                                                           new BoundImpl(1.0,
+                                                                         1.0)));
+        ViewImpl<String> b = new ViewImpl<>("a",
+                                            new BoundsImpl(new BoundImpl(0.0,
+                                                                         0.0),
+                                                           new BoundImpl(1.0,
+                                                                         1.0)));
+        assertEquals(a,
+                     b);
+
+        b.setDefinition("b");
+        assertNotEquals(a,
+                        b);
+
+        b.setDefinition("a");
+        b.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(5.0,
+                                                 5.0)));
+        assertNotEquals(a,
+                        b);
+        b.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(1.0,
+                                                 1.0)));
+
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testViewHashCode() {
+        ViewImpl<String> a = new ViewImpl<>("a",
+                                            new BoundsImpl(new BoundImpl(0.0,
+                                                                         0.0),
+                                                           new BoundImpl(1.0,
+                                                                         1.0)));
+        ViewImpl<String> b = new ViewImpl<>("a",
+                                            new BoundsImpl(new BoundImpl(0.0,
+                                                                         0.0),
+                                                           new BoundImpl(1.0,
+                                                                         1.0)));
+        assertEquals(a.hashCode(),
+                     b.hashCode());
+
+        b.setDefinition("b");
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+
+        b.setDefinition("a");
+        b.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(5.0,
+                                                 5.0)));
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+        b.setBounds(new BoundsImpl(new BoundImpl(0.0,
+                                                 0.0),
+                                   new BoundImpl(1.0,
+                                                 1.0)));
+
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewHashCodeAndEqualityTest.java
@@ -52,6 +52,11 @@ public class ViewHashCodeAndEqualityTest {
                                                  5.0)));
         assertNotEquals(a,
                         b);
+
+        b.setBounds(null);
+        assertNotEquals(a,
+                        b);
+
         b.setBounds(new BoundsImpl(new BoundImpl(0.0,
                                                  0.0),
                                    new BoundImpl(1.0,
@@ -86,6 +91,11 @@ public class ViewHashCodeAndEqualityTest {
                                                  5.0)));
         assertNotEquals(a.hashCode(),
                         b.hashCode());
+
+        b.setBounds(null);
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+
         b.setBounds(new BoundsImpl(new BoundImpl(0.0,
                                                  0.0),
                                    new BoundImpl(1.0,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElementHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElementHashCodeAndEqualityTest.java
@@ -56,10 +56,15 @@ public class AbstractElementHashCodeAndEqualityTest {
                      b);
 
         a.setContent("x");
+        b.setContent("z");
         assertNotEquals(a,
                         b);
 
-        b.setContent("x");
+        a.setContent(null);
+        assertNotEquals(a,
+                        b);
+
+        a.setContent("z");
         assertEquals(a, b);
     }
 
@@ -70,11 +75,17 @@ public class AbstractElementHashCodeAndEqualityTest {
         assertEquals(a.hashCode(),
                      b.hashCode());
 
+
         a.setContent("x");
+        b.setContent("z");
         assertNotEquals(a.hashCode(),
                         b.hashCode());
 
-        b.setContent("x");
+        a.setContent(null);
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+
+        a.setContent("z");
         assertEquals(a.hashCode(), b.hashCode());
 
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElementHashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElementHashCodeAndEqualityTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(JUnit4.class)
+public class AbstractElementHashCodeAndEqualityTest {
+
+    private static class ConcreteTestElement extends AbstractElement<String> {
+
+        public ConcreteTestElement(String uuid) {
+            super(uuid);
+        }
+
+        @Override
+        public Node<String, Edge> asNode() {
+            return null;
+        }
+
+        @Override
+        public Edge<String, Node> asEdge() {
+            return null;
+        }
+    }
+
+    @Test
+    public void testAbstractElementEquals() {
+        AbstractElement<String> a = new ConcreteTestElement("a");
+        AbstractElement<String> b = new ConcreteTestElement("a");
+        assertEquals(a,
+                     b);
+
+        a.setContent("x");
+        assertNotEquals(a,
+                        b);
+
+        b.setContent("x");
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testViewHashCode() {
+        AbstractElement<String> a = new ConcreteTestElement("a");
+        AbstractElement<String> b = new ConcreteTestElement("a");
+        assertEquals(a.hashCode(),
+                     b.hashCode());
+
+        a.setContent("x");
+        assertNotEquals(a.hashCode(),
+                        b.hashCode());
+
+        b.setContent("x");
+        assertEquals(a.hashCode(), b.hashCode());
+
+    }
+}


### PR DESCRIPTION
This is a preliminary PR after checking with @hasys that equals is not implemented in a few core classes.
Open issues:
- NodeImpl should probably be compared against their nodes as well, but the `Node` interface returns a List (e.g. `getInEdges`). I think it might be better to return a Set, otherwise it might be more cumbersome to deep equal those. e.g.: `forall e in that.getInEdges() this.inEdges.contains(e)` would be quadratic
- I'm not sure about GraphImpl. It compares against hashes, I guess they are expected to equal if the nodes are equal, but are they? At a first glance I can't say  EDIT: see review below

/cc @romartin 
