### PR TITLE
DROOLS-2332: [DMN Editor] Performance poor for lots of nested tables

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/DMNCanvasFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/DMNCanvasFactory.java
@@ -164,7 +164,7 @@ public class DMNCanvasFactory
                 .register(ClipboardControl.class,
                           clipboardControls)
                 .register(ControlPointControl.class,
-                        controlPointControls);
+                          controlPointControls);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommand.java
@@ -73,8 +73,8 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
 
     GridCellValue<?> extractGridCellValue(final int rowIndex,
                                           final int columnIndex) {
-        final GridCell<?> cell = cellTuple.getGridData().getCell(rowIndex,
-                                                                 columnIndex);
+        final GridCell<?> cell = cellTuple.getGridWidget().getModel().getCell(rowIndex,
+                                                                              columnIndex);
         return cell == null ? null : cell.getValue();
     }
 
@@ -121,7 +121,7 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
         return new AbstractCanvasCommand() {
             @Override
             public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler handler) {
-                final GridData gridData = cellTuple.getGridData();
+                final GridData gridData = cellTuple.getGridWidget().getModel();
                 gridData.setCellValue(cellTuple.getRowIndex(),
                                       cellTuple.getColumnIndex(),
                                       cellTuple.getValue());
@@ -134,12 +134,12 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
             @Override
             public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler handler) {
                 if (oldCellValue.isPresent()) {
-                    cellTuple.getGridData().setCellValue(cellTuple.getRowIndex(),
-                                                         cellTuple.getColumnIndex(),
-                                                         oldCellValue.get());
+                    cellTuple.getGridWidget().getModel().setCellValue(cellTuple.getRowIndex(),
+                                                                      cellTuple.getColumnIndex(),
+                                                                      oldCellValue.get());
                 } else {
-                    cellTuple.getGridData().deleteCell(cellTuple.getRowIndex(),
-                                                       cellTuple.getColumnIndex());
+                    cellTuple.getGridWidget().getModel().deleteCell(cellTuple.getRowIndex(),
+                                                                    cellTuple.getColumnIndex());
                 }
 
                 canvasOperation.execute();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/DeleteCellValueCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/DeleteCellValueCommand.java
@@ -59,8 +59,8 @@ public class DeleteCellValueCommand extends AbstractCanvasGraphCommand implement
 
     GridCellValue<?> extractGridCellValue(final int rowIndex,
                                           final int columnIndex) {
-        final GridCell<?> cell = cellTuple.getGridData().getCell(rowIndex,
-                                                                 columnIndex);
+        final GridCell<?> cell = cellTuple.getGridWidget().getModel().getCell(rowIndex,
+                                                                              columnIndex);
         return cell == null ? null : cell.getValue();
     }
 
@@ -95,9 +95,9 @@ public class DeleteCellValueCommand extends AbstractCanvasGraphCommand implement
         return new AbstractCanvasCommand() {
             @Override
             public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
-                cellTuple.getGridData().setCellValue(cellTuple.getRowIndex(),
-                                                     cellTuple.getColumnIndex(),
-                                                     null);
+                cellTuple.getGridWidget().getModel().setCellValue(cellTuple.getRowIndex(),
+                                                                  cellTuple.getColumnIndex(),
+                                                                  null);
                 canvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
@@ -105,9 +105,9 @@ public class DeleteCellValueCommand extends AbstractCanvasGraphCommand implement
 
             @Override
             public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
-                oldCellValue.ifPresent(v -> cellTuple.getGridData().setCellValue(cellTuple.getRowIndex(),
-                                                                                 cellTuple.getColumnIndex(),
-                                                                                 v));
+                oldCellValue.ifPresent(v -> cellTuple.getGridWidget().getModel().setCellValue(cellTuple.getRowIndex(),
+                                                                                              cellTuple.getColumnIndex(),
+                                                                                              v));
                 canvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/SetCellValueCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/SetCellValueCommand.java
@@ -60,8 +60,8 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
 
     GridCellValue<?> extractGridCellValue(final int rowIndex,
                                           final int columnIndex) {
-        final GridCell<?> cell = cellTuple.getGridData().getCell(rowIndex,
-                                                                 columnIndex);
+        final GridCell<?> cell = cellTuple.getGridWidget().getModel().getCell(rowIndex,
+                                                                              columnIndex);
         return cell == null ? null : cell.getValue();
     }
 
@@ -96,7 +96,7 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
         return new AbstractCanvasCommand() {
             @Override
             public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
-                final GridData gridData = cellTuple.getGridData();
+                final GridData gridData = cellTuple.getGridWidget().getModel();
                 gridData.setCellValue(cellTuple.getRowIndex(),
                                       cellTuple.getColumnIndex(),
                                       cellTuple.getValue());
@@ -109,12 +109,12 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
             @Override
             public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
                 if (oldCellValue.isPresent()) {
-                    cellTuple.getGridData().setCellValue(cellTuple.getRowIndex(),
-                                                         cellTuple.getColumnIndex(),
-                                                         oldCellValue.get());
+                    cellTuple.getGridWidget().getModel().setCellValue(cellTuple.getRowIndex(),
+                                                                      cellTuple.getColumnIndex(),
+                                                                      oldCellValue.get());
                 } else {
-                    cellTuple.getGridData().deleteCell(cellTuple.getRowIndex(),
-                                                       cellTuple.getColumnIndex());
+                    cellTuple.getGridWidget().getModel().deleteCell(cellTuple.getRowIndex(),
+                                                                    cellTuple.getColumnIndex());
                 }
 
                 canvasOperation.execute();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainer.java
@@ -37,7 +37,8 @@ public class ExpressionContainer extends BaseGridWidget {
               new ExpressionContainerRenderer());
         setEventPropagationMode(EventPropagationMode.NO_ANCESTORS);
 
-        final GridColumn expressionColumn = new ExpressionEditorColumn(new BaseHeaderMetaData(COLUMN_GROUP),
+        final GridColumn expressionColumn = new ExpressionEditorColumn(gridLayer,
+                                                                       new BaseHeaderMetaData(COLUMN_GROUP),
                                                                        this);
         expressionColumn.setMovable(false);
         expressionColumn.setResizable(true);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -171,7 +171,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     GridCellTuple getExpressionContainerTuple() {
         return new GridCellTuple(0,
                                  0,
-                                 expressionContainer.getModel());
+                                 expressionContainer);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -112,7 +112,8 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextUIModelMappe
 
     @Override
     public ContextUIModelMapper makeUiModelMapper() {
-        return new ContextUIModelMapper(this::getModel,
+        return new ContextUIModelMapper(this,
+                                        this::getModel,
                                         () -> expression,
                                         expressionEditorDefinitionsSupplier,
                                         listSelector);
@@ -140,7 +141,8 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextUIModelMappe
                                                                                   headerFactory),
                                                      factory,
                                                      this);
-        final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(new BaseHeaderMetaData("",
+        final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(gridLayer,
+                                                                                   new BaseHeaderMetaData("",
                                                                                                           EXPRESSION_COLUMN_GROUP),
                                                                                    this);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapper.java
@@ -33,22 +33,27 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowSelectionStrategy;
 
 public class ContextUIModelMapper extends BaseUIModelMapper<Context> {
 
     public static final String DEFAULT_ROW_CAPTION = "default";
 
-    private ListSelector listSelector;
+    private GridWidget gridWidget;
 
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
-    public ContextUIModelMapper(final Supplier<GridData> uiModel,
+    private ListSelector listSelector;
+
+    public ContextUIModelMapper(final GridWidget gridWidget,
+                                final Supplier<GridData> uiModel,
                                 final Supplier<Optional<Context>> dmnModel,
                                 final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
                                 final ListSelector listSelector) {
         super(uiModel,
               dmnModel);
+        this.gridWidget = gridWidget;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
         this.listSelector = listSelector;
     }
@@ -96,7 +101,7 @@ public class ContextUIModelMapper extends BaseUIModelMapper<Context> {
                     expressionEditorDefinition.ifPresent(ed -> {
                         final Optional<BaseExpressionGrid> editor = ed.getEditor(new GridCellTuple(rowIndex,
                                                                                                    columnIndex,
-                                                                                                   uiModel.get()),
+                                                                                                   gridWidget),
                                                                                  ce,
                                                                                  expression,
                                                                                  Optional.ofNullable(ce.getVariable()),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
@@ -30,20 +30,24 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.HasDOMElementResources;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridWidgetRegistry;
 
 public class ExpressionEditorColumn extends DMNGridColumn<Optional<BaseExpressionGrid>> implements RequiresResize,
                                                                                                    HasDOMElementResources {
 
-    public ExpressionEditorColumn(final HeaderMetaData headerMetaData,
+    public ExpressionEditorColumn(final GridWidgetRegistry registry,
+                                  final HeaderMetaData headerMetaData,
                                   final GridWidget gridWidget) {
-        this(Collections.singletonList(headerMetaData),
+        this(registry,
+             Collections.singletonList(headerMetaData),
              gridWidget);
     }
 
-    public ExpressionEditorColumn(final List<HeaderMetaData> headerMetaData,
+    public ExpressionEditorColumn(final GridWidgetRegistry registry,
+                                  final List<HeaderMetaData> headerMetaData,
                                   final GridWidget gridWidget) {
         super(headerMetaData,
-              new ExpressionEditorColumnRenderer(),
+              new ExpressionEditorColumnRenderer(registry),
               gridWidget);
         setMovable(false);
         setResizable(false);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRenderer.java
@@ -20,12 +20,20 @@ import java.util.Optional;
 
 import com.ait.lienzo.client.core.shape.Group;
 import com.google.gwt.core.client.GWT;
+import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.BaseGridColumnRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridWidgetRegistry;
 
 public class ExpressionEditorColumnRenderer extends BaseGridColumnRenderer<Optional<BaseExpressionGrid>> {
+
+    private final GridWidgetRegistry registry;
+
+    public ExpressionEditorColumnRenderer(final GridWidgetRegistry registry) {
+        this.registry = PortablePreconditions.checkNotNull("registry", registry);
+    }
 
     @Override
     public Group renderCell(final GridCell<Optional<BaseExpressionGrid>> cell,
@@ -37,7 +45,10 @@ public class ExpressionEditorColumnRenderer extends BaseGridColumnRenderer<Optio
         final Group g = GWT.create(Group.class);
         if (cell.getValue() != null && cell.getValue() instanceof ExpressionCellValue) {
             final ExpressionCellValue ecv = (ExpressionCellValue) cell.getValue();
-            ecv.getValue().ifPresent(editor -> g.add(editor.setX(editor.getPadding()).setY(editor.getPadding())));
+            ecv.getValue().ifPresent(editor -> {
+                g.add(editor.setX(editor.getPadding()).setY(editor.getPadding()));
+                registry.register(editor);
+            });
         }
 
         return g;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -113,7 +113,8 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
 
     @Override
     public FunctionUIModelMapper makeUiModelMapper() {
-        return new FunctionUIModelMapper(this::getModel,
+        return new FunctionUIModelMapper(this,
+                                         this::getModel,
                                          () -> expression,
                                          expressionEditorDefinitionsSupplier,
                                          supplementaryEditorDefinitionsSupplier);
@@ -128,7 +129,8 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
                                                                                                       sessionCommandManager,
                                                                                                       newHeaderHasNoValueCommand(),
                                                                                                       newHeaderHasValueCommand());
-        final GridColumn expressionColumn = new ExpressionEditorColumn(Arrays.asList(new FunctionColumnNameHeaderMetaData(() -> hasName.orElse(HasName.NOP).getName().getValue(),
+        final GridColumn expressionColumn = new ExpressionEditorColumn(gridLayer,
+                                                                       Arrays.asList(new FunctionColumnNameHeaderMetaData(() -> hasName.orElse(HasName.NOP).getName().getValue(),
                                                                                                                           (s) -> hasName.orElse(HasName.NOP).getName().setValue(s),
                                                                                                                           headerFactory),
                                                                                      new FunctionColumnParametersHeaderMetaData(this::extractExpressionLanguage,
@@ -242,7 +244,9 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
                            final FunctionDefinition function,
                            final Optional<ExpressionEditorDefinition<Expression>> oDefinition) {
         oDefinition.ifPresent(definition -> {
-            final GridCellTuple expressionParent = new GridCellTuple(0, 0, model);
+            final GridCellTuple expressionParent = new GridCellTuple(0,
+                                                                     0,
+                                                                     this);
             final Optional<Expression> expression = definition.getModelClass();
             final Optional<BaseExpressionGrid> gridWidget = definition.getEditor(expressionParent,
                                                                                  hasExpression,
@@ -262,7 +266,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
                    final Optional<BaseExpressionGrid> editor) {
         final GridCellValueTuple gcv = new GridCellValueTuple<>(0,
                                                                 0,
-                                                                model,
+                                                                this,
                                                                 new ExpressionCellValue(editor));
         sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                       new SetKindCommand(gcv,
@@ -277,7 +281,9 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
         final Optional<ExpressionEditorDefinition<Expression>> expressionEditorDefinition = expressionEditorDefinitionsSupplier.get().getExpressionEditorDefinition(type);
         expressionEditorDefinition.ifPresent(ed -> {
             final Optional<Expression> expression = ed.getModelClass();
-            final GridCellTuple expressionParent = new GridCellTuple(0, 0, model);
+            final GridCellTuple expressionParent = new GridCellTuple(0,
+                                                                     0,
+                                                                     this);
             final Optional<BaseExpressionGrid> editor = ed.getEditor(expressionParent,
                                                                      hasExpression,
                                                                      expression,
@@ -285,7 +291,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
                                                                      true);
             final GridCellValueTuple gcv = new GridCellValueTuple<>(0,
                                                                     0,
-                                                                    model,
+                                                                    this,
                                                                     new ExpressionCellValue(editor));
 
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapper.java
@@ -31,18 +31,22 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 public class FunctionUIModelMapper extends BaseUIModelMapper<FunctionDefinition> {
 
+    private GridWidget gridWidget;
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
     private Supplier<ExpressionEditorDefinitions> supplementaryEditorDefinitionsSupplier;
 
-    public FunctionUIModelMapper(final Supplier<GridData> uiModel,
+    public FunctionUIModelMapper(final GridWidget gridWidget,
+                                 final Supplier<GridData> uiModel,
                                  final Supplier<Optional<FunctionDefinition>> dmnModel,
                                  final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
                                  final Supplier<ExpressionEditorDefinitions> supplementaryEditorDefinitionsSupplier) {
         super(uiModel,
               dmnModel);
+        this.gridWidget = gridWidget;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
         this.supplementaryEditorDefinitionsSupplier = supplementaryEditorDefinitionsSupplier;
     }
@@ -81,7 +85,9 @@ public class FunctionUIModelMapper extends BaseUIModelMapper<FunctionDefinition>
                                   final int columnIndex,
                                   final FunctionDefinition function,
                                   final ExpressionEditorDefinition<Expression> ed) {
-        final GridCellTuple expressionParent = new GridCellTuple(0, 0, uiModel.get());
+        final GridCellTuple expressionParent = new GridCellTuple(0,
+                                                                 0,
+                                                                 gridWidget);
         final Optional<Expression> expression = Optional.ofNullable(function.getExpression());
         final Optional<BaseExpressionGrid> editor = ed.getEditor(expressionParent,
                                                                  function,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
@@ -104,7 +104,8 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Conte
 
     @Override
     public ContextUIModelMapper makeUiModelMapper() {
-        return new FunctionSupplementaryGridUIModelMapper(this::getModel,
+        return new FunctionSupplementaryGridUIModelMapper(this,
+                                                          this::getModel,
                                                           () -> expression,
                                                           expressionEditorDefinitionsSupplier,
                                                           listSelector);
@@ -113,7 +114,8 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Conte
     @Override
     public void initialiseUiColumns() {
         final DMNGridColumn<String> nameColumn = new NameColumn(this);
-        final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(new BaseHeaderMetaData("",
+        final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(gridLayer,
+                                                                                   new BaseHeaderMetaData("",
                                                                                                           EXPRESSION_COLUMN_GROUP),
                                                                                    this);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridUIModelMapper.java
@@ -24,14 +24,17 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionE
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ContextUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelector;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 public class FunctionSupplementaryGridUIModelMapper extends ContextUIModelMapper {
 
-    public FunctionSupplementaryGridUIModelMapper(final Supplier<GridData> uiModel,
+    public FunctionSupplementaryGridUIModelMapper(final GridWidget gridWidget,
+                                                  final Supplier<GridData> uiModel,
                                                   final Supplier<Optional<Context>> dmnModel,
                                                   final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
                                                   final ListSelector listSelector) {
-        super(uiModel,
+        super(gridWidget,
+              uiModel,
               dmnModel,
               expressionEditorDefinitionsSupplier,
               listSelector);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -108,7 +108,8 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationUIM
 
     @Override
     public InvocationUIModelMapper makeUiModelMapper() {
-        return new InvocationUIModelMapper(this::getModel,
+        return new InvocationUIModelMapper(this,
+                                           this::getModel,
                                            () -> expression,
                                            expressionEditorDefinitionsSupplier);
     }
@@ -139,7 +140,8 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationUIM
                                                                    expressionHeaderMetaData),
                                                      factory,
                                                      this);
-        final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(Arrays.asList(new BaseHeaderMetaData("",
+        final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(gridLayer,
+                                                                                   Arrays.asList(new BaseHeaderMetaData("",
                                                                                                                         EXPRESSION_COLUMN_GROUP),
                                                                                                  expressionHeaderMetaData),
                                                                                    this);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapper.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowSelectionStrategy;
 
 public class InvocationUIModelMapper extends BaseUIModelMapper<Invocation> {
@@ -43,13 +44,17 @@ public class InvocationUIModelMapper extends BaseUIModelMapper<Invocation> {
 
     public static final int BINDING_EXPRESSION_COLUMN_INDEX = 2;
 
+    private GridWidget gridWidget;
+
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
-    public InvocationUIModelMapper(final Supplier<GridData> uiModel,
+    public InvocationUIModelMapper(final GridWidget gridWidget,
+                                   final Supplier<GridData> uiModel,
                                    final Supplier<Optional<Invocation>> dmnModel,
                                    final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
         super(uiModel,
               dmnModel);
+        this.gridWidget = gridWidget;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
     }
 
@@ -80,7 +85,7 @@ public class InvocationUIModelMapper extends BaseUIModelMapper<Invocation> {
                     expressionEditorDefinition.ifPresent(ed -> {
                         final Optional<BaseExpressionGrid> editor = ed.getEditor(new GridCellTuple(rowIndex,
                                                                                                    columnIndex,
-                                                                                                   uiModel.get()),
+                                                                                                   gridWidget),
                                                                                  binding,
                                                                                  expression,
                                                                                  Optional.ofNullable(binding.getParameter()),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -159,7 +159,7 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
             if (grid instanceof HasListSelectorControl) {
                 final int parentUiRowIndex = getParentInformation().getRowIndex();
                 final int parentUiColumnIndex = getParentInformation().getColumnIndex();
-                final GridCell<?> parentCell = getParentInformation().getGridData().getCell(parentUiRowIndex, parentUiColumnIndex);
+                final GridCell<?> parentCell = getParentInformation().getGridWidget().getModel().getCell(parentUiRowIndex, parentUiColumnIndex);
 
                 if (parentCell instanceof HasCellEditorControls) {
                     final List<ListSelectorItem> parentItems = ((HasListSelectorControl) grid).getItems(parentUiRowIndex,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumn.java
@@ -64,7 +64,7 @@ public class RelationColumn extends DMNGridColumn<String> implements HasSingleto
 
     private double getMinimumWidthOfPeers() {
         final GridCellTuple parent = ((RelationGrid) gridWidget).getParentInformation();
-        final GridData parentUiModel = parent.getGridData();
+        final GridData parentUiModel = parent.getGridWidget().getModel();
         final int parentUiRowIndex = parent.getRowIndex();
         final int parentUiColumnIndex = parent.getColumnIndex();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -267,7 +267,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationUIModelMa
                                                                           uiModelMapper,
                                                                           () -> {
                                                                               final int parentColumnIndex = getParentInformation().getColumnIndex();
-                                                                              final GridData parentGridData = getParentInformation().getGridData();
+                                                                              final GridData parentGridData = getParentInformation().getGridWidget().getModel();
                                                                               final GridColumn<?> parentColumn = parentGridData.getColumns().get(parentColumnIndex);
                                                                               parentColumn.setWidth(getWidth() + getPadding() * 2);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
@@ -161,7 +161,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, Unde
             if (grid instanceof HasListSelectorControl) {
                 final int parentUiRowIndex = getParentInformation().getRowIndex();
                 final int parentUiColumnIndex = getParentInformation().getColumnIndex();
-                final GridCell<?> parentCell = getParentInformation().getGridData().getCell(parentUiRowIndex, parentUiColumnIndex);
+                final GridCell<?> parentCell = getParentInformation().getGridWidget().getModel().getCell(parentUiRowIndex, parentUiColumnIndex);
 
                 if (parentCell instanceof HasCellEditorControls) {
                     final List<ListSelectorItem> parentItems = ((HasListSelectorControl) grid).getItems(parentUiRowIndex,
@@ -212,7 +212,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, Unde
                                                                      isNested);
             final GridCellValueTuple gcv = new GridCellValueTuple<>(parent.getRowIndex(),
                                                                     parent.getColumnIndex(),
-                                                                    parent.getGridData(),
+                                                                    parent.getGridWidget(),
                                                                     new ExpressionCellValue(editor));
 
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/shape/view/DirectionalLine.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/shape/view/DirectionalLine.java
@@ -86,7 +86,7 @@ public class DirectionalLine extends AbstractDirectionalMultiPointShape<Directio
             final Point2D p1 = points.get(0);
             final double x1 = p1.getX();
             final double y1 = p1.getY();
-            final Point2D p2 = points.get(points.size() -1);
+            final Point2D p2 = points.get(points.size() - 1);
             final double x2 = p2.getX();
             final double y2 = p2.getY();
             getPathPartList()

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -66,7 +66,6 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.GridRendererContext;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
@@ -387,27 +386,11 @@ public abstract class BaseExpressionGrid<E extends Expression, M extends BaseUIM
             return true;
         };
 
-        allOtherCommands.stream().filter(renderHeader).forEach(p -> p.getK2().execute(makeGridRendererContext(p.getK1(),
-                                                                                                              isSelectionLayer)));
-        gridLineCommands.stream().filter(renderHeader).forEach(p -> p.getK2().execute(makeGridRendererContext(p.getK1(),
-                                                                                                              isSelectionLayer)));
-        selectedCellsCommands.stream().filter(renderHeader).forEach(p -> p.getK2().execute(makeGridRendererContext(p.getK1(),
-                                                                                                                   isSelectionLayer)));
-    }
-
-    private GridRendererContext makeGridRendererContext(final Group group,
-                                                        final boolean isSelectionLayer) {
-        return new GridRendererContext() {
-            @Override
-            public Group getGroup() {
-                return group;
-            }
-
-            @Override
-            public boolean isSelectionLayer() {
-                return isSelectionLayer;
-            }
-        };
+        renderQueue.clear();
+        allOtherCommands.stream().filter(renderHeader).forEach(p -> addCommandToRenderQueue(p.getK1(), p.getK2()));
+        gridLineCommands.stream().filter(renderHeader).forEach(p -> addCommandToRenderQueue(p.getK1(), p.getK2()));
+        selectedCellsCommands.stream().filter(renderHeader).forEach(p -> addCommandToRenderQueue(p.getK1(), p.getK2()));
+        super.executeRenderQueueCommands(isSelectionLayer);
     }
 
     public GridCellTuple getParentInformation() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/TextAreaDOMElement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/TextAreaDOMElement.java
@@ -26,7 +26,6 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
@@ -93,18 +92,17 @@ public class TextAreaDOMElement extends BaseDOMElement<String, TextArea> {
     public void flush(final String value) {
         final int rowIndex = context.getRowIndex();
         final int columnIndex = context.getColumnIndex();
-        final GridData uiModel = gridWidget.getModel();
 
         if (value == null || value.trim().isEmpty()) {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           hasNoValueCommand.apply(new GridCellTuple(rowIndex,
                                                                                     columnIndex,
-                                                                                    uiModel)));
+                                                                                    gridWidget)));
         } else {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           hasValueCommand.apply(new GridCellValueTuple<>(rowIndex,
                                                                                          columnIndex,
-                                                                                         uiModel,
+                                                                                         gridWidget,
                                                                                          new BaseGridCellValue<>(value))));
         }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/TextBoxDOMElement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/TextBoxDOMElement.java
@@ -25,7 +25,6 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
@@ -57,18 +56,17 @@ public class TextBoxDOMElement extends org.uberfire.ext.wires.core.grids.client.
     public void flush(final String value) {
         final int rowIndex = context.getRowIndex();
         final int columnIndex = context.getColumnIndex();
-        final GridData uiModel = gridWidget.getModel();
 
         if (value == null || value.trim().isEmpty()) {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           hasNoValueCommand.apply(new GridCellTuple(rowIndex,
                                                                                     columnIndex,
-                                                                                    uiModel)));
+                                                                                    gridWidget)));
         } else {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           hasValueCommand.apply(new GridCellValueTuple<>(rowIndex,
                                                                                          columnIndex,
-                                                                                         uiModel,
+                                                                                         gridWidget,
                                                                                          new BaseGridCellValue<>(value))));
         }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridColumn.java
@@ -59,7 +59,7 @@ public class DMNGridColumn<T> extends BaseGridColumn<T> {
         if (gridWidget instanceof BaseExpressionGrid) {
             final BaseExpressionGrid beg = (BaseExpressionGrid) gridWidget;
             final int parentColumnIndex = beg.getParentInformation().getColumnIndex();
-            final GridData parentGridData = beg.getParentInformation().getGridData();
+            final GridData parentGridData = beg.getParentInformation().getGridWidget().getModel();
             if (parentGridData != null) {
                 final GridColumn<?> parentColumn = parentGridData.getColumns().get(parentColumnIndex);
                 parentColumn.setWidth(gridWidget.getWidth() + beg.getPadding() * 2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
@@ -17,20 +17,20 @@
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 public class GridCellTuple implements RequiresResize {
 
     private int rowIndex;
     private int columnIndex;
-    private final GridData uiModel;
+    private final GridWidget gridWidget;
 
     public GridCellTuple(final int rowIndex,
                          final int columnIndex,
-                         final GridData uiModel) {
+                         final GridWidget gridWidget) {
         this.rowIndex = rowIndex;
         this.columnIndex = columnIndex;
-        this.uiModel = uiModel;
+        this.gridWidget = gridWidget;
     }
 
     public int getRowIndex() {
@@ -49,18 +49,18 @@ public class GridCellTuple implements RequiresResize {
         this.columnIndex = columnIndex;
     }
 
-    public GridData getGridData() {
-        return uiModel;
+    public GridWidget getGridWidget() {
+        return gridWidget;
     }
 
     public void assertWidth(final double width) {
-        uiModel.getColumns().get(columnIndex).setWidth(width);
+        gridWidget.getModel().getColumns().get(columnIndex).setWidth(width);
     }
 
     @Override
     public void onResize() {
         //This may look like it does nothing; however it forces the column to resize it's children
-        final GridColumn<?> parentColumn = uiModel.getColumns().get(columnIndex);
+        final GridColumn<?> parentColumn = gridWidget.getModel().getColumns().get(columnIndex);
         parentColumn.setWidth(parentColumn.getWidth());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellValueTuple.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellValueTuple.java
@@ -17,7 +17,7 @@
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 public class GridCellValueTuple<T extends GridCellValue> extends GridCellTuple {
 
@@ -25,11 +25,11 @@ public class GridCellValueTuple<T extends GridCellValue> extends GridCellTuple {
 
     public GridCellValueTuple(final int rowIndex,
                               final int columnIndex,
-                              final GridData uiModel,
+                              final GridWidget gridWidget,
                               final T value) {
         super(rowIndex,
               columnIndex,
-              uiModel);
+              gridWidget);
         this.value = value;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -16,13 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.widgets.layer;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import com.google.gwt.user.client.Command;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.dnd.DelegatingGridWidgetDndMouseMoveHandler;
-import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDMouseMoveHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
@@ -39,34 +34,6 @@ public class DMNGridLayer extends DefaultGridLayer {
     @Override
     public TransformMediator getDefaultTransformMediator() {
         return defaultTransformMediator;
-    }
-
-    @Override
-    public Set<GridWidget> getGridWidgets() {
-        final Set<GridWidget> gridWidgets = super.getGridWidgets();
-        final Set<GridWidget> allGridWidgets = new HashSet<>();
-        gridWidgets.forEach(grid -> allGridWidgets.addAll(collectGridWidgets(grid)));
-        return allGridWidgets;
-    }
-
-    private Set<GridWidget> collectGridWidgets(final GridWidget gridWidget) {
-        final Set<GridWidget> allGridWidgets = new HashSet<>();
-        allGridWidgets.add(gridWidget);
-
-        gridWidget.getModel()
-                .getRows()
-                .stream()
-                .forEach(row -> row.getCells().values()
-                        .stream()
-                        .filter(cell -> cell != null && cell.getValue() != null)
-                        .map(GridCell::getValue)
-                        .filter(value -> value instanceof ExpressionCellValue)
-                        .map(value -> (ExpressionCellValue) value)
-                        .filter(value -> value.getValue().isPresent())
-                        .map(value -> value.getValue().get())
-                        .forEach(editor -> allGridWidgets.addAll(collectGridWidgets(editor))));
-
-        return allGridWidgets;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommandTest.java
@@ -48,6 +48,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
@@ -63,6 +64,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddContextEntryCommandTest {
+
+    @Mock
+    private GridWidget gridWidget;
 
     @Mock
     private RowNumberColumn uiRowNumberColumn;
@@ -136,6 +140,7 @@ public class AddContextEntryCommandTest {
         this.uiModel.appendColumn(uiNameColumn);
         this.uiModel.appendColumn(uiExpressionEditorColumn);
 
+        doReturn(uiModel).when(gridWidget).getModel();
         doReturn(ruleManager).when(handler).getRuleManager();
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiNameColumn).getIndex();
@@ -155,7 +160,8 @@ public class AddContextEntryCommandTest {
                                                                                                              any(Optional.class),
                                                                                                              any(Optional.class),
                                                                                                              anyBoolean());
-        this.uiModelMapper = new ContextUIModelMapper(() -> uiModel,
+        this.uiModelMapper = new ContextUIModelMapper(gridWidget,
+                                                      () -> uiModel,
                                                       () -> Optional.of(context),
                                                       () -> expressionEditorDefinitions,
                                                       listSelector);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommandTest.java
@@ -40,6 +40,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -49,6 +50,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SetKindCommandTest {
+
+    @Mock
+    private GridWidget gridWidget;
 
     @Mock
     private GridColumn mockColumn;
@@ -99,13 +103,14 @@ public class SetKindCommandTest {
                                   0,
                                   new ExpressionCellValue(Optional.of(originalEditor)));
 
+        doReturn(uiModel).when(gridWidget).getModel();
         doReturn(ruleManager).when(handler).getRuleManager();
     }
 
     private void setupCommand() {
         final GridCellValueTuple gcv = new GridCellValueTuple<>(0,
                                                                 0,
-                                                                uiModel,
+                                                                gridWidget,
                                                                 new ExpressionCellValue(Optional.of(newEditor)));
         this.command = new SetKindCommand(gcv,
                                           function,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/AddParameterBindingCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/AddParameterBindingCommandTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
@@ -57,6 +58,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddParameterBindingCommandTest {
+
+    @Mock
+    private GridWidget gridWidget;
 
     @Mock
     private RowNumberColumn uiRowNumberColumn;
@@ -109,7 +113,8 @@ public class AddParameterBindingCommandTest {
         this.uiModel.appendColumn(uiNameColumn);
         this.uiModel.appendColumn(uiExpressionEditorColumn);
 
-        this.uiModelMapper = new InvocationUIModelMapper(() -> uiModel,
+        this.uiModelMapper = new InvocationUIModelMapper(gridWidget,
+                                                         () -> uiModel,
                                                          () -> Optional.of(invocation),
                                                          () -> expressionEditorDefinitions);
 
@@ -124,6 +129,7 @@ public class AddParameterBindingCommandTest {
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiNameColumn).getIndex();
         doReturn(2).when(uiExpressionEditorColumn).getIndex();
+        doReturn(uiModel).when(gridWidget).getModel();
 
         doReturn(Optional.empty()).when(expressionEditorDefinitions).getExpressionEditorDefinition(any(Optional.class));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/DeleteCellValueCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/DeleteCellValueCommandTest.java
@@ -38,6 +38,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -59,6 +60,9 @@ public class DeleteCellValueCommandTest {
 
     @Mock
     private DMNGridLayer gridLayer;
+
+    @Mock
+    private GridWidget gridWidget;
 
     @Mock
     private GridData gridModel;
@@ -93,10 +97,11 @@ public class DeleteCellValueCommandTest {
                                COLUMN_INDEX)).thenReturn(gridCell);
         when(gridCell.getValue()).thenReturn(gridCellValue);
         when(gridCellValue.getValue()).thenReturn(CELL_VALUE);
+        when(gridWidget.getModel()).thenReturn(gridModel);
 
         this.command = new DeleteCellValueCommand(new GridCellTuple(ROW_INDEX,
                                                                     COLUMN_INDEX,
-                                                                    gridModel),
+                                                                    gridWidget),
                                                   () -> uiModelMapper,
                                                   gridLayer::batch);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/SetCellValueCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/SetCellValueCommandTest.java
@@ -37,6 +37,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -59,6 +60,9 @@ public class SetCellValueCommandTest {
 
     @Mock
     private DMNGridLayer gridLayer;
+
+    @Mock
+    private GridWidget gridWidget;
 
     @Mock
     private GridData gridModel;
@@ -106,10 +110,11 @@ public class SetCellValueCommandTest {
         }
         when(newGridCell.getValue()).thenReturn(newGridCellValue);
         when(newGridCellValue.getValue()).thenReturn(NEW_CELL_VALUE);
+        when(gridWidget.getModel()).thenReturn(gridModel);
 
         this.command = new SetCellValueCommand(new GridCellValueTuple<>(ROW_INDEX,
                                                                         COLUMN_INDEX,
-                                                                        gridModel,
+                                                                        gridWidget,
                                                                         newGridCellValue),
                                                () -> uiModelMapper,
                                                gridLayer::batch);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
@@ -42,7 +42,6 @@ import org.mockito.Mock;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
@@ -171,10 +170,11 @@ public class CommandUtilsTest {
 
     @Test
     public void testUpdateParentInformation_WithExpressionColumn() {
-        setupUiModel(Pair.newPair(new ExpressionEditorColumn(new BaseHeaderMetaData("column"), gridWidget),
+        setupUiModel(Pair.newPair(new ExpressionEditorColumn(gridLayer,
+                                                             new BaseHeaderMetaData("column"), gridWidget),
                                   (rowIndex) -> {
                                       final BaseExpressionGrid grid = mock(BaseExpressionGrid.class);
-                                      final GridCellTuple gct = new GridCellTuple(rowIndex, 0, mock(GridData.class));
+                                      final GridCellTuple gct = new GridCellTuple(rowIndex, 0, mock(GridWidget.class));
                                       when(grid.getParentInformation()).thenReturn(gct);
                                       return new ExpressionCellValue(Optional.of(grid));
                                   }));
@@ -188,10 +188,12 @@ public class CommandUtilsTest {
 
     @Test
     public void testUpdateParentInformation_WithExpressionColumnNullValues() {
-        setupUiModelNullValues(Pair.newPair(new ExpressionEditorColumn(new BaseHeaderMetaData("column"), gridWidget),
+        setupUiModelNullValues(Pair.newPair(new ExpressionEditorColumn(gridLayer,
+                                                                       new BaseHeaderMetaData("column"),
+                                                                       gridWidget),
                                             (rowIndex) -> {
                                                 final BaseExpressionGrid grid = mock(BaseExpressionGrid.class);
-                                                final GridCellTuple gct = new GridCellTuple(rowIndex, 0, mock(GridData.class));
+                                                final GridCellTuple gct = new GridCellTuple(rowIndex, 0, mock(GridWidget.class));
                                                 when(grid.getParentInformation()).thenReturn(gct);
                                                 return new ExpressionCellValue(Optional.of(grid));
                                             }));
@@ -204,10 +206,12 @@ public class CommandUtilsTest {
 
     @Test
     public void testUpdateParentInformation_WithMultipleColumns() {
-        setupUiModel(Pair.newPair(new ExpressionEditorColumn(new BaseHeaderMetaData("column"), gridWidget),
+        setupUiModel(Pair.newPair(new ExpressionEditorColumn(gridLayer,
+                                                             new BaseHeaderMetaData("column"),
+                                                             gridWidget),
                                   (rowIndex) -> {
                                       final BaseExpressionGrid grid = mock(BaseExpressionGrid.class);
-                                      final GridCellTuple gct = new GridCellTuple(rowIndex, 0, mock(GridData.class));
+                                      final GridCellTuple gct = new GridCellTuple(rowIndex, 0, mock(GridWidget.class));
                                       when(grid.getParentInformation()).thenReturn(gct);
                                       return new ExpressionCellValue(Optional.of(grid));
                                   }),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/BaseContextUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/BaseContextUIModelMapperTest.java
@@ -41,6 +41,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
@@ -82,6 +83,9 @@ public abstract class BaseContextUIModelMapperTest<M extends ContextUIModelMappe
 
     @Mock
     protected Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
+
+    @Mock
+    protected GridWidget gridWidget;
 
     protected BaseGridData uiModel;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapperTest.java
@@ -32,7 +32,8 @@ public class ContextUIModelMapperTest extends BaseContextUIModelMapperTest<Conte
 
     @Override
     protected ContextUIModelMapper getMapper() {
-        return new ContextUIModelMapper(() -> uiModel,
+        return new ContextUIModelMapper(gridWidget,
+                                        () -> uiModel,
                                         () -> Optional.of(context),
                                         expressionEditorDefinitionsSupplier,
                                         listSelector);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRendererTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRendererTest.java
@@ -30,6 +30,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridWidgetRegistry;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
@@ -39,6 +40,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class ExpressionEditorColumnRendererTest {
+
+    @Mock
+    private GridWidgetRegistry registry;
 
     @Mock
     private GridBodyCellRenderContext context;
@@ -60,7 +64,7 @@ public class ExpressionEditorColumnRendererTest {
     public void setUp() throws Exception {
         GwtMockito.useProviderForType(Group.class, aClass -> renderedGroup);
 
-        renderer = new ExpressionEditorColumnRenderer();
+        renderer = new ExpressionEditorColumnRenderer(registry);
 
         doReturn(editorGroup).when(widget).setX(anyDouble());
         doReturn(editorGroup).when(editorGroup).setY(anyDouble());
@@ -78,5 +82,6 @@ public class ExpressionEditorColumnRendererTest {
         cell = new BaseGridCell<>(new ExpressionCellValue(Optional.of(widget)));
         renderer.renderCell(cell, context);
         verify(renderedGroup).add(editorGroup);
+        verify(registry).register(widget);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
@@ -103,7 +103,7 @@ public class ExpressionEditorColumnTest {
     public void setUp() throws Exception {
         gridData = new BaseGridData();
         widget = new BaseGridWidget(gridData, selectionManager, pinnedModeManager, renderer);
-        column = new ExpressionEditorColumn(new BaseHeaderMetaData("column header"), widget);
+        column = new ExpressionEditorColumn(gridLayer, new BaseHeaderMetaData("column header"), widget);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapperTest.java
@@ -39,6 +39,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -48,6 +49,9 @@ import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FunctionUIModelMapperTest {
+
+    @Mock
+    private GridWidget gridWidget;
 
     @Mock
     private ExpressionEditorColumn uiExpressionEditorColumn;
@@ -90,6 +94,7 @@ public class FunctionUIModelMapperTest {
         this.uiModel.appendRow(new DMNGridRow());
         this.uiModel.appendColumn(uiExpressionEditorColumn);
         doReturn(0).when(uiExpressionEditorColumn).getIndex();
+        doReturn(uiModel).when(gridWidget).getModel();
 
         //Core Editor definitions
         final ExpressionEditorDefinitions expressionEditorDefinitions = new ExpressionEditorDefinitions();
@@ -119,7 +124,8 @@ public class FunctionUIModelMapperTest {
 
         this.function = new FunctionDefinition();
 
-        this.mapper = new FunctionUIModelMapper(() -> uiModel,
+        this.mapper = new FunctionUIModelMapper(gridWidget,
+                                                () -> uiModel,
                                                 () -> Optional.of(function),
                                                 expressionEditorDefinitionsSupplier,
                                                 supplementaryEditorDefinitionsSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridUIModelMapperTest.java
@@ -31,7 +31,8 @@ public class FunctionSupplementaryGridUIModelMapperTest extends BaseContextUIMod
 
     @Override
     protected FunctionSupplementaryGridUIModelMapper getMapper() {
-        return new FunctionSupplementaryGridUIModelMapper(() -> uiModel,
+        return new FunctionSupplementaryGridUIModelMapper(gridWidget,
+                                                          () -> uiModel,
                                                           () -> Optional.of(context),
                                                           expressionEditorDefinitionsSupplier,
                                                           listSelector);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapperTest.java
@@ -40,6 +40,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowSelectionStrategy;
 
@@ -52,6 +53,9 @@ import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InvocationUIModelMapperTest {
+
+    @Mock
+    private GridWidget gridWidget;
 
     @Mock
     private RowNumberColumn uiRowNumberColumn;
@@ -93,6 +97,7 @@ public class InvocationUIModelMapperTest {
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiNameColumn).getIndex();
         doReturn(2).when(uiExpressionEditorColumn).getIndex();
+        doReturn(uiModel).when(gridWidget).getModel();
 
         final ExpressionEditorDefinitions expressionEditorDefinitions = new ExpressionEditorDefinitions();
         expressionEditorDefinitions.add(literalExpressionEditorDefinition);
@@ -120,7 +125,8 @@ public class InvocationUIModelMapperTest {
         this.invocation.setExpression(invocationExpression);
         this.invocation.getBinding().add(binding);
 
-        this.mapper = new InvocationUIModelMapper(() -> uiModel,
+        this.mapper = new InvocationUIModelMapper(gridWidget,
+                                                  () -> uiModel,
                                                   () -> Optional.of(invocation),
                                                   expressionEditorDefinitionsSupplier);
         this.cellValueSupplier = Optional::empty;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -160,7 +160,7 @@ public class LiteralExpressionGridTest {
     public void testFireExpressionEditorSelectedEventSelectsParentGridWidget() {
         final GridData mockParentUiModel = mock(GridData.class);
         final BaseExpressionGrid mockParentGrid = mock(BaseExpressionGrid.class);
-        doReturn(mockParentUiModel).when(parent).getGridData();
+        doReturn(mockParentGrid).when(parent).getGridWidget();
         doReturn(mockParentUiModel).when(mockParentGrid).getModel();
         doReturn(new HashSet<GridWidget>() {{
             add(mockParentGrid);
@@ -178,7 +178,7 @@ public class LiteralExpressionGridTest {
 
     @Test
     public void testGetItemsWithNoParent() {
-        when(parent.getGridData()).thenReturn(mock(GridData.class));
+        when(parent.getGridWidget()).thenReturn(mock(GridWidget.class));
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(mock(BaseGridWidget.class)));
 
         final List<HasListSelectorControl.ListSelectorItem> items = grid.getItems(0, 0);
@@ -192,7 +192,7 @@ public class LiteralExpressionGridTest {
         final GridData parentGridData = mock(GridData.class);
         final ContextGrid parentGridWidget = mock(ContextGrid.class);
         final HasListSelectorControl.ListSelectorItem listSelectorItem = mock(HasListSelectorControl.ListSelectorItem.class);
-        when(parent.getGridData()).thenReturn(parentGridData);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(parentGridWidget));
         when(parentGridWidget.getModel()).thenReturn(parentGridData);
         when(parentGridWidget.getItems(anyInt(), anyInt())).thenReturn(Collections.singletonList(listSelectorItem));
@@ -211,7 +211,7 @@ public class LiteralExpressionGridTest {
         final GridData parentGridData = mock(GridData.class);
         final ContextGrid parentGridWidget = mock(ContextGrid.class);
         final HasListSelectorControl.ListSelectorItem listSelectorItem = mock(HasListSelectorControl.ListSelectorItem.class);
-        when(parent.getGridData()).thenReturn(parentGridData);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(parentGridWidget));
         when(parentGridWidget.getModel()).thenReturn(parentGridData);
         when(parentGridWidget.getItems(anyInt(), anyInt())).thenReturn(Collections.singletonList(listSelectorItem));
@@ -226,7 +226,7 @@ public class LiteralExpressionGridTest {
     public void testGetItemsWithParentThatDoesNotSupportCellControls() {
         final GridData parentGridData = mock(GridData.class);
         final BaseExpressionGrid parentGridWidget = mock(BaseExpressionGrid.class);
-        when(parent.getGridData()).thenReturn(parentGridData);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(parentGridWidget));
         when(parentGridWidget.getModel()).thenReturn(parentGridData);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumnTest.java
@@ -42,6 +42,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -61,6 +62,9 @@ public class RelationColumnTest {
 
     @Mock
     private RelationGrid gridWidget;
+
+    @Mock
+    private GridWidget parentGridWidget;
 
     @Mock
     private GridBodyCellRenderContext context;
@@ -95,8 +99,9 @@ public class RelationColumnTest {
         parentUiModel.appendRow(new BaseGridRow());
         parentUiModel.appendRow(new BaseGridRow());
         parentUiModel.appendColumn(mock(ExpressionEditorColumn.class));
-        parent = new GridCellTuple(0, 0, parentUiModel);
+        parent = new GridCellTuple(0, 0, parentGridWidget);
 
+        doReturn(parentUiModel).when(parentGridWidget).getModel();
         doReturn(textArea).when(textAreaDOMElement).getWidget();
         doReturn(parent).when(gridWidget).getParentInformation();
         doReturn(100.0).when(gridWidget).getWidth();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.relation;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import javax.enterprise.event.Event;
@@ -41,7 +42,6 @@ import org.kie.workbench.common.dmn.client.session.DMNClientFullSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControls;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelector;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -54,6 +54,7 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
@@ -85,12 +86,17 @@ public class RelationGridTest {
 
     private final static int DELETE_ROW = 5;
 
+    @Mock
     private GridCellTuple parent;
 
-    private GridData parentUiModel;
+    @Mock
+    private GridWidget parentGridWidget;
 
     @Mock
-    private GridColumn parentUiColumn;
+    private GridData parentGridData;
+
+    @Mock
+    private GridColumn parentGridColumn;
 
     @Mock
     private HasExpression hasExpression;
@@ -150,9 +156,6 @@ public class RelationGridTest {
         doReturn(abstractCanvasHandler).when(dmnClientFullSession).getCanvasHandler();
         doReturn(dmnClientFullSession).when(sessionManager).getCurrentSession();
         doAnswer((i) -> i.getArguments()[0].toString()).when(translationService).format(anyString());
-        parentUiModel = new DMNGridData(gridLayer);
-        parentUiModel.appendColumn(parentUiColumn);
-        parent = new GridCellTuple(0, 0, parentUiModel);
     }
 
     private void makeRelationGrid() {
@@ -168,6 +171,9 @@ public class RelationGridTest {
                                             cellEditorControls,
                                             translationService,
                                             listSelector));
+        doReturn(parentGridWidget).when(parent).getGridWidget();
+        doReturn(parentGridData).when(parentGridWidget).getModel();
+        doReturn(Collections.singletonList(parentGridColumn)).when(parentGridData).getColumns();
     }
 
     @Test
@@ -426,7 +432,7 @@ public class RelationGridTest {
         verify(sessionCommandManager).execute(eq(abstractCanvasHandler), deleteColumnCommand.capture());
 
         deleteColumnCommand.getValue().execute(abstractCanvasHandler);
-        verify(parentUiColumn).setWidth(relationGrid.getWidth() + relationGrid.getPadding() * 2);
+        verify(parentGridColumn).setWidth(relationGrid.getWidth() + relationGrid.getPadding() * 2);
         verify(gridPanel).refreshScrollPosition();
         verify(gridPanel).updatePanelSize();
         verify(gridLayer).batch();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionColumnTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.undefined;
 
+import java.util.Collections;
+
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +25,8 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -39,6 +43,15 @@ public class UndefinedExpressionColumnTest {
     private UndefinedExpressionGrid gridWidget;
 
     @Mock
+    private GridWidget parentGridWidget;
+
+    @Mock
+    private GridData parentGridData;
+
+    @Mock
+    private GridColumn parentGridColumn;
+
+    @Mock
     private GridCellTuple parent;
 
     private UndefinedExpressionColumn column;
@@ -49,6 +62,9 @@ public class UndefinedExpressionColumnTest {
                                                         gridWidget));
 
         doReturn(parent).when(gridWidget).getParentInformation();
+        doReturn(parentGridWidget).when(parent).getGridWidget();
+        doReturn(parentGridData).when(parentGridWidget).getModel();
+        doReturn(Collections.singletonList(parentGridColumn)).when(parentGridData).getColumns();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
@@ -56,6 +56,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
@@ -113,6 +114,9 @@ public class UndefinedExpressionGridTest {
     private GridCellTuple parent;
 
     @Mock
+    private GridWidget parentGridWidget;
+
+    @Mock
     private HasExpression hasExpression;
 
     @Mock
@@ -163,7 +167,8 @@ public class UndefinedExpressionGridTest {
 
         doReturn(0).when(parent).getRowIndex();
         doReturn(0).when(parent).getColumnIndex();
-        doReturn(mock(GridData.class)).when(parent).getGridData();
+        doReturn(parentGridWidget).when(parent).getGridWidget();
+        doReturn(mock(GridData.class)).when(parentGridWidget).getModel();
 
         doReturn(session).when(sessionManager).getCurrentSession();
         doReturn(handler).when(session).getCanvasHandler();
@@ -210,7 +215,7 @@ public class UndefinedExpressionGridTest {
     public void testGetItemsWithParentWithoutCellControls() {
         final GridData parentGridData = mock(GridData.class);
         final BaseExpressionGrid parentGridWidget = mock(BaseExpressionGrid.class);
-        when(parent.getGridData()).thenReturn(parentGridData);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(parentGridWidget));
         when(parentGridWidget.getModel()).thenReturn(parentGridData);
 
@@ -229,7 +234,7 @@ public class UndefinedExpressionGridTest {
         final GridData parentGridData = mock(GridData.class);
         final ContextGrid parentGridWidget = mock(ContextGrid.class);
         final HasListSelectorControl.ListSelectorItem listSelectorItem = mock(HasListSelectorControl.ListSelectorItem.class);
-        when(parent.getGridData()).thenReturn(parentGridData);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(parentGridWidget));
         when(parentGridWidget.getModel()).thenReturn(parentGridData);
         when(parentGridWidget.getItems(anyInt(), anyInt())).thenReturn(Collections.singletonList(listSelectorItem));
@@ -254,7 +259,7 @@ public class UndefinedExpressionGridTest {
         final GridData parentGridData = mock(GridData.class);
         final ContextGrid parentGridWidget = mock(ContextGrid.class);
         final HasListSelectorControl.ListSelectorItem listSelectorItem = mock(HasListSelectorControl.ListSelectorItem.class);
-        when(parent.getGridData()).thenReturn(parentGridData);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(parentGridWidget));
         when(parentGridWidget.getModel()).thenReturn(parentGridData);
         when(parentGridWidget.getItems(anyInt(), anyInt())).thenReturn(Collections.singletonList(listSelectorItem));
@@ -274,7 +279,7 @@ public class UndefinedExpressionGridTest {
     public void testGetItemsWithParentThatDoesNotSupportCellControls() {
         final GridData parentGridData = mock(GridData.class);
         final BaseExpressionGrid parentGridWidget = mock(BaseExpressionGrid.class);
-        when(parent.getGridData()).thenReturn(parentGridData);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
         when(gridLayer.getGridWidgets()).thenReturn(Collections.singleton(parentGridWidget));
         when(parentGridWidget.getModel()).thenReturn(parentGridData);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
@@ -344,11 +344,10 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
         final BaseExpressionGrid parentGrid = mock(BaseExpressionGrid.class);
         final GridData parentGridData = mock(GridData.class);
         final DMNGridColumn parentColumn = mockColumn(100, null);
-        doReturn(parentGridData).when(parentCell).getGridData();
+        doReturn(parentGrid).when(parentCell).getGridWidget();
         doReturn(parentGridData).when(parentGrid).getModel();
         doReturn(Collections.singletonList(parentColumn)).when(parentGridData).getColumns();
         doReturn(Collections.singleton(parentGrid)).when(gridLayer).getGridWidgets();
-
 
         // nested columns
         final List<DMNGridColumn> columns = Arrays.stream(widthsOfNestedColumns)
@@ -402,6 +401,7 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private DMNGridColumn mockColumn(final double width,
                                      final GridWidget gridWidget) {
         final GridColumn.HeaderMetaData headerMetaData = mock(GridColumn.HeaderMetaData.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import com.ait.lienzo.client.core.Context2D;
-import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.common.client.api.IsElement;
@@ -42,6 +41,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyRenderCon
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBoundaryRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.GridRendererContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderBodyGridBackgroundCommand;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderBodyGridContentCommand;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderBodyGridLinesCommand;
@@ -193,10 +193,10 @@ public class BaseExpressionGridRenderingTest extends BaseExpressionGridTest {
 
         grid.drawWithTransforms(context, 1.0, new BoundingBox());
 
-        verify(renderHeaderBackgroundCommand, never()).execute(any(Group.class));
-        verify(renderHeaderGridLinesCommand, never()).execute(any(Group.class));
-        verify(renderHeaderContentCommand, never()).execute(any(Group.class));
-        verify(renderHeaderBodyDividerCommand, never()).execute(any(Group.class));
+        verify(renderHeaderBackgroundCommand, never()).execute(any(GridRendererContext.class));
+        verify(renderHeaderGridLinesCommand, never()).execute(any(GridRendererContext.class));
+        verify(renderHeaderContentCommand, never()).execute(any(GridRendererContext.class));
+        verify(renderHeaderBodyDividerCommand, never()).execute(any(GridRendererContext.class));
 
         final InOrder order = inOrder(renderBodyGridBackgroundCommand,
                                       renderBodyGridContentCommand,
@@ -204,11 +204,11 @@ public class BaseExpressionGridRenderingTest extends BaseExpressionGridTest {
                                       renderGridBoundaryCommand,
                                       renderSelectedCellsCommand);
 
-        order.verify(renderBodyGridBackgroundCommand).execute(any(Group.class));
-        order.verify(renderBodyGridContentCommand).execute(any(Group.class));
-        order.verify(renderGridBoundaryCommand).execute(any(Group.class));
-        order.verify(renderBodyGridLinesCommand).execute(any(Group.class));
-        order.verify(renderSelectedCellsCommand).execute(any(Group.class));
+        order.verify(renderBodyGridBackgroundCommand).execute(any(GridRendererContext.class));
+        order.verify(renderBodyGridContentCommand).execute(any(GridRendererContext.class));
+        order.verify(renderGridBoundaryCommand).execute(any(GridRendererContext.class));
+        order.verify(renderBodyGridLinesCommand).execute(any(GridRendererContext.class));
+        order.verify(renderSelectedCellsCommand).execute(any(GridRendererContext.class));
     }
 
     @Test
@@ -226,13 +226,13 @@ public class BaseExpressionGridRenderingTest extends BaseExpressionGridTest {
                                       renderBodyGridLinesCommand,
                                       renderSelectedCellsCommand);
 
-        order.verify(renderHeaderBackgroundCommand).execute(any(Group.class));
-        order.verify(renderHeaderContentCommand).execute(any(Group.class));
-        order.verify(renderBodyGridBackgroundCommand).execute(any(Group.class));
-        order.verify(renderBodyGridContentCommand).execute(any(Group.class));
-        order.verify(renderGridBoundaryCommand).execute(any(Group.class));
-        order.verify(renderHeaderGridLinesCommand).execute(any(Group.class));
-        order.verify(renderBodyGridLinesCommand).execute(any(Group.class));
-        order.verify(renderSelectedCellsCommand).execute(any(Group.class));
+        order.verify(renderHeaderBackgroundCommand).execute(any(GridRendererContext.class));
+        order.verify(renderHeaderContentCommand).execute(any(GridRendererContext.class));
+        order.verify(renderBodyGridBackgroundCommand).execute(any(GridRendererContext.class));
+        order.verify(renderBodyGridContentCommand).execute(any(GridRendererContext.class));
+        order.verify(renderGridBoundaryCommand).execute(any(GridRendererContext.class));
+        order.verify(renderHeaderGridLinesCommand).execute(any(GridRendererContext.class));
+        order.verify(renderBodyGridLinesCommand).execute(any(GridRendererContext.class));
+        order.verify(renderSelectedCellsCommand).execute(any(GridRendererContext.class));
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2332

This PR removes the need to "walk" the (nested) data model of parent-child grids when looking for a "parent grid".