### PR TITLE
Enable sourcemaps profile for more stable and fast debugging

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -1014,6 +1014,55 @@
       </build>
     </profile>
 
+    <!-- Fast compiled build including Source maps for easier debugging. -->
+    <profile>
+      <id>sourcemaps</id>
+      <activation>
+        <property>
+          <name>sourcemaps</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <module>org.kie.workbench.common.stunner.standalone.StunnerStandaloneShowcaseWithSourceMap</module>
+              <saveSource>true</saveSource>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-source-maps</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>war</goal>
+                </goals>
+                <configuration>
+                  <webResources>
+                    <resource>
+                      <directory>${basedir}/target/extra/org.kie.workbench.common.stunner.standalone.StunnerStandaloneShowcase/src</directory>
+                      <targetPath>sourcemaps</targetPath>
+                    </resource>
+                    <resource>
+                      <directory>${basedir}/target/extra/org.kie.workbench.common.stunner.standalone.StunnerStandaloneShowcase/symbolMaps</directory>
+                      <includes>
+                        <include>*.json</include>
+                      </includes>
+                      <targetPath>sourcemaps</targetPath>
+                    </resource>
+                  </webResources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/StunnerStandaloneShowcaseWithSourceMap.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/StunnerStandaloneShowcaseWithSourceMap.gwt.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module rename-to="org.kie.workbench.common.stunner.standalone.StunnerStandaloneShowcase">
+
+  <inherits name="org.kie.workbench.common.stunner.standalone.StunnerStandaloneShowcase"/>
+
+  <!--
+  Reduce GWT compile to just one permutations (includes all locales and browsers)
+  <collapse-all-properties />
+  -->
+  <set-property name="locale" value="default"/>
+  <set-property name="user.agent" value="safari"/>
+
+  <set-property name="compiler.useSourceMaps" value="true"/>
+  <set-configuration-property name="includeSourceMapUrl"
+                              value="sourcemaps/__HASH___sourceMap__FRAGMENT__.json"/>
+</module>


### PR DESCRIPTION
Hi @romartin, @tiagodolphine, @Josephblt, @wmedvede,  @alepintus, @evacchi, @manstis 

I added profile to compile Stunner showcase project with sources in WAR file for easier debugging of Stunner in Chrome browser.

How to use it go to:
`kie-wb-common/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone`
execute
`mvn clean package -Psourcemaps`
Deploy `target/kie-wb-common-stunner-showcase-standalone.war` to wildfly and you will have war file with source code to debug Stunner showcase in Chrome browser.

Advantages:
* It is more stable than gwt:run
* It is faster than gwt:run
* Not so RAM consuming which can be critical for laptop with 8/16 GB owners

Disadvantages:
* No hot fix recompilation
* Manual deploy of result war file

P.S. inspired by https://github.com/kiegroup/kie-wb-distributions/pull/678
