### PR TITLE
AF-985: [Project Oriented] Project doesn't show all imported assets.

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/backend/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/backend/DefaultLuceneConfigProducer.java
@@ -20,7 +20,9 @@ import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -31,6 +33,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.ModuleRoo
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.event.BatchIndexEvent;
 import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 
 /**
@@ -42,6 +45,9 @@ public class DefaultLuceneConfigProducer {
 
     private MetadataConfig config;
 
+    @Inject
+    private Event<BatchIndexEvent> batchIndexEvent;
+
     @PostConstruct
     public void setup() {
         final Map<String, Analyzer> analyzers = getAnalyzers();
@@ -50,6 +56,7 @@ public class DefaultLuceneConfigProducer {
                 .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
                 .useDirectoryBasedIndex()
                 .useNIODirectory()
+                .useCDIBatchIndexObserver(batchIndexEvent)
                 .build();
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/ProjectAssetListUpdated.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/ProjectAssetListUpdated.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.library.api;
+
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+/**
+ * <p>
+ * Fired when a client of the {@link LibraryService} should reload the asset list
+ * (for example when a batch of files is indexed).
+ */
+@Portable
+public class ProjectAssetListUpdated {
+
+    private final WorkspaceProject project;
+
+    public ProjectAssetListUpdated(final @MapsTo("project") WorkspaceProject project) {
+        this.project = project;
+    }
+
+    public WorkspaceProject getProject() {
+        return project;
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/Remote.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/Remote.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.library.api;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Qualifier;
+
+
+/**
+ * <p>
+ * A qualifier indicating an event originates from the server and not the client.
+ *
+ * <p>
+ * Why would you want this? If you want to observe a server-side event direclty form a client-side view, you can run into timing issues.
+ * Particularly, because the Errai Bus must subscribe to the event channel when the view is created, it's possible to miss events for a short time
+ * after the view is instantiated.
+ *
+ * <p>A useful pattern to avoid this is to observe an event in an {@link ApplicationScoped} bean with the {@link Remote} qualifier,
+ * and refire the event from the client with the {@link Routed} qualifier.
+ */
+@Documented
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, FIELD, METHOD, PARAMETER, ANNOTATION_TYPE})
+public @interface Remote {
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/Routed.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/Routed.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.library.api;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Qualifier;
+
+
+/**
+ * <p>
+ * A qualifier for re-routing Errai CDI events from the server to a client destination.
+ *
+ * <p>
+ * Why would you want this? If you want to observe a server-side event direclty form a client-side view, you can run into timing issues.
+ * Particularly, because the Errai Bus must subscribe to the event channel when the view is created, it's possible to miss events for a short time
+ * after the view is instantiated.
+ *
+ * <p>A useful pattern to avoid this is to observe an event in an {@link ApplicationScoped} bean with the {@link Remote} qualifier,
+ * and refire the event from the client with the {@link Routed} qualifier.
+ */
+@Documented
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, FIELD, METHOD, PARAMETER, ANNOTATION_TYPE})
+public @interface Routed {
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetUpdateNotifier.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetUpdateNotifier.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.impl;
+
+import java.util.stream.Stream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.project.service.WorkspaceProjectService;
+import org.kie.workbench.common.screens.library.api.ProjectAssetListUpdated;
+import org.kie.workbench.common.screens.library.api.Remote;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.ext.metadata.event.BatchIndexEvent;
+
+@ApplicationScoped
+public class LibraryAssetUpdateNotifier {
+
+    private final WorkspaceProjectService projectService;
+    private final Event<ProjectAssetListUpdated> assetListUpdateEvent;
+    private final LibraryIndexer libraryIndexer;
+
+    // For proxying
+    public LibraryAssetUpdateNotifier() {
+        this(null, null, null);
+    }
+
+    @Inject
+    public LibraryAssetUpdateNotifier(final WorkspaceProjectService projectService,
+                                      final LibraryIndexer libraryIndexer,
+                                      final @Remote Event<ProjectAssetListUpdated> assetListUpdateEvent) {
+        this.projectService = projectService;
+        this.libraryIndexer = libraryIndexer;
+        this.assetListUpdateEvent = assetListUpdateEvent;
+    }
+
+    public void notifyOnUpdatedAssets(@Observes BatchIndexEvent event) {
+        // Assume that all indexed items are from the same project.
+        event.getIndexed()
+             .stream()
+             .map(kobject -> kobject.getKey())
+             .map(path -> org.uberfire.java.nio.file.Paths.get(path))
+             .filter(path -> libraryIndexer.supportsPath(path))
+             .flatMap(path -> {
+                 try {
+                     WorkspaceProject project = projectService.resolveProject(Paths.convert(path));
+                     return (project == null) ? Stream.empty() : Stream.of(project);
+                 } catch (Throwable t) {
+                     return Stream.empty();
+                 }
+             })
+             .map(project -> new ProjectAssetListUpdated(project))
+             .findFirst()
+             .ifPresent(clientEvent -> assetListUpdateEvent.fire(clientEvent));
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryIndexer.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryIndexer.java
@@ -51,6 +51,10 @@ public class LibraryIndexer extends AbstractFileIndexer {
 
     private LibraryAssetTypeDefinition filter;
 
+    // For proxying
+    public LibraryIndexer() {
+    }
+
     @Inject
     public LibraryIndexer(final LibraryAssetTypeDefinition filter) {
         this.filter = filter;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/AssetsScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/AssetsScreen.java
@@ -25,6 +25,8 @@ import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.screens.library.api.LibraryService;
+import org.kie.workbench.common.screens.library.api.ProjectAssetListUpdated;
+import org.kie.workbench.common.screens.library.api.Routed;
 import org.kie.workbench.common.screens.library.client.resources.i18n.LibraryConstants;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
 import org.kie.workbench.common.widgets.client.handlers.NewResourceSuccessEvent;
@@ -72,8 +74,14 @@ public class AssetsScreen {
         this.showAssets();
     }
 
-    private void observeAddAsset(@Observes NewResourceSuccessEvent event) {
+    public void observeAddAsset(@Observes NewResourceSuccessEvent event) {
         this.showAssets();
+    }
+
+    public void onAssetListUpdated(@Observes @Routed ProjectAssetListUpdated event) {
+        if (event.getProject().getRepository().getIdentifier().equals(projectInfo.getRepository().getIdentifier())) {
+            this.showAssets();
+        }
     }
 
     protected void showAssets() {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.explorer.model.URIStructureExplorerModel;
 import org.kie.workbench.common.screens.library.api.LibraryService;
+import org.kie.workbench.common.screens.library.api.ProjectAssetListUpdated;
 import org.kie.workbench.common.screens.library.client.events.AssetDetailEvent;
 import org.kie.workbench.common.screens.library.client.events.WorkbenchProjectMetricsEvent;
 import org.kie.workbench.common.screens.library.client.perspective.LibraryPerspective;
@@ -152,6 +153,9 @@ public class LibraryPlacesTest {
     @Mock
     private WorkspaceProjectContextChangeEvent current;
 
+    @Mock
+    private Event<ProjectAssetListUpdated> assetListUpdateEvent;
+
     @Captor
     private ArgumentCaptor<WorkspaceProjectContextChangeEvent> projectContextChangeEventArgumentCaptor;
 
@@ -189,7 +193,8 @@ public class LibraryPlacesTest {
                                               vfsServiceCaller,
                                               projectScopedResolutionStrategySupplier,
                                               preferencesCentralInitializationEvent,
-                                              importRepositoryPopUpPresenters));
+                                              importRepositoryPopUpPresenters,
+                                              assetListUpdateEvent));
         libraryPlaces.setup();
 
         verify(libraryToolBarView).getElement();

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultLuceneConfigProducer.java
@@ -21,7 +21,9 @@ import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -34,6 +36,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNa
 import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
+import org.uberfire.ext.metadata.event.BatchIndexEvent;
 import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 
 /**
@@ -45,6 +48,9 @@ public class DefaultLuceneConfigProducer {
 
     private MetadataConfig config;
 
+    @Inject
+    private Event<BatchIndexEvent> batchIndexEvent;
+
     @PostConstruct
     public void setup() {
         final Map<String, Analyzer> analyzers = getAnalyzers();
@@ -53,6 +59,7 @@ public class DefaultLuceneConfigProducer {
                 .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
                 .useDirectoryBasedIndex()
                 .useNIODirectory()
+                .useCDIBatchIndexObserver(batchIndexEvent)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/backend/DefaultLuceneConfigProducer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/backend/DefaultLuceneConfigProducer.java
@@ -21,7 +21,9 @@ import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -32,6 +34,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.ModuleRoo
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.uberfire.ext.metadata.MetadataConfig;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.event.BatchIndexEvent;
 import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 
 /**
@@ -43,6 +46,9 @@ public class DefaultLuceneConfigProducer {
 
     private MetadataConfig config;
 
+    @Inject
+    private Event<BatchIndexEvent> batchIndexEvent;
+
     @PostConstruct
     public void setup() {
         final Map<String, Analyzer> analyzers = getAnalyzers();
@@ -51,6 +57,7 @@ public class DefaultLuceneConfigProducer {
                 .usingAnalyzerWrapperFactory(ImpactAnalysisAnalyzerWrapperFactory.getInstance())
                 .useDirectoryBasedIndex()
                 .useNIODirectory()
+                .useCDIBatchIndexObserver(batchIndexEvent)
                 .build();
     }
 


### PR DESCRIPTION
A fix for AF-985 and a forward port of RHDM-382 are bundled together in this PR as they both affect related code.

The AF-985 fix will cause the project screen to reload whenever a place request to it is made, even if it is already in focus. This allows clicking on the breadcrumb to refresh.