### PR TITLE
AF-985+: Fix duplicate loading of assets when page is updated rapidly.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/AssetQueryService.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/AssetQueryService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.library.client.screens.assets;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.client.api.messaging.Message;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.kie.workbench.common.screens.library.api.AssetQueryResult;
+import org.kie.workbench.common.screens.library.api.LibraryService;
+import org.kie.workbench.common.screens.library.api.ProjectAssetsQuery;
+
+@Dependent
+public class AssetQueryService {
+
+    private final Caller<LibraryService> libraryServiceCaller;
+
+    private Object tokenForGetProjectAssets = null;
+    private Object tokenForGetNumberOfAssets = null;
+
+    @Inject
+    public AssetQueryService(final Caller<LibraryService> libraryServiceCaller) {
+        this.libraryServiceCaller = libraryServiceCaller;
+    }
+
+    public Invoker<AssetQueryResult> getAssets(ProjectAssetsQuery query) {
+        return new Invoker<>(libraryService -> libraryService.getProjectAssets(query),
+                             () -> tokenForGetProjectAssets,
+                             newToken -> tokenForGetProjectAssets = newToken);
+    }
+
+    public Invoker<Integer> getNumberOfAssets(ProjectAssetsQuery query) {
+        return new Invoker<>(libraryService -> libraryService.getNumberOfAssets(query),
+                             () -> tokenForGetNumberOfAssets,
+                             newToken -> tokenForGetNumberOfAssets = newToken);
+    }
+
+    public class Invoker<T> {
+
+        private final Function<LibraryService, T> methodCall;
+        private final Supplier<Object> activeTokenGetter;
+        private final Consumer<Object> activeTokenSetter;
+
+        private Invoker(Function<LibraryService, T> methodCall, Supplier<Object> activeTokenGetter, Consumer<Object> activeTokenSetter) {
+            this.methodCall = methodCall;
+            this.activeTokenGetter = activeTokenGetter;
+            this.activeTokenSetter = activeTokenSetter;
+        }
+
+        public void call(RemoteCallback<T> callback, ErrorCallback<Message> errorCallback) {
+            Object token = new Object();
+            activeTokenSetter.accept(token);
+            methodCall.apply(libraryServiceCaller.call(wrap(token, callback), wrap(token, errorCallback)));
+        }
+
+        private ErrorCallback<Message> wrap(Object token, ErrorCallback<Message> errorCallback) {
+            return (msg, error) -> {
+                return validToken(token) && errorCallback != null && errorCallback.error(msg, error);
+            };
+        }
+
+        private RemoteCallback<T> wrap(Object token, RemoteCallback<T> callback) {
+            return t -> {
+                if (validToken(token)) {
+                    callback.callback(t);
+                }
+            };
+        }
+
+        private boolean validToken(Object token) {
+            return token == activeTokenGetter.get();
+        }
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/assets/AssetQueryServiceTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/assets/AssetQueryServiceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.screens.library.client.screens.assets;
+
+import org.jboss.errai.bus.client.api.messaging.Message;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.library.api.LibraryService;
+import org.kie.workbench.common.screens.library.api.ProjectAssetsQuery;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AssetQueryServiceTest {
+
+    private AssetQueryService assetQueryService;
+
+    @Mock
+    private Caller<LibraryService> caller;
+
+    @Mock
+    private LibraryService libraryService;
+
+    @Mock
+    private ProjectAssetsQuery query;
+
+    private List<RemoteCallback<?>> remoteCallbacks;
+    private List<ErrorCallback<Message>> errorCallbacks;
+
+    @Before
+    public void setup() {
+        remoteCallbacks = new ArrayList<>();
+        errorCallbacks = new ArrayList<>();
+        assetQueryService = new AssetQueryService(caller);
+
+        when(caller.call(any(), any()))
+        .then(inv -> {
+            remoteCallbacks.add(inv.getArgumentAt(0, RemoteCallback.class));
+            errorCallbacks.add(inv.getArgumentAt(1, ErrorCallback.class));
+
+            return libraryService;
+        });
+    }
+
+    @Test
+    public void onlyLatestGetAssetCallbackIsInvocable() throws Exception {
+        final boolean[] observed = { false, false };
+        assetQueryService.getAssets(query).call(ignore -> {
+            throw new AssertionError("First callback should not be invoked.");
+        }, (msg, error) -> {
+            throw new AssertionError("First error callback should not be invoked.");
+        });
+
+        assetQueryService.getAssets(query).call(ignore -> observed[0] = true, (msg, error) -> observed[1] = true);
+
+        RemoteCallback<?> firstCallback = remoteCallbacks.get(0);
+        ErrorCallback<Message> firstErrorCallback = errorCallbacks.get(0);
+        RemoteCallback<?> secondCallback = remoteCallbacks.get(1);
+        ErrorCallback<Message> secondErrorCallback = errorCallbacks.get(1);
+
+        firstCallback.callback(null);
+        firstErrorCallback.error(null, null);
+
+        secondCallback.callback(null);
+        assertTrue("Latest callback not invoked.", observed[0]);
+        secondErrorCallback.error(null, null);
+        assertTrue("Latest error callback not invoked.", observed[1]);
+    }
+
+    @Test
+    public void onlyLatestGetAssetCountCallbackIsInvocable() throws Exception {
+        final boolean[] observed = { false, false };
+        assetQueryService.getNumberOfAssets(query).call(ignore -> {
+            throw new AssertionError("First callback should not be invoked.");
+        }, (msg, error) -> {
+            throw new AssertionError("First error callback should not be invoked.");
+        });
+
+        assetQueryService.getNumberOfAssets(query).call(ignore -> observed[0] = true, (msg, error) -> observed[1] = true);
+
+        RemoteCallback<?> firstCallback = remoteCallbacks.get(0);
+        ErrorCallback<Message> firstErrorCallback = errorCallbacks.get(0);
+        RemoteCallback<?> secondCallback = remoteCallbacks.get(1);
+        ErrorCallback<Message> secondErrorCallback = errorCallbacks.get(1);
+
+        firstCallback.callback(null);
+        firstErrorCallback.error(null, null);
+
+        secondCallback.callback(null);
+        assertTrue("Latest callback not invoked.", observed[0]);
+        secondErrorCallback.error(null, null);
+        assertTrue("Latest error callback not invoked.", observed[1]);
+    }
+
+    @Test
+    public void getAssetsAndGetNumberOfAssetsDoNotEffectEachother() throws Exception {
+        final boolean[] getAssets = { false, false };
+        final boolean[] getNumberOfAssets = { false, false };
+
+        assetQueryService.getAssets(query).call(ignore -> getAssets[0] = true, (msg, error) -> getAssets[1] = true);
+        assetQueryService.getNumberOfAssets(query).call(ignore -> getNumberOfAssets[0] = true, (msg, error) -> getNumberOfAssets[1] = true);
+
+        assertFalse(getAssets[0]);
+        remoteCallbacks.get(0).callback(null);
+        assertTrue(getAssets[0]);
+
+        assertFalse(getAssets[1]);
+        errorCallbacks.get(0).error(null, null);
+        assertTrue(getAssets[1]);
+
+        assertFalse(getNumberOfAssets[0]);
+        remoteCallbacks.get(1).callback(null);
+        assertTrue(getNumberOfAssets[0]);
+
+        assertFalse(getNumberOfAssets[1]);
+        errorCallbacks.get(1).error(null, null);
+        assertTrue(getNumberOfAssets[1]);
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/assets/PopulatedAssetsScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/assets/PopulatedAssetsScreenTest.java
@@ -16,6 +16,19 @@
 
 package org.kie.workbench.common.screens.library.client.screens.assets;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -49,11 +62,6 @@ import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
 import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.category.Others;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PopulatedAssetsScreenTest extends ProjectScreenTestBase {
@@ -121,7 +129,7 @@ public class PopulatedAssetsScreenTest extends ProjectScreenTestBase {
                                                               new EventSourceMock<>(),
                                                               emptyState,
                                                               categoryUtils,
-                                                              new CallerMock<>(libraryService),
+                                                              new AssetQueryService(new CallerMock<>(libraryService)),
                                                               contextChangeEvent));
     }
 


### PR DESCRIPTION
Note that because of other changes in master, the loading popup prevents you from easily reproducing the original issue.

The easiest way I found to test this is open the chrome inspector while the asset list is loading and hide the overlay. Then you can rapidly click the project breadcrumb.