### PR TITLE
AF-1080: New project with the same name as another project in different space disappear after server restarts

### DIFF
--- a/kie-wb-common-cli/kie-wb-common-cli-migration-tool/README.md
+++ b/kie-wb-common-cli/kie-wb-common-cli-migration-tool/README.md
@@ -8,7 +8,9 @@ Included Migration Tools
 
 * **Project Migration Tool:** migrates KIE projects from the old project layout (7.4.x and previous) to the new project-oriented structure.
 
-* **Forms Migration Tool:** migrates old jBPM Form Modeler forms into the new Forms format. Requires **Project Migration Tool** to be executed first
+* **System Configuration Migration Tool:** migrates the previously used directory structure into the new one. Requires **Project Migration Tool** to be executed first.
+
+* **Forms Migration Tool:** migrates old jBPM Form Modeler forms into the new Forms format. Requires **Project Migration Tool** and **System Configuration Migration Tool:** to be executed first.
 
 Maven Build
 -----------
@@ -59,13 +61,13 @@ Windows -
 
 The tool will show a Wizard to choose between:
 
-* Run one of the available migration tools (Project or Forms Migration)
+* Run one of the available migration tools (Project, System Configuration or Forms Migration)
 * Run all the available migration tools sequentially.
 * Exit the migration tool. 
 
 The tool will do the migration in-place: when the tool finishes a successful run, the `$NIOGIT` directory will be ready for use with the new workbench.
 
-*IMPORTANT*: Because the tool migrates in-place, it's important to make backups before use.
+*VERY IMPORTANT*: Because the tool migrates in-place, it's important to make backups before use.
 
 Batch Mode
 ----------

--- a/kie-wb-common-cli/kie-wb-common-cli-migration-tool/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-migration-tool/pom.xml
@@ -29,6 +29,10 @@
       <groupId>org.kie.workbench</groupId>
       <artifactId>kie-wb-common-cli-forms-migration</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.kie.workbench</groupId>
+      <artifactId>kie-wb-common-cli-system-configuration-migration</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/main/java/org/kie/workbench/common/forms/migration/tool/cdi/MigrationServicesCDIWrapper.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/main/java/org/kie/workbench/common/forms/migration/tool/cdi/MigrationServicesCDIWrapper.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.guvnor.common.services.backend.util.CommentedOptionFactory;
+import org.guvnor.structure.repositories.Repository;
 import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
