### PR TITLE
[AF-1074]: Removed unused OrganizationalUnitManager View that made connected clients crash.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -402,11 +402,6 @@
       <artifactId>uberfire-message-console-backend</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-organizationalunit-manager</artifactId>
-    </dependency>
-
     <!-- Common -->
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
@@ -1177,7 +1172,6 @@
             <compileSourcesArtifact>org.uberfire:uberfire-project-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-message-console-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-message-console-client</compileSourcesArtifact>
-            <compileSourcesArtifact>org.uberfire:uberfire-organizationalunit-manager</compileSourcesArtifact>
 
             <!-- Common dependencies -->
             <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-library-client</compileSourcesArtifact>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectShowcase.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectShowcase.gwt.xml
@@ -29,7 +29,6 @@
   <inherits name="org.guvnor.common.services.workingset.GuvnorWorkingsetAPI"/>
   <inherits name="org.guvnor.common.services.workingset.GuvnorWorkingsetClient"/>
   <inherits name="org.guvnor.messageconsole.GuvnorMessageConsoleClient"/>
-  <inherits name='org.guvnor.organizationalunit.manager.GuvnorOrganizationalUnitManager'/>
 
   <!--Common Screens -->
   <inherits name="org.kie.workbench.common.screens.library.LibraryClient"/>


### PR DESCRIPTION
https://github.com/kiegroup/appformer/pull/247
https://github.com/kiegroup/kie-wb-common/pull/1511
https://github.com/kiegroup/kie-wb-distributions/pull/709
https://github.com/kiegroup/drools-wb/pull/832