### PR TITLE
AF-1043: [Project Oriented] Error on file upload in a project with spaces

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploader.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/main/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploader.java
@@ -133,7 +133,7 @@ public class NewFileUploader
                                busyIndicatorView.hideBusyIndicator();
                                presenter.complete();
                                notifySuccess();
-                               newResourceSuccessEvent.fire(new NewResourceSuccessEvent(path));
+                               newResourceSuccessEvent.fire(new NewResourceSuccessEvent(newPath));
                                placeManager.goTo(newPath);
                            },
                            () -> busyIndicatorView.hideBusyIndicator());

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/test/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploaderTest.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/test/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploaderTest.java
@@ -151,6 +151,7 @@ public class NewFileUploaderTest {
     public void testCreateSuccess() {
         final ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass(Command.class);
         final ArgumentCaptor<Path> pathArgumentCaptor = ArgumentCaptor.forClass(Path.class);
+        final ArgumentCaptor<NewResourceSuccessEvent> newResourceSuccessEventArgumentCaptor = ArgumentCaptor.forClass(NewResourceSuccessEvent.class);
 
         uploader.create(pkg,
                         "file",
@@ -175,7 +176,7 @@ public class NewFileUploaderTest {
         verify(presenter,
                times(1)).complete();
         verify(newResourceSuccessEventMock,
-               times(1)).fire(any(NewResourceSuccessEvent.class));
+               times(1)).fire(newResourceSuccessEventArgumentCaptor.capture());
         verify(placeManager,
                times(1)).goTo(pathArgumentCaptor.capture());
 
@@ -183,6 +184,9 @@ public class NewFileUploaderTest {
         final Path routedPath = pathArgumentCaptor.getValue();
         assertEquals("default://p0/src/main/resources/file.txt",
                      routedPath.toURI());
+        final NewResourceSuccessEvent newResourceSuccessEvent = newResourceSuccessEventArgumentCaptor.getValue();
+        assertEquals("default://p0/src/main/resources/file.txt",
+                     newResourceSuccessEvent.getPath().toURI());
     }
 
     @Test


### PR DESCRIPTION
The import asset was already working (on master) when the project name contained spaces. This fixes the NewResourceSuccessEvent path, which was causing a wrong breadcrumb to be shown after the import process was completed.