@@ -35,13 +36,21 @@ public class MigrationServicesCDIWrapper {
 
     private CommentedOptionFactory commentedOptionFactory;
 
+    private Repository systemRepository;
+
+    private IOService systemIoService;
+
     @Inject
-    public MigrationServicesCDIWrapper(@Named("ioStrategy") IOService ioService,
-                                       FormDefinitionSerializer formDefinitionSerializer,
-                                       CommentedOptionFactory commentedOptionFactory) {
+    public MigrationServicesCDIWrapper(final @Named("ioStrategy") IOService ioService,
+                                       final FormDefinitionSerializer formDefinitionSerializer,
+                                       final CommentedOptionFactory commentedOptionFactory,
+                                       final @Named("system") Repository systemRepository,
+                                       final @Named("configIO") IOService systemIoService) {
         this.ioService = ioService;
         this.formDefinitionSerializer = formDefinitionSerializer;
         this.commentedOptionFactory = commentedOptionFactory;
+        this.systemRepository = systemRepository;
+        this.systemIoService = systemIoService;
     }
 
     public IOService getIOService() {
@@ -54,5 +63,13 @@ public class MigrationServicesCDIWrapper {
 
     public void write(Path path, String content, String comment) {
         ioService.write(Paths.convert(path), content, commentedOptionFactory.makeCommentedOption(comment));
+    }
+
+    public Repository getSystemRepository() {
+        return systemRepository;
+    }
+
+    public IOService getSystemIoService() {
+        return systemIoService;
     }
 }

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/cli/InternalMigrationService.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/cli/InternalMigrationService.java
@@ -25,21 +25,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.guvnor.common.services.project.model.WorkspaceProject;
-import org.guvnor.common.services.project.project.WorkspaceProjectMigrationService;
-import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.guvnor.structure.repositories.EnvironmentParameters;
 import org.guvnor.structure.repositories.Repository;
-import org.guvnor.structure.repositories.RepositoryService;
 import org.guvnor.structure.server.config.ConfigGroup;
 import org.guvnor.structure.server.config.ConfigItem;
 import org.guvnor.structure.server.config.ConfigType;
-import org.guvnor.structure.server.config.ConfigurationService;
 import org.kie.workbench.common.migration.cli.SystemAccess;
+import org.kie.workbench.common.project.config.MigrationConfigurationServiceImpl;
+import org.kie.workbench.common.project.config.MigrationRepositoryServiceImpl;
+import org.kie.workbench.common.project.config.MigrationWorkspaceProjectMigrationServiceImpl;
+import org.kie.workbench.common.project.config.MigrationWorkspaceProjectServiceImpl;
 
 /**
  * <p>
@@ -50,16 +49,16 @@ import org.kie.workbench.common.migration.cli.SystemAccess;
 public class InternalMigrationService {
 
     @Inject
-    private WorkspaceProjectService projectService;
+    private MigrationWorkspaceProjectServiceImpl projectService;
 
     @Inject
-    private ConfigurationService configService;
+    private MigrationConfigurationServiceImpl configService;
 
     @Inject
-    private WorkspaceProjectMigrationService projectMigrationService;
+    private MigrationWorkspaceProjectMigrationServiceImpl projectMigrationService;
 
     @Inject
-    private RepositoryService repoService;
+    private MigrationRepositoryServiceImpl repoService;
 
     @Inject
     private SystemAccess system;

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/cli/MigrationSetup.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/cli/MigrationSetup.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.cli;
+
+import java.nio.file.Path;
+
+import org.kie.workbench.common.migration.cli.SystemAccess;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration;
+
+public class MigrationSetup {
+
+    public static void configureProperties(final SystemAccess system,
+                                           final Path niogitDir) {
+        system.setProperty(JGitFileSystemProviderConfiguration.GIT_NIO_DIR, niogitDir.getParent().toString());
+        system.setProperty(JGitFileSystemProviderConfiguration.GIT_NIO_DIR_NAME, niogitDir.getFileName().toString());
+        system.setProperty(JGitFileSystemProviderConfiguration.GIT_DAEMON_ENABLED, "false");
+        system.setProperty(JGitFileSystemProviderConfiguration.GIT_SSH_ENABLED, "false");
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/cli/PromptService.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/cli/PromptService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.cli;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.kie.workbench.common.migration.cli.SystemAccess;
+import org.kie.workbench.common.migration.cli.ToolConfig;
+
+public class PromptService {
+
+    private SystemAccess system;
+    private ToolConfig config;
+    private Path niogitDir;
+
+    public PromptService(final SystemAccess system,
+                         final ToolConfig config) {
+        this.system = system;
+        this.config = config;
+        this.niogitDir = config.getTarget();
+    }
+
+    public boolean maybePromptForBackup() {
+        return config.isBatch() || promptForBackup();
+    }
+
+    private boolean promptForBackup() {
+        SystemAccess.Console console = system.console();
+        console.format("WARNING: Please ensure that you have made backups of the directory [%s] before proceeding.\n", niogitDir);
+        Collection<String> validResponses = Arrays.asList("yes", "no");
+        String response;
+        do {
+            response = console.readLine("Do you wish to continue? [yes/no]: ").toLowerCase();
+        } while (!validResponses.contains(response));
+
+        return "yes".equals(response);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationConfigurationFactoryImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationConfigurationFactoryImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Vetoed;
+import javax.inject.Inject;
+
+import org.guvnor.structure.backend.config.ConfigurationFactoryImpl;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigType;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.guvnor.structure.server.config.PasswordService;
+
+@Alternative
+public class MigrationConfigurationFactoryImpl extends ConfigurationFactoryImpl implements ConfigurationFactory {
+
+    public MigrationConfigurationFactoryImpl() {
+    }
+
+    @Inject
+    public MigrationConfigurationFactoryImpl(final PasswordService secureService) {
+        super(secureService);
+    }
+
+    @Override
+    public ConfigGroup newConfigGroup(ConfigType type,
+                                      final String name,
+                                      final String description) {
+        if (ConfigType.SPACE.equals(type)) {
+            type = ConfigType.ORGANIZATIONAL_UNIT;
+        }
+
+        final ConfigGroup configGroup = new ConfigGroup();
+        configGroup.setDescription(description);
+        configGroup.setName(name);
+        configGroup.setType(type);
+        configGroup.setEnabled(true);
+        return configGroup;
+    }
+
+    @Override
+    public ConfigGroup newConfigGroup(final ConfigType type,
+                                      final String namespace,
+                                      final String name,
+                                      final String description) {
+        return newConfigGroup(type,
+                              name,
+                              description);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationConfigurationServiceImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationConfigurationServiceImpl.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Vetoed;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.naming.InitialContext;
+
+import org.guvnor.structure.backend.config.ConfigGroupMarshaller;
+import org.guvnor.structure.backend.config.ConfigurationServiceImpl;
+import org.guvnor.structure.backend.config.OrgUnit;
+import org.guvnor.structure.backend.config.Repository;
+import org.guvnor.structure.backend.config.watch.AsyncConfigWatchService;
+import org.guvnor.structure.backend.config.watch.AsyncWatchServiceCallback;
+import org.guvnor.structure.backend.config.watch.ConfigServiceWatchServiceExecutor;
+import org.guvnor.structure.backend.config.watch.ConfigServiceWatchServiceExecutorImpl;
+import org.guvnor.structure.config.SystemRepositoryChangedEvent;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigType;
+import org.guvnor.structure.server.config.ConfigurationService;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.uberfire.commons.async.DescriptiveRunnable;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.base.WatchContext;
+import org.uberfire.java.nio.base.options.CommentedOption;
+import org.uberfire.java.nio.file.DirectoryStream;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Files;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.StandardWatchEventKind;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchKey;
+import org.uberfire.java.nio.file.WatchService;
+
+@Alternative
+@ApplicationScoped
+public class MigrationConfigurationServiceImpl extends ConfigurationServiceImpl
+                                               implements ConfigurationService,
+                                                          AsyncWatchServiceCallback {
+
+    public MigrationConfigurationServiceImpl() {
+    }
+
+    @Inject
+    public MigrationConfigurationServiceImpl(final @Named("system") org.guvnor.structure.repositories.Repository systemRepository,
+                                             final ConfigGroupMarshaller marshaller,
+                                             final User identity,
+                                             final @Named("configIO") IOService ioService,
+                                             final @Repository Event<SystemRepositoryChangedEvent> repoChangedEvent,
+                                             final @OrgUnit Event<SystemRepositoryChangedEvent> orgUnitChangedEvent,
+                                             final Event<SystemRepositoryChangedEvent> changedEvent,
+                                             final @Named("systemFS") FileSystem fs) {
+        super(systemRepository,
+              marshaller,
+              identity,
+              ioService,
+              repoChangedEvent,
+              orgUnitChangedEvent,
+              changedEvent,
+              fs);
+    }
+
+    @Override
+    public List<ConfigGroup> getConfiguration(ConfigType configType) {
+        if (ConfigType.SPACE.equals(configType)) {
+            configType = ConfigType.ORGANIZATIONAL_UNIT;
+        }
+
+        final ConfigType type = configType;
+
+        final List<ConfigGroup> configGroups = new ArrayList<>();
+        final DirectoryStream<Path> foundConfigs = ioService.newDirectoryStream(ioService.get(systemRepository.getUri()),
+                                                                                entry -> {
+                                                                                    if (!Files.isDirectory(entry) &&
+                                                                                            !entry.getFileName().toString().startsWith(".") &&
+                                                                                            entry.getFileName().toString().endsWith(type.getExt())) {
+                                                                                        return true;
+                                                                                    }
+                                                                                    return false;
+                                                                                }
+        );
+
+        //Only load and cache if a file was found!
+        final Iterator<Path> it = foundConfigs.iterator();
+        if (it.hasNext()) {
+            while (it.hasNext()) {
+                final String content = ioService.readAllString(it.next());
+                final ConfigGroup configGroup = marshaller.unmarshall(content);
+                configGroups.add(configGroup);
+            }
+            configGroupsByTypeWithoutNamespace.put(type,
+                                                   configGroups);
+        }
+        return configGroups;
+    }
+
+    @Override
+    public List<ConfigGroup> getConfiguration(ConfigType type,
+                                              final String namespace) {
+        if (ConfigType.SPACE.equals(type)) {
+            type = ConfigType.ORGANIZATIONAL_UNIT;
+        }
+
+        if (!ConfigType.REPOSITORY.equals(type)) {
+            return Collections.emptyList();
+        }
+
+        return getConfiguration(type).stream()
+                .filter(repoConfig -> namespace.equals(repoConfig.getConfigItemValue("space")))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<String, List<ConfigGroup>> getConfigurationByNamespace(ConfigType type) {
+        if (ConfigType.SPACE.equals(type)) {
+            type = ConfigType.ORGANIZATIONAL_UNIT;
+        }
+
+        if (!ConfigType.REPOSITORY.equals(type)) {
+            return Collections.emptyMap();
+        }
+
+        final Map<String, List<ConfigGroup>> repoConfigsBySpace = new HashMap<>();
+        final List<ConfigGroup> repoConfigs = getConfiguration(type);
+        for (ConfigGroup repoConfig : repoConfigs) {
+            final String space = repoConfig.getConfigItemValue("space");
+
+            if (space != null) {
+                if (!repoConfigsBySpace.containsKey(space)) {
+                    repoConfigsBySpace.put(space,
+                                           new ArrayList<>());
+                }
+
+                repoConfigsBySpace.get(space).add(repoConfig);
+            }
+        }
+
+        return repoConfigsBySpace;
+    }
+
+    @Override
+    public boolean addConfiguration(final ConfigGroup configGroup) {
+        if (ConfigType.SPACE.equals(configGroup.getType())) {
+            configGroup.setType(ConfigType.ORGANIZATIONAL_UNIT);
+        }
+
+        String filename = configGroup.getName().replaceAll(INVALID_FILENAME_CHARS,
+                                                           "_");
+
+        final Path filePath = ioService.get(systemRepository.getUri()).resolve(filename + configGroup.getType().getExt());
+        // avoid duplicated writes to not cause cyclic cluster sync
+        if (ioService.exists(filePath)) {
+            return true;
+        }
+
+        final CommentedOption commentedOption = new CommentedOption(getIdentityName(),
+                                                                    "Created config " + filePath.getFileName());
+        saveConfiguration(configGroup,
+                          filePath,
+                          commentedOption);
+
+        configGroupsByTypeWithoutNamespace.remove(configGroup.getType());
+
+        return true;
+    }
+
+    @Override
+    public boolean updateConfiguration(final ConfigGroup configGroup) {
+        if (ConfigType.SPACE.equals(configGroup.getType())) {
+            configGroup.setType(ConfigType.ORGANIZATIONAL_UNIT);
+        }
+
+        String filename = configGroup.getName().replaceAll(INVALID_FILENAME_CHARS,
+                                                           "_");
+
+        final Path filePath = ioService.get(systemRepository.getUri()).resolve(filename + configGroup.getType().getExt());
+
+        final CommentedOption commentedOption = new CommentedOption(getIdentityName(),
+                                                                    "Updated config " + filePath.getFileName());
+        saveConfiguration(configGroup,
+                          filePath,
+                          commentedOption);
+
+        configGroupsByTypeWithoutNamespace.remove(configGroup.getType());
+
+        return true;
+    }
+
+    @Override
+    public boolean removeConfiguration(final ConfigGroup configGroup) {
+        if (ConfigType.SPACE.equals(configGroup.getType())) {
+            configGroup.setType(ConfigType.ORGANIZATIONAL_UNIT);
+        }
+
+        configGroupsByTypeWithoutNamespace.remove(configGroup.getType());
+
+        String filename = configGroup.getName().replaceAll(INVALID_FILENAME_CHARS,
+                                                           "_");
+
+        final Path filePath = ioService.get(systemRepository.getUri()).resolve(filename + configGroup.getType().getExt());
+
+        if (!ioService.exists(filePath)) {
+            return true;
+        }
+
+        boolean result;
+        try {
+            ioService.startBatch(filePath.getFileSystem());
+            result = ioService.deleteIfExists(filePath);
+            if (result) {
+                updateLastModified();
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            ioService.endBatch();
+        }
+
+        return result;
+    }
+
+    private void saveConfiguration(final ConfigGroup configGroup,
+                                   final Path filePath,
+                                   final CommentedOption commentedOption) {
+        try {
+            ioService.startBatch(filePath.getFileSystem());
+            ioService.write(filePath,
+                            marshaller.marshall(configGroup),
+                            commentedOption);
+
+            updateLastModified();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            ioService.endBatch();
+        }
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationConfiguredRepositories.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationConfiguredRepositories.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.structure.backend.repositories.ConfiguredRepositoriesImpl;
+import org.guvnor.structure.repositories.Repository;
+import org.guvnor.structure.server.repositories.RepositoryFactory;
+
+@Alternative
+@ApplicationScoped
+public class MigrationConfiguredRepositories extends ConfiguredRepositoriesImpl {
+
+    public MigrationConfiguredRepositories() {
+        super();
+    }
+
+    @Inject
+    public MigrationConfiguredRepositories(final MigrationConfigurationServiceImpl configurationService,
+                                           final RepositoryFactory repositoryFactory,
+                                           final @Named("system") Repository systemRepository) {
+        super(configurationService,
+              repositoryFactory,
+              systemRepository);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationOrganizationalUnitFactoryImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationOrganizationalUnitFactoryImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import org.guvnor.structure.backend.backcompat.BackwardCompatibleUtil;
+import org.guvnor.structure.backend.organizationalunit.OrganizationalUnitFactoryImpl;
+import org.uberfire.spaces.SpacesAPI;
+
+@Alternative
+public class MigrationOrganizationalUnitFactoryImpl extends OrganizationalUnitFactoryImpl {
+
+    @Inject
+    public MigrationOrganizationalUnitFactoryImpl(final MigrationRepositoryServiceImpl repositoryService,
+                                                  final BackwardCompatibleUtil backward,
+                                                  final SpacesAPI spacesAPI) {
+        super(repositoryService,
+              backward,
+              spacesAPI);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationOrganizationalUnitServiceImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationOrganizationalUnitServiceImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import org.guvnor.structure.backend.backcompat.BackwardCompatibleUtil;
+import org.guvnor.structure.backend.organizationalunit.OrganizationalUnitServiceImpl;
+import org.guvnor.structure.organizationalunit.NewOrganizationalUnitEvent;
+import org.guvnor.structure.organizationalunit.RemoveOrganizationalUnitEvent;
+import org.guvnor.structure.organizationalunit.RepoAddedToOrganizationalUnitEvent;
+import org.guvnor.structure.organizationalunit.RepoRemovedFromOrganizationalUnitEvent;
+import org.guvnor.structure.organizationalunit.UpdatedOrganizationalUnitEvent;
+import org.jboss.errai.bus.server.annotations.Service;
+import org.uberfire.rpc.SessionInfo;
+import org.uberfire.security.authz.AuthorizationManager;
+import org.uberfire.spaces.SpacesAPI;
+
+@Alternative
+@Service
+@ApplicationScoped
+public class MigrationOrganizationalUnitServiceImpl extends OrganizationalUnitServiceImpl {
+
+    public MigrationOrganizationalUnitServiceImpl() {
+        super();
+    }
+
+    @Inject
+    public MigrationOrganizationalUnitServiceImpl(final MigrationConfigurationServiceImpl configurationService,
+                                                  final MigrationConfigurationFactoryImpl configurationFactory,
+                                                  final MigrationOrganizationalUnitFactoryImpl organizationalUnitFactory,
+                                                  final MigrationRepositoryServiceImpl repositoryService,
+                                                  final BackwardCompatibleUtil backward,
+                                                  final Event<NewOrganizationalUnitEvent> newOrganizationalUnitEvent,
+                                                  final Event<RemoveOrganizationalUnitEvent> removeOrganizationalUnitEvent,
+                                                  final Event<RepoAddedToOrganizationalUnitEvent> repoAddedToOrgUnitEvent,
+                                                  final Event<RepoRemovedFromOrganizationalUnitEvent> repoRemovedFromOrgUnitEvent,
+                                                  final Event<UpdatedOrganizationalUnitEvent> updatedOrganizationalUnitEvent,
+                                                  final AuthorizationManager authorizationManager,
+                                                  final SpacesAPI spaces,
+                                                  final SessionInfo sessionInfo) {
+        super(configurationService,
+              configurationFactory,
+              organizationalUnitFactory,
+              repositoryService,
+              backward,
+              newOrganizationalUnitEvent,
+              removeOrganizationalUnitEvent,
+              repoAddedToOrgUnitEvent,
+              repoRemovedFromOrgUnitEvent,
+              updatedOrganizationalUnitEvent,
+              authorizationManager,
+              spaces,
+              sessionInfo);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationRepositoryCopierImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationRepositoryCopierImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.structure.backend.repositories.RepositoryCopierImpl;
+import org.guvnor.structure.repositories.NewBranchEvent;
+import org.uberfire.io.IOService;
+
+@Alternative
+public class MigrationRepositoryCopierImpl extends RepositoryCopierImpl {
+
+    public MigrationRepositoryCopierImpl() {
+        super();
+    }
+
+    @Inject
+    public MigrationRepositoryCopierImpl(final @Named("ioStrategy") IOService ioService,
+                                         final Event<NewBranchEvent> newBranchEventEvent,
+                                         final MigrationConfiguredRepositories configuredRepositories,
+                                         final MigrationRepositoryServiceImpl repositoryService) {
+        super(ioService,
+              newBranchEventEvent,
+              configuredRepositories,
+              repositoryService);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationRepositoryServiceImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationRepositoryServiceImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.structure.backend.backcompat.BackwardCompatibleUtil;
+import org.guvnor.structure.backend.repositories.RepositoryServiceImpl;
+import org.guvnor.structure.repositories.GitMetadataStore;
+import org.guvnor.structure.repositories.NewRepositoryEvent;
+import org.guvnor.structure.repositories.RepositoryRemovedEvent;
+import org.guvnor.structure.server.repositories.RepositoryFactory;
+import org.jboss.errai.bus.server.annotations.Service;
+import org.uberfire.io.IOService;
+import org.uberfire.rpc.SessionInfo;
+import org.uberfire.security.authz.AuthorizationManager;
+import org.uberfire.spaces.SpacesAPI;
+
+@Alternative
+@Service
+@ApplicationScoped
+public class MigrationRepositoryServiceImpl extends RepositoryServiceImpl {
+
+    public MigrationRepositoryServiceImpl() {
+        super();
+    }
+
+    @Inject
+    public MigrationRepositoryServiceImpl(@Named("ioStrategy") final IOService ioService,
+                                          final GitMetadataStore metadataStore,
+                                          final MigrationConfigurationServiceImpl configurationService,
+                                          final MigrationOrganizationalUnitServiceImpl organizationalUnitService,
+                                          final MigrationConfigurationFactoryImpl configurationFactory,
+                                          final RepositoryFactory repositoryFactory,
+                                          final Event<NewRepositoryEvent> event,
+                                          final Event<RepositoryRemovedEvent> repositoryRemovedEvent,
+                                          final BackwardCompatibleUtil backward,
+                                          final MigrationConfiguredRepositories configuredRepositories,
+                                          final AuthorizationManager authorizationManager,
+                                          final SessionInfo sessionInfo,
+                                          final SpacesAPI spacesAPI) {
+        super(ioService,
+              metadataStore,
+              configurationService,
+              organizationalUnitService,
+              configurationFactory,
+              repositoryFactory,
+              event,
+              repositoryRemovedEvent,
+              backward,
+              configuredRepositories,
+              authorizationManager,
+              sessionInfo,
+              spacesAPI);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationWorkspaceProjectMigrationServiceImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationWorkspaceProjectMigrationServiceImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.common.services.project.backend.server.WorkspaceProjectMigrationServiceImpl;
+import org.guvnor.common.services.project.events.NewProjectEvent;
+import org.guvnor.common.services.project.model.Module;
+import org.guvnor.common.services.project.service.ModuleService;
+import org.uberfire.io.IOService;
+
+@Alternative
+public class MigrationWorkspaceProjectMigrationServiceImpl extends WorkspaceProjectMigrationServiceImpl {
+
+    public MigrationWorkspaceProjectMigrationServiceImpl() {
+        super();
+    }
+
+    @Inject
+    public MigrationWorkspaceProjectMigrationServiceImpl(final MigrationWorkspaceProjectServiceImpl workspaceProjectService,
+                                                         final MigrationRepositoryServiceImpl repositoryService,
+                                                         final MigrationOrganizationalUnitServiceImpl organizationalUnitService,
+                                                         final Event<NewProjectEvent> newProjectEvent,
+                                                         final MigrationRepositoryCopierImpl repositoryCopier,
+                                                         final ModuleService<? extends Module> moduleService,
+                                                         final @Named("ioStrategy") IOService ioService) {
+        super(workspaceProjectService,
+              repositoryService,
+              organizationalUnitService,
+              newProjectEvent,
+              repositoryCopier,
+              moduleService,
+              ioService);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationWorkspaceProjectServiceImpl.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/java/org/kie/workbench/common/project/config/MigrationWorkspaceProjectServiceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.backend.server.WorkspaceProjectServiceImpl;
+import org.guvnor.common.services.project.events.NewProjectEvent;
+import org.guvnor.common.services.project.model.Module;
+import org.guvnor.common.services.project.service.ModuleService;
+import org.uberfire.spaces.SpacesAPI;
+
+@Alternative
+public class MigrationWorkspaceProjectServiceImpl extends WorkspaceProjectServiceImpl {
+
+    public MigrationWorkspaceProjectServiceImpl() {
+        super();
+    }
+
+    @Inject
+    public MigrationWorkspaceProjectServiceImpl(final MigrationOrganizationalUnitServiceImpl organizationalUnitService,
+                                                final MigrationRepositoryServiceImpl repositoryService,
+                                                final SpacesAPI spaces,
+                                                final Event<NewProjectEvent> newProjectEvent,
+                                                final Instance<ModuleService<? extends Module>> moduleServices) {
+        super(organizationalUnitService,
+              repositoryService,
+              spaces,
+              newProjectEvent,
+              moduleServices);
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/resources/META-INF/beans.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,16 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_2.xsd"
+       bean-discovery-mode="all">
+  <alternatives>
+    <class>org.kie.workbench.common.project.config.MigrationConfigurationFactoryImpl</class>
+    <class>org.kie.workbench.common.project.config.MigrationConfigurationServiceImpl</class>
+    <class>org.kie.workbench.common.project.config.MigrationConfiguredRepositories</class>
+    <class>org.kie.workbench.common.project.config.MigrationOrganizationalUnitFactoryImpl</class>
+    <class>org.kie.workbench.common.project.config.MigrationOrganizationalUnitServiceImpl</class>
+    <class>org.kie.workbench.common.project.config.MigrationRepositoryCopierImpl</class>
+    <class>org.kie.workbench.common.project.config.MigrationRepositoryServiceImpl</class>
+    <class>org.kie.workbench.common.project.config.MigrationWorkspaceProjectMigrationServiceImpl</class>
+    <class>org.kie.workbench.common.project.config.MigrationWorkspaceProjectServiceImpl</class>
+  </alternatives>
+</beans>

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/test/java/org/kie/workbench/common/project/config/MigrationConfigurationFactoryImplTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/test/java/org/kie/workbench/common/project/config/MigrationConfigurationFactoryImplTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import org.guvnor.structure.backend.config.DefaultPasswordServiceImpl;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigType;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.guvnor.structure.server.config.PasswordService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MigrationConfigurationFactoryImplTest {
+
+    private PasswordService passwordService;
+
+    private ConfigurationFactory configurationFactory;
+
+    @Before
+    public void setup() {
+        passwordService = new DefaultPasswordServiceImpl();
+        configurationFactory = new MigrationConfigurationFactoryImpl(passwordService);
+    }
+
+    @Test
+    public void newConfigGroupWithoutNamespaceTest() {
+        final ConfigGroup configGroup = configurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                            "my-config",
+                                                                            "my-description");
+
+        assertEquals(ConfigType.GLOBAL,
+                     configGroup.getType());
+        assertEquals("my-config",
+                     configGroup.getName());
+        assertEquals("my-description",
+                     configGroup.getDescription());
+        assertTrue(configGroup.isEnabled());
+    }
+
+    @Test
+    public void newConfigGroupWithNamespaceTest() {
+        final ConfigGroup configGroup = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                            "my-namespace",
+                                                                            "my-config",
+                                                                            "my-description");
+
+        assertEquals(ConfigType.REPOSITORY,
+                     configGroup.getType());
+        assertEquals("my-config",
+                     configGroup.getName());
+        assertEquals("my-description",
+                     configGroup.getDescription());
+        assertTrue(configGroup.isEnabled());
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/test/java/org/kie/workbench/common/project/config/MigrationConfigurationServiceImplTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/src/test/java/org/kie/workbench/common/project/config/MigrationConfigurationServiceImplTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.project.config;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import javax.enterprise.event.Event;
+
+import org.guvnor.structure.backend.config.ConfigGroupMarshaller;
+import org.guvnor.structure.backend.config.DefaultPasswordServiceImpl;
+import org.guvnor.structure.config.SystemRepositoryChangedEvent;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigType;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.guvnor.structure.server.config.ConfigurationService;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.mocks.FileSystemTestingUtils;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MigrationConfigurationServiceImplTest {
+
+    private static FileSystemTestingUtils fileSystemTestingUtils = new FileSystemTestingUtils();
+
+    @Mock
+    private org.guvnor.structure.repositories.Repository systemRepository;
+
+    @Mock
+    private User identity;
+
+    @Mock
+    private Event<SystemRepositoryChangedEvent> repoChangedEvent;
+
+    @Mock
+    private Event<SystemRepositoryChangedEvent> spaceChangedEvent;
+
+    @Mock
+    private Event<SystemRepositoryChangedEvent> changedEvent;
+
+    private ConfigGroupMarshaller marshaller;
+
+    private IOService ioService;
+
+    private ConfigurationFactory configurationFactory;
+
+    private ConfigurationService configurationService;
+
+    @Before
+    public void setup() throws IOException {
+        fileSystemTestingUtils.setup();
+        when(systemRepository.getUri()).thenReturn("git://amend-repo-test");
+
+        marshaller = new ConfigGroupMarshaller();
+        configurationFactory = new MigrationConfigurationFactoryImpl(new DefaultPasswordServiceImpl());
+        ioService = mockIoService();
+        configurationService = new MigrationConfigurationServiceImpl(systemRepository,
+                                                                     marshaller,
+                                                                     identity,
+                                                                     ioService,
+                                                                     repoChangedEvent,
+                                                                     spaceChangedEvent,
+                                                                     changedEvent,
+                                                                     fileSystemTestingUtils.getFileSystem());
+    }
+
+    @After
+    public void cleanupFileSystem() {
+        fileSystemTestingUtils.cleanup();
+    }
+
+    @Test
+    public void addAndGetConfigurationWithoutNamespaceTest() {
+        configurationService.addConfiguration(configurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                                  "global1",
+                                                                                  "global1-description"));
+        configurationService.addConfiguration(configurationFactory.newConfigGroup(ConfigType.SPACE,
+                                                                                  "space1",
+                                                                                  "space1-description"));
+        configurationService.addConfiguration(configurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                                  "global2",
+                                                                                  "global2-description"));
+
+        final List<ConfigGroup> globalConfigGroups = configurationService.getConfiguration(ConfigType.GLOBAL);
+        assertEquals(2,
+                     globalConfigGroups.size());
+        assertEquals("global1",
+                     globalConfigGroups.get(0).getName());
+        assertEquals("global2",
+                     globalConfigGroups.get(1).getName());
+
+        final List<ConfigGroup> spaceConfigGroups = configurationService.getConfiguration(ConfigType.SPACE);
+        assertEquals(1,
+                     spaceConfigGroups.size());
+        assertEquals("space1",
+                     spaceConfigGroups.get(0).getName());
+    }
+
+    @Test
+    public void addAndGetConfigurationWithNamespaceTest() {
+        final ConfigGroup configGroup1 = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                             "namespace1",
+                                                                             "repo1",
+                                                                             "repo1-description");
+        configGroup1.addConfigItem(configurationFactory.newConfigItem("space", "namespace1"));
+        configurationService.addConfiguration(configGroup1);
+        final ConfigGroup configGroup2 = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                             "namespace1",
+                                                                             "repo2",
+                                                                             "repo2-description");
+        configGroup2.addConfigItem(configurationFactory.newConfigItem("space", "namespace1"));
+        configurationService.addConfiguration(configGroup2);
+        configurationService.addConfiguration(configurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                                  "global1",
+                                                                                  "global1-description"));
+        final ConfigGroup configGroup3 = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                             "namespace2",
+                                                                             "repo3",
+                                                                             "repo3-description");
+        configGroup3.addConfigItem(configurationFactory.newConfigItem("space", "namespace2"));
+        configurationService.addConfiguration(configGroup3);
+
+        final List<ConfigGroup> repositoryNamespace1ConfigGroups = configurationService.getConfiguration(ConfigType.REPOSITORY,
+                                                                                                         "namespace1");
+        assertEquals(2,
+                     repositoryNamespace1ConfigGroups.size());
+        assertEquals("repo1",
+                     repositoryNamespace1ConfigGroups.get(0).getName());
+        assertEquals("repo2",
+                     repositoryNamespace1ConfigGroups.get(1).getName());
+
+        final List<ConfigGroup> repositoryNamespace2ConfigGroups = configurationService.getConfiguration(ConfigType.REPOSITORY,
+                                                                                                         "namespace2");
+        assertEquals(1,
+                     repositoryNamespace2ConfigGroups.size());
+        assertEquals("repo3",
+                     repositoryNamespace2ConfigGroups.get(0).getName());
+
+        final List<ConfigGroup> globalConfigGroups = configurationService.getConfiguration(ConfigType.GLOBAL);
+        assertEquals(1,
+                     globalConfigGroups.size());
+        assertEquals("global1",
+                     globalConfigGroups.get(0).getName());
+    }
+
+    @Test
+    public void addAndGetConfigurationByNamespaceTest() {
+        final ConfigGroup configGroup1 = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                             "namespace1",
+                                                                             "repo1",
+                                                                             "repo1-description");
+        configGroup1.addConfigItem(configurationFactory.newConfigItem("space", "namespace1"));
+        configurationService.addConfiguration(configGroup1);
+        final ConfigGroup configGroup2 = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                             "namespace1",
+                                                                             "repo2",
+                                                                             "repo2-description");
+        configGroup2.addConfigItem(configurationFactory.newConfigItem("space", "namespace1"));
+        configurationService.addConfiguration(configGroup2);
+        final ConfigGroup configGroup3 = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                             "namespace2",
+                                                                             "repo3",
+                                                                             "repo3-description");
+        configGroup3.addConfigItem(configurationFactory.newConfigItem("space", "namespace2"));
+        configurationService.addConfiguration(configGroup3);
+
+        final Map<String, List<ConfigGroup>> configGroupsByNamespace = configurationService.getConfigurationByNamespace(ConfigType.REPOSITORY);
+        assertEquals(2,
+                     configGroupsByNamespace.size());
+
+        final List<ConfigGroup> repositoryNamespace1ConfigGroups = configGroupsByNamespace.get("namespace1");
+        assertEquals(2,
+                     repositoryNamespace1ConfigGroups.size());
+        assertEquals("repo1",
+                     repositoryNamespace1ConfigGroups.get(0).getName());
+        assertEquals("repo2",
+                     repositoryNamespace1ConfigGroups.get(1).getName());
+
+        final List<ConfigGroup> repositoryNamespace2ConfigGroups = configGroupsByNamespace.get("namespace2");
+        assertEquals(1,
+                     repositoryNamespace2ConfigGroups.size());
+        assertEquals("repo3",
+                     repositoryNamespace2ConfigGroups.get(0).getName());
+    }
+
+    @Test
+    public void updateConfigurationWithoutNamespaceTest() {
+        final ConfigGroup config = configurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                       "config",
+                                                                       "description");
+        configurationService.addConfiguration(config);
+        config.setDescription("new-description");
+
+        configurationService.updateConfiguration(config);
+
+        final List<ConfigGroup> configGroups = configurationService.getConfiguration(ConfigType.GLOBAL);
+        assertEquals(1,
+                     configGroups.size());
+        assertEquals("config",
+                     configGroups.get(0).getName());
+        assertEquals("new-description",
+                     configGroups.get(0).getDescription());
+    }
+
+    @Test
+    public void updateConfigurationWithNamespaceTest() {
+        final ConfigGroup config = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                       "namespace",
+                                                                       "config",
+                                                                       "description");
+        config.addConfigItem(configurationFactory.newConfigItem("space", "namespace"));
+        configurationService.addConfiguration(config);
+        config.setDescription("new-description");
+
+        configurationService.updateConfiguration(config);
+
+        final List<ConfigGroup> configGroups = configurationService.getConfiguration(ConfigType.REPOSITORY,
+                                                                                     "namespace");
+        assertEquals(1,
+                     configGroups.size());
+        assertEquals("config",
+                     configGroups.get(0).getName());
+        assertEquals("new-description",
+                     configGroups.get(0).getDescription());
+    }
+
+    @Test
+    public void removeConfigurationWithoutNamespaceTest() {
+        final ConfigGroup config = configurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                       "config",
+                                                                       "description");
+
+        configurationService.removeConfiguration(config);
+
+        final List<ConfigGroup> configGroups = configurationService.getConfiguration(ConfigType.GLOBAL);
+        assertEquals(0,
+                     configGroups.size());
+    }
+
+    @Test
+    public void removeConfigurationWithNamespaceTest() {
+        final ConfigGroup config = configurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                       "namespace",
+                                                                       "config",
+                                                                       "description");
+        configurationService.addConfiguration(config);
+
+        configurationService.removeConfiguration(config);
+
+        final List<ConfigGroup> configGroups = configurationService.getConfiguration(ConfigType.REPOSITORY,
+                                                                                     "namespace");
+        assertEquals(0,
+                     configGroups.size());
+    }
+
+    private IOService mockIoService() {
+        final IOService ioService = spy(fileSystemTestingUtils.getIoService());
+
+        doNothing().when(ioService).startBatch(any(FileSystem.class));
+        doNothing().when(ioService).endBatch();
+        doReturn(fileSystemTestingUtils.getFileSystem()).when(ioService).newFileSystem(any(URI.class),
+                                                                                       anyMap());
+
+        return ioService;
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/pom.xml
@@ -1,13 +1,33 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-cli-tools</artifactId>
+    <groupId>org.kie.workbench</groupId>
     <version>7.7.0-SNAPSHOT</version>
   </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>kie-wb-common-cli-project-migration</artifactId>
-  <name>KIE Workbench Common CLI Project Migration</name>
+  <artifactId>kie-wb-common-cli-system-configuration-migration</artifactId>
+
+  <name>KIE Workbench Common CLI System Configuration Migration</name>
 
   <dependencies>
     <dependency>
@@ -19,16 +39,16 @@
       <artifactId>uberfire-project-backend</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-services-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-backend</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-bus</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -64,27 +84,19 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-structure-backend</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-security-api</artifactId>
+      <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-nio2-model</artifactId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-structure-backend</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
@@ -107,6 +119,10 @@
       <artifactId>jboss-servlet-api_3.1_spec</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>
@@ -118,16 +134,59 @@
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.kie.workbench</groupId>
       <artifactId>kie-wb-common-cli-api</artifactId>
     </dependency>
-
-    <!-- XXX maybe enable logging to a file for troubleshooting? -->
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>jbpm-simulation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse</groupId>
+      <artifactId>org.eclipse.bpmn2</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench</groupId>
+      <artifactId>kie-wb-common-cli-project-migration</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-layout-editor-api</artifactId>
+    </dependency>
+
+    <!-- test -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/java/org/kie/workbench/common/system/configuration/ConfigGroupsMigrationService.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/java/org/kie/workbench/common/system/configuration/ConfigGroupsMigrationService.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.system.configuration;
+
+import java.util.Iterator;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.structure.backend.config.ConfigGroupMarshaller;
+import org.guvnor.structure.repositories.Repository;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigType;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.kie.workbench.common.migration.cli.SystemAccess;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.base.options.CommentedOption;
+import org.uberfire.java.nio.file.DirectoryStream;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Files;
+import org.uberfire.workbench.type.FileNameUtil;
+
+@ApplicationScoped
+public class ConfigGroupsMigrationService {
+
+    private Repository systemRepository;
+
+    private ConfigGroupMarshaller marshaller;
+
+    private IOService ioService;
+
+    private FileSystem fs;
+
+    private SystemAccess system;
+
+    private User identity;
+
+    public ConfigGroupsMigrationService() {
+    }
+
+    @Inject
+    public ConfigGroupsMigrationService(final @Named("system") Repository systemRepository,
+                                        final ConfigGroupMarshaller marshaller,
+                                        final @Named("configIO") IOService ioService,
+                                        final @Named("systemFS") FileSystem fs,
+                                        final SystemAccess system,
+                                        final User identity) {
+        this.systemRepository = systemRepository;
+        this.marshaller = marshaller;
+        this.ioService = ioService;
+        this.fs = fs;
+        this.system = system;
+        this.identity = identity;
+    }
+
+    public void groupSystemConfigGroups() {
+        try {
+            startBatch();
+            system.out().println("Moving existing configurations to their type directories...");
+            groupConfigGroupsByType();
+            system.out().println("Moving existing repositories configurations to their space directories...");
+            groupRepositoryConfigGroupsBySpace();
+        } finally {
+            endBatch();
+        }
+    }
+
+    private void startBatch() {
+        ioService.startBatch(ioService.get(systemRepository.getUri()).getFileSystem());
+    }
+
+    private void endBatch() {
+        ioService.endBatch();
+    }
+
+    private void groupConfigGroupsByType() {
+        final org.uberfire.java.nio.file.Path systemDir = ioService.get(systemRepository.getUri());
+        for (ConfigType oldType : ConfigType.values()) {
+            final String oldExt = oldType.getExt();
+            final DirectoryStream<org.uberfire.java.nio.file.Path> foundConfigs = getDirectoryStreamForFilesWithParticularExtension(systemDir,
+                                                                                                                                    oldExt);
+
+            final ConfigType newType = getNewType(oldType);
+            final org.uberfire.java.nio.file.Path newTypeDir = systemDir.resolve(newType.getDir());
+            if (!ioService.exists(newTypeDir)) {
+                ioService.createDirectory(newTypeDir);
+            }
+
+            final Iterator<org.uberfire.java.nio.file.Path> it = foundConfigs.iterator();
+            while (it.hasNext()) {
+                final org.uberfire.java.nio.file.Path oldPath = it.next();
+                final String newExt = newType.getExt();
+                final String oldFileName = Paths.convert(oldPath).getFileName();
+                final String newFileName = FileNameUtil.removeExtension(oldFileName,
+                                                                        oldExt.substring(1)) + newExt;
+                final org.uberfire.java.nio.file.Path newPath = newTypeDir.resolve(newFileName);
+
+                ioService.move(oldPath,
+                               newPath);
+
+                if (!newType.equals(oldType)) {
+                    final String content = ioService.readAllString(newPath);
+                    final ConfigGroup configGroup = marshaller.unmarshall(content);
+                    configGroup.setType(newType);
+                    ioService.write(newPath,
+                                    marshaller.marshall(configGroup),
+                                    new CommentedOption(getIdentityName(),
+                                                        "Updated configuration type."));
+                }
+            }
+        }
+    }
+
+    private ConfigType getNewType(final ConfigType oldType) {
+        if (ConfigType.ORGANIZATIONAL_UNIT.equals(oldType)) {
+            return ConfigType.SPACE;
+        }
+
+        return oldType;
+    }
+
+    private DirectoryStream<org.uberfire.java.nio.file.Path> getDirectoryStreamForFilesWithParticularExtension(final org.uberfire.java.nio.file.Path dir,
+                                                                                                               final String extension) {
+        return ioService.newDirectoryStream(dir,
+                                            entry -> {
+                                                if (!Files.isDirectory(entry) &&
+                                                        !entry.getFileName().toString().startsWith(".") &&
+                                                        entry.getFileName().toString().endsWith(extension)) {
+                                                    return true;
+                                                }
+                                                return false;
+                                            });
+    }
+
+    private void groupRepositoryConfigGroupsBySpace() {
+        final org.uberfire.java.nio.file.Path systemDir = ioService.get(systemRepository.getUri());
+        final org.uberfire.java.nio.file.Path repositoriesDir = systemDir.resolve(ConfigType.REPOSITORY.getDir());
+        final DirectoryStream<org.uberfire.java.nio.file.Path> repoConfigs = getDirectoryStreamForFilesWithParticularExtension(repositoriesDir,
+                                                                                                                               ConfigType.REPOSITORY.getExt());
+
+        final Iterator<org.uberfire.java.nio.file.Path> it = repoConfigs.iterator();
+        while (it.hasNext()) {
+            final org.uberfire.java.nio.file.Path oldPath = it.next();
+            final String fileName = Paths.convert(oldPath).getFileName();
+
+            final String content = ioService.readAllString(oldPath);
+            final ConfigGroup repoConfig = marshaller.unmarshall(content);
+            final String space = repoConfig.getConfigItemValue("space");
+
+            final org.uberfire.java.nio.file.Path newPath = repositoriesDir.resolve(space).resolve(fileName);
+
+            ioService.move(oldPath,
+                           newPath);
+        }
+    }
+
+    protected String getIdentityName() {
+        try {
+            return identity.getIdentifier();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/java/org/kie/workbench/common/system/configuration/SystemConfigurationMigrationTool.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/java/org/kie/workbench/common/system/configuration/SystemConfigurationMigrationTool.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.system.configuration;
+
+import java.nio.file.Path;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.kie.workbench.common.migration.cli.MigrationConstants;
+import org.kie.workbench.common.migration.cli.MigrationTool;
+import org.kie.workbench.common.migration.cli.SystemAccess;
+import org.kie.workbench.common.migration.cli.ToolConfig;
+import org.kie.workbench.common.project.cli.MigrationSetup;
+import org.kie.workbench.common.project.cli.PromptService;
+
+public class SystemConfigurationMigrationTool implements MigrationTool {
+
+    public static final String NAME = "System configuration directory structure migration";
+
+    private SystemAccess system;
+    private ToolConfig config;
+
+    @Override
+    public String getTitle() {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Moves old system configuration directory structure to the new one";
+    }
+
+    @Override
+    public Integer getPriority() {
+        return 1;
+    }
+
+    @Override
+    public void run(final ToolConfig config,
+                    final SystemAccess system) {
+        this.config = config;
+        this.system = system;
+
+        final PromptService promptService = new PromptService(system,
+                                                              config);
+
+        system.out().println("Starting system configuration directory structure migration");
+
+        if (validateTarget() && promptService.maybePromptForBackup()) {
+            final Path niogitDir = config.getTarget();
+            MigrationSetup.configureProperties(system,
+                                               niogitDir);
+            migrate();
+        }
+    }
+
+    private void migrate() {
+        WeldContainer container = null;
+        try {
+            container = new Weld().initialize();
+            final ConfigGroupsMigrationService configGroupsMigrationService = loadMigrationService(container);
+            configGroupsMigrationService.groupSystemConfigGroups();
+        } catch (Throwable t) {
+            system.err().println("Error during migration: ");
+            t.printStackTrace(system.err());
+        } finally {
+            if (container != null && container.isRunning()) {
+                quietShutdown(container);
+            }
+        }
+    }
+
+    private void quietShutdown(WeldContainer container) {
+        try {
+            container.shutdown();
+        } catch (Throwable ignore) {
+            // Suppress exceptions from bad shutdown
+        }
+    }
+
+    private boolean validateTarget() {
+        if (!config.getTarget().resolve("system").resolve(MigrationConstants.SYSTEM_GIT).toFile().exists()) {
+            system.err().println(String.format("The PROJECT STRUCTURE MIGRATION must be ran before this one."));
+            return false;
+        }
+
+        return true;
+    }
+
+    private static ConfigGroupsMigrationService loadMigrationService(final WeldContainer container) {
+        return container.instance().select(ConfigGroupsMigrationService.class).get();
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/resources/META-INF/services/org.kie.workbench.common.migration.cli.MigrationTool
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/resources/META-INF/services/org.kie.workbench.common.migration.cli.MigrationTool
@@ -1,0 +1,17 @@
+#
+# Copyright 2018 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.kie.workbench.common.system.configuration.SystemConfigurationMigrationTool

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/main/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,18 @@
+#
+# Copyright 2018 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/test/java/org/kie/workbench/common/system/configuration/ConfigGroupsMigrationServiceTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/test/java/org/kie/workbench/common/system/configuration/ConfigGroupsMigrationServiceTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.system.configuration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import javax.enterprise.event.Event;
+
+import org.guvnor.structure.backend.config.ConfigGroupMarshaller;
+import org.guvnor.structure.backend.config.ConfigurationFactoryImpl;
+import org.guvnor.structure.backend.config.ConfigurationServiceImpl;
+import org.guvnor.structure.backend.config.DefaultPasswordServiceImpl;
+import org.guvnor.structure.config.SystemRepositoryChangedEvent;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigType;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.guvnor.structure.server.config.ConfigurationService;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.migration.cli.RealSystemAccess;
+import org.kie.workbench.common.project.config.MigrationConfigurationFactoryImpl;
+import org.kie.workbench.common.project.config.MigrationConfigurationServiceImpl;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.mocks.FileSystemTestingUtils;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigGroupsMigrationServiceTest {
+
+    private static FileSystemTestingUtils fileSystemTestingUtils = new FileSystemTestingUtils();
+
+    @Mock
+    private org.guvnor.structure.repositories.Repository systemRepository;
+
+    @Mock
+    private Event<SystemRepositoryChangedEvent> repoChangedEvent;
+
+    @Mock
+    private Event<SystemRepositoryChangedEvent> spaceChangedEvent;
+
+    @Mock
+    private Event<SystemRepositoryChangedEvent> changedEvent;
+
+    @Mock
+    private User identity;
+
+    @InjectMocks
+    private RealSystemAccess system;
+
+    private ConfigGroupMarshaller marshaller;
+
+    private IOService ioService;
+
+    private ConfigurationFactory oldConfigurationFactory;
+
+    private ConfigurationService oldConfigurationService;
+
+    private ConfigurationService newConfigurationService;
+
+    private ConfigGroupsMigrationService configGroupsMigrationService;
+
+    @Before
+    public void setup() throws IOException {
+        fileSystemTestingUtils.setup();
+        when(systemRepository.getUri()).thenReturn("git://amend-repo-test");
+
+        marshaller = new ConfigGroupMarshaller();
+        ioService = mockIoService();
+        oldConfigurationFactory = new MigrationConfigurationFactoryImpl(new DefaultPasswordServiceImpl());
+        oldConfigurationService = new MigrationConfigurationServiceImpl(systemRepository,
+                                                                        marshaller,
+                                                                        identity,
+                                                                        ioService,
+                                                                        repoChangedEvent,
+                                                                        spaceChangedEvent,
+                                                                        changedEvent,
+                                                                        fileSystemTestingUtils.getFileSystem());
+        newConfigurationService = new ConfigurationServiceImpl(systemRepository,
+                                                               marshaller,
+                                                               identity,
+                                                               ioService,
+                                                               repoChangedEvent,
+                                                               spaceChangedEvent,
+                                                               changedEvent,
+                                                               fileSystemTestingUtils.getFileSystem());
+        configGroupsMigrationService = new ConfigGroupsMigrationService(systemRepository,
+                                                                        marshaller,
+                                                                        ioService,
+                                                                        fileSystemTestingUtils.getFileSystem(),
+                                                                        system,
+                                                                        identity);
+    }
+
+    @After
+    public void cleanupFileSystem() {
+        fileSystemTestingUtils.cleanup();
+    }
+
+    @Test
+    public void groupSystemConfigGroupsTest() {
+        createConfigGroupsWithOldConfigurationService();
+        migrateConfigGroups();
+        checkConfigGroupsWithNewConfigurationService();
+    }
+
+    private void createConfigGroupsWithOldConfigurationService() {
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                                        "global1",
+                                                                                        "global1-description"));
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.GLOBAL,
+                                                                                        "global2",
+                                                                                        "global2-description"));
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.ORGANIZATIONAL_UNIT,
+                                                                                        "ou1",
+                                                                                        "ou1-description"));
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.ORGANIZATIONAL_UNIT,
+                                                                                        "ou2",
+                                                                                        "ou2-description"));
+        final ConfigGroup repo1 = oldConfigurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                         "repo1",
+                                                                         "repo1-description");
+        repo1.addConfigItem(oldConfigurationFactory.newConfigItem("space",
+                                                                  "ou1"));
+        oldConfigurationService.addConfiguration(repo1);
+        final ConfigGroup repo2 = oldConfigurationFactory.newConfigGroup(ConfigType.REPOSITORY,
+                                                                         "repo2",
+                                                                         "repo2-description");
+        repo2.addConfigItem(oldConfigurationFactory.newConfigItem("space",
+                                                                  "ou1"));
+        oldConfigurationService.addConfiguration(repo2);
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.EDITOR,
+                                                                                        "editor1",
+                                                                                        "editor1-description"));
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.EDITOR,
+                                                                                        "editor2",
+                                                                                        "editor2-description"));
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.DEPLOYMENT,
+                                                                                        "deployment1",
+                                                                                        "deployment1-description"));
+        oldConfigurationService.addConfiguration(oldConfigurationFactory.newConfigGroup(ConfigType.DEPLOYMENT,
+                                                                                        "deployment2",
+                                                                                        "deployment2-description"));
+    }
+
+    private void migrateConfigGroups() {
+        configGroupsMigrationService.groupSystemConfigGroups();
+    }
+
+    private void checkConfigGroupsWithNewConfigurationService() {
+        checkConfigGroupsOfAType(ConfigType.GLOBAL,
+                                 2,
+                                 "global1",
+                                 "global2");
+        checkConfigGroupsOfAType(ConfigType.ORGANIZATIONAL_UNIT,
+                                 0);
+        checkConfigGroupsOfAType(ConfigType.SPACE,
+                                 2,
+                                 "ou1",
+                                 "ou2");
+        checkConfigGroupsOfAType(ConfigType.REPOSITORY,
+                                 "ou1",
+                                 2,
+                                 "repo1",
+                                 "repo2");
+        checkConfigGroupsOfAType(ConfigType.REPOSITORY,
+                                 "ou2",
+                                 0);
+        checkConfigGroupsOfAType(ConfigType.EDITOR,
+                                 2,
+                                 "editor1",
+                                 "editor2");
+        checkConfigGroupsOfAType(ConfigType.DEPLOYMENT,
+                                 2,
+                                 "deployment1",
+                                 "deployment2");
+    }
+
+    private void checkConfigGroupsOfAType(final ConfigType configType,
+                                          final int size,
+                                          final String... names) {
+        final List<ConfigGroup> configGroups = newConfigurationService.getConfiguration(configType);
+        checkConfigGroups(configGroups,
+                          size,
+                          names);
+    }
+
+    private void checkConfigGroupsOfAType(final ConfigType configType,
+                                          final String namespace,
+                                          final int size,
+                                          final String... names) {
+        final List<ConfigGroup> configGroups = newConfigurationService.getConfiguration(configType,
+                                                                                        namespace);
+        checkConfigGroups(configGroups,
+                          size,
+                          names);
+    }
+
+    private void checkConfigGroups(final List<ConfigGroup> configGroups,
+                                   final int size,
+                                   final String... names) {
+        assertEquals(size,
+                     configGroups.size());
+
+        int i = 0;
+        for (String name : names) {
+            assertEquals(name,
+                         configGroups.get(i++).getName());
+        }
+    }
+
+    private IOService mockIoService() {
+        final IOService ioService = spy(fileSystemTestingUtils.getIoService());
+
+        doNothing().when(ioService).startBatch(any(FileSystem.class));
+        doNothing().when(ioService).endBatch();
+        doReturn(fileSystemTestingUtils.getFileSystem()).when(ioService).newFileSystem(any(URI.class),
+                                                                                       anyMap());
+
+        return ioService;
+    }
+}

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,1 @@
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/pom.xml
@@ -34,6 +34,7 @@
     <module>kie-wb-common-cli-api</module>
     <module>kie-wb-common-cli-project-migration</module>
     <module>kie-wb-common-cli-forms-migration</module>
+    <module>kie-wb-common-cli-system-configuration-migration</module>
   </modules>
 
 </project>

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
@@ -281,6 +281,7 @@ public class ExamplesServiceImpl implements ExamplesService {
             }};
 
             final ConfigGroup repositoryConfig = configurationFactory.newConfigGroup(REPOSITORY,
+                                                                                     "system",
                                                                                      alias,
                                                                                      "");
             for (final Map.Entry<String, Object> entry : env.entrySet()) {

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImplCheckNoIndexConfigTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImplCheckNoIndexConfigTest.java
@@ -115,9 +115,10 @@ public class ExamplesServiceImplCheckNoIndexConfigTest {
     @Test
     public void testCheckRepositoryConfig_NoIndex() {
         final ConfigGroup configGroup = new ConfigGroup();
-        when(configurationFactory.newConfigGroup(any(ConfigType.class),
-                                                 anyString(),
-                                                 anyString())).thenReturn(configGroup);
+        doReturn(configGroup).when(configurationFactory).newConfigGroup(any(ConfigType.class),
+                                                                        anyString(),
+                                                                        anyString(),
+                                                                        anyString());
 
         service.getProjects(new ExampleRepository("https://github.com/guvnorngtestuser1/guvnorng-playground.git"));
 

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImplTest.java
@@ -168,6 +168,7 @@ public class ExamplesServiceImplTest {
         when(user.getIdentifier()).thenReturn("user");
         when(configurationFactory.newConfigGroup(any(ConfigType.class),
                                                  anyString(),
+                                                 anyString(),
                                                  anyString())).thenReturn(mock(ConfigGroup.class));
     }
 
@@ -484,6 +485,7 @@ public class ExamplesServiceImplTest {
 
         ConfigGroup configGroup = new ConfigGroup();
         when(configurationFactory.newConfigGroup(any(ConfigType.class),
+                                                 anyString(),
                                                  anyString(),
                                                  anyString())).thenReturn(configGroup);
         doCallRealMethod().when(configurationFactory).newConfigItem(anyString(),


### PR DESCRIPTION
Part of an ensemble:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/723
* https://github.com/kiegroup/appformer/pull/251
* https://github.com/kiegroup/kie-wb-common/pull/1520

=============================================================

Old system.git structure example:
```
.
├── anotherOU-myrepo.repository
├── anotherOU.organizationalunit
├── another-repo.repository
├── myrepo.repository
├── myteam.organizationalunit
├── readme.md
├── settings.global
└── work-items-editor-settings.editor
```

New system.git structure example:
```
.
├── deployments
├── editors
│   └── work-items-editor-settings.editor
├── global
│   └── settings.global
├── projects
├── readme.md
├── repositories
│   ├── anotherOU
│   │   ├── project1-inside-anotherOU-myrepo.repository
│   │   └── project2-inside-anotherOU-myrepo.repository
│   └── myteam
│       ├── project-inside-another-repo.repository
│       └── project-inside-myrepo.repository
└── spaces
    ├── anotherOU.space
    └── myteam.space
```
