### PR TITLE
DROOLS-2392: [DMN Designer] Undo and Redo does not update user interface

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
@@ -16,10 +16,15 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -27,8 +32,10 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
-public abstract class BaseEditorDefinition<T extends Expression> implements ExpressionEditorDefinition<T> {
+public abstract class BaseEditorDefinition<E extends Expression, D extends GridData> implements ExpressionEditorDefinition<E>,
+                                                                                                GridDataCache<E, D> {
 
     protected DMNGridPanel gridPanel;
     protected DMNGridLayer gridLayer;
@@ -39,6 +46,8 @@ public abstract class BaseEditorDefinition<T extends Expression> implements Expr
     protected CellEditorControlsView.Presenter cellEditorControls;
     protected ListSelectorView.Presenter listSelector;
     protected TranslationService translationService;
+
+    protected Map<String, D> cache = new HashMap<>();
 
     public BaseEditorDefinition() {
         //CDI proxy
@@ -63,4 +72,21 @@ public abstract class BaseEditorDefinition<T extends Expression> implements Expr
         this.listSelector = listSelector;
         this.translationService = translationService;
     }
+
+    @Override
+    public CacheResult<D> getData(final Optional<String> nodeUUID,
+                                  final Optional<E> expression) {
+        if (!nodeUUID.isPresent()) {
+            return new CacheResult<>(makeGridData(expression), false);
+        }
+        if (!cache.containsKey(nodeUUID.get())) {
+            final D gridData = makeGridData(expression);
+            cache.put(nodeUUID.get(),
+                      gridData);
+            return new CacheResult<>(gridData, false);
+        }
+        return new CacheResult<>(cache.get(nodeUUID.get()), true);
+    }
+
+    protected abstract D makeGridData(final Optional<E> expression);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -48,7 +49,7 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
-public class ContextEditorDefinition extends BaseEditorDefinition<Context> {
+public class ContextEditorDefinition extends BaseEditorDefinition<Context, ContextGridData> {
 
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
@@ -113,6 +114,7 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context> {
                                                   final int nesting) {
         return Optional.of(new ContextGrid(parent,
                                            nodeUUID,
+                                           this,
                                            hasExpression,
                                            expression,
                                            hasName,
@@ -127,5 +129,14 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context> {
                                            translationService,
                                            nesting,
                                            expressionEditorDefinitionsSupplier));
+    }
+
+    @Override
+    protected ContextGridData makeGridData(final Optional<Context> expression) {
+        return new ContextGridData(new DMNGridData(),
+                                   sessionManager,
+                                   sessionCommandManager,
+                                   expression,
+                                   gridLayer::batch);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -38,9 +38,9 @@ import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.HasRowDragRestrictions;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -56,8 +56,8 @@ import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlers
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState.GridWidgetHandlersOperation;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
-public class ContextGrid extends BaseExpressionGrid<Context, ContextUIModelMapper> implements HasRowDragRestrictions,
-                                                                                              HasListSelectorControl {
+public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, ContextUIModelMapper> implements HasRowDragRestrictions,
+                                                                                                               HasListSelectorControl {
 
     private static final String EXPRESSION_COLUMN_GROUP = "ContextGrid$ExpressionColumn1";
 
@@ -65,6 +65,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextUIModelMappe
 
     public ContextGrid(final GridCellTuple parent,
                        final Optional<String> nodeUUID,
+                       final GridDataCache<Context, ContextGridData> cache,
                        final HasExpression hasExpression,
                        final Optional<Context> expression,
                        final Optional<HasName> hasName,
@@ -86,11 +87,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextUIModelMappe
               hasName,
               gridPanel,
               gridLayer,
-              new ContextGridData(new DMNGridData(),
-                                  sessionManager,
-                                  sessionCommandManager,
-                                  expression,
-                                  gridLayer::batch),
+              cache.getData(nodeUUID, expression),
               new ContextGridRenderer(nesting > 0),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
@@ -41,6 +41,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -52,7 +53,7 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
-public class DecisionTableEditorDefinition extends BaseEditorDefinition<DecisionTable> {
+public class DecisionTableEditorDefinition extends BaseEditorDefinition<DecisionTable, DecisionTableGridData> {
 
     static final String INPUT_CLAUSE_EXPRESSION_TEXT = "input";
 
@@ -147,6 +148,7 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
                                                   final int nesting) {
         return Optional.of(new DecisionTableGrid(parent,
                                                  nodeUUID,
+                                                 this,
                                                  hasExpression,
                                                  expression,
                                                  hasName,
@@ -161,5 +163,14 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
                                                  translationService,
                                                  nesting,
                                                  hitPolicyEditor));
+    }
+
+    @Override
+    protected DecisionTableGridData makeGridData(final Optional<DecisionTable> expression) {
+        return new DecisionTableGridData(new DMNGridData(),
+                                         sessionManager,
+                                         sessionCommandManager,
+                                         expression,
+                                         gridLayer::batch);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -52,9 +52,9 @@ import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextBoxS
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -68,8 +68,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.mvp.Command;
 
-public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, DecisionTableUIModelMapper> implements HasListSelectorControl,
-                                                                                                                HasHitPolicyControl {
+public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, DecisionTableGridData, DecisionTableUIModelMapper> implements HasListSelectorControl,
+                                                                                                                                       HasHitPolicyControl {
 
     public static final BuiltinAggregator DEFAULT_AGGREGATOR = BuiltinAggregator.COUNT;
 
@@ -100,6 +100,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
 
     public DecisionTableGrid(final GridCellTuple parent,
                              final Optional<String> nodeUUID,
+                             final GridDataCache<DecisionTable, DecisionTableGridData> cache,
                              final HasExpression hasExpression,
                              final Optional<DecisionTable> expression,
                              final Optional<HasName> hasName,
@@ -121,11 +122,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
               hasName,
               gridPanel,
               gridLayer,
-              new DecisionTableGridData(new DMNGridData(),
-                                        sessionManager,
-                                        sessionCommandManager,
-                                        expression,
-                                        gridLayer::batch),
+              cache.getData(nodeUUID, expression),
               new DecisionTableGridRenderer(),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -47,7 +48,7 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
-public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefinition> {
+public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefinition, DMNGridData> {
 
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
     private Supplier<ExpressionEditorDefinitions> supplementaryEditorDefinitionsSupplier;
@@ -112,6 +113,7 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
                                                   final int nesting) {
         return Optional.of(new FunctionGrid(parent,
                                             nodeUUID,
+                                            this,
                                             hasExpression,
                                             expression,
                                             hasName,
@@ -128,5 +130,10 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
                                             expressionEditorDefinitionsSupplier,
                                             supplementaryEditorDefinitionsSupplier,
                                             parametersEditor));
+    }
+
+    @Override
+    protected DMNGridData makeGridData(final Optional<FunctionDefinition> expression) {
+        return new DMNGridData();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -48,9 +48,11 @@ import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -62,8 +64,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.mvp.Command;
 
-public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, FunctionUIModelMapper> implements HasListSelectorControl,
-                                                                                                           HasParametersControl {
+public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGridData, FunctionUIModelMapper> implements HasListSelectorControl,
+                                                                                                                        HasParametersControl {
 
     private final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
     private final Supplier<ExpressionEditorDefinitions> supplementaryEditorDefinitionsSupplier;
@@ -71,6 +73,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
 
     public FunctionGrid(final GridCellTuple parent,
                         final Optional<String> nodeUUID,
+                        final GridDataCache<FunctionDefinition, DMNGridData> cache,
                         final HasExpression hasExpression,
                         final Optional<FunctionDefinition> expression,
                         final Optional<HasName> hasName,
@@ -94,6 +97,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, Functio
               hasName,
               gridPanel,
               gridLayer,
+              cache.getData(nodeUUID, expression),
               new FunctionGridRenderer(nesting > 0),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
@@ -34,9 +34,9 @@ import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
-public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, ContextUIModelMapper> implements HasListSelectorControl {
+public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, FunctionSupplementaryGridData, ContextUIModelMapper> implements HasListSelectorControl {
 
     private static final String EXPRESSION_COLUMN_GROUP = "FunctionSupplementaryGrid$ExpressionColumn1";
 
@@ -55,6 +55,7 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Conte
 
     public FunctionSupplementaryGrid(final GridCellTuple parent,
                                      final Optional<String> nodeUUID,
+                                     final GridDataCache<Context, FunctionSupplementaryGridData> cache,
                                      final HasExpression hasExpression,
                                      final Optional<Context> expression,
                                      final Optional<HasName> hasName,
@@ -76,11 +77,7 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Conte
               hasName,
               gridPanel,
               gridLayer,
-              new FunctionSupplementaryGridData(new DMNGridData(),
-                                                sessionManager,
-                                                sessionCommandManager,
-                                                expression,
-                                                gridLayer::batch),
+              cache.getData(nodeUUID, expression),
               new ContextGridRenderer(true),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
@@ -36,10 +36,12 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionE
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.FunctionGridSupplementaryEditor;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.FunctionSupplementaryGrid;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.FunctionSupplementaryGridData;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -52,7 +54,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
 @FunctionGridSupplementaryEditor
-public class JavaFunctionEditorDefinition extends BaseEditorDefinition<Context> {
+public class JavaFunctionEditorDefinition extends BaseEditorDefinition<Context, FunctionSupplementaryGridData> {
 
     public static final String VARIABLE_CLASS = "class";
 
@@ -125,6 +127,7 @@ public class JavaFunctionEditorDefinition extends BaseEditorDefinition<Context> 
                                                   final int nesting) {
         return Optional.of(new FunctionSupplementaryGrid(parent,
                                                          nodeUUID,
+                                                         this,
                                                          hasExpression,
                                                          expression,
                                                          hasName,
@@ -139,5 +142,14 @@ public class JavaFunctionEditorDefinition extends BaseEditorDefinition<Context> 
                                                          translationService,
                                                          nesting,
                                                          expressionEditorDefinitionsSupplier));
+    }
+
+    @Override
+    protected FunctionSupplementaryGridData makeGridData(final Optional<Context> expression) {
+        return new FunctionSupplementaryGridData(new DMNGridData(),
+                                                 sessionManager,
+                                                 sessionCommandManager,
+                                                 expression,
+                                                 gridLayer::batch);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
@@ -36,10 +36,12 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionE
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.FunctionGridSupplementaryEditor;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.FunctionSupplementaryGrid;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.FunctionSupplementaryGridData;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -52,7 +54,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
 @FunctionGridSupplementaryEditor
-public class PMMLFunctionEditorDefinition extends BaseEditorDefinition<Context> {
+public class PMMLFunctionEditorDefinition extends BaseEditorDefinition<Context, FunctionSupplementaryGridData> {
 
     public static final String VARIABLE_DOCUMENT = "document";
 
@@ -125,6 +127,7 @@ public class PMMLFunctionEditorDefinition extends BaseEditorDefinition<Context> 
                                                   final int nesting) {
         return Optional.of(new FunctionSupplementaryGrid(parent,
                                                          nodeUUID,
+                                                         this,
                                                          hasExpression,
                                                          expression,
                                                          hasName,
@@ -139,5 +142,14 @@ public class PMMLFunctionEditorDefinition extends BaseEditorDefinition<Context> 
                                                          translationService,
                                                          nesting,
                                                          expressionEditorDefinitionsSupplier));
+    }
+
+    @Override
+    protected FunctionSupplementaryGridData makeGridData(final Optional<Context> expression) {
+        return new FunctionSupplementaryGridData(new DMNGridData(),
+                                                 sessionManager,
+                                                 sessionCommandManager,
+                                                 expression,
+                                                 gridLayer::batch);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -49,7 +50,7 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
-public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation> {
+public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation, InvocationGridData> {
 
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
@@ -111,6 +112,7 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation>
                                                   final int nesting) {
         return Optional.of(new InvocationGrid(parent,
                                               nodeUUID,
+                                              this,
                                               hasExpression,
                                               expression,
                                               hasName,
@@ -125,5 +127,14 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation>
                                               translationService,
                                               nesting,
                                               expressionEditorDefinitionsSupplier));
+    }
+
+    @Override
+    protected InvocationGridData makeGridData(final Optional<Invocation> expression) {
+        return new InvocationGridData(new DMNGridData(),
+                                      sessionManager,
+                                      sessionCommandManager,
+                                      expression,
+                                      gridLayer::batch);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -45,9 +45,9 @@ import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextBoxS
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -59,7 +59,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
-public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationUIModelMapper> implements HasListSelectorControl {
+public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGridData, InvocationUIModelMapper> implements HasListSelectorControl {
 
     private static final String EXPRESSION_COLUMN_GROUP = "InvocationGrid$ExpressionColumn1";
 
@@ -67,6 +67,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationUIM
 
     public InvocationGrid(final GridCellTuple parent,
                           final Optional<String> nodeUUID,
+                          final GridDataCache<Invocation, InvocationGridData> cache,
                           final HasExpression hasExpression,
                           final Optional<Invocation> expression,
                           final Optional<HasName> hasName,
@@ -88,11 +89,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationUIM
               hasName,
               gridPanel,
               gridLayer,
-              new InvocationGridData(new DMNGridData(),
-                                     sessionManager,
-                                     sessionCommandManager,
-                                     expression,
-                                     gridLayer::batch),
+              cache.getData(nodeUUID, expression),
               new InvocationGridRenderer(nesting > 0),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -43,7 +44,7 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
-public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<LiteralExpression> {
+public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<LiteralExpression, DMNGridData> {
 
     public LiteralExpressionEditorDefinition() {
         //CDI proxy
@@ -94,6 +95,7 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
                                                   final int nesting) {
         return Optional.of(new LiteralExpressionGrid(parent,
                                                      nodeUUID,
+                                                     this,
                                                      hasExpression,
                                                      expression,
                                                      hasName,
@@ -107,5 +109,10 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
                                                      listSelector,
                                                      translationService,
                                                      nesting));
+    }
+
+    @Override
+    protected DMNGridData makeGridData(final Optional<LiteralExpression> expression) {
+        return new DMNGridData();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -31,8 +31,10 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorCo
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -44,12 +46,13 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
-public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression, LiteralExpressionUIModelMapper> implements HasListSelectorControl {
+public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression, DMNGridData, LiteralExpressionUIModelMapper> implements HasListSelectorControl {
 
     public static final double PADDING = 0.0;
 
     public LiteralExpressionGrid(final GridCellTuple parent,
                                  final Optional<String> nodeUUID,
+                                 final GridDataCache<LiteralExpression, DMNGridData> cache,
                                  final HasExpression hasExpression,
                                  final Optional<LiteralExpression> expression,
                                  final Optional<HasName> hasName,
@@ -70,6 +73,7 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
               hasName,
               gridPanel,
               gridLayer,
+              cache.getData(nodeUUID, expression),
               new LiteralExpressionGridRenderer(nesting > 0),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -45,7 +46,7 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
-public class RelationEditorDefinition extends BaseEditorDefinition<Relation> {
+public class RelationEditorDefinition extends BaseEditorDefinition<Relation, RelationGridData> {
 
     public RelationEditorDefinition() {
         //CDI proxy
@@ -103,6 +104,7 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation> {
                                                   final int nesting) {
         return Optional.of(new RelationGrid(parent,
                                             nodeUUID,
+                                            this,
                                             hasExpression,
                                             expression,
                                             hasName,
@@ -116,5 +118,14 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation> {
                                             listSelector,
                                             translationService,
                                             nesting));
+    }
+
+    @Override
+    protected RelationGridData makeGridData(final Optional<Relation> expression) {
+        return new RelationGridData(new DMNGridData(),
+                                    sessionManager,
+                                    sessionCommandManager,
+                                    expression,
+                                    gridLayer::batch);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -38,9 +38,9 @@ import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextBoxS
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -51,13 +51,14 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
-public class RelationGrid extends BaseExpressionGrid<Relation, RelationUIModelMapper> implements HasListSelectorControl {
+public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData, RelationUIModelMapper> implements HasListSelectorControl {
 
     private final TextAreaSingletonDOMElementFactory factory = getBodyTextAreaFactory();
     private final TextBoxSingletonDOMElementFactory headerFactory = getHeaderTextBoxFactory();
 
     public RelationGrid(final GridCellTuple parent,
                         final Optional<String> nodeUUID,
+                        final GridDataCache<Relation, RelationGridData> cache,
                         final HasExpression hasExpression,
                         final Optional<Relation> expression,
                         final Optional<HasName> hasName,
@@ -78,11 +79,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationUIModelMa
               hasName,
               gridPanel,
               gridLayer,
-              new RelationGridData(new DMNGridData(),
-                                   sessionManager,
-                                   sessionCommandManager,
-                                   expression,
-                                   gridLayer::batch),
+              cache.getData(nodeUUID, expression),
               new RelationGridRenderer(),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
@@ -45,7 +46,7 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
-public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Expression> {
+public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Expression, DMNGridData> {
 
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
@@ -100,6 +101,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                   final int nesting) {
         return Optional.of(new UndefinedExpressionGrid(parent,
                                                        nodeUUID,
+                                                       this,
                                                        hasExpression,
                                                        expression,
                                                        hasName,
@@ -114,5 +116,10 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                        translationService,
                                                        nesting,
                                                        expressionEditorDefinitionsSupplier));
+    }
+
+    @Override
+    protected DMNGridData makeGridData(final Optional<Expression> expression) {
+        return new DMNGridData();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
@@ -37,9 +37,11 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorCo
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -52,7 +54,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
-public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, UndefinedExpressionUIModelMapper> implements HasListSelectorControl {
+public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNGridData, UndefinedExpressionUIModelMapper> implements HasListSelectorControl {
 
     public static final double PADDING = 0.0;
 
@@ -62,6 +64,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, Unde
 
     public UndefinedExpressionGrid(final GridCellTuple parent,
                                    final Optional<String> nodeUUID,
+                                   final GridDataCache<Expression, DMNGridData> cache,
                                    final HasExpression hasExpression,
                                    final Optional<Expression> expression,
                                    final Optional<HasName> hasName,
@@ -83,6 +86,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, Unde
               hasName,
               gridPanel,
               gridLayer,
+              cache.getData(nodeUUID, expression),
               new UndefinedExpressionGridRenderer(),
               definitionUtils,
               sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridDataCache.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridDataCache.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.model;
+
+import java.util.Optional;
+
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+
+public interface GridDataCache<E extends Expression, D extends GridData> {
+
+    CacheResult<D> getData(final Optional<String> nodeUUID,
+                           final Optional<E> expression);
+
+    class CacheResult<D> {
+
+        private final D gridData;
+        private final boolean isCacheHit;
+
+        public CacheResult(final D gridData,
+                           final boolean isCacheHit) {
+            this.gridData = gridData;
+            this.isCacheHit = isCacheHit;
+        }
+
+        public D getGridData() {
+            return gridData;
+        }
+
+        public boolean isCacheHit() {
+            return isCacheHit;
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinitionTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions.types;
+
+import java.util.Optional;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
+import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class BaseEditorDefinitionTest {
+
+    @Mock
+    private DMNGridPanel gridPanel;
+
+    @Mock
+    private DMNGridLayer gridLayer;
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+
+    @Mock
+    private CellEditorControlsView.Presenter cellEditorControls;
+
+    @Mock
+    private ListSelectorView.Presenter listSelector;
+
+    @Mock
+    private TranslationService translationService;
+
+    @Mock
+    private LiteralExpressionGrid editor;
+
+    private BaseEditorDefinition<LiteralExpression, DMNGridData> definition;
+
+    @Before
+    public void setup() {
+        this.definition = new BaseEditorDefinition<LiteralExpression, DMNGridData>(gridPanel,
+                                                                                   gridLayer,
+                                                                                   definitionUtils,
+                                                                                   sessionManager,
+                                                                                   sessionCommandManager,
+                                                                                   canvasCommandFactory,
+                                                                                   cellEditorControls,
+                                                                                   listSelector,
+                                                                                   translationService) {
+            @Override
+            protected DMNGridData makeGridData(final Optional<LiteralExpression> expression) {
+                return new DMNGridData();
+            }
+
+            @Override
+            public ExpressionType getType() {
+                return ExpressionType.LITERAL_EXPRESSION;
+            }
+
+            @Override
+            public String getName() {
+                return LiteralExpression.class.getName();
+            }
+
+            @Override
+            public Optional<LiteralExpression> getModelClass() {
+                return Optional.of(new LiteralExpression());
+            }
+
+            @Override
+            public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
+                                                          final Optional nodeUUID,
+                                                          final HasExpression hasExpression,
+                                                          final Optional expression,
+                                                          final Optional optional,
+                                                          final int nesting) {
+                return Optional.of(editor);
+            }
+        };
+    }
+
+    @Test
+    public void testCacheWhenNested() {
+        final Optional<String> UUID = Optional.empty();
+        final GridDataCache.CacheResult<DMNGridData> result1 = definition.getData(UUID, definition.getModelClass());
+        assertCacheResult(result1, false);
+
+        final GridDataCache.CacheResult<DMNGridData> result2 = definition.getData(UUID, definition.getModelClass());
+        assertCacheResult(result2, false);
+
+        final DMNGridData uiModel1 = result1.getGridData();
+        final DMNGridData uiModel2 = result2.getGridData();
+        assertThat(uiModel1).isNotSameAs(uiModel2);
+    }
+
+    @Test
+    public void testCacheWhenNotNested() {
+        final Optional<String> UUID = Optional.of("uuid");
+        final GridDataCache.CacheResult<DMNGridData> result1 = definition.getData(UUID, definition.getModelClass());
+        assertCacheResult(result1, false);
+
+        final GridDataCache.CacheResult<DMNGridData> result2 = definition.getData(UUID, definition.getModelClass());
+        assertCacheResult(result2, true);
+
+        final DMNGridData uiModel1 = result1.getGridData();
+        final DMNGridData uiModel2 = result2.getGridData();
+
+        assertThat(uiModel1).isSameAs(uiModel2);
+    }
+
+    private void assertCacheResult(final GridDataCache.CacheResult<DMNGridData> result, final boolean hit) {
+        assertThat(result).isNotNull();
+        assertThat(result.isCacheHit()).isEqualTo(hit);
+        assertThat(result.getGridData()).isInstanceOf(DMNGridData.class);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
@@ -33,8 +33,10 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellE
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -385,6 +387,7 @@ public class ExpressionEditorColumnTest {
                                       hasName,
                                       gridPanel,
                                       gridLayer,
+                                      new GridDataCache.CacheResult(new DMNGridData(), false),
                                       renderer,
                                       definitionUtils,
                                       sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridCacheTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridCacheTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid;
+
+import java.util.Optional;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class BaseExpressionGridCacheTest extends BaseExpressionGridTest {
+
+    @Mock
+    private GridRow uiRow;
+
+    @Mock
+    private GridColumn uiColumn;
+
+    private GridDataCache.CacheResult<DMNGridData> cacheResult = new GridDataCache.CacheResult<>(new DMNGridData(), false);
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public BaseExpressionGrid getGrid() {
+        final HasExpression hasExpression = mock(HasExpression.class);
+        final Optional<LiteralExpression> expression = Optional.of(mock(LiteralExpression.class));
+        final Optional<HasName> hasName = Optional.of(mock(HasName.class));
+
+        return new BaseExpressionGrid(parentCell,
+                                      Optional.empty(),
+                                      hasExpression,
+                                      expression,
+                                      hasName,
+                                      gridPanel,
+                                      gridLayer,
+                                      cacheResult,
+                                      renderer,
+                                      definitionUtils,
+                                      sessionManager,
+                                      sessionCommandManager,
+                                      canvasCommandFactory,
+                                      cellEditorControls,
+                                      listSelector,
+                                      translationService,
+                                      0) {
+            @Override
+            protected BaseUIModelMapper makeUiModelMapper() {
+                return mapper;
+            }
+
+            @Override
+            protected void initialiseUiColumns() {
+                model.appendColumn(uiColumn);
+            }
+
+            @Override
+            protected void initialiseUiModel() {
+                model.appendRow(uiRow);
+            }
+
+            @Override
+            protected boolean isHeaderHidden() {
+                return false;
+            }
+        };
+    }
+
+    @Test
+    public void testCachedModelReuse() {
+        //Initial CacheResult and Grid were created during Unit Test setup
+        final BaseExpressionGrid grid1 = grid;
+        assertGridModelDefinition(grid1);
+
+        cacheResult = new GridDataCache.CacheResult<>(cacheResult.getGridData(), true);
+        final BaseExpressionGrid grid2 = getGrid();
+        assertGridModelDefinition(grid2);
+
+        assertThat(grid1.getModel()).isSameAs(grid2.getModel());
+        assertThat(grid1).isNotSameAs(grid2);
+    }
+
+    private void assertGridModelDefinition(final BaseExpressionGrid grid) {
+        assertThat(grid.getModel().getRowCount()).isEqualTo(1);
+        assertThat(grid.getModel().getRows().get(0)).isSameAs(uiRow);
+        assertThat(grid.getModel().getColumnCount()).isEqualTo(1);
+        assertThat(grid.getModel().getColumns().get(0)).isSameAs(uiColumn);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
@@ -32,7 +32,9 @@ import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -73,6 +75,7 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
                                       hasName,
                                       gridPanel,
                                       gridLayer,
+                                      new GridDataCache.CacheResult(new DMNGridData(), false),
                                       renderer,
                                       definitionUtils,
                                       sessionManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
@@ -30,8 +30,10 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridDataCache;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
@@ -158,6 +160,7 @@ public class BaseExpressionGridRenderingTest extends BaseExpressionGridTest {
                                       hasName,
                                       gridPanel,
                                       gridLayer,
+                                      new GridDataCache.CacheResult(new DMNGridData(), false),
                                       renderer,
                                       definitionUtils,
                                       sessionManager,


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2392

This PR adds support for caching the UI model used for "top level" Expressions.

The problem was that each time the User navigates back to the "graph" view and then again back to (the same) "grid" the UI model was recreated and commands in the undo/redo queue remained associated with the old UI model. With the cache "top level" Expressions, with a UUID (from Stunner), cache and re-use the UI model.