### PR TITLE
RHBA-514: migration tool window launcher

### DIFF
--- a/kie-wb-common-cli/kie-wb-common-project-migration/README.md
+++ b/kie-wb-common-cli/kie-wb-common-project-migration/README.md
@@ -12,7 +12,7 @@ To build the project, simply run
 
 This will generate a zip file in the target directory:
 
-    kie-wb-common-project-migration-$VERSION-linux.zip
+    kie-wb-common-project-migration-$VERSION-dist.zip
 
 The zip file is a standalone artifact that contains all the necessary dependencies to run the CLI tool.
 
@@ -23,7 +23,7 @@ Installing the Tool
 
 To install the tool, simply unzip it into the desired location, like so:
 
-    unzip -d $INSTALL_DIR kie-wb-common-project-migration-$VERSION-linux.zip
+    unzip -d $INSTALL_DIR kie-wb-common-project-migration-$VERSION-dist.zip
 
 This should create a directory (`kie-wb-common-project-migration-$VERSION`) in the `$INSTALL_DIR`.
 
@@ -42,7 +42,13 @@ Simple Usage
 
 The simplest way to invoke the tool is
 
+Linux -
     $TOOL_DIR/bin/migration-tool.sh -t $NIOGIT
+
+
+Windows -
+    $TOOL_DIR/bin/migration-tool.bat -t $NIOGIT
+    
 
 The tool will migrate projects in-place: when the tool finishes a successful run, the `$NIOGIT` directory will be ready for use with the new workbench.
 
@@ -55,5 +61,12 @@ The simple invocation will prompt the user to confirm before migration is attemp
 
 If you wish to run the tool without this prompt, you can add the `-b` flag like so:
 
-
+Linux -
+    ```
     $TOOL_DIR/bin/migration-tool.sh -b -t $NIOGIT
+    ```
+
+Windows -
+    ```
+    $TOOL_DIR/bin/migration-tool.bat -b -t $NIOGIT
+    ```

--- a/kie-wb-common-cli/kie-wb-common-project-migration/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-project-migration/pom.xml
@@ -102,10 +102,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
-    <!--<dependency>-->
-      <!--<groupId>org.slf4j</groupId>-->
-      <!--<artifactId>slf4j-nop</artifactId>-->
-    <!--</dependency>-->
   </dependencies>
   
   <build>

--- a/kie-wb-common-cli/kie-wb-common-project-migration/src/assembly/descriptor.xml
+++ b/kie-wb-common-cli/kie-wb-common-project-migration/src/assembly/descriptor.xml
@@ -1,13 +1,13 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-  <id>linux</id>
+  <id>dist</id>
   <formats>
     <format>zip</format>
   </formats>
   <dependencySets>
     <dependencySet>
-      <outputDirectory>/lib</outputDirectory>
+      <outputDirectory>lib</outputDirectory>
       <includes>
         <include>*:*</include>
       </includes>
@@ -16,7 +16,12 @@
   <files>
     <file>
       <source>src/main/sh/migration-tool.sh</source>
-      <outputDirectory>/bin</outputDirectory>
+      <outputDirectory>bin</outputDirectory>
+      <filtered>true</filtered>
+    </file>
+    <file>
+      <source>src/main/sh/migration-tool.bat</source>
+      <outputDirectory>bin</outputDirectory>
       <filtered>true</filtered>
     </file>
   </files>

