### PR TITLE
DROOLS-2420: [DMN Designer] Hit Policy Collect does not need an Aggregation function

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -71,8 +71,6 @@ import org.uberfire.mvp.Command;
 public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, DecisionTableUIModelMapper> implements HasListSelectorControl,
                                                                                                                 HasHitPolicyControl {
 
-    public static final BuiltinAggregator DEFAULT_AGGREGATOR = BuiltinAggregator.COUNT;
-
     public static final String DESCRIPTION_GROUP = "DecisionTable$Description";
 
     private final HitPolicyEditorView.Presenter hitPolicyEditor;
@@ -437,12 +435,9 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                              final Command onSuccess) {
         expression.ifPresent(dtable -> {
             final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder = new CompositeCommand.Builder<>();
-            if (requiresDefaultAggregation(hitPolicy)) {
-                commandBuilder.addCommand(new SetBuiltinAggregatorCommand(dtable,
-                                                                          getDefaultAggregation(dtable, hitPolicy),
-                                                                          gridLayer::batch));
-            }
-
+            commandBuilder.addCommand(new SetBuiltinAggregatorCommand(dtable,
+                                                                      null,
+                                                                      gridLayer::batch));
             commandBuilder.addCommand(new SetHitPolicyCommand(dtable,
                                                               hitPolicy,
                                                               () -> {
@@ -453,21 +448,6 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           commandBuilder.build());
         });
-    }
-
-    boolean requiresDefaultAggregation(final HitPolicy hitPolicy) {
-        return HitPolicy.COLLECT.equals(hitPolicy);
-    }
-
-    BuiltinAggregator getDefaultAggregation(final DecisionTable dtable,
-                                            final HitPolicy hitPolicy) {
-        if (requiresDefaultAggregation(hitPolicy)) {
-            if (dtable.getAggregation() == null) {
-                return DEFAULT_AGGREGATOR;
-            }
-            return dtable.getAggregation();
-        }
-        return null;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/BuiltinAggregatorUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/BuiltinAggregatorUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hitpolicy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.dmn.api.definition.v1_1.BuiltinAggregator;
+import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
+
+@ApplicationScoped
+public class BuiltinAggregatorUtils {
+
+    private TranslationService translationService;
+
+    public BuiltinAggregatorUtils() {
+        //CDI proxy
+    }
+
+    @Inject
+    public BuiltinAggregatorUtils(final TranslationService translationService) {
+        this.translationService = translationService;
+    }
+
+    public List<BuiltinAggregator> getAllValues() {
+        final List<BuiltinAggregator> builtinAggregators = new ArrayList<>();
+        builtinAggregators.add(null);
+        builtinAggregators.addAll(Arrays.asList(BuiltinAggregator.values()));
+        return builtinAggregators;
+    }
+
+    public String toString(final BuiltinAggregator aggregator) {
+        if (aggregator == null) {
+            return translationService.getTranslation(DMNEditorConstants.DecisionTableEditor_NullBuiltinAggregator);
+        }
+        return aggregator.value();
+    }
+
+    public BuiltinAggregator toEnum(final String value) {
+        if (value.equals(translationService.getTranslation(DMNEditorConstants.DecisionTableEditor_NullBuiltinAggregator))) {
+            return null;
+        }
+        return BuiltinAggregator.fromValue(value);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImpl.java
@@ -69,12 +69,8 @@ public class HitPolicyEditorImpl implements HitPolicyEditorView.Presenter {
             } else {
                 view.enableHitPolicies(true);
                 view.initSelectedHitPolicy(b.getHitPolicy());
-                if (!HitPolicy.COLLECT.equals(b.getHitPolicy())) {
-                    view.enableBuiltinAggregators(false);
-                } else {
-                    view.enableBuiltinAggregators(true);
-                    view.initSelectedBuiltinAggregator(b.getBuiltinAggregator());
-                }
+                view.enableBuiltinAggregators(HitPolicy.COLLECT.equals(b.getHitPolicy()));
+                view.initSelectedBuiltinAggregator(b.getBuiltinAggregator());
             }
 
             if (b.getDecisionTableOrientation() == null) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImpl.java
@@ -38,12 +38,13 @@ public class HitPolicyEditorImpl implements HitPolicyEditorView.Presenter {
     }
 
     @Inject
-    public HitPolicyEditorImpl(final HitPolicyEditorView view) {
+    public HitPolicyEditorImpl(final HitPolicyEditorView view,
+                               final BuiltinAggregatorUtils builtinAggregatorUtils) {
         this.view = view;
 
         view.init(this);
         view.initHitPolicies(Arrays.asList(HitPolicy.values()));
-        view.initBuiltinAggregators(Arrays.asList(BuiltinAggregator.values()));
+        view.initBuiltinAggregators(builtinAggregatorUtils.getAllValues());
         view.initDecisionTableOrientations(Arrays.asList(DecisionTableOrientation.values()));
     }
 
@@ -68,7 +69,7 @@ public class HitPolicyEditorImpl implements HitPolicyEditorView.Presenter {
             } else {
                 view.enableHitPolicies(true);
                 view.initSelectedHitPolicy(b.getHitPolicy());
-                if (!HitPolicy.COLLECT.equals(b.getHitPolicy()) || b.getBuiltinAggregator() == null) {
+                if (!HitPolicy.COLLECT.equals(b.getHitPolicy())) {
                     view.enableBuiltinAggregators(false);
                 } else {
                     view.enableBuiltinAggregators(true);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorViewImpl.java
@@ -45,6 +45,8 @@ public class HitPolicyEditorViewImpl implements HitPolicyEditorView {
     @DataField("lstDecisionTableOrientation")
     private Select lstDecisionTableOrientation;
 
+    private BuiltinAggregatorUtils builtinAggregatorUtils;
+
     private HitPolicyEditorView.Presenter presenter;
 
     public HitPolicyEditorViewImpl() {
@@ -54,10 +56,12 @@ public class HitPolicyEditorViewImpl implements HitPolicyEditorView {
     @Inject
     public HitPolicyEditorViewImpl(final Select lstHitPolicies,
                                    final Select lstBuiltinAggregator,
-                                   final Select lstDecisionTableOrientation) {
+                                   final Select lstDecisionTableOrientation,
+                                   final BuiltinAggregatorUtils builtinAggregatorUtils) {
         this.lstHitPolicies = lstHitPolicies;
         this.lstBuiltinAggregator = lstBuiltinAggregator;
         this.lstDecisionTableOrientation = lstDecisionTableOrientation;
+        this.builtinAggregatorUtils = builtinAggregatorUtils;
 
         setupHitPolicyEventHandler();
         setupBuiltinAggregatorEventHandler();
@@ -75,7 +79,7 @@ public class HitPolicyEditorViewImpl implements HitPolicyEditorView {
     private void setupBuiltinAggregatorEventHandler() {
         setupChangeEventHandler(lstBuiltinAggregator,
                                 () -> {
-                                    final BuiltinAggregator aggregator = BuiltinAggregator.fromValue(lstBuiltinAggregator.getValue());
+                                    final BuiltinAggregator aggregator = builtinAggregatorUtils.toEnum(lstBuiltinAggregator.getValue());
                                     presenter.setBuiltinAggregator(aggregator);
                                 });
     }
@@ -108,7 +112,7 @@ public class HitPolicyEditorViewImpl implements HitPolicyEditorView {
 
     @Override
     public void initBuiltinAggregators(final List<BuiltinAggregator> aggregators) {
-        aggregators.forEach(a -> lstBuiltinAggregator.addOption(a.value()));
+        aggregators.forEach(a -> lstBuiltinAggregator.addOption(builtinAggregatorUtils.toString(a)));
     }
 
     @Override
@@ -125,7 +129,7 @@ public class HitPolicyEditorViewImpl implements HitPolicyEditorView {
     @Override
     public void initSelectedBuiltinAggregator(final BuiltinAggregator aggregator) {
         initSelect(lstBuiltinAggregator,
-                   aggregator.value());
+                   builtinAggregatorUtils.toString(aggregator));
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/resources/i18n/DMNEditorConstants.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/resources/i18n/DMNEditorConstants.java
@@ -129,4 +129,7 @@ public class DMNEditorConstants {
 
     @TranslationKey(defaultValue = "")
     public static final String DecisionTableEditor_DeleteOutputClause = "DecisionTableEditor.DeleteOutputClause";
+
+    @TranslationKey(defaultValue = "")
+    public static final String DecisionTableEditor_NullBuiltinAggregator = "DecisionTableEditor.NullBuiltinAggregator";
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
@@ -51,3 +51,4 @@ DecisionTableEditor.DeleteOutputClause=Delete Output Clause
 DecisionTableEditor.InsertDecisionRuleAbove=Insert rule above
 DecisionTableEditor.InsertDecisionRuleBelow=Insert rule below
 DecisionTableEditor.DeleteDecisionRule=Delete rule
+DecisionTableEditor.NullBuiltinAggregator=<None>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
@@ -86,6 +86,7 @@ import org.uberfire.mvp.Command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.expressions.types.GridFactoryCommandUtils.assertCommands;
 import static org.mockito.Matchers.any;
@@ -634,69 +635,18 @@ public class DecisionTableGridTest {
                                               setHitPolicyCommandCaptor.capture());
 
         final CompositeCommand<AbstractCanvasHandler, CanvasViolation> setHitPolicyCommand = setHitPolicyCommandCaptor.getValue();
-        assertEquals(1,
+        assertEquals(2,
                      setHitPolicyCommand.getCommands().size());
-        assertTrue(setHitPolicyCommand.getCommands().get(0) instanceof SetHitPolicyCommand);
+        assertTrue(setHitPolicyCommand.getCommands().get(0) instanceof SetBuiltinAggregatorCommand);
+        assertTrue(setHitPolicyCommand.getCommands().get(1) instanceof SetHitPolicyCommand);
 
         setHitPolicyCommand.execute(canvasHandler);
 
         verify(gridLayer, atLeast(1)).batch();
         verify(command).execute();
-    }
 
-    @Test
-    public void testSetHitPolicyRequiresBuiltInAggregator() {
-        final HitPolicy hitPolicy = HitPolicy.COLLECT;
-        final BuiltinAggregator aggregator = BuiltinAggregator.SUM;
-
-        setupGrid(makeHasNameForDecision(), 0);
-
-        expression.get().setAggregation(aggregator);
-
-        grid.setHitPolicy(hitPolicy,
-                          command);
-
-        verify(sessionCommandManager).execute(eq(canvasHandler),
-                                              setHitPolicyCommandCaptor.capture());
-
-        final CompositeCommand<AbstractCanvasHandler, CanvasViolation> setHitPolicyCommand = setHitPolicyCommandCaptor.getValue();
-        assertEquals(2,
-                     setHitPolicyCommand.getCommands().size());
-        assertTrue(setHitPolicyCommand.getCommands().get(0) instanceof SetBuiltinAggregatorCommand);
-        assertTrue(setHitPolicyCommand.getCommands().get(1) instanceof SetHitPolicyCommand);
-
-        setHitPolicyCommand.execute(canvasHandler);
-
-        assertEquals(hitPolicy,
-                     expression.get().getHitPolicy());
-        assertEquals(aggregator,
-                     expression.get().getAggregation());
-    }
-
-    @Test
-    public void testSetHitPolicyRequiresBuiltInAggregatorUseDefaultWhenNotSet() {
-        final HitPolicy hitPolicy = HitPolicy.COLLECT;
-
-        setupGrid(makeHasNameForDecision(), 0);
-
-        grid.setHitPolicy(hitPolicy,
-                          command);
-
-        verify(sessionCommandManager).execute(eq(canvasHandler),
-                                              setHitPolicyCommandCaptor.capture());
-
-        final CompositeCommand<AbstractCanvasHandler, CanvasViolation> setHitPolicyCommand = setHitPolicyCommandCaptor.getValue();
-        assertEquals(2,
-                     setHitPolicyCommand.getCommands().size());
-        assertTrue(setHitPolicyCommand.getCommands().get(0) instanceof SetBuiltinAggregatorCommand);
-        assertTrue(setHitPolicyCommand.getCommands().get(1) instanceof SetHitPolicyCommand);
-
-        setHitPolicyCommand.execute(canvasHandler);
-
-        assertEquals(hitPolicy,
-                     expression.get().getHitPolicy());
-        assertEquals(DecisionTableGrid.DEFAULT_AGGREGATOR,
-                     expression.get().getAggregation());
+        assertEquals(hitPolicy, expression.get().getHitPolicy());
+        assertNull(expression.get().getAggregation());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/BuiltinAggregatorUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/BuiltinAggregatorUtilsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hitpolicy;
+
+import java.util.List;
+
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.BuiltinAggregator;
+import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BuiltinAggregatorUtilsTest {
+
+    @Mock
+    private TranslationService translationService;
+
+    private BuiltinAggregatorUtils builtinAggregatorUtils;
+
+    @Before
+    public void setup() {
+        this.builtinAggregatorUtils = new BuiltinAggregatorUtils(translationService);
+
+        doAnswer((i) -> i.getArguments()[0].toString()).when(translationService).getTranslation(anyString());
+    }
+
+    @Test
+    public void testGetAllValues() {
+        final List<BuiltinAggregator> builtinAggregators = builtinAggregatorUtils.getAllValues();
+
+        assertThat(builtinAggregators.size()).isEqualTo(BuiltinAggregator.values().length + 1);
+        assertThat(builtinAggregators.get(0)).isNull();
+        assertThat(builtinAggregators.subList(1, builtinAggregators.size())).containsOnly(BuiltinAggregator.values());
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(builtinAggregatorUtils.toString(null)).isEqualTo(DMNEditorConstants.DecisionTableEditor_NullBuiltinAggregator);
+
+        assertThat(builtinAggregatorUtils.toString(BuiltinAggregator.COUNT)).isEqualTo(BuiltinAggregator.COUNT.value());
+        assertThat(builtinAggregatorUtils.toString(BuiltinAggregator.MAX)).isEqualTo(BuiltinAggregator.MAX.value());
+        assertThat(builtinAggregatorUtils.toString(BuiltinAggregator.MIN)).isEqualTo(BuiltinAggregator.MIN.value());
+        assertThat(builtinAggregatorUtils.toString(BuiltinAggregator.SUM)).isEqualTo(BuiltinAggregator.SUM.value());
+    }
+
+    @Test
+    public void testToEnum() {
+        assertThat(builtinAggregatorUtils.toEnum(DMNEditorConstants.DecisionTableEditor_NullBuiltinAggregator)).isNull();
+
+        assertThat(builtinAggregatorUtils.toEnum(BuiltinAggregator.COUNT.value())).isEqualTo(BuiltinAggregator.COUNT);
+        assertThat(builtinAggregatorUtils.toEnum(BuiltinAggregator.MAX.value())).isEqualTo(BuiltinAggregator.MAX);
+        assertThat(builtinAggregatorUtils.toEnum(BuiltinAggregator.MIN.value())).isEqualTo(BuiltinAggregator.MIN);
+        assertThat(builtinAggregatorUtils.toEnum(BuiltinAggregator.SUM.value())).isEqualTo(BuiltinAggregator.SUM);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImplTest.java
@@ -158,6 +158,11 @@ public class HitPolicyEditorImplTest {
         assertHitPolicyAggregationConfiguration(HitPolicy.COLLECT, null);
     }
 
+    @Test
+    public void testBindNonNullControlHitPolicyNotRequiringAggregation() {
+        assertHitPolicyAggregationConfiguration(HitPolicy.ANY, null);
+    }
+
     private void assertHitPolicyAggregationConfiguration(final HitPolicy hitPolicy,
                                                          final BuiltinAggregator builtinAggregator) {
         reset(view);
@@ -171,7 +176,7 @@ public class HitPolicyEditorImplTest {
 
         verify(view).enableHitPolicies(eq(true));
         verify(view).initSelectedHitPolicy(eq(hitPolicy));
-        verify(view).enableBuiltinAggregators(eq(true));
+        verify(view).enableBuiltinAggregators(eq(HitPolicy.COLLECT.equals(hitPolicy)));
         verify(view).initSelectedBuiltinAggregator(eq(builtinAggregator));
         verify(view).enableDecisionTableOrientation(eq(false));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorImplTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hit
 import java.util.List;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +33,9 @@ import org.uberfire.mvp.Command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -52,6 +55,9 @@ public class HitPolicyEditorImplTest {
     @Mock
     private HasHitPolicyControl control;
 
+    @Mock
+    private TranslationService translationService;
+
     @Captor
     private ArgumentCaptor<List<HitPolicy>> hitPoliciesCaptor;
 
@@ -66,13 +72,19 @@ public class HitPolicyEditorImplTest {
 
     private HitPolicyEditorView.Presenter editor;
 
+    private BuiltinAggregatorUtils builtinAggregatorUtils;
+
     @Before
     public void setup() {
-        this.editor = new HitPolicyEditorImpl(view);
+        this.builtinAggregatorUtils = new BuiltinAggregatorUtils(translationService);
+        this.editor = new HitPolicyEditorImpl(view,
+                                              builtinAggregatorUtils);
 
         when(control.getHitPolicy()).thenReturn(null);
         when(control.getBuiltinAggregator()).thenReturn(null);
         when(control.getDecisionTableOrientation()).thenReturn(null);
+
+        doAnswer((i) -> i.getArguments()[0].toString()).when(translationService).format(anyString());
     }
 
     @Test
@@ -83,7 +95,7 @@ public class HitPolicyEditorImplTest {
         verify(view).initDecisionTableOrientations(orientationsCaptor.capture());
 
         assertThat(hitPoliciesCaptor.getValue()).containsOnly(HitPolicy.values());
-        assertThat(builtInAggregatorsCaptor.getValue()).containsOnly(BuiltinAggregator.values());
+        assertThat(builtInAggregatorsCaptor.getValue()).containsOnlyElementsOf(builtinAggregatorUtils.getAllValues());
         assertThat(orientationsCaptor.getValue()).containsOnly(DecisionTableOrientation.values());
     }
 
@@ -138,13 +150,20 @@ public class HitPolicyEditorImplTest {
 
     @Test
     public void testBindNonNullControlHitPolicyWithAggregation() {
-        final HitPolicy hitPolicy = HitPolicy.COLLECT;
-        final BuiltinAggregator aggregator = BuiltinAggregator.COUNT;
+        assertHitPolicyAggregationConfiguration(HitPolicy.COLLECT, BuiltinAggregator.COUNT);
+    }
 
+    @Test
+    public void testBindNonNullControlHitPolicyWithoutAggregation() {
+        assertHitPolicyAggregationConfiguration(HitPolicy.COLLECT, null);
+    }
+
+    private void assertHitPolicyAggregationConfiguration(final HitPolicy hitPolicy,
+                                                         final BuiltinAggregator builtinAggregator) {
         reset(view);
 
         when(control.getHitPolicy()).thenReturn(hitPolicy);
-        when(control.getBuiltinAggregator()).thenReturn(aggregator);
+        when(control.getBuiltinAggregator()).thenReturn(builtinAggregator);
 
         editor.bind(control,
                     UI_ROW_INDEX,
@@ -153,7 +172,7 @@ public class HitPolicyEditorImplTest {
         verify(view).enableHitPolicies(eq(true));
         verify(view).initSelectedHitPolicy(eq(hitPolicy));
         verify(view).enableBuiltinAggregators(eq(true));
-        verify(view).initSelectedBuiltinAggregator(eq(aggregator));
+        verify(view).initSelectedBuiltinAggregator(eq(builtinAggregator));
         verify(view).enableDecisionTableOrientation(eq(false));
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyEditorViewImplTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +32,8 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.HitPolicy;
 import org.mockito.Mock;
 import org.uberfire.client.views.pfly.widgets.Select;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
@@ -55,7 +58,12 @@ public class HitPolicyEditorViewImplTest {
     @Mock
     private HTMLElement lstDecisionTableOrientationElement;
 
+    @Mock
+    private TranslationService translationService;
+
     private HitPolicyEditorViewImpl testedView;
+
+    private BuiltinAggregatorUtils builtinAggregatorUtils;
 
     @Before
     public void setUp() throws Exception {
@@ -63,9 +71,13 @@ public class HitPolicyEditorViewImplTest {
         doReturn(lstBuiltinAggregatorElement).when(lstBuiltinAggregator).getElement();
         doReturn(lstDecisionTableOrientationElement).when(lstDecisionTableOrientation).getElement();
 
+        builtinAggregatorUtils = new BuiltinAggregatorUtils(translationService);
         testedView = new HitPolicyEditorViewImpl(lstHitPolicies,
                                                  lstBuiltinAggregator,
-                                                 lstDecisionTableOrientation);
+                                                 lstDecisionTableOrientation,
+                                                 builtinAggregatorUtils);
+
+        doAnswer((i) -> i.getArguments()[0].toString()).when(translationService).getTranslation(anyString());
     }
 
     @Test
@@ -77,10 +89,10 @@ public class HitPolicyEditorViewImplTest {
 
     @Test
     public void testInitAggregator() throws Exception {
-        final List<BuiltinAggregator> aggregators = Arrays.asList(BuiltinAggregator.values());
+        final List<BuiltinAggregator> aggregators = builtinAggregatorUtils.getAllValues();
         testedView.initBuiltinAggregators(aggregators);
 
-        aggregators.stream().forEach(agg -> verify(lstBuiltinAggregator).addOption(agg.value()));
+        aggregators.stream().forEach(agg -> verify(lstBuiltinAggregator).addOption(builtinAggregatorUtils.toString(agg)));
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2420

Basically, when the ```HitPolicy``` is ```COLLECT``` you don't need to specify a ```BuiltinAggregator```.