### PR TITLE
Project explorer download zip fix

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/ExplorerMenuViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/ExplorerMenuViewImpl.java
@@ -49,8 +49,6 @@ public class ExplorerMenuViewImpl
     private final AnchorListItem treeExplorer = new AnchorListItem(ProjectExplorerConstants.INSTANCE.showAsFolders());
     private final AnchorListItem breadcrumbExplorer = new AnchorListItem(ProjectExplorerConstants.INSTANCE.showAsLinks());
     private final AnchorListItem showTagFilter = new AnchorListItem(ProjectExplorerConstants.INSTANCE.enableTagFiltering());
-    private final AnchorListItem archiveRepository = new AnchorListItem(ProjectExplorerConstants.INSTANCE.downloadRepository());
-
     private final AnchorListItem archiveProject = new AnchorListItem(ProjectExplorerConstants.INSTANCE.downloadProject());
 
     private ExplorerMenu presenter;
@@ -107,14 +105,6 @@ public class ExplorerMenuViewImpl
             @Override
             public void onClick(ClickEvent event) {
                 presenter.onArchiveActiveProject();
-            }
-        });
-
-        archiveRepository.setIcon(IconType.DOWNLOAD);
-        archiveRepository.addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent event) {
-                presenter.onArchiveActiveRepository();
             }
         });
     }
@@ -201,7 +191,6 @@ public class ExplorerMenuViewImpl
                                         add(showTagFilter);
                                         add(new Divider());
                                         add(archiveProject);
-                                        add(archiveRepository);
                                     }});
                                 }};
                             }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/resources/i18n/ProjectExplorerConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/resources/i18n/ProjectExplorerConstants.java
@@ -69,8 +69,6 @@ public interface ProjectExplorerConstants
 
     String LoadingDotDotDot();
 
-    String downloadRepository();
-
     String downloadProject();
 
     String openProjectEditor();

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/resources/org/kie/workbench/common/screens/explorer/client/resources/i18n/ProjectExplorerConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/resources/org/kie/workbench/common/screens/explorer/client/resources/i18n/ProjectExplorerConstants.properties
@@ -34,7 +34,6 @@ showAsFolders=Show as Folders
 showAsLinks=Show as Links
 miscellaneous_files=Miscellaneous
 LoadingDotDotDot=Loading...
-downloadRepository=Download Repository
 downloadProject=Download Project
 openProjectEditor=Open Project Editor
 sort=Sort


### PR DESCRIPTION
AF-1016: [Project Oriented] Project Explorer "Download Project" no longer makes sense. "Download Project" should be what download repository was before and download repository should not be listed.

AF-1004: [Project Oriented] Downloaded repository is flattened