### PR TITLE
DROOLS-2410: [DMN Designer] Active entries not highlighted correctly when scrolling

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -41,6 +42,7 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
 public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression, LiteralExpressionUIModelMapper> implements HasListSelectorControl {
 
@@ -84,6 +86,17 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
     }
 
     @Override
+    protected NodeMouseClickHandler getGridMouseClickHandler(final GridSelectionManager selectionManager) {
+        return (event) -> gridLayer.select(parent.getGridWidget());
+    }
+
+    @Override
+    public void selectFirstCell() {
+        parent.getGridWidget().getModel().selectCell(parent.getRowIndex(),
+                                                     parent.getColumnIndex());
+    }
+
+    @Override
     protected void doInitialisation() {
         // Defer initialisation until after the constructor completes as
         // LiteralExpressionUIModelMapper needs ListSelector to have been set
@@ -93,7 +106,8 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
     public LiteralExpressionUIModelMapper makeUiModelMapper() {
         return new LiteralExpressionUIModelMapper(this::getModel,
                                                   () -> expression,
-                                                  listSelector);
+                                                  listSelector,
+                                                  parent);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
@@ -29,22 +30,41 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 public class LiteralExpressionUIModelMapper extends BaseUIModelMapper<LiteralExpression> {
 
     private final ListSelectorView.Presenter listSelector;
+    private final GridCellTuple parent;
 
     public LiteralExpressionUIModelMapper(final Supplier<GridData> uiModel,
                                           final Supplier<Optional<LiteralExpression>> dmnModel,
-                                          final ListSelectorView.Presenter listSelector) {
+                                          final ListSelectorView.Presenter listSelector,
+                                          final GridCellTuple parent) {
         super(uiModel,
               dmnModel);
         this.listSelector = listSelector;
+        this.parent = parent;
     }
 
     @Override
     public void fromDMNModel(final int rowIndex,
                              final int columnIndex) {
-        dmnModel.get().ifPresent(literalExpression -> uiModel.get().setCell(rowIndex,
-                                                                            columnIndex,
-                                                                            () -> new LiteralExpressionCell<>(new BaseGridCellValue<>(literalExpression.getText()),
-                                                                                                              listSelector)));
+        dmnModel.get().ifPresent(literalExpression -> {
+            uiModel.get().setCell(rowIndex,
+                                  columnIndex,
+                                  () -> new LiteralExpressionCell<>(new BaseGridCellValue<>(literalExpression.getText()),
+                                                                    listSelector));
+            uiModel.get().getCell(rowIndex,
+                                  columnIndex).setSelectionStrategy((final GridData model,
+                                                                     final int uiRowIndex,
+                                                                     final int uiColumnIndex,
+                                                                     final boolean isShiftKeyDown,
+                                                                     final boolean isControlKeyDown) -> {
+                final GridData parentUiModel = parent.getGridWidget().getModel();
+                return parentUiModel.getCell(parent.getRowIndex(),
+                                             parent.getColumnIndex()).getSelectionStrategy().handleSelection(parentUiModel,
+                                                                                                             parent.getRowIndex(),
+                                                                                                             parent.getColumnIndex(),
+                                                                                                             isShiftKeyDown,
+                                                                                                             isControlKeyDown);
+            });
+        });
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -49,6 +50,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
 public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, UndefinedExpressionUIModelMapper> implements HasListSelectorControl {
 
@@ -101,6 +103,17 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, Unde
     }
 
     @Override
+    protected NodeMouseClickHandler getGridMouseClickHandler(final GridSelectionManager selectionManager) {
+        return (event) -> gridLayer.select(parent.getGridWidget());
+    }
+
+    @Override
+    public void selectFirstCell() {
+        parent.getGridWidget().getModel().selectCell(parent.getRowIndex(),
+                                                     parent.getColumnIndex());
+    }
+
+    @Override
     protected void doInitialisation() {
         // Defer initialisation until after the constructor completes as
         // UndefinedExpressionColumn needs expressionEditorDefinitionsSupplier to have been set
@@ -111,7 +124,8 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, Unde
         return new UndefinedExpressionUIModelMapper(this::getModel,
                                                     () -> expression,
                                                     listSelector,
-                                                    hasExpression);
+                                                    hasExpression,
+                                                    parent);
     }
 
     @Override
@@ -202,7 +216,10 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, Unde
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new SetCellValueCommand(gcv,
                                                                   () -> uiModelMapper,
-                                                                  () -> synchroniseViewWhenExpressionEditorChanged(editor.get())));
+                                                                  () -> editor.ifPresent(e -> {
+                                                                      e.selectFirstCell();
+                                                                      synchroniseViewWhenExpressionEditorChanged(e);
+                                                                  })));
         });
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
@@ -24,23 +24,26 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 public class UndefinedExpressionUIModelMapper extends BaseUIModelMapper<Expression> {
 
     private final ListSelectorView.Presenter listSelector;
-
     private final HasExpression hasExpression;
+    private final GridCellTuple parent;
 
     public UndefinedExpressionUIModelMapper(final Supplier<GridData> uiModel,
                                             final Supplier<Optional<Expression>> dmnModel,
                                             final ListSelectorView.Presenter listSelector,
-                                            final HasExpression hasExpression) {
+                                            final HasExpression hasExpression,
+                                            final GridCellTuple parent) {
         super(uiModel,
               dmnModel);
         this.listSelector = listSelector;
         this.hasExpression = hasExpression;
+        this.parent = parent;
     }
 
     @Override
@@ -49,6 +52,20 @@ public class UndefinedExpressionUIModelMapper extends BaseUIModelMapper<Expressi
         uiModel.get().setCell(rowIndex,
                               columnIndex,
                               () -> new UndefinedExpressionCell(listSelector));
+        uiModel.get().getCell(rowIndex,
+                              columnIndex).setSelectionStrategy((final GridData model,
+                                                                 final int uiRowIndex,
+                                                                 final int uiColumnIndex,
+                                                                 final boolean isShiftKeyDown,
+                                                                 final boolean isControlKeyDown) -> {
+            final GridData parentUiModel = parent.getGridWidget().getModel();
+            return parentUiModel.getCell(parent.getRowIndex(),
+                                         parent.getColumnIndex()).getSelectionStrategy().handleSelection(parentUiModel,
+                                                                                                         parent.getRowIndex(),
+                                                                                                         parent.getColumnIndex(),
+                                                                                                         isShiftKeyDown,
+                                                                                                         isControlKeyDown);
+        });
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -354,12 +354,6 @@ public abstract class BaseExpressionGrid<E extends Expression, M extends BaseUIM
     }
 
     @Override
