### PR TITLE
DROOLS-2330: [DMN Editor] Improve visual identification of selected (nested) editor

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommand.java
@@ -71,8 +71,6 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
         this.oldCellValue = extractGridCellValue(cellTuple);
     }
 
-
-
     @Override
     protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler handler) {
         return new AbstractGraphCommand() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainer.java
@@ -31,7 +31,7 @@ public class ExpressionContainer extends BaseGridWidget {
     private static final String COLUMN_GROUP = "ExpressionContainer$Expression0";
 
     public ExpressionContainer(final DMNGridLayer gridLayer) {
-        super(new DMNGridData(gridLayer),
+        super(new DMNGridData(),
               gridLayer,
               gridLayer,
               new ExpressionContainerRenderer());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -84,7 +84,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextUIModelMappe
               hasName,
               gridPanel,
               gridLayer,
-              new ContextGridData(new DMNGridData(gridLayer),
+              new ContextGridData(new DMNGridData(),
                                   sessionManager,
                                   sessionCommandManager,
                                   expression,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -86,7 +86,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
               hasName,
               gridPanel,
               gridLayer,
-              new DecisionTableGridData(new DMNGridData(gridLayer),
+              new DecisionTableGridData(new DMNGridData(),
                                         sessionManager,
                                         sessionCommandManager,
                                         expression,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
@@ -76,7 +76,7 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Conte
               hasName,
               gridPanel,
               gridLayer,
-              new FunctionSupplementaryGridData(new DMNGridData(gridLayer),
+              new FunctionSupplementaryGridData(new DMNGridData(),
                                                 sessionManager,
                                                 sessionCommandManager,
                                                 expression,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -78,7 +78,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationUIM
               hasName,
               gridPanel,
               gridLayer,
-              new InvocationGridData(new DMNGridData(gridLayer),
+              new InvocationGridData(new DMNGridData(),
                                      sessionManager,
                                      sessionCommandManager,
                                      expression,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -79,7 +79,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationUIModelMa
               hasName,
               gridPanel,
               gridLayer,
-              new RelationGridData(new DMNGridData(gridLayer),
+              new RelationGridData(new DMNGridData(),
                                    sessionManager,
                                    sessionCommandManager,
                                    expression,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -170,7 +170,7 @@ public abstract class BaseExpressionGrid<E extends Expression, M extends BaseUIM
              hasName,
              gridPanel,
              gridLayer,
-             new DMNGridData(gridLayer),
+             new DMNGridData(),
              gridRenderer,
              sessionManager,
              sessionCommandManager,
@@ -311,7 +311,14 @@ public abstract class BaseExpressionGrid<E extends Expression, M extends BaseUIM
     @Override
     public void select() {
         fireExpressionEditorSelectedEvent();
+        selectFirstCell();
         super.select();
+    }
+
+    @Override
+    public void deselect() {
+        getModel().clearSelections();
+        super.deselect();
     }
 
     protected void fireExpressionEditorSelectedEvent() {
@@ -434,7 +441,7 @@ public abstract class BaseExpressionGrid<E extends Expression, M extends BaseUIM
     public void selectFirstCell() {
         final GridData uiModel = getModel();
         if (uiModel.getRowCount() == 0 || uiModel.getColumnCount() == 0) {
-            gridLayer.clearAllSelections();
+            gridLayer.getGridWidgets().forEach(gw -> gw.getModel().clearSelections());
         }
         uiModel.getColumns()
                 .stream()

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTheme.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTheme.java
@@ -67,6 +67,8 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
 
     public static final String FONT_FAMILY_EXPRESSION = "Courier New";
 
+    public static final double STROKE_WIDTH = 1.0;
+
     @Override
     public String getName() {
         return "DMN Editor";
@@ -103,7 +105,7 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
     public MultiPath getHeaderGridLine() {
         return new MultiPath()
                 .setStrokeColor(GRID_STROKE_COLOUR)
-                .setStrokeWidth(1.0)
+                .setStrokeWidth(STROKE_WIDTH)
                 .setVisible(true);
     }
 
@@ -151,7 +153,7 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
     public MultiPath getBodyGridLine() {
         return new MultiPath()
                 .setStrokeColor(GRID_STROKE_COLOUR)
-                .setStrokeWidth(1.0)
+                .setStrokeWidth(STROKE_WIDTH)
                 .setVisible(true);
     }
 
@@ -170,7 +172,7 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
     public Rectangle getGridBoundary() {
         return new Rectangle(0, 0)
                 .setStrokeColor(GRID_STROKE_COLOUR)
-                .setStrokeWidth(1.0)
+                .setStrokeWidth(STROKE_WIDTH)
                 .setVisible(true);
     }
 
@@ -178,7 +180,7 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
     public Line getGridHeaderBodyDivider() {
         return new Line()
                 .setStrokeColor(GRID_STROKE_COLOUR)
-                .setStrokeWidth(1.0)
+                .setStrokeWidth(STROKE_WIDTH)
                 .setVisible(true);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTheme.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTheme.java
@@ -67,6 +67,8 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
 
     public static final String FONT_FAMILY_EXPRESSION = "Courier New";
 
+    public static final double SELECTOR_STROKE_WIDTH = 2.0;
+
     public static final double STROKE_WIDTH = 1.0;
 
     @Override
@@ -81,7 +83,9 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
 
     @Override
     public Rectangle getCellSelectorBorder() {
-        return new Rectangle(0, 0).setStrokeColor(HOVER_STATE_STROKE_COLOUR).setStrokeWidth(2.0);
+        return new Rectangle(0, 0)
+                .setStrokeColor(HOVER_STATE_STROKE_COLOUR)
+                .setStrokeWidth(SELECTOR_STROKE_WIDTH);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridData.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
 import java.util.function.Supplier;
 
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -26,31 +25,8 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 
 public class DMNGridData extends BaseGridData {
 
-    private final DMNGridLayer selectionManager;
-
-    public DMNGridData(final DMNGridLayer selectionManager) {
+    public DMNGridData() {
         super(false);
-        this.selectionManager = selectionManager;
-    }
-
-    @Override
-    public Range selectCell(final int rowIndex,
-                            final int columnIndex) {
-        selectionManager.clearAllSelections();
-        return super.selectCell(rowIndex,
-                                columnIndex);
-    }
-
-    @Override
-    public Range selectCells(final int rowIndex,
-                             final int columnIndex,
-                             final int width,
-                             final int height) {
-        selectionManager.clearAllSelections();
-        return super.selectCells(rowIndex,
-                                 columnIndex,
-                                 width,
-                                 height);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -16,11 +16,26 @@
 
 package org.kie.workbench.common.dmn.client.widgets.layer;
 
+import java.util.Optional;
+
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.IPathClipper;
+import com.ait.lienzo.client.core.shape.Layer;
+import com.ait.lienzo.client.core.shape.Rectangle;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.shared.core.types.ColorName;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Command;
+import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainer;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.dnd.DelegatingGridWidgetDndMouseMoveHandler;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDMouseMoveHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 
 public class DMNGridLayer extends DefaultGridLayer {
@@ -29,6 +44,89 @@ public class DMNGridLayer extends DefaultGridLayer {
 
     public void setDefaultTransformMediator(final TransformMediator defaultTransformMediator) {
         this.defaultTransformMediator = defaultTransformMediator;
+    }
+
+    @Override
+    //This is overridden as Lienzo calls to draw() when the LienzoPanel is resized
+    //which causes flickering of the 'ghosting' when an Expression type is selected
+    //from the UndefinedExpressionGrid.
+    public Layer draw() {
+        return batch();
+    }
+
+    @Override
+    public Layer batch() {
+        return batch(new GridLayerRedrawManager.PrioritizedCommand(Integer.MIN_VALUE) {
+            @Override
+            public void execute() {
+                doBatch();
+            }
+        });
+    }
+
+    Layer doBatch() {
+        final Layer layer = super.draw();
+        findExpressionContainer()
+                .ifPresent(container -> findSelectedExpressionGrid()
+                        .ifPresent(gridWidget -> addGhost(container, gridWidget)));
+
+        return layer;
+    }
+
+    Optional<ExpressionContainer> findExpressionContainer() {
+        return getGridWidgets().stream()
+                .filter(gw -> gw instanceof ExpressionContainer)
+                .map(gw -> (ExpressionContainer) gw)
+                .findFirst();
+    }
+
+    Optional<BaseExpressionGrid> findSelectedExpressionGrid() {
+        return getGridWidgets().stream()
+                .filter(GridWidget::isSelected)
+                .filter(gw -> gw instanceof BaseExpressionGrid)
+                .map(gw -> (BaseExpressionGrid) gw)
+                .findFirst();
+    }
+
+    void addGhost(final ExpressionContainer container,
+                  final BaseExpressionGrid gridWidget) {
+        GridWidget gw = gridWidget;
+        // LiteralExpression and UndefinedExpression are not handled as grids in
+        // their own right. In these circumstances use their parent GridWidget.
+        if (gridWidget instanceof LiteralExpressionGrid) {
+            gw = gridWidget.getParentInformation().getGridWidget();
+        } else if (gridWidget instanceof UndefinedExpressionGrid) {
+            gw = gridWidget.getParentInformation().getGridWidget();
+        }
+
+        //Rectangle the size of the ExpressionContainer
+        final Rectangle r = getGhostRectangle();
+        r.setWidth(container.getWidth() + BaseExpressionGridTheme.STROKE_WIDTH);
+        r.setHeight(container.getHeight() + BaseExpressionGridTheme.STROKE_WIDTH);
+        r.setFillColor(ColorName.WHITE);
+        r.setAlpha(0.50);
+        r.setListening(false);
+
+        //Clip the inner GridWidget so everything outside of it is ghosted
+        final IPathClipper clipper = new InverseGridWidgetClipper(container, gw);
+        clipper.setActive(true);
+
+        final Group g = GWT.create(Group.class);
+        final Transform transform = getViewport().getTransform();
+        g.setX(container.getX() + transform.getTranslateX());
+        g.setY(container.getY() + transform.getTranslateY());
+        g.setPathClipper(clipper);
+        g.add(r);
+
+        g.drawWithTransforms(getContext(),
+                             1.0,
+                             getStorageBounds());
+    }
+
+    // Moved to method for Unit Testing. Rectangle has no
+    // zero-argument Constructor so unable to use GWT.create(..)
+    Rectangle getGhostRectangle() {
+        return new Rectangle(0, 0);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -149,8 +149,4 @@ public class DMNGridLayer extends DefaultGridLayer {
         return new DelegatingGridWidgetDndMouseMoveHandler(this,
                                                            getGridWidgetHandlersState());
     }
-
-    public void clearAllSelections() {
-        getGridWidgets().forEach(grid -> grid.getModel().clearSelections());
-    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/InverseGridWidgetClipper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/InverseGridWidgetClipper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.layer;
+
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.shape.IPathClipper;
+import com.ait.lienzo.client.core.types.BoundingBox;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+
+public class InverseGridWidgetClipper implements IPathClipper {
+
+    private final BoundingBox outerBoundingBox;
+    private final BoundingBox innerBoundingBox;
+    private boolean isActive = false;
+
+    public InverseGridWidgetClipper(final GridWidget outer,
+                                    final GridWidget inner) {
+        this.outerBoundingBox = new BoundingBox(outer.getAbsoluteX(),
+                                                outer.getAbsoluteY(),
+                                                outer.getWidth() + BaseExpressionGridTheme.STROKE_WIDTH,
+                                                outer.getHeight() + BaseExpressionGridTheme.STROKE_WIDTH);
+        this.innerBoundingBox = new BoundingBox(inner.getAbsoluteX(),
+                                                inner.getAbsoluteY(),
+                                                inner.getAbsoluteX() + inner.getWidth() + BaseExpressionGridTheme.STROKE_WIDTH,
+                                                inner.getAbsoluteY() + inner.getHeight() + BaseExpressionGridTheme.STROKE_WIDTH);
+    }
+
+    @Override
+    public boolean clip(final Context2D context) {
+        context.beginPath();
+
+        //Left edge
+        context.rect(0,
+                     0,
+                     innerBoundingBox.getMinX(),
+                     outerBoundingBox.getHeight());
+        //Top edge
+        context.rect(innerBoundingBox.getMinX(),
+                     0,
+                     innerBoundingBox.getWidth(),
+                     innerBoundingBox.getMinY());
+        //Bottom edge
+        context.rect(innerBoundingBox.getMinX(),
+                     innerBoundingBox.getMaxY(),
+                     innerBoundingBox.getWidth(),
+                     outerBoundingBox.getMaxY() - innerBoundingBox.getMaxY());
+        //Right edge
+        context.rect(innerBoundingBox.getMaxX(),
+                     0,
+                     outerBoundingBox.getMaxX() - innerBoundingBox.getMaxX(),
+                     outerBoundingBox.getHeight());
+
+        context.clip();
+
+        return true;
+    }
+
+    @Override
+    public boolean isActive() {
+        return isActive;
+    }
+
+    @Override
+    public boolean setActive(final boolean isActive) {
+        this.isActive = isActive;
+        return isActive;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/MoveRowsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/MoveRowsCommandTest.java
@@ -30,7 +30,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.context.Exp
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.NameColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -58,9 +57,6 @@ public class MoveRowsCommandTest {
     protected static final String II1 = "ii1";
     protected static final String II2 = "ii2";
     protected static final String II3 = "ii3";
-
-    @Mock
-    protected DMNGridLayer gridLayer;
 
     @Mock
     protected RowNumberColumn uiRowNumberColumn;
@@ -92,7 +88,7 @@ public class MoveRowsCommandTest {
     @Before
     public void setup() {
         this.context = new Context();
-        this.uiModel = new DMNGridData(gridLayer);
+        this.uiModel = new DMNGridData();
         doReturn(ruleManager).when(handler).getRuleManager();
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiNameColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
@@ -31,7 +31,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -67,9 +66,6 @@ public class AddDecisionRuleCommandTest {
     private AddDecisionRuleCommand command;
 
     @Mock
-    private DMNGridLayer selectionManager;
-
-    @Mock
     private RowNumberColumn uiRowNumberColumn;
 
     @Mock
@@ -94,7 +90,7 @@ public class AddDecisionRuleCommandTest {
     public void setup() {
         this.dtable = new DecisionTable();
         this.rule = new DecisionRule();
-        this.uiModel = new DMNGridData(selectionManager);
+        this.uiModel = new DMNGridData();
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.uiModelRow = new DMNGridRow();
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.UnaryTests;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.DecisionTableUIModelMapper;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.InputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -50,9 +49,6 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddInputClauseCommandTest {
-
-    @Mock
-    private DMNGridLayer selectionManager;
 
     @Mock
     private RowNumberColumn uiRowNumberColumn;
@@ -82,7 +78,7 @@ public class AddInputClauseCommandTest {
     @Before
     public void setUp() throws Exception {
         this.dtable = new DecisionTable();
-        this.uiModel = new DMNGridData(selectionManager);
+        this.uiModel = new DMNGridData();
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.inputClause = new InputClause();
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -32,7 +32,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Deci
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.InputClauseColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -53,9 +52,6 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddOutputClauseCommandTest {
-
-    @Mock
-    private DMNGridLayer selectionManager;
 
     @Mock
     private RowNumberColumn uiRowNumberColumn;
@@ -88,7 +84,7 @@ public class AddOutputClauseCommandTest {
     @Before
     public void setUp() throws Exception {
         this.dtable = new DecisionTable();
-        this.uiModel = new DMNGridData(selectionManager);
+        this.uiModel = new DMNGridData();
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.outputClause = new OutputClause();
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommandTest.java
@@ -32,7 +32,6 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.UnaryTests;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.InputClauseColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -50,9 +49,6 @@ import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MoveColumnsCommandTest {
-
-    @Mock
-    private DMNGridLayer selectionManager;
 
     @Mock
     private RowNumberColumn uiRowNumberColumn;
@@ -115,7 +111,7 @@ public class MoveColumnsCommandTest {
     @Before
     public void setUp() throws Exception {
         this.dtable = new DecisionTable();
-        this.uiModel = new DMNGridData(selectionManager);
+        this.uiModel = new DMNGridData();
 
         dtable.getInput().add(inputClauseOne);
         dtable.getInput().add(inputClauseTwo);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveRowsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveRowsCommandTest.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -50,9 +49,6 @@ import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MoveRowsCommandTest {
-
-    @Mock
-    private DMNGridLayer selectionManager;
 
     @Mock
     private DecisionTableRowNumberColumn uiRowNumberColumn;
@@ -93,7 +89,7 @@ public class MoveRowsCommandTest {
     @Before
     public void setUp() throws Exception {
         this.dtable = new DecisionTable();
-        this.uiModel = new DMNGridData(selectionManager);
+        this.uiModel = new DMNGridData();
 
         dtable.getInput().add(inputClause);
         dtable.getOutput().add(outputClause);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/supplementary/MoveRowsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/supplementary/MoveRowsCommandTest.java
@@ -31,7 +31,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.function.su
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -58,9 +57,6 @@ public class MoveRowsCommandTest {
 
     protected static final String II1 = "ii1";
     protected static final String II2 = "ii2";
-
-    @Mock
-    protected DMNGridLayer gridLayer;
 
     @Mock
     protected RowNumberColumn uiRowNumberColumn;
@@ -95,7 +91,7 @@ public class MoveRowsCommandTest {
     @Before
     public void setup() {
         this.context = new Context();
-        this.uiModel = new DMNGridData(gridLayer);
+        this.uiModel = new DMNGridData();
         doReturn(ruleManager).when(handler).getRuleManager();
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiNameColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/MoveRowsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/MoveRowsCommandTest.java
@@ -30,7 +30,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.context.Exp
 import org.kie.workbench.common.dmn.client.editors.expressions.types.invocation.NameColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -58,9 +57,6 @@ public class MoveRowsCommandTest {
     protected static final String II1 = "ii1";
     protected static final String II2 = "ii2";
     protected static final String II3 = "ii3";
-
-    @Mock
-    protected DMNGridLayer gridLayer;
 
     @Mock
     protected RowNumberColumn uiRowNumberColumn;
@@ -92,7 +88,7 @@ public class MoveRowsCommandTest {
     @Before
     public void setup() {
         this.invocation = new Invocation();
-        this.uiModel = new DMNGridData(gridLayer);
+        this.uiModel = new DMNGridData();
         doReturn(ruleManager).when(handler).getRuleManager();
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiNameColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/BaseMoveCommandsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/BaseMoveCommandsTest.java
@@ -24,7 +24,6 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
@@ -38,9 +37,6 @@ public abstract class BaseMoveCommandsTest<C extends AbstractCanvasGraphCommand>
 
     protected static final String II1 = "ii1";
     protected static final String II2 = "ii2";
-
-    @Mock
-    protected DMNGridLayer gridLayer;
 
     @Mock
     protected RowNumberColumn uiRowNumberColumn;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommandTest.java
@@ -47,7 +47,7 @@ public class MoveColumnsCommandTest extends BaseMoveCommandsTest<MoveColumnsComm
     @Before
     public void setup() {
         this.relation = new Relation();
-        this.uiModel = new DMNGridData(gridLayer);
+        this.uiModel = new DMNGridData();
         doReturn(ruleManager).when(handler).getRuleManager();
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiModelColumn1).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveRowsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveRowsCommandTest.java
@@ -47,7 +47,7 @@ public class MoveRowsCommandTest extends BaseMoveCommandsTest<MoveRowsCommand> {
     @Before
     public void setup() {
         this.relation = new Relation();
-        this.uiModel = new DMNGridData(gridLayer);
+        this.uiModel = new DMNGridData();
         doReturn(ruleManager).when(handler).getRuleManager();
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiModelColumn1).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
@@ -104,7 +104,7 @@ public class CommandUtilsTest {
 
         rowsToMove.clear();
 
-        uiModel = new DMNGridData(gridLayer);
+        uiModel = new DMNGridData();
         gridWidget = new BaseGridWidget(uiModel,
                                         selectionManager,
                                         pinnedModeManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridDataTest.java
@@ -27,7 +27,6 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.dtable.MoveColumnsCommand;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.dtable.MoveRowsCommand;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -53,9 +52,6 @@ public class DecisionTableGridDataTest {
     private GridColumn gridColumn;
 
     @Mock
-    private DMNGridLayer gridLayer;
-
-    @Mock
     private SessionManager sessionManager;
 
     @Mock
@@ -78,7 +74,7 @@ public class DecisionTableGridDataTest {
 
     @Before
     public void setup() {
-        this.delegate = spy(new DMNGridData(gridLayer));
+        this.delegate = spy(new DMNGridData());
         this.uiModel = new DecisionTableGridData(delegate,
                                                  sessionManager,
                                                  sessionCommandManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridDataTest.java
@@ -27,7 +27,6 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.context.MoveRowsCommand;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.relation.MoveColumnsCommand;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -55,9 +54,6 @@ public class RelationGridDataTest {
     private GridColumn gridColumn;
 
     @Mock
-    private DMNGridLayer gridLayer;
-
-    @Mock
     private SessionManager sessionManager;
 
     @Mock
@@ -80,7 +76,7 @@ public class RelationGridDataTest {
 
     @Before
     public void setup() {
-        this.delegate = spy(new DMNGridData(gridLayer));
+        this.delegate = spy(new DMNGridData());
         this.uiModel = new RelationGridData(delegate,
                                             sessionManager,
                                             sessionCommandManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
+import org.kie.workbench.common.dmn.client.events.ExpressionEditorSelectedEvent;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorControls;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridCell;
@@ -47,6 +48,8 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.Gr
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
@@ -165,6 +168,29 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     public void testGetLayerGridNotAttachedToLayer() {
         assertEquals(gridLayer,
                      grid.getLayer());
+    }
+
+    @Test
+    public void testSelect() {
+        grid.select();
+
+        verify(editorSelectedEvent).fire(any(ExpressionEditorSelectedEvent.class));
+
+        verify(grid).selectFirstCell();
+    }
+
+    @Test
+    public void testDeselect() {
+        grid.getModel().appendRow(new DMNGridRow());
+        appendColumns(GridColumn.class);
+        
+        //Select a cell so we can check deselection clears selections
+        grid.getModel().selectCell(0, 0);
+        assertFalse(grid.getModel().getSelectedCells().isEmpty());
+
+        grid.deselect();
+
+        assertTrue(grid.getModel().getSelectedCells().isEmpty());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/BaseDOMElementSingletonColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/BaseDOMElementSingletonColumnTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -51,9 +50,6 @@ public abstract class BaseDOMElementSingletonColumnTest<F extends BaseSingletonD
     @Mock
     protected GridBodyCellRenderContext context;
 
-    @Mock
-    protected DMNGridLayer gridLayer;
-
     @Captor
     protected ArgumentCaptor<Callback<D>> domElementOnCreationCallbackCaptor;
 
@@ -74,7 +70,7 @@ public abstract class BaseDOMElementSingletonColumnTest<F extends BaseSingletonD
 
     @Before
     public void setup() {
-        this.model = new DMNGridData(gridLayer);
+        this.model = new DMNGridData();
         this.factory = getFactory();
         this.domElement = getDomElement();
         this.widget = getWidget();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridDataTest.java
@@ -24,7 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionEditorColumn;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
@@ -32,7 +31,6 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,14 +43,11 @@ public class DMNGridDataTest {
     @Mock
     private DMNGridCell uiCell;
 
-    private DMNGridLayer gridLayer;
-
     private DMNGridData uiModel;
 
     @Before
     public void setup() {
-        this.gridLayer = spy(new DMNGridLayer());
-        this.uiModel = new DMNGridData(gridLayer);
+        this.uiModel = new DMNGridData();
         IntStream.range(0, 3).forEach(i -> uiModel.appendRow(new DMNGridRow()));
         IntStream.range(0, 2).forEach(i -> {
             final DMNGridColumn uiColumn = mock(DMNGridColumn.class);
@@ -70,8 +65,6 @@ public class DMNGridDataTest {
         assertThat(r.getMinRowIndex()).isEqualTo(0);
         assertThat(r.getMaxRowIndex()).isEqualTo(0);
 
-        verify(gridLayer).clearAllSelections();
-
         final List<GridData.SelectedCell> selections = uiModel.getSelectedCells();
 
         assertThat(selections).isNotEmpty();
@@ -86,8 +79,6 @@ public class DMNGridDataTest {
 
         assertThat(r.getMinRowIndex()).isEqualTo(0);
         assertThat(r.getMaxRowIndex()).isEqualTo(0);
-
-        verify(gridLayer).clearAllSelections();
 
         final List<GridData.SelectedCell> selections = uiModel.getSelectedCells();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
@@ -26,6 +26,7 @@ import com.ait.lienzo.client.core.shape.Rectangle;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.shared.core.types.ColorName;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwtmockito.GwtMockito;
 import org.junit.Before;
@@ -168,6 +169,10 @@ public class DMNGridLayerTest {
 
         verify(ghostRectangle).setWidth(eq(CONTAINER_WIDTH + BaseExpressionGridTheme.STROKE_WIDTH));
         verify(ghostRectangle).setHeight(eq(CONTAINER_HEIGHT + BaseExpressionGridTheme.STROKE_WIDTH));
+        verify(ghostRectangle).setFillColor(ColorName.WHITE);
+        verify(ghostRectangle).setAlpha(0.50);
+        verify(ghostRectangle).setListening(false);
+
         verify(ghostGroup).setX(CONTAINER_X + VIEWPORT_TRANSLATE_X);
         verify(ghostGroup).setY(CONTAINER_Y + VIEWPORT_TRANSLATE_Y);
         verify(ghostGroup).setPathClipper(any(InverseGridWidgetClipper.class));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
@@ -16,26 +16,176 @@
 
 package org.kie.workbench.common.dmn.client.widgets.layer;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.Rectangle;
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.BoundingBox;
+import com.ait.lienzo.client.core.types.Transform;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwtmockito.GwtMockito;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainer;
 import org.kie.workbench.common.dmn.client.widgets.dnd.DelegatingGridWidgetDndMouseMoveHandler;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class DMNGridLayerTest {
+
+    private static final double CONTAINER_WIDTH = 1000.0;
+
+    private static final double CONTAINER_HEIGHT = 500.0;
+
+    private static final double CONTAINER_X = 25.0;
+
+    private static final double CONTAINER_Y = 50.0;
+
+    private static final double VIEWPORT_TRANSLATE_X = 15.0;
+
+    private static final double VIEWPORT_TRANSLATE_Y = 35.0;
+
+    @Mock
+    private Context2D context2D;
+
+    @Mock
+    private ExpressionContainer container;
+
+    @Mock
+    private BaseExpressionGrid expressionGrid;
+
+    @Mock
+    private Viewport viewport;
+
+    @Mock
+    private Transform transform;
+
+    @Mock
+    private Group ghostGroup;
+
+    @Mock
+    private Rectangle ghostRectangle;
+
+    @Captor
+    private ArgumentCaptor<GridLayerRedrawManager.PrioritizedCommand> drawCommand;
 
     private DMNGridLayer gridLayer;
 
     @Before
     public void setup() {
-        this.gridLayer = new DMNGridLayer();
+        this.gridLayer = spy(new TestDMNGridLayer(context2D));
+
+        doReturn(viewport).when(gridLayer).getViewport();
+        when(viewport.getTransform()).thenReturn(transform);
+        when(container.getWidth()).thenReturn(CONTAINER_WIDTH);
+        when(container.getHeight()).thenReturn(CONTAINER_HEIGHT);
+        when(container.getX()).thenReturn(CONTAINER_X);
+        when(container.getY()).thenReturn(CONTAINER_Y);
+        when(transform.getTranslateX()).thenReturn(VIEWPORT_TRANSLATE_X);
+        when(transform.getTranslateY()).thenReturn(VIEWPORT_TRANSLATE_Y);
     }
 
     @Test
     public void checkGridWidgetDnDMouseMoveHandler() {
         assertTrue(gridLayer.getGridWidgetDnDMouseMoveHandler() instanceof DelegatingGridWidgetDndMouseMoveHandler);
+    }
+
+    @Test
+    public void testDrawDelegatesToBatch() {
+        gridLayer.draw();
+
+        verify(gridLayer).batch();
+    }
+
+    @Test
+    public void testBatchDelegatesToDoBatch() {
+        gridLayer.batch();
+
+        verify(gridLayer).batch(drawCommand.capture());
+
+        drawCommand.getValue().execute();
+
+        verify(gridLayer).doBatch();
+    }
+
+    @Test
+    public void testNoGhostAddedWhenNoContainerFound() {
+        gridLayer.doBatch();
+
+        verify(gridLayer, never()).findSelectedExpressionGrid();
+        verify(gridLayer, never()).addGhost(any(ExpressionContainer.class), any(BaseExpressionGrid.class));
+    }
+
+    @Test
+    public void testNoGhostAddedWhenContainerFoundButNoExpressionGridFound() {
+        doReturn(Collections.singleton(container)).when(gridLayer).getGridWidgets();
+
+        gridLayer.doBatch();
+
+        verify(gridLayer).findSelectedExpressionGrid();
+        verify(gridLayer, never()).addGhost(any(ExpressionContainer.class), any(BaseExpressionGrid.class));
+    }
+
+    @Test
+    public void testGhostAddedWhenContainerFoundAndExpressionGridFound() {
+        doReturn(new HashSet<>(Arrays.asList(container, expressionGrid))).when(gridLayer).getGridWidgets();
+        when(expressionGrid.isSelected()).thenReturn(true);
+
+        gridLayer.doBatch();
+
+        verify(gridLayer).findSelectedExpressionGrid();
+        verify(gridLayer).addGhost(eq(container), eq(expressionGrid));
+    }
+
+    @Test
+    public void testGhostRendering() {
+        GwtMockito.useProviderForType(Group.class, clazz -> ghostGroup);
+        doReturn(new HashSet<>(Arrays.asList(container, expressionGrid))).when(gridLayer).getGridWidgets();
+        doReturn(ghostRectangle).when(gridLayer).getGhostRectangle();
+        when(expressionGrid.isSelected()).thenReturn(true);
+
+        gridLayer.doBatch();
+
+        verify(ghostRectangle).setWidth(eq(CONTAINER_WIDTH + BaseExpressionGridTheme.STROKE_WIDTH));
+        verify(ghostRectangle).setHeight(eq(CONTAINER_HEIGHT + BaseExpressionGridTheme.STROKE_WIDTH));
+        verify(ghostGroup).setX(CONTAINER_X + VIEWPORT_TRANSLATE_X);
+        verify(ghostGroup).setY(CONTAINER_Y + VIEWPORT_TRANSLATE_Y);
+        verify(ghostGroup).setPathClipper(any(InverseGridWidgetClipper.class));
+        verify(ghostGroup).add(ghostRectangle);
+        verify(ghostGroup).drawWithTransforms(eq(context2D), anyDouble(), any(BoundingBox.class));
+    }
+
+    private static class TestDMNGridLayer extends DMNGridLayer {
+
+        private Context2D context2D;
+
+        private TestDMNGridLayer(final Context2D context2D) {
+            this.context2D = context2D;
+        }
+
+        @Override
+        public Context2D getContext() {
+            return context2D;
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/InverseGridWidgetClipperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/InverseGridWidgetClipperTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.layer;
+
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class InverseGridWidgetClipperTest {
+
+    private static final double OUTER_WIDTH = 1000.0;
+
+    private static final double OUTER_HEIGHT = 500.0;
+
+    private static final double OUTER_ABSOLUTE_X = 0.0;
+
+    private static final double OUTER_ABSOLUTE_Y = 0.0;
+
+    private static final double INNER_WIDTH = 200.0;
+
+    private static final double INNER_HEIGHT = 50.0;
+
+    private static final double INNER_ABSOLUTE_X = 100.0;
+
+    private static final double INNER_ABSOLUTE_Y = 75.0;
+
+    @Mock
+    private Context2D context2D;
+
+    @Mock
+    private GridWidget outer;
+
+    @Mock
+    private GridWidget inner;
+
+    private InverseGridWidgetClipper clipper;
+
+    @Test
+    public void testIsActive() {
+        clipper = new InverseGridWidgetClipper(outer, inner);
+
+        clipper.setActive(true);
+
+        assertThat(clipper.isActive()).isTrue();
+
+        clipper.setActive(false);
+
+        assertThat(clipper.isActive()).isFalse();
+    }
+
+    @Test
+    public void testClip() {
+        setupClipper(OUTER_WIDTH, OUTER_HEIGHT, OUTER_ABSOLUTE_X, OUTER_ABSOLUTE_Y,
+                     INNER_WIDTH, INNER_HEIGHT, INNER_ABSOLUTE_X, INNER_ABSOLUTE_Y);
+
+        clipper.clip(context2D);
+
+        verify(context2D).beginPath();
+
+        //Left edge
+        verify(context2D).rect(eq(OUTER_ABSOLUTE_X),
+                               eq(OUTER_ABSOLUTE_Y),
+                               eq(INNER_ABSOLUTE_X),
+                               eq(OUTER_HEIGHT + BaseExpressionGridTheme.STROKE_WIDTH));
+
+        //Top edge
+        verify(context2D).rect(eq(INNER_ABSOLUTE_X),
+                               eq(OUTER_ABSOLUTE_Y),
+                               eq(INNER_WIDTH + BaseExpressionGridTheme.STROKE_WIDTH),
+                               eq(INNER_ABSOLUTE_Y));
+
+        //Bottom edge
+        verify(context2D).rect(eq(INNER_ABSOLUTE_X),
+                               eq(INNER_ABSOLUTE_Y + INNER_HEIGHT + BaseExpressionGridTheme.STROKE_WIDTH),
+                               eq(INNER_WIDTH + BaseExpressionGridTheme.STROKE_WIDTH),
+                               eq(OUTER_ABSOLUTE_Y + OUTER_HEIGHT - (INNER_ABSOLUTE_Y + INNER_HEIGHT)));
+
+        //Right edge
+        verify(context2D).rect(eq(INNER_ABSOLUTE_X + INNER_WIDTH + BaseExpressionGridTheme.STROKE_WIDTH),
+                               eq(OUTER_ABSOLUTE_Y),
+                               eq(OUTER_ABSOLUTE_X + OUTER_WIDTH - (INNER_ABSOLUTE_X + INNER_WIDTH)),
+                               eq(OUTER_HEIGHT + BaseExpressionGridTheme.STROKE_WIDTH));
+
+        verify(context2D).clip();
+    }
+
+    private void setupClipper(final double outerWidth,
+                              final double outerHeight,
+                              final double outerAbsoluteX,
+                              final double outerAbsoluteY,
+                              final double innerWidth,
+                              final double innerHeight,
+                              final double innerAbsoluteX,
+                              final double innerAbsoluteY) {
+        when(outer.getWidth()).thenReturn(outerWidth);
+        when(outer.getHeight()).thenReturn(outerHeight);
+        when(outer.getAbsoluteX()).thenReturn(outerAbsoluteX);
+        when(outer.getAbsoluteY()).thenReturn(outerAbsoluteY);
+
+        when(inner.getWidth()).thenReturn(innerWidth);
+        when(inner.getHeight()).thenReturn(innerHeight);
+        when(inner.getAbsoluteX()).thenReturn(innerAbsoluteX);
+        when(inner.getAbsoluteY()).thenReturn(innerAbsoluteY);
+
+        clipper = new InverseGridWidgetClipper(outer, inner);
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2330

This PR changes the opacity of the deselected grids.

![drools-2330](https://user-images.githubusercontent.com/497544/36591033-8174615a-1888-11e8-9986-946e017704eb.png)
