### PR TITLE
AF-819: Renaming assets discards changes

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
@@ -75,7 +75,7 @@ import org.uberfire.workbench.type.FileNameUtil;
 
 @Dependent
 @WorkbenchEditor(identifier = FormEditorPresenter.ID, supportedTypes = {FormDefinitionResourceType.class})
-public class FormEditorPresenter extends KieEditor {
+public class FormEditorPresenter extends KieEditor<FormModelerContent> {
 
     public static final String ID = "FormEditor";
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/pom.xml
@@ -89,6 +89,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-api</artifactId>
     </dependency>
     <dependency>

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
@@ -100,7 +100,7 @@ import org.uberfire.workbench.model.menu.Menus;
         supportedTypes = {JavaResourceType.class},
         priority = Integer.MAX_VALUE)
 public class DataModelerScreenPresenter
-        extends KieEditor {
+        extends KieEditor<String> {
 
     public interface DataModelerScreenView
             extends

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/PersistenceDescriptorEditorPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/PersistenceDescriptorEditorPresenter.java
@@ -69,7 +69,7 @@ import org.uberfire.workbench.model.menu.Menus;
         supportedTypes = { PersistenceDescriptorType.class },
         priority = Integer.MAX_VALUE )
 public class PersistenceDescriptorEditorPresenter
-        extends KieEditor
+        extends KieEditor<PersistenceDescriptorEditorContent>
         implements PersistenceDescriptorEditorView.Presenter {
 
     private PersistenceDescriptorEditorView view;

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/editor/datasource/DataSourceDefEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/editor/datasource/DataSourceDefEditor.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -56,7 +57,7 @@ import org.uberfire.workbench.events.NotificationEvent;
 @WorkbenchEditor(identifier = "DataSourceDefEditor",
         supportedTypes = {DataSourceDefType.class})
 public class DataSourceDefEditor
-        extends BaseEditor
+        extends BaseEditor<DataSourceDefEditorContent, Metadata>
         implements DataSourceDefEditorView.Presenter {
 
     private DataSourceDefEditorView view;

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/editor/driver/DriverDefEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/editor/driver/DriverDefEditor.java
@@ -20,6 +20,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -52,7 +53,7 @@ import org.uberfire.workbench.events.NotificationEvent;
 @WorkbenchEditor( identifier = "DriverDefEditor",
         supportedTypes = { DriverDefType.class } )
 public class DriverDefEditor
-        extends BaseEditor
+        extends BaseEditor<DriverDefEditorContent, Metadata>
         implements DriverDefEditorView.Presenter {
 
     private DriverDefEditorView view;

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-api/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>uberfire-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-api/src/main/java/org/kie/workbench/common/screens/defaulteditor/service/DefaultEditorService.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-api/src/main/java/org/kie/workbench/common/screens/defaulteditor/service/DefaultEditorService.java
@@ -17,13 +17,14 @@
 package org.kie.workbench.common.screens.defaulteditor.service;
 
 import org.guvnor.common.services.shared.file.SupportsUpdate;
-import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.bus.server.annotations.Remote;
-import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
-public interface DefaultEditorService extends SupportsUpdate<String> {
+public interface DefaultEditorService extends SupportsUpdate<String>,
+                                              SupportsSaveAndRename<String, Metadata> {
 
     DefaultEditorContent loadContent(Path path);
 }

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-backend/pom.xml
@@ -56,6 +56,15 @@
       <artifactId>kie-wb-common-services-backend</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-backend/src/main/java/org/kie/workbench/common/screens/defaulteditor/backend/server/DefaultEditorServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-backend/src/main/java/org/kie/workbench/common/screens/defaulteditor/backend/server/DefaultEditorServiceImpl.java
@@ -16,9 +16,9 @@
 
 package org.kie.workbench.common.screens.defaulteditor.backend.server;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.backend.util.CommentedOptionFactory;
@@ -30,7 +30,8 @@ import org.kie.workbench.common.screens.defaulteditor.service.DefaultEditorServi
 import org.kie.workbench.common.services.backend.service.KieService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.io.IOService;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.service.RenameService;
 
 @Service
 @ApplicationScoped
@@ -40,6 +41,17 @@ public class DefaultEditorServiceImpl
 
     @Inject
     CommentedOptionFactory commentedOptionFactory;
+
+    @Inject
+    SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
+    @Inject
+    RenameService renameService;
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
+    }
 
     @Override
     public DefaultEditorContent loadContent(Path path) {
@@ -59,7 +71,6 @@ public class DefaultEditorServiceImpl
                             commentedOptionFactory.makeCommentedOption(comment));
 
             return resource;
-
         } catch (Exception e) {
             throw ExceptionUtilities.handleException(e);
         }
@@ -68,5 +79,21 @@ public class DefaultEditorServiceImpl
     @Override
     protected DefaultEditorContent constructContent(Path path, Overview overview) {
         return new DefaultEditorContent(overview);
+    }
+
+    @Override
+    public Path rename(final Path path,
+                       final String newName,
+                       final String comment) {
+        return renameService.rename(path, newName, comment);
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final String content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/GuvnorDefaultEditorPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/GuvnorDefaultEditorPresenter.java
@@ -47,7 +47,7 @@ import org.uberfire.workbench.model.menu.Menus;
 @Dependent
 @WorkbenchEditor(identifier = "GuvnorDefaultFileEditor", supportedTypes = {AnyResourceType.class}, priority = -1)
 public class GuvnorDefaultEditorPresenter
-        extends KieEditor {
+        extends KieEditor<String> {
 
     private final GuvnorDefaultEditorView view;
 

--- a/kie-wb-common-screens/kie-wb-common-java-editor/kie-wb-common-java-editor-client/src/main/java/org/kie/workbench/common/screens/javaeditor/client/editor/JavaEditorPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-java-editor/kie-wb-common-java-editor-client/src/main/java/org/kie/workbench/common/screens/javaeditor/client/editor/JavaEditorPresenter.java
@@ -35,7 +35,7 @@ import org.uberfire.mvp.PlaceRequest;
 
 @WorkbenchEditor(identifier = "JavaEditor", supportedTypes = {JavaResourceType.class})
 public class JavaEditorPresenter
-        extends KieEditor {
+        extends KieEditor<String> {
 
     @Inject
     private Caller<VFSService> vfsServices;

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/pom.xml
@@ -77,6 +77,11 @@
       <artifactId>uberfire-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/src/main/java/org/kie/workbench/common/screens/projecteditor/service/PomEditorService.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/src/main/java/org/kie/workbench/common/screens/projecteditor/service/PomEditorService.java
@@ -21,16 +21,16 @@ import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.screens.defaulteditor.service.DefaultEditorContent;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
-public interface PomEditorService {
+public interface PomEditorService extends SupportsSaveAndRename<String, Metadata> {
 
-    DefaultEditorContent loadContent( final Path path );
+    DefaultEditorContent loadContent(final Path path);
 
-    Path save( final Path path,
-               final String content,
-               final Metadata metadata,
-               final String comment,
-               final DeploymentMode mode );
-
+    Path save(final Path path,
+              final String content,
+              final Metadata metadata,
+              final String comment,
+              final DeploymentMode mode);
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/pom.xml
@@ -162,10 +162,21 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.1_spec</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/main/java/org/kie/workbench/common/screens/projecteditor/backend/server/PomEditorServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/main/java/org/kie/workbench/common/screens/projecteditor/backend/server/PomEditorServiceImpl.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.screens.projecteditor.backend.server;
 
 import java.io.IOException;
 import java.util.Set;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -46,6 +48,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.service.RenameService;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.io.IOService;
 
 @Service
@@ -68,6 +73,8 @@ public class PomEditorServiceImpl implements PomEditorService {
     private POMContentHandler pomContentHandler;
     private ModuleRepositoryResolver repositoryResolver;
     private ModuleRepositoriesService moduleRepositoriesService;
+    private RenameService renameService;
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
 
     public PomEditorServiceImpl() {
         //Zero-parameter constructor for WELD proxies
@@ -81,16 +88,25 @@ public class PomEditorServiceImpl implements PomEditorService {
                                 final KieModuleService moduleService,
                                 final POMContentHandler pomContentHandler,
                                 final ModuleRepositoryResolver repositoryResolver,
-                                final ModuleRepositoriesService moduleRepositoriesService) {
+                                final ModuleRepositoriesService moduleRepositoriesService,
+                                final RenameService renameService,
+                                final SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService) {
+
         this.ioService = ioService;
         this.defaultEditorService = defaultEditorService;
         this.metadataService = metadataService;
         this.commentedOptionFactory = commentedOptionFactory;
-
         this.moduleService = moduleService;
         this.pomContentHandler = pomContentHandler;
         this.repositoryResolver = repositoryResolver;
         this.moduleRepositoriesService = moduleRepositoriesService;
+        this.renameService = renameService;
+        this.saveAndRenameService = saveAndRenameService;
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -153,5 +169,29 @@ public class PomEditorServiceImpl implements PomEditorService {
             throw new GAVAlreadyExistsException(pom.getGav(),
                                                 repositories);
         }
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final String content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
+    }
+
+    @Override
+    public Path rename(final Path path,
+                       final String newName,
+                       final String comment) {
+        return renameService.rename(path, newName, comment);
+    }
+
+    @Override
+    public Path save(final Path path,
+                     final String content,
+                     final Metadata metadata,
+                     final String comment) {
+        return save(path, content, metadata, comment, DeploymentMode.FORCED);
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/test/java/org/kie/workbench/common/screens/defaulteditor/backend/server/DefaultEditorServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/test/java/org/kie/workbench/common/screens/defaulteditor/backend/server/DefaultEditorServiceImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.defaulteditor.backend.server;
+
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.service.RenameService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultEditorServiceImplTest {
+
+    @Mock
+    private RenameService renameService;
+
+    @Mock
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
+    @InjectMocks
+    private DefaultEditorServiceImpl service;
+
+    @Test
+    public void init() throws Exception {
+
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void rename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newName = "newName";
+        final String comment = "comment";
+
+        service.rename(path, newName, comment);
+
+        verify(renameService).rename(path, newName, comment);
+    }
+
+    @Test
+    public void saveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final Metadata metadata = mock(Metadata.class);
+        final String newName = "newName";
+        final String content = "content";
+        final String comment = "comment";
+
+        service.saveAndRename(path, newName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newName, metadata, content, comment);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-imports-editor/kie-wb-common-project-imports-editor-client/src/test/java/org/kie/workbench/common/screens/projectimportsscreen/client/forms/ProjectImportsScreenPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-imports-editor/kie-wb-common-project-imports-editor-client/src/test/java/org/kie/workbench/common/screens/projectimportsscreen/client/forms/ProjectImportsScreenPresenterTest.java
@@ -21,6 +21,10 @@ import java.util.Optional;
 import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
 import org.guvnor.common.services.project.client.security.ProjectController;
 import org.guvnor.common.services.project.model.WorkspaceProject;
+import java.util.function.Supplier;
+
+import org.guvnor.common.services.project.model.ProjectImports;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
@@ -42,13 +46,21 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
+import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.MenuItem;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectImportsScreenPresenterTest {
@@ -84,10 +96,19 @@ public class ProjectImportsScreenPresenterTest {
     protected Overview overview;
 
     @Mock
+    protected ProjectController projectController;
+
+    @Mock
+    protected SaveAndRenameCommandBuilder<ProjectImports, Metadata> saveAndRenameCommandBuilder;
+
+    @Mock
     private Message message;
 
     @Mock
     private Throwable cause;
+
+    @Mock
+    private WorkspaceProjectContext workbenchContext;
 
     @Mock
     private HasBusyIndicatorDefaultErrorCallback errorCallback;
@@ -95,15 +116,8 @@ public class ProjectImportsScreenPresenterTest {
     @Mock
     private Caller<ProjectImportsService> serviceCaller;
 
-    @Mock
-    protected ProjectController projectController;
-
-    @Mock
-    protected WorkspaceProjectContext workbenchContext;
-
     @InjectMocks
-    protected ProjectImportsScreenPresenter presenter = new ProjectImportsScreenPresenter(view,
-                                                                                          serviceCaller);
+    protected ProjectImportsScreenPresenter presenter = makeProjectImportsScreen();
 
     @Before
     public void initTest() {
@@ -113,8 +127,7 @@ public class ProjectImportsScreenPresenterTest {
         when(menuBuilder.addSave(any(MenuItem.class))).thenReturn(menuBuilder);
         when(menuBuilder.addCopy(any(Path.class),
                                  any(Validator.class))).thenReturn(menuBuilder);
-        when(menuBuilder.addRename(any(Path.class),
-                                   any(Validator.class))).thenReturn(menuBuilder);
+        when(menuBuilder.addRename(any(Command.class))).thenReturn(menuBuilder);
         when(menuBuilder.addDelete(any(Path.class))).thenReturn(menuBuilder);
         when(menuBuilder.addNewTopLevelMenu(any(MenuItem.class))).thenReturn(menuBuilder);
 
@@ -162,12 +175,9 @@ public class ProjectImportsScreenPresenterTest {
         presenter.makeMenuBar();
 
         verify(menuBuilder).addSave(any(MenuItem.class));
-        verify(menuBuilder).addCopy(any(Path.class),
-                                    any(AssetUpdateValidator.class));
-        verify(menuBuilder).addRename(any(Path.class),
-                                      any(AssetUpdateValidator.class));
-        verify(menuBuilder).addDelete(any(Path.class),
-                                      any(AssetUpdateValidator.class));
+        verify(menuBuilder).addCopy(any(Path.class), any(AssetUpdateValidator.class));
+        verify(menuBuilder).addRename(any(Command.class));
+        verify(menuBuilder).addDelete(any(Path.class), any(AssetUpdateValidator.class));
     }
 
     @Test
@@ -177,16 +187,39 @@ public class ProjectImportsScreenPresenterTest {
 
         presenter.makeMenuBar();
 
-        verify(menuBuilder,
-               never()).addSave(any(MenuItem.class));
-        verify(menuBuilder,
-               never()).addCopy(any(Path.class),
-                                any(AssetUpdateValidator.class));
-        verify(menuBuilder,
-               never()).addRename(any(Path.class),
-                                  any(AssetUpdateValidator.class));
-        verify(menuBuilder,
-               never()).addDelete(any(Path.class),
-                                  any(AssetUpdateValidator.class));
+        verify(menuBuilder, never()).addSave(any(MenuItem.class));
+        verify(menuBuilder, never()).addCopy(any(Path.class), any(AssetUpdateValidator.class));
+        verify(menuBuilder, never()).addRename(any(Command.class));
+        verify(menuBuilder, never()).addDelete(any(Path.class), any(AssetUpdateValidator.class));
+    }
+
+    @Test
+    public void testGetContentSupplier() {
+
+        final ProjectImports content = mock(ProjectImports.class);
+
+        presenter.setModel(content);
+
+        final Supplier<ProjectImports> contentSupplier = presenter.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() {
+
+        final Caller<? extends SupportsSaveAndRename<ProjectImports, Metadata>> serviceCaller = presenter.getSaveAndRenameServiceCaller();
+
+        assertEquals(this.serviceCaller, serviceCaller);
+    }
+
+    private ProjectImportsScreenPresenter makeProjectImportsScreen() {
+
+        return new ProjectImportsScreenPresenter(view, serviceCaller) {
+            @Override
+            protected Command getSaveAndRename() {
+                return mock(Command.class);
+            }
+        };
     }
 }

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/DataModelServiceConstructorTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/DataModelServiceConstructorTest.java
@@ -104,6 +104,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.server.io.ConfigIOServiceProducer;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.service.RenameService;
 import org.uberfire.io.IOService;
 import org.uberfire.io.impl.IOServiceDotFileImpl;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
@@ -143,6 +145,8 @@ public class DataModelServiceConstructorTest {
             throws IllegalArgumentException, FileSystemNotFoundException, SecurityException, URISyntaxException {
 
         final URL packageUrl = this.getClass().getResource("/DataModelServiceConstructorTest/src/main/java/t1p1");
+        final RenameService renameService = mock(RenameService.class);
+        final SaveAndRenameServiceImpl saveAndRenameService = mock(SaveAndRenameServiceImpl.class);
 
         IOService ioService = new IOServiceDotFileImpl();
         Collection<Role> roles = new ArrayList<>();
@@ -173,7 +177,9 @@ public class DataModelServiceConstructorTest {
         CommentedOptionFactory commentedOptionFactory = new CommentedOptionFactoryImpl(sessionInfo);
         ProjectConfigurationContentHandler moduleConfigurationContentHandler = new ProjectConfigurationContentHandler();
         ProjectImportsService moduleImportsService = new ProjectImportsServiceImpl(ioService,
-                                                                                   moduleConfigurationContentHandler);
+                                                                                   moduleConfigurationContentHandler,
+                                                                                   renameService,
+                                                                                   saveAndRenameService);
 
         Event<NewModuleEvent> newModuleEvent = new EventSourceMock<>();
         Event<NewPackageEvent> newPackageEvent = new EventSourceMock<>();
@@ -263,7 +269,9 @@ public class DataModelServiceConstructorTest {
         kModuleService.setModuleService(moduleService);
 
         ProjectImportsService importsService = new ProjectImportsServiceImpl(ioService,
-                                                                             moduleConfigurationContentHandler);
+                                                                             moduleConfigurationContentHandler,
+                                                                             renameService,
+                                                                             saveAndRenameService);
         Instance<BuildValidationHelper> buildValidationHelperBeans = null;
         Instance<Predicate<String>> classFilterBeans = null;
         HackedLRUModuleDependenciesClassLoaderCache dependenciesClassLoaderCache = new HackedLRUModuleDependenciesClassLoaderCache();

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/project/ProjectImportsService.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/project/ProjectImportsService.java
@@ -18,17 +18,18 @@ package org.kie.workbench.common.services.shared.project;
 
 import org.guvnor.common.services.project.model.ProjectImports;
 import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
-public interface ProjectImportsService
-        extends SupportsRead<ProjectImports>,
-        SupportsUpdate<ProjectImports> {
+public interface ProjectImportsService extends SupportsRead<ProjectImports>,
+                                               SupportsUpdate<ProjectImports>,
+                                               SupportsSaveAndRename<ProjectImports, Metadata> {
 
-        ProjectImportsContent loadContent(Path path);
+    ProjectImportsContent loadContent(final Path path);
 
-        void saveProjectImports( final Path projectRootPath );
-
+    void saveProjectImports(final Path projectRootPath);
 }

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/project/ProjectImportsServiceImpl.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/project/ProjectImportsServiceImpl.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.services.backend.project;
 
 import java.util.Objects;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -35,6 +36,8 @@ import org.kie.workbench.common.services.shared.project.ProjectImportsContent;
 import org.kie.workbench.common.services.shared.project.ProjectImportsService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.service.RenameService;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
 
@@ -46,15 +49,28 @@ public class ProjectImportsServiceImpl
 
     protected ProjectConfigurationContentHandler projectConfigurationContentHandler;
 
+    private RenameService renameService;
+
+    private SaveAndRenameServiceImpl<ProjectImports, Metadata> saveAndRenameService;
+
     public ProjectImportsServiceImpl() {
     }
 
     @Inject
     public ProjectImportsServiceImpl(final @Named("ioStrategy") IOService ioService,
-                                     final ProjectConfigurationContentHandler projectConfigurationContentHandler) {
+                                     final ProjectConfigurationContentHandler projectConfigurationContentHandler,
+                                     final RenameService renameService,
+                                     final SaveAndRenameServiceImpl<ProjectImports, Metadata> saveAndRenameService) {
 
         this.ioService = ioService;
         this.projectConfigurationContentHandler = projectConfigurationContentHandler;
+        this.renameService = renameService;
+        this.saveAndRenameService = saveAndRenameService;
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     public void saveProjectImports(final Path path) {
@@ -135,5 +151,21 @@ public class ProjectImportsServiceImpl
         } catch (Exception e) {
             throw ExceptionUtilities.handleException(e);
         }
+    }
+
+    @Override
+    public Path rename(final Path path,
+                       final String newName,
+                       final String comment) {
+        return renameService.rename(path, newName, comment);
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final ProjectImports content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -94,7 +94,7 @@ import org.uberfire.workbench.model.menu.Menus;
 import static java.util.logging.Level.FINE;
 
 // TODO: i18n.
-public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType> extends KieEditor {
+public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType> extends KieEditor<ProjectDiagram> {
 
     private static Logger LOGGER = Logger.getLogger(AbstractProjectDiagramEditor.class.getName());
     private static final String TITLE_FORMAT_TEMPLATE = "#title.#suffix - #type";

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/KieEditorTest.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/KieEditorTest.java
@@ -16,12 +16,14 @@
 
 package org.kie.workbench.common.widgets.metadata.client;
 
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import java.util.Optional;
+import java.util.function.Supplier;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
 import org.guvnor.common.services.project.client.security.ProjectController;
 import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,12 +35,20 @@ import org.mockito.Spy;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
+import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.Command;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class KieEditorTest {
@@ -63,17 +73,23 @@ public class KieEditorTest {
     protected EventSourceMock<NotificationEvent> notification;
 
     @Mock
+    protected SaveAndRenameCommandBuilder<String, Metadata> saveAndRenameCommandBuilder;
+
+    @Mock
+    protected Metadata metadata;
+
+    @Mock
     protected KieEditorWrapperView kieView;
 
     @Spy
     @InjectMocks
     protected AssetUpdateValidator assetUpdateValidator;
 
-    protected KieEditor presenter;
+    protected KieEditor<String> presenter;
 
     @Before
     public void setup() {
-        presenter = spy(new KieEditor() {
+        presenter = spy(new KieEditor<String>() {
             {
                 fileMenuBuilder = KieEditorTest.this.fileMenuBuilder;
                 projectController = KieEditorTest.this.projectController;
@@ -82,16 +98,26 @@ public class KieEditorTest {
                 assetUpdateValidator = KieEditorTest.this.assetUpdateValidator;
                 notification = KieEditorTest.this.notification;
                 kieView = KieEditorTest.this.kieView;
+                saveAndRenameCommandBuilder = KieEditorTest.this.saveAndRenameCommandBuilder;
+                metadata = KieEditorTest.this.metadata;
+            }
+
+            @Override
+            protected Command getSaveAndRename() {
+                return mock(Command.class);
             }
 
             @Override
             protected void loadContent() {
+            }
 
+            @Override
+            protected Supplier<String> getContentSupplier() {
+                return null;
             }
 
             @Override
             protected void onSave() {
-
             }
         });
     }
@@ -104,12 +130,9 @@ public class KieEditorTest {
         presenter.makeMenuBar();
 
         verify(fileMenuBuilder).addSave(any(MenuItem.class));
-        verify(fileMenuBuilder).addCopy(any(Path.class),
-                                        any(AssetUpdateValidator.class));
-        verify(fileMenuBuilder).addRename(any(Path.class),
-                                          any(AssetUpdateValidator.class));
-        verify(fileMenuBuilder).addDelete(any(Path.class),
-                                          any(AssetUpdateValidator.class));
+        verify(fileMenuBuilder).addCopy(any(Path.class), any(AssetUpdateValidator.class));
+        verify(fileMenuBuilder).addRename(any(Command.class));
+        verify(fileMenuBuilder).addDelete(any(Path.class), any(AssetUpdateValidator.class));
     }
 
     @Test
@@ -119,17 +142,10 @@ public class KieEditorTest {
 
         presenter.makeMenuBar();
 
-        verify(fileMenuBuilder,
-               never()).addSave(any(MenuItem.class));
-        verify(fileMenuBuilder,
-               never()).addCopy(any(Path.class),
-                                any(AssetUpdateValidator.class));
-        verify(fileMenuBuilder,
-               never()).addRename(any(Path.class),
-                                  any(AssetUpdateValidator.class));
-        verify(fileMenuBuilder,
-               never()).addDelete(any(Path.class),
-                                  any(AssetUpdateValidator.class));
+        verify(fileMenuBuilder, never()).addSave(any(MenuItem.class));
+        verify(fileMenuBuilder, never()).addCopy(any(Path.class), any(AssetUpdateValidator.class));
+        verify(fileMenuBuilder, never()).addRename(any(Command.class));
+        verify(fileMenuBuilder, never()).addDelete(any(Path.class), any(AssetUpdateValidator.class));
     }
 
     @Test
@@ -154,5 +170,21 @@ public class KieEditorTest {
                                                         NotificationEvent.NotificationType.ERROR));
         verify(presenter,
                never()).onSave();
+    }
+
+    @Test
+    public void testGetMetadataSupplier() {
+
+        final Supplier<Metadata> metadataSupplier = presenter.getMetadataSupplier();
+
+        assertEquals(metadata, metadataSupplier.get());
+    }
+
+    @Test
+    public void testGetRenameValidator() {
+
+        final Validator renameValidator = presenter.getRenameValidator();
+
+        assertEquals(assetUpdateValidator, renameValidator);
     }
 }


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/RHBA-148
- https://issues.jboss.org/browse/AF-819

---
Demo:
![demo](https://user-images.githubusercontent.com/1079279/35909185-e79488d6-0bd9-11e8-8223-97e9718f444f.gif)

---

Important topics:

I) I'm keeping the editors, that have their own implementation of the save-and-rename operation, intact;

II) I couldn't apply the generic approach on `jbpm-designer`, due to the save operation that is coupled to native JS code. Thus, I needed to implement a custom solution there;

III) The "save commit" and the "rename commit" are not being squashed. I don't think that it's a problem since we're showing explicitly to the user that two operations are being executed (but, maybe I'm missing something, wdyt @manstis?).

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/170
- https://github.com/kiegroup/kie-wb-common/pull/1414
- https://github.com/kiegroup/drools-wb/pull/804
- https://github.com/kiegroup/optaplanner-wb/pull/251
- https://github.com/kiegroup/jbpm-designer/pull/743