### PR TITLE
JBPM-6817: Stunner - Embedded sub-process has the same icon in toolbox as Ad-Hoc sub-process

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/resources/BPMNSVGGlyphFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/resources/BPMNSVGGlyphFactory.java
@@ -117,12 +117,6 @@ public interface BPMNSVGGlyphFactory {
                             BPMNImageResources.INSTANCE.eventEndError().getSafeUri())
                     .build("eventEndError");
 
-    SvgDataUriGlyph INTERMEDIATE_NONE_EVENT_GLYPH =
-            SvgDataUriGlyph.Builder
-                    .create()
-                    .setUri(BPMNImageResources.INSTANCE.eventIntermediate().getSafeUri())
-                    .build();
-
     SvgDataUriGlyph INTERMEDIATE_MESSAGE_EVENT_GLYPH =
             SvgDataUriGlyph.Builder
                     .create()
@@ -186,5 +180,7 @@ public interface BPMNSVGGlyphFactory {
             SvgDataUriGlyph.Builder
                     .create()
                     .setUri(BPMNImageResources.INSTANCE.subProcessEvent().getSafeUri())
+                    .addUri("subProcessEvent",
+                            BPMNImageResources.INSTANCE.subProcessAdHoc().getSafeUri())
                     .build("subProcessEvent");
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/SubprocessShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/SubprocessShapeDef.java
@@ -48,16 +48,16 @@ public class SubprocessShapeDef extends BaseDimensionedShapeDef
     public static final Map<Class<? extends BaseSubprocess>, SvgDataUriGlyph> GLYPHS =
             new HashMap<Class<? extends BaseSubprocess>, SvgDataUriGlyph>() {{
                 put(ReusableSubprocess.class, BPMNSVGGlyphFactory.REUSABLE_SUBPROCESS_GLYPH);
-                put(EmbeddedSubprocess.class, BPMNSVGGlyphFactory.ADHOC_SUBPROCESS_GLYPH);
+                put(EmbeddedSubprocess.class, BPMNSVGGlyphFactory.EMBEDDED_SUBPROCESS_GLYPH);
                 put(EventSubprocess.class, BPMNSVGGlyphFactory.EVENT_SUBPROCESS_GLYPH);
                 put(AdHocSubprocess.class, BPMNSVGGlyphFactory.ADHOC_SUBPROCESS_GLYPH);
             }};
 
     private static HasTitle.Position getSubprocessTextPosition(final BaseSubprocess bean) {
-        if ((bean instanceof EmbeddedSubprocess) || (bean instanceof EventSubprocess) || (bean instanceof AdHocSubprocess)) {
-            return HasTitle.Position.TOP;
+        if (bean instanceof ReusableSubprocess) {
+           return HasTitle.Position.CENTER;
         } else {
-            return HasTitle.Position.CENTER;
+            return HasTitle.Position.TOP;
         }
     }
 
@@ -71,12 +71,12 @@ public class SubprocessShapeDef extends BaseDimensionedShapeDef
     @Override
     public SizeHandler<BaseSubprocess, SVGShapeView> newSizeHandler() {
         return newSizeHandlerBuilder()
-                .width(task -> task.getDimensionsSet().getWidth().getValue())
-                .height(task -> task.getDimensionsSet().getHeight().getValue())
-                .minWidth(task -> 25d)
-                .maxWidth(task -> 1200d)
-                .minHeight(task -> 25d)
-                .maxHeight(task -> 1200d)
+                .width(subprocess -> subprocess.getDimensionsSet().getWidth().getValue())
+                .height(subprocess -> subprocess.getDimensionsSet().getHeight().getValue())
+                .minWidth(subprocess -> 25d)
+                .maxWidth(subprocess -> 1200d)
+                .minHeight(subprocess -> 25d)
+                .maxHeight(subprocess -> 1200d)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/SubprocessShapeDefTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/SubprocessShapeDefTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.shape.def;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class SubprocessShapeDefTest {
+
+
+    @Test
+    public void testGlyphs() {
+        SubprocessShapeDef.GLYPHS.forEach((subprocessClass, icons) -> {
+            assertEquals(getSubprocessType(subprocessClass.getSimpleName()),
+                         getSubprocessType(icons.getValidUseRefIds().iterator().next()));
+        });
+    }
+
+    private String getSubprocessType(String value) {
+        return value.toLowerCase().replace("subprocess", "");
+    }
+}


### PR DESCRIPTION
Hi @romartin, @wmedvede,

I am accidentally found how to fix one small issue.

In general, I guess, we need some global refactoring for easier test coverage here, but I am not sure about the future about this component does it cost to refactor now or not.