### PR TITLE
DROOLS-2424: [DMN Designer] Expression type can not be changed after cleared multiple times

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
@@ -58,7 +58,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final GridCellTuple parent = new GridCellTuple(0, 0, this);
+    private final GridCellTuple parent;
 
     private String nodeUUID;
     private HasExpression hasExpression;
@@ -85,6 +85,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
         this.translationService = translationService;
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
+        this.parent = new GridCellTuple(0, 0, this);
 
         this.uiModelMapper = new ExpressionContainerUIModelMapper(parent,
                                                                   this::getModel,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.function.s
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import javax.enterprise.context.Dependent;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -52,7 +52,7 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
-@Dependent
+@ApplicationScoped
 @FunctionGridSupplementaryEditor
 public class JavaFunctionEditorDefinition extends BaseEditorDefinition<Context, FunctionSupplementaryGridData> {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.function.s
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import javax.enterprise.context.Dependent;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -52,7 +52,7 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
-@Dependent
+@ApplicationScoped
 @FunctionGridSupplementaryEditor
 public class PMMLFunctionEditorDefinition extends BaseEditorDefinition<Context, FunctionSupplementaryGridData> {
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2424

I didn't see how I could write a test for this fix really.. but open to ideas. I moved the instantiation of ```parent``` from "inline" to "in the constructor". In Java I don't see what difference it'd make but in GWT it seems to make a world of difference.