-    public void select() {
-        selectFirstCell();
-        super.select();
-    }
-
-    @Override
     public void deselect() {
         getModel().clearSelections();
         super.deselect();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -144,9 +144,19 @@ public class DMNGridLayer extends DefaultGridLayer {
     @Override
     public void select(final GridWidget selectedGridWidget) {
         this.selectedGridWidget = Optional.of(selectedGridWidget);
-        getAllGridWidgets().stream().forEach(GridWidget::deselect);
-        selectedGridWidget.select();
-        batch();
+        boolean selectionChanged = false;
+        for (GridWidget gridWidget : getAllGridWidgets()) {
+            if (!gridWidget.equals(selectedGridWidget)) {
+                selectionChanged = true;
+                gridWidget.deselect();
+            } else if (gridWidget.equals(selectedGridWidget)) {
+                selectionChanged = true;
+                gridWidget.select();
+            }
+        }
+        if (selectionChanged) {
+            batch();
+        }
     }
 
     private Set<GridWidget> getAllGridWidgets() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -16,7 +16,9 @@
 
 package org.kie.workbench.common.dmn.client.widgets.layer;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPathClipper;
@@ -27,11 +29,12 @@ import com.ait.lienzo.shared.core.types.ColorName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Command;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainerGrid;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.dnd.DelegatingGridWidgetDndMouseMoveHandler;
-import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDMouseMoveHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
@@ -41,6 +44,8 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMe
 public class DMNGridLayer extends DefaultGridLayer {
 
     private TransformMediator defaultTransformMediator;
+
+    private Optional<GridWidget> selectedGridWidget = Optional.empty();
 
     public void setDefaultTransformMediator(final TransformMediator defaultTransformMediator) {
         this.defaultTransformMediator = defaultTransformMediator;
@@ -66,10 +71,7 @@ public class DMNGridLayer extends DefaultGridLayer {
 
     Layer doBatch() {
         final Layer layer = super.draw();
-        findExpressionContainer()
-                .ifPresent(container -> findSelectedExpressionGrid()
-                        .ifPresent(gridWidget -> addGhost(container, gridWidget)));
-
+        findExpressionContainer().ifPresent(container -> selectedGridWidget.ifPresent(gridWidget -> addGhost(container, gridWidget)));
         return layer;
     }
 
@@ -80,25 +82,8 @@ public class DMNGridLayer extends DefaultGridLayer {
                 .findFirst();
     }
 
-    Optional<BaseExpressionGrid> findSelectedExpressionGrid() {
-        return getGridWidgets().stream()
-                .filter(GridWidget::isSelected)
-                .filter(gw -> gw instanceof BaseExpressionGrid)
-                .map(gw -> (BaseExpressionGrid) gw)
-                .findFirst();
-    }
-
     void addGhost(final ExpressionContainerGrid container,
-                  final BaseExpressionGrid gridWidget) {
-        GridWidget gw = gridWidget;
-        // LiteralExpression and UndefinedExpression are not handled as grids in
-        // their own right. In these circumstances use their parent GridWidget.
-        if (gridWidget instanceof LiteralExpressionGrid) {
-            gw = gridWidget.getParentInformation().getGridWidget();
-        } else if (gridWidget instanceof UndefinedExpressionGrid) {
-            gw = gridWidget.getParentInformation().getGridWidget();
-        }
-
+                  final GridWidget gridWidget) {
         //Rectangle the size of the ExpressionContainerGrid
         final Rectangle r = getGhostRectangle();
         r.setWidth(container.getWidth() + BaseExpressionGridTheme.STROKE_WIDTH);
@@ -107,16 +92,24 @@ public class DMNGridLayer extends DefaultGridLayer {
         r.setAlpha(0.50);
         r.setListening(false);
 
-        //Clip the inner GridWidget so everything outside of it is ghosted
-        final IPathClipper clipper = new InverseGridWidgetClipper(container, gw);
-        clipper.setActive(true);
-
         final Group g = GWT.create(Group.class);
         final Transform transform = getViewport().getTransform();
         g.setX(container.getX() + transform.getTranslateX());
         g.setY(container.getY() + transform.getTranslateY());
-        g.setPathClipper(clipper);
         g.add(r);
+
+        // LiteralExpression and UndefinedExpression are not handled as grids in
+        // their own right. In these circumstances use their parent GridWidget.
+        GridWidget gw = gridWidget;
+        if (gw instanceof LiteralExpressionGrid) {
+            gw = ((LiteralExpressionGrid) gw).getParentInformation().getGridWidget();
+        } else if (gw instanceof UndefinedExpressionGrid) {
+            gw = ((UndefinedExpressionGrid) gw).getParentInformation().getGridWidget();
+        }
+        //Clip the inner GridWidget so everything outside of it is ghosted
+        final IPathClipper clipper = new InverseGridWidgetClipper(container, gw);
+        clipper.setActive(true);
+        g.setPathClipper(clipper);
 
         g.drawWithTransforms(getContext(),
                              1.0,
@@ -127,6 +120,10 @@ public class DMNGridLayer extends DefaultGridLayer {
     // zero-argument Constructor so unable to use GWT.create(..)
     Rectangle getGhostRectangle() {
         return new Rectangle(0, 0);
+    }
+
+    Optional<GridWidget> getSelectedGridWidget() {
+        return selectedGridWidget;
     }
 
     @Override
@@ -142,6 +139,57 @@ public class DMNGridLayer extends DefaultGridLayer {
     @Override
     public void updatePinnedContext(final GridWidget gridWidget) throws IllegalStateException {
         //Do nothing. ExpressionEditor grid is a place-holder for the real content.
+    }
+
+    @Override
+    public void select(final GridWidget selectedGridWidget) {
+        this.selectedGridWidget = Optional.of(selectedGridWidget);
+        getAllGridWidgets().stream().forEach(GridWidget::deselect);
+        selectedGridWidget.select();
+        batch();
+    }
+
+    private Set<GridWidget> getAllGridWidgets() {
+        final Set<GridWidget> gridWidgets = super.getGridWidgets();
+        final Set<GridWidget> allGridWidgets = new HashSet<>();
+        gridWidgets.forEach(grid -> allGridWidgets.addAll(collectGridWidgets(grid)));
+        return allGridWidgets;
+    }
+
+    private Set<GridWidget> collectGridWidgets(final GridWidget gridWidget) {
+        final Set<GridWidget> allGridWidgets = new HashSet<>();
+        allGridWidgets.add(gridWidget);
+
+        gridWidget.getModel()
+                .getRows()
+                .stream()
+                .forEach(row -> row.getCells().values()
+                        .stream()
+                        .filter(cell -> cell != null && cell.getValue() != null)
+                        .map(GridCell::getValue)
+                        .filter(value -> value instanceof ExpressionCellValue)
+                        .map(value -> (ExpressionCellValue) value)
+                        .filter(value -> value.getValue().isPresent())
+                        .map(value -> value.getValue().get())
+                        .forEach(editor -> allGridWidgets.addAll(collectGridWidgets(editor))));
+
+        return allGridWidgets;
+    }
+
+    @Override
+    public void deregister(final GridWidget gridWidget) {
+        if (selectedGridWidget.isPresent()) {
+            if (selectedGridWidget.get().equals(gridWidget)) {
+                selectedGridWidget = Optional.empty();
+            }
+        }
+        super.deregister(gridWidget);
+    }
+
+    @Override
+    public Layer removeAll() {
+        selectedGridWidget = Optional.empty();
+        return super.removeAll();
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.widgets.layer;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -146,10 +147,10 @@ public class DMNGridLayer extends DefaultGridLayer {
         this.selectedGridWidget = Optional.of(selectedGridWidget);
         boolean selectionChanged = false;
         for (GridWidget gridWidget : getAllGridWidgets()) {
-            if (!gridWidget.equals(selectedGridWidget)) {
+            if (!Objects.equals(gridWidget, selectedGridWidget)) {
                 selectionChanged = true;
                 gridWidget.deselect();
-            } else if (gridWidget.equals(selectedGridWidget)) {
+            } else if (Objects.equals(gridWidget, selectedGridWidget)) {
                 selectionChanged = true;
                 gridWidget.select();
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.ait.lienzo.client.core.event.NodeMouseClickEvent;
+import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
@@ -64,6 +66,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.mvp.Command;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,6 +76,7 @@ import static org.kie.workbench.common.dmn.client.editors.expressions.types.Grid
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -136,7 +140,19 @@ public class LiteralExpressionGridTest {
     private GridCellTuple parent;
 
     @Mock
+    private GridWidget parentGridWidget;
+
+    @Mock
+    private GridData parentGridUiModel;
+
+    @Mock
     private HasExpression hasExpression;
+
+    @Mock
+    private GridSelectionManager selectionManager;
+
+    @Mock
+    private NodeMouseClickEvent mouseClickEvent;
 
     private Optional<LiteralExpression> expression = Optional.empty();
 
@@ -179,6 +195,10 @@ public class LiteralExpressionGridTest {
         when(canvasCommandFactory.updatePropertyValue(any(Element.class),
                                                       anyString(),
                                                       any())).thenReturn(mock(UpdateElementPropertyCommand.class));
+        when(parentGridWidget.getModel()).thenReturn(parentGridUiModel);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
+        when(parent.getRowIndex()).thenReturn(0);
+        when(parent.getColumnIndex()).thenReturn(1);
     }
 
     private void setupGrid(final int nesting) {
@@ -188,6 +208,26 @@ public class LiteralExpressionGridTest {
                                                                      expression,
                                                                      hasName,
                                                                      nesting).get());
+    }
+
+    @Test
+    public void testGridMouseClickHandler() {
+        setupGrid(0);
+
+        final NodeMouseClickHandler handler = grid.getGridMouseClickHandler(selectionManager);
+
+        handler.onNodeMouseClick(mouseClickEvent);
+
+        verify(gridLayer).select(parentGridWidget);
+    }
+
+    @Test
+    public void testSelectFirstCell() {
+        setupGrid(0);
+
+        grid.selectFirstCell();
+
+        verify(parentGridUiModel).selectCell(eq(0), eq(1));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
@@ -23,17 +23,29 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LiteralExpressionUIModelMapperTest {
+
+    private static final int PARENT_ROW_INDEX = 0;
+
+    private static final int PARENT_COLUMN_INDEX = 1;
 
     @Mock
     private LiteralExpressionColumn uiLiteralExpressionColumn;
@@ -44,6 +56,18 @@ public class LiteralExpressionUIModelMapperTest {
     @Mock
     private ListSelectorView.Presenter listSelector;
 
+    @Mock
+    private GridWidget parentGridWidget;
+
+    @Mock
+    private GridData parentGridUiModel;
+
+    @Mock
+    private GridCell parentGridUiCell;
+
+    @Mock
+    private CellSelectionStrategy parentGridUiCellCellSelectionStrategy;
+
     private BaseGridData uiModel;
 
     private LiteralExpression literalExpression;
@@ -51,17 +75,24 @@ public class LiteralExpressionUIModelMapperTest {
     private LiteralExpressionUIModelMapper mapper;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() {
         uiModel = new BaseGridData();
         uiModel.appendRow(new DMNGridRow());
         uiModel.appendColumn(uiLiteralExpressionColumn);
         doReturn(0).when(uiLiteralExpressionColumn).getIndex();
+        when(parentGridWidget.getModel()).thenReturn(parentGridUiModel);
+        when(parentGridUiModel.getCell(eq(PARENT_ROW_INDEX), eq(PARENT_COLUMN_INDEX))).thenReturn(parentGridUiCell);
+        when(parentGridUiCell.getSelectionStrategy()).thenReturn(parentGridUiCellCellSelectionStrategy);
 
         literalExpression = new LiteralExpression();
 
         mapper = new LiteralExpressionUIModelMapper(() -> uiModel,
                                                     () -> Optional.of(literalExpression),
-                                                    listSelector);
+                                                    listSelector,
+                                                    new GridCellTuple(PARENT_ROW_INDEX,
+                                                                      PARENT_COLUMN_INDEX,
+                                                                      parentGridWidget));
     }
 
     @Test
@@ -84,6 +115,21 @@ public class LiteralExpressionUIModelMapperTest {
         mapper.fromDMNModel(0, 0);
 
         assertTrue(uiModel.getCell(0, 0) instanceof LiteralExpressionCell);
+    }
+
+    @Test
+    public void testFromDmn_CellSelectionStrategy() {
+        mapper.fromDMNModel(0, 0);
+
+        final CellSelectionStrategy strategy = uiModel.getCell(0, 0).getSelectionStrategy();
+
+        strategy.handleSelection(uiModel, 0, 0, true, false);
+
+        verify(parentGridUiCellCellSelectionStrategy).handleSelection(eq(parentGridUiModel),
+                                                                      eq(PARENT_ROW_INDEX),
+                                                                      eq(PARENT_COLUMN_INDEX),
+                                                                      eq(true),
+                                                                      eq(false));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
@@ -28,19 +28,28 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.context.Exp
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UndefinedExpressionUIModelMapperTest {
+
+    private static final int PARENT_ROW_INDEX = 0;
+
+    private static final int PARENT_COLUMN_INDEX = 1;
 
     @Mock
     private Expression expression;
@@ -57,6 +66,18 @@ public class UndefinedExpressionUIModelMapperTest {
     @Mock
     private UndefinedExpressionColumn uiColumn;
 
+    @Mock
+    private GridWidget parentGridWidget;
+
+    @Mock
+    private GridData parentGridUiModel;
+
+    @Mock
+    private GridCell parentGridUiCell;
+
+    @Mock
+    private CellSelectionStrategy parentGridUiCellCellSelectionStrategy;
+
     private GridData uiModel;
 
     private Supplier<Optional<GridCellValue<?>>> cellValueSupplier;
@@ -64,6 +85,7 @@ public class UndefinedExpressionUIModelMapperTest {
     private UndefinedExpressionUIModelMapper mapper;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() {
         this.uiModel = new BaseGridData();
         this.uiModel.appendColumn(uiColumn);
@@ -71,8 +93,15 @@ public class UndefinedExpressionUIModelMapperTest {
         this.mapper = new UndefinedExpressionUIModelMapper(() -> uiModel,
                                                            () -> Optional.ofNullable(expression),
                                                            listSelector,
-                                                           hasExpression);
+                                                           hasExpression,
+                                                           new GridCellTuple(PARENT_ROW_INDEX,
+                                                                             PARENT_COLUMN_INDEX,
+                                                                             parentGridWidget));
         this.cellValueSupplier = () -> Optional.of(new ExpressionCellValue(Optional.of(editor)));
+
+        when(parentGridWidget.getModel()).thenReturn(parentGridUiModel);
+        when(parentGridUiModel.getCell(eq(PARENT_ROW_INDEX), eq(PARENT_COLUMN_INDEX))).thenReturn(parentGridUiCell);
+        when(parentGridUiCell.getSelectionStrategy()).thenReturn(parentGridUiCellCellSelectionStrategy);
     }
 
     @Test
@@ -80,6 +109,21 @@ public class UndefinedExpressionUIModelMapperTest {
         mapper.fromDMNModel(0, 0);
 
         assertThat(mapper.getUiModel().get().getCell(0, 0)).isInstanceOf(UndefinedExpressionCell.class);
+    }
+
+    @Test
+    public void testFromDMNCellSelectionStrategy() {
+        mapper.fromDMNModel(0, 0);
+
+        final CellSelectionStrategy strategy = uiModel.getCell(0, 0).getSelectionStrategy();
+
+        strategy.handleSelection(uiModel, 0, 0, true, false);
+
+        verify(parentGridUiCellCellSelectionStrategy).handleSelection(eq(parentGridUiModel),
+                                                                      eq(PARENT_ROW_INDEX),
+                                                                      eq(PARENT_COLUMN_INDEX),
+                                                                      eq(true),
+                                                                      eq(false));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
@@ -172,13 +172,6 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     }
 
     @Test
-    public void testSelect() {
-        grid.select();
-
-        verify(grid).selectFirstCell();
-    }
-
-    @Test
     public void testDeselect() {
         grid.getModel().appendRow(new DMNGridRow());
         appendColumns(GridColumn.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
@@ -233,7 +233,12 @@ public class DMNGridLayerTest {
 
     @Test
     public void testSelectGridWidget() {
+        when(expressionGrid.getModel()).thenReturn(new BaseGridData(false));
+        when(expressionGrid.asNode()).thenReturn(mock(Node.class));
+
         assertThat(gridLayer.getSelectedGridWidget().isPresent()).isFalse();
+
+        gridLayer.add(expressionGrid);
 
         gridLayer.select(expressionGrid);
 
@@ -251,6 +256,7 @@ public class DMNGridLayerTest {
         gridData.setCellValue(0, 0, new ExpressionCellValue(Optional.of(expressionGrid)));
 
         gridLayer.register(gridWidget);
+        gridLayer.register(expressionGrid);
 
         assertThat(gridLayer.getSelectedGridWidget().isPresent()).isFalse();
 
@@ -262,20 +268,18 @@ public class DMNGridLayerTest {
         assertThat(gridLayer.getSelectedGridWidget().isPresent()).isTrue();
         assertThat(gridLayer.getSelectedGridWidget().get()).isEqualTo(expressionGrid);
 
-        verify(gridWidget).deselect();
-        verify(expressionGrid).deselect();
         verify(expressionGrid).select();
 
-        //Select outer grid
+        //Select outer grid, deselecting nested grid
         reset(gridWidget, expressionGrid);
         when(gridWidget.getModel()).thenReturn(gridData);
         when(expressionGrid.getModel()).thenReturn(new BaseGridData(false));
+        when(expressionGrid.isSelected()).thenReturn(true);
         gridLayer.select(gridWidget);
 
         assertThat(gridLayer.getSelectedGridWidget().isPresent()).isTrue();
         assertThat(gridLayer.getSelectedGridWidget().get()).isEqualTo(gridWidget);
 
-        verify(gridWidget).deselect();
         verify(gridWidget).select();
         verify(expressionGrid).deselect();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
@@ -19,9 +19,11 @@ package org.kie.workbench.common.dmn.client.widgets.layer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 
 import com.ait.lienzo.client.core.Context2D;
 import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.Node;
 import com.ait.lienzo.client.core.shape.Rectangle;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.BoundingBox;
@@ -33,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainerGrid;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.dnd.DelegatingGridWidgetDndMouseMoveHandler;
@@ -42,8 +45,14 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
@@ -51,6 +60,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -134,31 +144,31 @@ public class DMNGridLayerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testNoGhostAddedWhenNoContainerFound() {
         gridLayer.doBatch();
 
-        verify(gridLayer, never()).findSelectedExpressionGrid();
-        verify(gridLayer, never()).addGhost(any(ExpressionContainerGrid.class), any(BaseExpressionGrid.class));
+        verify(gridLayer, never()).addGhost(any(ExpressionContainerGrid.class), any(GridWidget.class));
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testNoGhostAddedWhenContainerFoundButNoExpressionGridFound() {
         doReturn(Collections.singleton(container)).when(gridLayer).getGridWidgets();
 
         gridLayer.doBatch();
 
-        verify(gridLayer).findSelectedExpressionGrid();
-        verify(gridLayer, never()).addGhost(any(ExpressionContainerGrid.class), any(BaseExpressionGrid.class));
+        verify(gridLayer, never()).addGhost(any(ExpressionContainerGrid.class), any(GridWidget.class));
     }
 
     @Test
     public void testGhostAddedWhenContainerFoundAndExpressionGridFound() {
         doReturn(new HashSet<>(Arrays.asList(container, expressionGrid))).when(gridLayer).getGridWidgets();
-        when(expressionGrid.isSelected()).thenReturn(true);
+
+        gridLayer.select(expressionGrid);
 
         gridLayer.doBatch();
 
-        verify(gridLayer).findSelectedExpressionGrid();
         verify(gridLayer).addGhost(eq(container), eq(expressionGrid));
     }
 
@@ -167,7 +177,8 @@ public class DMNGridLayerTest {
         GwtMockito.useProviderForType(Group.class, clazz -> ghostGroup);
         doReturn(new HashSet<>(Arrays.asList(container, expressionGrid))).when(gridLayer).getGridWidgets();
         doReturn(ghostRectangle).when(gridLayer).getGhostRectangle();
-        doReturn(true).when(expressionGrid).isSelected();
+
+        gridLayer.select(expressionGrid);
 
         gridLayer.doBatch();
 
@@ -181,8 +192,9 @@ public class DMNGridLayerTest {
         GwtMockito.useProviderForType(Group.class, clazz -> ghostGroup);
         doReturn(new HashSet<>(Arrays.asList(container, literalExpressionGrid))).when(gridLayer).getGridWidgets();
         doReturn(ghostRectangle).when(gridLayer).getGhostRectangle();
-        doReturn(true).when(literalExpressionGrid).isSelected();
         doReturn(parentGridCellTuple).when(literalExpressionGrid).getParentInformation();
+
+        gridLayer.select(literalExpressionGrid);
 
         gridLayer.doBatch();
 
@@ -196,8 +208,9 @@ public class DMNGridLayerTest {
         GwtMockito.useProviderForType(Group.class, clazz -> ghostGroup);
         doReturn(new HashSet<>(Arrays.asList(container, undefinedExpressionGrid))).when(gridLayer).getGridWidgets();
         doReturn(ghostRectangle).when(gridLayer).getGhostRectangle();
-        doReturn(true).when(undefinedExpressionGrid).isSelected();
         doReturn(parentGridCellTuple).when(undefinedExpressionGrid).getParentInformation();
+
+        gridLayer.select(undefinedExpressionGrid);
 
         gridLayer.doBatch();
 
@@ -216,6 +229,112 @@ public class DMNGridLayerTest {
         verify(ghostGroup).setPathClipper(any(InverseGridWidgetClipper.class));
         verify(ghostGroup).add(ghostRectangle);
         verify(ghostGroup).drawWithTransforms(eq(context2D), anyDouble(), any(BoundingBox.class));
+    }
+
+    @Test
+    public void testSelectGridWidget() {
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isFalse();
+
+        gridLayer.select(expressionGrid);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isTrue();
+        assertThat(gridLayer.getSelectedGridWidget().get()).isEqualTo(expressionGrid);
+        verify(expressionGrid).select();
+    }
+
+    @Test
+    public void testSelectNestedGridWidget() {
+        final GridWidget gridWidget = mock(GridWidget.class);
+        final GridData gridData = new BaseGridData(false);
+        gridData.appendRow(new BaseGridRow());
+        gridData.appendColumn(mock(GridColumn.class));
+        gridData.setCellValue(0, 0, new ExpressionCellValue(Optional.of(expressionGrid)));
+
+        gridLayer.register(gridWidget);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isFalse();
+
+        //Select nested grid
+        when(gridWidget.getModel()).thenReturn(gridData);
+        when(expressionGrid.getModel()).thenReturn(new BaseGridData(false));
+        gridLayer.select(expressionGrid);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isTrue();
+        assertThat(gridLayer.getSelectedGridWidget().get()).isEqualTo(expressionGrid);
+
+        verify(gridWidget).deselect();
+        verify(expressionGrid).deselect();
+        verify(expressionGrid).select();
+
+        //Select outer grid
+        reset(gridWidget, expressionGrid);
+        when(gridWidget.getModel()).thenReturn(gridData);
+        when(expressionGrid.getModel()).thenReturn(new BaseGridData(false));
+        gridLayer.select(gridWidget);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isTrue();
+        assertThat(gridLayer.getSelectedGridWidget().get()).isEqualTo(gridWidget);
+
+        verify(gridWidget).deselect();
+        verify(gridWidget).select();
+        verify(expressionGrid).deselect();
+    }
+
+    @Test
+    public void testDeregister() {
+        final GridWidget gridWidget = mock(GridWidget.class);
+
+        gridLayer.select(gridWidget);
+
+        gridLayer.deregister(expressionGrid);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isTrue();
+        assertThat(gridLayer.getSelectedGridWidget().get()).isEqualTo(gridWidget);
+
+        gridLayer.deregister(gridWidget);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isFalse();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRemove() {
+        final GridWidget gridWidget = mock(GridWidget.class);
+        when(gridWidget.getModel()).thenReturn(new BaseGridData(false));
+        when(expressionGrid.getModel()).thenReturn(new BaseGridData(false));
+        when(gridWidget.asNode()).thenReturn(mock(Node.class));
+        when(expressionGrid.asNode()).thenReturn(mock(Node.class));
+
+        gridLayer.add(gridWidget);
+        gridLayer.add(expressionGrid);
+        gridLayer.select(expressionGrid);
+
+        gridLayer.remove(gridWidget);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isTrue();
+        assertThat(gridLayer.getSelectedGridWidget().get()).isEqualTo(expressionGrid);
+
+        gridLayer.remove(expressionGrid);
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isFalse();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRemoveAll() {
+        final GridWidget gridWidget = mock(GridWidget.class);
+        when(gridWidget.getModel()).thenReturn(new BaseGridData(false));
+        when(expressionGrid.getModel()).thenReturn(new BaseGridData(false));
+        when(gridWidget.asNode()).thenReturn(mock(Node.class));
+        when(expressionGrid.asNode()).thenReturn(mock(Node.class));
+
+        gridLayer.add(gridWidget);
+        gridLayer.add(expressionGrid);
+        gridLayer.select(expressionGrid);
+
+        gridLayer.removeAll();
+
+        assertThat(gridLayer.getSelectedGridWidget().isPresent()).isFalse();
     }
 
     private static class TestDMNGridLayer extends DMNGridLayer {


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2410

The problem was that grids "off screen" are no longer registered and hence when they moved "off screen" a "selected" grid could not be found and the ghost not rendered. 

I also fixed a problem I found when if you select a cell in a grid scroll it "off screen" and select a different cell in a different nested grid; then scroll back the original selection remained. This too was caused by "off screen" grids no longer being registered. I now walk the data models and deselect all grids whether "on screen" or "off screen". This is quite a (relatively) slow operation (and was removed elsewhere for performance reasons) but is OK to use when selecting a grid as it's driven by the User's interactions and performance is not critical.
 
Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/256
- https://github.com/kiegroup/kie-wb-common/pull/1530