### PR TITLE
Restoring duplicate and reimport functions to the project

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
@@ -403,8 +403,6 @@ public class ExamplesServiceImpl implements ExamplesService {
             } catch (IOException ioe) {
                 logger.error("Unable to create Example(s).",
                              ioe);
-            } finally {
-                ioService.endBatch();
             }
         }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
@@ -403,4 +403,10 @@ public class LibraryConstants {
 
     @TranslationKey(defaultValue = "")
     public static final String PreferenceDisableGAVConflictCheck_Tooltip = "PreferenceDisableGAVConflictCheck.Tooltip";
+
+    @TranslationKey(defaultValue = "")
+    public static final String ItemSuccessfullyDuplicated = "ItemSuccessfullyDuplicated";
+
+    @TranslationKey(defaultValue = "")
+    public static final String ReimportSuccessful = "ReimportSuccessful";
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectView.html
@@ -34,7 +34,8 @@
                             <li><a data-field="add-asset" data-i18n-key="AddAsset"></a></li>
                             <li><a data-field="import-asset" data-i18n-key="ImportAsset"></a></li>
                             <li><a data-field="edit-contributors" data-i18n-key="EditContributors"></a></li>
-                            <li hidden><a data-field="duplicate" data-i18n-key="Duplicate"></a></li>
+                            <li><a data-field="duplicate" data-i18n-key="Duplicate"></a></li>
+                            <li><a data-field="reimport" data-i18n-key="Reimport"></a></li>
                             <li hidden><a data-field="rename" data-i18n-key="Rename"></a></li>
                             <li><a data-field="delete-project" data-i18n-key="Delete"></a></li>
                         </ul>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectView.java
@@ -27,9 +27,11 @@ import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLLIElement;
 import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.screens.library.client.resources.i18n.LibraryConstants;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
@@ -40,6 +42,9 @@ public class ProjectView implements ProjectScreen.View,
 
     public static final String ACTIVE = "active";
     private ProjectScreen presenter;
+
+    @Inject
+    private TranslationService translationService;
 
     @Inject
     private Elemental2DomUtil domUtil;
@@ -115,6 +120,14 @@ public class ProjectView implements ProjectScreen.View,
     private HTMLAnchorElement editContributors;
 
     @Inject
+    @DataField("duplicate")
+    private HTMLAnchorElement duplicate;
+
+    @Inject
+    @DataField("reimport")
+    private HTMLAnchorElement reimport;
+
+    @Inject
     @DataField("build")
     private HTMLButtonElement build;
 
@@ -171,6 +184,21 @@ public class ProjectView implements ProjectScreen.View,
     @Override
     public void setDeleteProjectVisible(boolean visible) {
         this.deleteProject.hidden = !visible;
+    }
+
+    @Override
+    public String getLoadingMessage() {
+        return translationService.getTranslation(LibraryConstants.Loading);
+    }
+
+    @Override
+    public String getItemSuccessfullyDuplicatedMessage() {
+        return translationService.getTranslation(LibraryConstants.ItemSuccessfullyDuplicated);
+    }
+
+    @Override
+    public String getReimportSuccessfulMessage() {
+        return translationService.getTranslation(LibraryConstants.ReimportSuccessful);
     }
 
     @Override
@@ -239,6 +267,16 @@ public class ProjectView implements ProjectScreen.View,
     @EventHandler("add-asset")
     public void addAsset(final ClickEvent event) {
         presenter.addAsset();
+    }
+
+    @EventHandler("duplicate")
+    public void duplicate(final ClickEvent event) {
+        presenter.duplicate();
+    }
+
+    @EventHandler("reimport")
+    public void reimport(final ClickEvent event) {
+        presenter.reimport();
     }
 
     private void activate(HTMLLIElement element) {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/Library.properties
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/Library.properties
@@ -433,3 +433,5 @@ ShowAuthenticationOptions=Show Authentication Options
 HideAuthenticationOptions=Hide Authentication Options
 UserName=User Name
 Password=Password
+ItemSuccessfullyDuplicated=Item successfully duplicated.
+ReimportSuccessful=Reimport successful.

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenTestBase.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/ProjectScreenTestBase.java
@@ -90,6 +90,8 @@ public class ProjectScreenTestBase {
         doReturn("mainModuleName").when(module).getModuleName();
         doReturn("modulePath").when(module).getIdentifier();
         doReturn(rootPath).when(module).getRootPath();
+        final Path pomPath = mock(Path.class);
+        doReturn(pomPath).when(module).getPomXMLPath();
 
         final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
         final Repository repository = mock(Repository.class);

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectScreenTest.java
@@ -17,9 +17,12 @@
 
 package org.kie.workbench.common.screens.library.client.screens.project;
 
+import javax.enterprise.event.Event;
+
 import elemental2.dom.HTMLElement;
 import org.guvnor.common.services.project.client.security.ProjectController;
 import org.guvnor.structure.client.security.OrganizationalUnitController;
+import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,11 +39,19 @@ import org.kie.workbench.common.screens.library.client.screens.project.rename.Re
 import org.kie.workbench.common.screens.library.client.settings.SettingsPresenter;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
 import org.kie.workbench.common.screens.projecteditor.client.build.BuildExecutor;
+import org.kie.workbench.common.screens.projecteditor.client.validation.ProjectNameValidator;
+import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.popups.CopyPopUpPresenter;
+import org.uberfire.ext.editor.commons.client.file.popups.CopyPopUpView;
 import org.uberfire.mocks.CallerMock;
+import org.uberfire.promise.SyncPromises;
+import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.mockito.Mockito.*;
 
@@ -106,8 +117,25 @@ public class ProjectScreenTest extends ProjectScreenTestBase {
     @Mock
     private SettingsPresenter settingsPresenter;
 
+    @Mock
+    private ProjectScreenService projectScreenService;
+    private Caller<ProjectScreenService> projectScreenServiceCaller;
+
+    @Mock
+    private CopyPopUpPresenter copyPopUpPresenter;
+
+    @Mock
+    private ProjectNameValidator projectNameValidator;
+
+    @Mock
+    private Event<NotificationEvent> notificationEvent;
+
+    private SyncPromises promises;
+
     @Before
     public void setUp() {
+        projectScreenServiceCaller = new CallerMock<>(projectScreenService);
+        promises = spy(new SyncPromises());
 
         when(editContributorsPopUpPresenterInstance.get()).thenReturn(editContributorsPopUpPresenter);
         when(deleteProjectPopUpScreenInstance.get()).thenReturn(deleteProjectPopUpScreen);
@@ -128,7 +156,12 @@ public class ProjectScreenTest extends ProjectScreenTestBase {
                                                this.editContributorsPopUpPresenterInstance,
                                                this.deleteProjectPopUpScreenInstance,
                                                this.renameProjectPopUpScreenInstance,
-                                               new CallerMock<>(this.libraryService)));
+                                               new CallerMock<>(this.libraryService),
+                                               projectScreenServiceCaller,
+                                               copyPopUpPresenter,
+                                               projectNameValidator,
+                                               promises,
+                                               notificationEvent));
 
         this.presenter.workspaceProject = createProject();
     }
@@ -247,6 +280,70 @@ public class ProjectScreenTest extends ProjectScreenTestBase {
             this.presenter.build();
             verify(this.buildExecutor,
                    times(1)).triggerBuild();
+        }
+    }
+
+    @Test
+    public void testDuplicate() {
+        {
+            doReturn(false).when(this.presenter).userCanCreateProjects();
+            this.presenter.duplicate();
+            verify(this.copyPopUpPresenter,
+                   never()).show(any(),
+                                 any(),
+                                 any());
+        }
+        {
+            doReturn(true).when(this.presenter).userCanCreateProjects();
+            CommandWithFileNameAndCommitMessage duplicateCommand = mock(CommandWithFileNameAndCommitMessage.class);
+            doReturn(duplicateCommand).when(presenter).getDuplicateCommand();
+            this.presenter.duplicate();
+            verify(this.copyPopUpPresenter).show(presenter.workspaceProject.getMainModule().getPomXMLPath(),
+                                                 projectNameValidator,
+                                                 duplicateCommand);
+        }
+    }
+
+    @Test
+    public void testDuplicateCommand() {
+        doNothing().when(projectScreenService).copy(any(),
+                                                    any());
+        final CopyPopUpView copyPopUpView = mock(CopyPopUpView.class);
+        doReturn(copyPopUpView).when(copyPopUpPresenter).getView();
+
+        this.presenter.getDuplicateCommand().execute(new FileNameAndCommitMessage("newFileName",
+                                                                                  "commitMessage"));
+
+        verify(copyPopUpView).hide();
+        verify(view).showBusyIndicator(anyString());
+        verify(projectScreenService).copy(presenter.workspaceProject,
+                                          "newFileName");
+        verify(view).hideBusyIndicator();
+        verify(notificationEvent).fire(any());
+        verify(promises).resolve();
+    }
+
+    @Test
+    public void testReimport() {
+        {
+            doReturn(false).when(this.presenter).userCanUpdateProject();
+            this.presenter.reimport();
+            verify(this.copyPopUpPresenter,
+                   never()).show(any(),
+                                 any(),
+                                 any());
+        }
+        {
+            doNothing().when(projectScreenService).reImport(any());
+            doReturn(true).when(this.presenter).userCanUpdateProject();
+            CommandWithFileNameAndCommitMessage duplicateCommand = mock(CommandWithFileNameAndCommitMessage.class);
+            doReturn(duplicateCommand).when(presenter).getDuplicateCommand();
+            this.presenter.reimport();
+            verify(view).showBusyIndicator(anyString());
+            verify(projectScreenService).reImport(presenter.workspaceProject.getMainModule().getPomXMLPath());
+            verify(view).hideBusyIndicator();
+            verify(notificationEvent).fire(any());
+            verify(promises).resolve();
         }
     }
 }


### PR DESCRIPTION
Also fixes: 
* AF-1020: [Project Oriented] When you copy a project (in Settings > Copy) the copy modal is not closed.
* AF-1021: [Project Oriented] When you copy a project (Settings -> Copy) there is 'New Asset Name' in the modal instead of 'New Project Name'