### PR TITLE
DROOLS-2328: Replace the internal api call with public api call

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
@@ -36,6 +36,7 @@ import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.compiler.kie.builder.impl.KieFileSystemImpl;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
+import org.drools.compiler.kie.builder.impl.MemoryKieModule;
 import org.guvnor.common.services.backend.file.DotFileFilter;
 import org.guvnor.common.services.backend.file.JavaFileFilter;
 import org.guvnor.common.services.project.builder.model.BuildMessage;
@@ -193,7 +194,7 @@ public class Builder implements Serializable {
 
         if (this.kieBuilder != null) {
             kieBuilder = createKieBuilder(kieFileSystemClone);
-            kieBuilder.setkModule(((KieBuilderImpl) this.kieBuilder).getkModule());
+            kieBuilder.setkModule((MemoryKieModule) this.kieBuilder.getKieModule());
             kieBuilder.setTrgMfs(((KieFileSystemImpl) kieFileSystemClone).getMfs());
         }
 


### PR DESCRIPTION
This change is needed due to internal api changes introduced by work on DROOLS-2284

@tarilabs 
@baldimir 
@manstis 

Guys, please have a look.