### PR TITLE
DROOLS-2389: [DMN Editor] Add proper support for 3-part QName

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
@@ -30,7 +30,10 @@ public class FunctionDefinition extends Expression implements HasExpression {
 
     public static final String DROOLS_PREFIX = "drools";
 
-    public static final QName KIND_QNAME = new QName("{" + DMNModelInstrumentedBase.URI_KIE + "}" + DROOLS_PREFIX + ":kind");
+    public static final String KIND_LOCAL_PART = "kind";
+
+    public static final QName KIND_QNAME = new QName(DMNModelInstrumentedBase.URI_KIE,
+                                                     KIND_LOCAL_PART);
 
     private Expression expression;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
@@ -17,11 +17,14 @@ package org.kie.workbench.common.dmn.api.property.dmn;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.dmn.api.property.DMNProperty;
 import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldReadOnly;
 import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldValue;
 import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.I18nMode;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.property.ReadOnly;
 import org.kie.workbench.common.stunner.core.definition.annotation.property.Value;
 
 @Portable
@@ -30,16 +33,55 @@ import org.kie.workbench.common.stunner.core.definition.annotation.property.Valu
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class QName implements DMNProperty {
 
+    public static final String NULL_NS_URI = "";
+
+    public static final String DEFAULT_NS_PREFIX = "";
+
+    @ReadOnly
+    @FieldReadOnly
+    public static final Boolean readOnly = true;
+
     @Value
     @FieldValue
     private String value;
 
+    private String namespaceURI;
+
+    private String localPart;
+
+    private String prefix;
+
     public QName() {
-        this("feel:string");
+        this(NULL_NS_URI,
+             "string",
+             "feel");
     }
 
-    public QName(final String value) {
-        this.value = value;
+    public QName(final String namespaceURI,
+                 final String localPart) {
+        this(namespaceURI,
+             localPart,
+             DEFAULT_NS_PREFIX);
+    }
+
+    public QName(final String namespaceURI,
+                 final String localPart,
+                 final String prefix) {
+        if (namespaceURI == null) {
+            this.namespaceURI = NULL_NS_URI;
+        } else {
+            this.namespaceURI = namespaceURI;
+        }
+        this.localPart = PortablePreconditions.checkNotNull("localPart", localPart);
+        this.prefix = PortablePreconditions.checkNotNull("prefix", prefix);
+
+        //For now we simply store the String representation of the QName
+        //This will change when we add support for Data Types.
+        this.value = getStringRepresentation();
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
     }
 
     public String getValue() {
@@ -50,6 +92,34 @@ public class QName implements DMNProperty {
         this.value = value;
     }
 
+    public String getNamespaceURI() {
+        return namespaceURI;
+    }
+
+    public String getLocalPart() {
+        return localPart;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    private String getStringRepresentation() {
+        if (namespaceURI.equals(NULL_NS_URI)) {
+            return localPart;
+        } else {
+            return "{" + namespaceURI + "}" + localPart;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getStringRepresentation();
+    }
+
+    /**
+     * See {@link javax.xml.namespace.QName#equals(Object)}
+     */
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -61,11 +131,21 @@ public class QName implements DMNProperty {
 
         QName qName = (QName) o;
 
-        return value != null ? value.equals(qName.value) : qName.value == null;
+        if (!namespaceURI.equals(qName.namespaceURI)) {
+            return false;
+        }
+        return localPart.equals(qName.localPart);
     }
 
+    /**
+     * See {@link javax.xml.namespace.QName#hashCode()}
+     */
     @Override
     public int hashCode() {
-        return value != null ? value.hashCode() : 0;
+        int result = namespaceURI.hashCode();
+        result = ~~result;
+        result = 31 * result + localPart.hashCode();
+        result = ~~result;
+        return result;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameTest.java
@@ -27,27 +27,40 @@ import static org.junit.Assert.assertTrue;
 
 public class QNameTest {
 
-    private static final String VALUE = "value";
+    private final static String NAMESPACE_URI = "namespace-uri";
 
-    private final static QName qName1 = new QName(VALUE);
+    private final static String LOCAL_PART = "local-part";
 
-    private final static QName qName2 = new QName(VALUE);
+    private final static String PREFIX = "prefix";
+
+    private final static QName QNAME1 = new QName(NAMESPACE_URI, LOCAL_PART, PREFIX);
+
+    private final static QName QNAME2 = new QName(NAMESPACE_URI, LOCAL_PART, PREFIX);
+
+    private final static QName QNAME3 = new QName(NAMESPACE_URI, LOCAL_PART);
 
     @Test
     public void checkEquals() {
-        assertEquals(qName1, qName2);
+        assertEquals(QNAME1, QNAME2);
+        assertEquals(QNAME1, QNAME3);
+        assertEquals(QNAME2, QNAME3);
 
-        assertNotEquals(qName1, FunctionDefinition.KIND_QNAME);
+        assertNotEquals(QNAME1, FunctionDefinition.KIND_QNAME);
+        assertNotEquals(QNAME2, FunctionDefinition.KIND_QNAME);
+        assertNotEquals(QNAME3, FunctionDefinition.KIND_QNAME);
     }
 
     @Test
     public void checkHashCode() {
-        assertEquals(qName1.hashCode(), qName2.hashCode());
+        assertEquals(QNAME1.hashCode(), QNAME2.hashCode());
+        assertEquals(QNAME1.hashCode(), QNAME3.hashCode());
+        assertEquals(QNAME2.hashCode(), QNAME3.hashCode());
 
         final HashSet<QName> qNames = new HashSet<>();
 
-        qNames.add(qName1);
+        qNames.add(QNAME1);
 
-        assertTrue(qNames.contains(qName2));
+        assertTrue(qNames.contains(QNAME2));
+        assertTrue(qNames.contains(QNAME3));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverter.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.dmn.backend.definition.v1_1;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import org.kie.dmn.backend.marshalling.v1_1.xstream.MarshallingUtils;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class QNamePropertyConverter {
@@ -28,7 +27,9 @@ public class QNamePropertyConverter {
      * @return maybe null
      */
     public static QName wbFromDMN(final javax.xml.namespace.QName qName) {
-        return (qName != null) ? new QName("{" + qName.getNamespaceURI() + "}" + (qName.getPrefix().equals("") ? "" : qName.getPrefix() + ":") + qName.getLocalPart()) : null;
+        return (qName != null) ? new QName(qName.getNamespaceURI(),
+                                           qName.getLocalPart(),
+                                           qName.getPrefix()) : null;
     }
 
     /*
@@ -37,13 +38,15 @@ public class QNamePropertyConverter {
     public static void setDMNfromWB(final QName qname,
                                     final Consumer<javax.xml.namespace.QName> setter) {
         if (qname != null) {
-            setter.accept(MarshallingUtils.parseQNameString(qname.getValue()));
+            setter.accept(dmnFromWB(qname).orElse(null));
         }
     }
 
     public static Optional<javax.xml.namespace.QName> dmnFromWB(final QName wb) {
         if (wb != null) {
-            return Optional.of(MarshallingUtils.parseQNameString(wb.getValue()));
+            return Optional.of(new javax.xml.namespace.QName(wb.getNamespaceURI(),
+                                                             wb.getLocalPart(),
+                                                             wb.getPrefix()));
         } else {
             return Optional.empty();
         }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2389

@jomarko I've made the ```QName``` in the "Properties panel" read-only for now; since it is the return data-type of the ```Decision```/```BusinessKnowledgeModel``` node. Data-types are yet to be implemented; and how we want to interact with it at the graph level is undefined (e.g. do we want it as a "Properties panel" property; or do we want another icon on the node itself to define it's data-type.

@tarilabs Looks OK now?