--- a/kie-wb-common-cli/kie-wb-common-project-migration/src/main/sh/migration-tool.bat
+++ b/kie-wb-common-cli/kie-wb-common-project-migration/src/main/sh/migration-tool.bat
@@ -1,0 +1,95 @@
+@REM ----------------------------------------------------------------------------
+@REM Copyright 2018 Red Hat, Inc. and/or its affiliates.
+@REM
+@REM Licensed under the Apache License, Version 2.0, available at
+@REM http://apache.org/licenses/LICENSE-2.0
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Migration tool script
+@REM
+
+@echo off
+
+if "%OS%"=="Windows_NT" SET "SCRIPT_HOME=%~dp0.."
+if "%OS%"=="WINNT" SET "SCRIPT_HOME=%~dp0.."
+
+@REM Remove extraneous quotes from variables
+if not "%JAVA_HOME%" == "" set JAVA_HOME=%JAVA_HOME:"=%
+
+set ERROR_CODE=0
+
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" @setlocal
+if "%OS%"=="WINNT" @setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+@REM Try to infer the JAVA_HOME location from the registry
+FOR /F "skip=2 tokens=2*" %%A IN ('REG QUERY "HKLM\Software\JavaSoft\Java Runtime Environment" /v CurrentVersion') DO set CurVer=%%B
+
+FOR /F "skip=2 tokens=2*" %%A IN ('REG QUERY "HKLM\Software\JavaSoft\Java Runtime Environment\%CurVer%" /v JavaHome') DO set JAVA_HOME=%%B
+
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo ERROR: JAVA_HOME not found in your environment.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto chkJVersion
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory.
+echo JAVA_HOME = "%JAVA_HOME%"
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation
+echo.
+goto error
+
+:chkJVersion
+set PATH="%JAVA_HOME%\bin";%PATH%
+
+for /f "tokens=3" %%g in ('java -version 2^>^&1 ^| findstr /i "version"') do (
+   set JAVAVER=%%g
+)
+for /f "delims=. tokens=1-3" %%v in ("%JAVAVER%") do (
+   set JAVAVER_MINOR=%%w
+)
+
+if %JAVAVER_MINOR% geq 8 goto run
+
+echo.
+echo A Java 1.8 or higher JRE is required to run. "%JAVA_HOME%\bin\java.exe" is version %JAVAVER%
+echo.
+goto error
+@REM ==== END VALIDATION ====
+
+goto run
+
+@REM Start migration tool
+:run
+
+echo Using Java at %JAVA_HOME%
+
+"%JAVA_HOME%"\bin\java.exe -cp "%SCRIPT_HOME%\lib\*" ${mainClass} %*
+
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+if "%OS%"=="Windows_NT" @end:local
+if "%OS%"=="WINNT" @endlocal
+set ERROR_CODE=1
+
+:end
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" goto endNT
+if "%OS%"=="WINNT" goto endNT
+
+:endNT
+@endlocal & set ERROR_CODE=%ERROR_CODE%

--- a/kie-wb-common-cli/kie-wb-common-project-migration/src/main/sh/migration-tool.sh
+++ b/kie-wb-common-cli/kie-wb-common-project-migration/src/main/sh/migration-tool.sh
@@ -1,7 +1,35 @@
 #!/bin/sh
+SCRIPTDIR="`pwd`"
 
-SCRIPTDIR="`dirname $0`"
-export CLASSPATH="`find "$SCRIPTDIR/../lib" -name '*.jar' | tr '\n' ':' | sed -E 's/:$//'`"
+CLASSPATH="$SCRIPTDIR/lib/*"
 
-java ${mainClass} $@
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="`which java`"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo "  We cannot execute $JAVACMD"
+  exit 1
+fi
+JAVAVER=`"$JAVACMD" -version 2>&1`
+
+case $JAVAVER in
+*1.[8-9]*) ;;
+*1.[1-7]*)
+	echo " Error: a Java 1.8 or higher JRE is required to run Migration tool; found [$JAVACMD -version == $JAVAVER]."
+	exit 1
+ ;;
+esac
+
+exec "$JAVACMD" -cp $CLASSPATH ${mainClass} $@
 

--- a/kie-wb-common-cli/kie-wb-common-project-migration/src/main/sh/migration-tool.sh
+++ b/kie-wb-common-cli/kie-wb-common-project-migration/src/main/sh/migration-tool.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
-SCRIPTDIR="`pwd`"
+#SCRIPTDIR="cd $(dirname $0) && pwd"
+
+saveddir=`pwd`
+SCRIPT_HOME=`dirname "$0"`/..
+
+# make it fully qualified
+SCRIPTDIR=`cd "$SCRIPT_HOME" && pwd`
+cd "$saveddir"
 
 CLASSPATH="$SCRIPTDIR/lib/*"
 
@@ -31,5 +38,5 @@ case $JAVAVER in
  ;;
 esac
 
-exec "$JAVACMD" -cp $CLASSPATH ${mainClass} $@
+exec "$JAVACMD" -cp "$CLASSPATH" org.kie.workbench.common.project.MigrationTool $@
 


### PR DESCRIPTION
This PR enhances linux launcher to get proper java and removes the setting global CLASSPATH with all jars in lib folder.

Also I added Windows launcher and changed distribution zip assembly to be dist instead of only Linux.

Fixed platform dependent assembly descriptor to use absolute paths for bin and lib.