### PR TITLE
JBPM-6777: Stunner - Cannot edit element names inline RHBA-444

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/DMNCanvasFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/DMNCanvasFactory.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.SingleLineTextEditorBox;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.EdgeBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.NodeBuilderControl;
@@ -96,7 +97,7 @@ public class DMNCanvasFactory
                             final ManagedInstance<ConnectionAcceptorControl> connectionAcceptorControls,
                             final ManagedInstance<ContainmentAcceptorControl> containmentAcceptorControls,
                             final ManagedInstance<DockingAcceptorControl> dockingAcceptorControls,
-                            final ManagedInstance<CanvasInPlaceTextEditorControl> inPlaceTextEditorControls,
+                            final @SingleLineTextEditorBox ManagedInstance<CanvasInPlaceTextEditorControl> inPlaceTextEditorControls,
                             final @MultipleSelection ManagedInstance<SelectionControl> selectionControls,
                             final ManagedInstance<LocationControl> locationControls,
                             final @DMNEditor ManagedInstance<ToolboxControl> toolboxControls,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManager.java
@@ -41,6 +41,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseClickE
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseDoubleClickEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseEnterEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseExitEvent;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextDoubleClickEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TouchEventImpl;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TouchHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEvent;
@@ -144,6 +145,10 @@ public class ViewEventHandlerManager {
     @SuppressWarnings("unchecked")
     protected HandlerRegistration[] doAddHandler(final ViewEventType type,
                                                  final ViewHandler<? extends ViewEvent> eventHandler) {
+
+        if ((ViewEventType.TEXT_DBL_CLICK.equals(type))) {
+            return registerTextDoubleClickHandler((ViewHandler<ViewEvent>) eventHandler);
+        }
         if (ViewEventType.MOUSE_CLICK.equals(type)) {
             return registerClickHandler((ViewHandler<ViewEvent>) eventHandler);
         }
@@ -314,6 +319,25 @@ public class ViewEventHandlerManager {
                         event.setButtonLeft(nodeMouseDoubleClickEvent.isButtonLeft());
                         event.setButtonMiddle(nodeMouseDoubleClickEvent.isButtonMiddle());
                         event.setButtonRight(nodeMouseDoubleClickEvent.isButtonRight());
+                        eventHandler.handle(event);
+                        restoreClickHandler();
+                    }
+                })
+        };
+    }
+
+    protected HandlerRegistration[] registerTextDoubleClickHandler(final ViewHandler<ViewEvent> eventHandler) {
+        return new HandlerRegistration[]{
+                node.addNodeMouseDoubleClickHandler(nodeMouseDoubleClickEvent -> {
+                    if (isEnabled()) {
+                        skipClickHandler();
+                        final TextDoubleClickEvent event = new TextDoubleClickEvent(nodeMouseDoubleClickEvent.getX(),
+                                                                                    nodeMouseDoubleClickEvent.getY(),
+                                                                                    nodeMouseDoubleClickEvent.getMouseEvent().getClientX(),
+                                                                                    nodeMouseDoubleClickEvent.getMouseEvent().getClientY());
+                        event.setShiftKeyDown(nodeMouseDoubleClickEvent.isShiftKeyDown());
+                        event.setAltKeyDown(nodeMouseDoubleClickEvent.isAltKeyDown());
+                        event.setMetaKeyDown(nodeMouseDoubleClickEvent.isMetaKeyDown());
                         eventHandler.handle(event);
                         restoreClickHandler();
                     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -294,7 +294,6 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
             }
             if (ViewEventType.TEXT_DBL_CLICK.equals(type)) {
                 textViewDecorator.setTextDblClickHandler((ViewHandler<TextDoubleClickEvent>) eventHandler);
-                delegate = false;
             }
             if (delegate) {
                 eventHandlerManager.addHandler(type,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManagerTest.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseDouble
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseEnterEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseExitEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ShapeViewSupportedEvents;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextDoubleClickEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewHandler;
@@ -114,11 +115,12 @@ public class ViewEventHandlerManagerTest {
         this.tested = new ViewEventHandlerManager(node,
                                                   shape,
                                                   ViewEventType.MOUSE_CLICK,
-                                                  ViewEventType.MOUSE_DBL_CLICK);
+                                                  ViewEventType.MOUSE_DBL_CLICK,
+                                                  ViewEventType.TEXT_DBL_CLICK);
         assertTrue(tested.supports(ViewEventType.MOUSE_CLICK));
         assertTrue(tested.supports(ViewEventType.MOUSE_DBL_CLICK));
+        assertTrue(tested.supports(ViewEventType.TEXT_DBL_CLICK));
         assertFalse(tested.supports(ViewEventType.TEXT_CLICK));
-        assertFalse(tested.supports(ViewEventType.TEXT_DBL_CLICK));
         assertFalse(tested.supports(ViewEventType.TEXT_ENTER));
         assertFalse(tested.supports(ViewEventType.TEXT_EXIT));
         assertFalse(tested.supports(ViewEventType.MOUSE_ENTER));
@@ -238,6 +240,58 @@ public class ViewEventHandlerManagerTest {
         assertTrue(viewEvent.isMetaKeyDown());
         assertTrue(viewEvent.isShiftKeyDown());
         assertNotNull(tested.getRegistrationMap().get(ViewEventType.MOUSE_DBL_CLICK));
+    }
+
+
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testTextDoubleClickHandler() {
+        final ViewHandler<ViewEvent> clickHandler = mock(ViewHandler.class);
+        final HandlerRegistration handlerRegistration = mock(HandlerRegistration.class);
+        when(node.addNodeMouseDoubleClickHandler(any(NodeMouseDoubleClickHandler.class))).thenReturn(handlerRegistration);
+        tested.addHandler(ViewEventType.TEXT_DBL_CLICK,
+                          clickHandler);
+        final ArgumentCaptor<NodeMouseDoubleClickHandler> clickHandlerArgumentCaptor =
+                ArgumentCaptor.forClass(NodeMouseDoubleClickHandler.class);
+        verify(node,
+               times(1)).addNodeMouseDoubleClickHandler(clickHandlerArgumentCaptor.capture());
+        final NodeMouseDoubleClickHandler nodeCLickHandler = clickHandlerArgumentCaptor.getValue();
+        final NodeMouseDoubleClickEvent clickEvent = mock(NodeMouseDoubleClickEvent.class);
+        final MouseEvent mouseEvent = mock(MouseEvent.class);
+        final int x = 102;
+        final int y = 410;
+        when(clickEvent.getX()).thenReturn(x);
+        when(clickEvent.getY()).thenReturn(y);
+        when(clickEvent.isShiftKeyDown()).thenReturn(true);
+        when(clickEvent.isAltKeyDown()).thenReturn(true);
+        when(clickEvent.isMetaKeyDown()).thenReturn(true);
+        when(clickEvent.getMouseEvent()).thenReturn(mouseEvent);
+        when(mouseEvent.getClientX()).thenReturn(x);
+        when(mouseEvent.getClientY()).thenReturn(y);
+        nodeCLickHandler.onNodeMouseDoubleClick(clickEvent);
+        final ArgumentCaptor<ViewEvent> eventArgumentCaptor =
+                ArgumentCaptor.forClass(ViewEvent.class);
+        verify(clickHandler,
+               times(1)).handle(eventArgumentCaptor.capture());
+        final TextDoubleClickEvent viewEvent = (TextDoubleClickEvent) eventArgumentCaptor.getValue();
+        assertEquals(x,
+                     viewEvent.getX(),
+                     0d);
+        assertEquals(y,
+                     viewEvent.getY(),
+                     0d);
+        assertEquals(x,
+                     viewEvent.getClientX(),
+                     0d);
+        assertEquals(y,
+                     viewEvent.getClientY(),
+                     0d);
+        assertTrue(viewEvent.isAltKeyDown());
+        assertTrue(viewEvent.isMetaKeyDown());
+        assertTrue(viewEvent.isShiftKeyDown());
+        assertNotNull(tested.getRegistrationMap().get(ViewEventType.TEXT_DBL_CLICK));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBox.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBox.css
@@ -1,12 +1,20 @@
 .nameEditBoxTable {
-    z-index: 10;
     min-height: 20px;
     min-width: 80px;
     display: table;
+    border: 2px solid #5f9ea0;
+    padding: 3px;
+    background-color: white;
 }
 
 .nameEditBoxRow {
     display: table-row;
+}
+
+.nameEditButtonsRow{
+    display: table-row;
+    float: right;
+    margin-top: 3px;
 }
 
 .nameEditBoxCell {
@@ -18,9 +26,14 @@
 }
 
 .nameEditBoxButton {
-    background-color: black;
+    background-color: white;
     padding: 2px;
-    color: white;
+    color: black;
     margin-left: 5px;
     cursor: pointer;
+}
+
+textarea.nameEditBoxNameBox{
+    min-height:50px;
+    min-width:180px;
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBox.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBox.html
@@ -1,9 +1,11 @@
-<div>
+<div data-field="editNameBox" tabindex="-1">
     <div class="nameEditBoxTable">
         <div class="nameEditBoxRow">
             <span class="nameEditBoxCell">
-                <input type="text" class="form-control nameEditBoxNameBox" data-field="nameBox">
+                <input type="text" class="form-control nameEditBoxNameBox" data-field="nameField">
             </span>
+        </div>
+        <div class="nameEditButtonsRow">
             <span class="nameEditBoxCell">
                 <i class="fa fa-check nameEditBoxButton fa-2x" data-field="saveButton"></i>
             </span>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBoxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBoxView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,30 @@
 package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.components.actions.TextEditorBox;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextEditorBox;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.uberfire.client.mvp.UberElement;
 
 public interface TextEditorBoxView extends UberElement<TextEditorBoxView.Presenter> {
 
+    void show(final String name);
+
+    void hide();
+
+    boolean isVisible();
+
     interface Presenter extends TextEditorBox<AbstractCanvasHandler, Element> {
 
         void onSave();
 
-        void onKeyPress(int keyCode,
-                        String value);
-
         void onClose();
 
-        void onChangeName(String name);
+        void onChangeName(final String name);
+
+        void onKeyPress(final int keyCode,
+                        final boolean shiftKeyPressed,
+                        final String value);
+
+        String getNameValue();
     }
-
-    void show(final String name);
-
-    void hide();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBox.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.MultiLineTextEditorBox;
+
+@Dependent
+@MultiLineTextEditorBox
+public class TextEditorMultiLineBox extends AbstractTextEditorBox {
+
+    private final TextEditorBoxView view;
+
+    @Inject
+    public TextEditorMultiLineBox(final @MultiLineTextEditorBox TextEditorMultiLineBoxView view) {
+        this.view = view;
+    }
+
+    @Override
+    protected TextEditorBoxView getView() {
+        return view;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxView.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.Event;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.TextArea;
+import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.SinkNative;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.MultiLineTextEditorBox;
+import org.uberfire.mvp.Command;
+
+@Templated(value = "TextEditorBox.html", stylesheet = "TextEditorBox.css")
+@MultiLineTextEditorBox
+public class TextEditorMultiLineBoxView
+        extends AbstractTextEditorBoxView
+        implements TextEditorBoxView,
+                   IsElement {
+
+    @Inject
+    @DataField
+    private TextArea nameField;
+
+    @Inject
+    public TextEditorMultiLineBoxView(final TranslationService translationService) {
+        super();
+        this.translationService = translationService;
+    }
+
+    TextEditorMultiLineBoxView(final TranslationService translationService,
+                               final Div editNameBox,
+                               final TextArea nameField,
+                               final Command showCommand,
+                               final Command hideCommand,
+                               final HTMLElement closeButton,
+                               final HTMLElement saveButton) {
+        super(showCommand, hideCommand, closeButton, saveButton);
+        this.translationService = translationService;
+        this.nameField = nameField;
+        super.editNameBox = editNameBox;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        super.initialize();
+        nameField.setAttribute("placeHolder",
+                               translationService.getTranslation(StunnerWidgetsConstants.NameEditBoxWidgetViewImp_name));
+    }
+
+    @Override
+    public void init(TextEditorBoxView.Presenter presenter) {
+        super.presenter = presenter;
+    }
+
+    @Override
+    public void show(final String name) {
+        nameField.setValue(name);
+        nameField.setTextContent(name);
+        nameField.setRows(2);
+        nameField.setCols(25);
+        setVisible();
+    }
+
+    @EventHandler("nameField")
+    @SinkNative(Event.ONCHANGE | Event.ONKEYPRESS)
+    public void onChangeName(Event event) {
+        switch (event.getTypeInt()) {
+            case Event.ONCHANGE:
+                presenter.onChangeName(nameField.getValue());
+                break;
+            case Event.ONKEYPRESS:
+                presenter.onKeyPress(event.getKeyCode(),
+                                     event.getShiftKey(),
+                                     nameField.getValue());
+                break;
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBox.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.SingleLineTextEditorBox;
+
+@Dependent
+@SingleLineTextEditorBox
+public class TextEditorSingleLineBox extends AbstractTextEditorBox {
+
+    private final TextEditorBoxView view;
+
+    @Inject
+    public TextEditorSingleLineBox(final @SingleLineTextEditorBox TextEditorBoxView view) {
+        this.view = view;
+    }
+
+    @Override
+    protected TextEditorBoxView getView() {
+        return view;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxView.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.Event;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.TextInput;
+import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.SinkNative;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.SingleLineTextEditorBox;
+import org.uberfire.mvp.Command;
+
+@Templated(value = "TextEditorBox.html", stylesheet = "TextEditorBox.css")
+@SingleLineTextEditorBox
+public class TextEditorSingleLineBoxView
+        extends AbstractTextEditorBoxView
+        implements TextEditorBoxView,
+                   IsElement {
+
+    @Inject
+    @DataField
+    protected TextInput nameField;
+
+    @Inject
+    public TextEditorSingleLineBoxView(final TranslationService translationService) {
+        super();
+        this.translationService = translationService;
+    }
+
+    TextEditorSingleLineBoxView(final TranslationService translationService,
+                                final Div editNameBox,
+                                final TextInput nameField,
+                                final Command showCommand,
+                                final Command hideCommand,
+                                final HTMLElement closeButton,
+                                final HTMLElement saveButton) {
+        super(showCommand, hideCommand, closeButton, saveButton);
+        this.translationService = translationService;
+        this.nameField = nameField;
+        super.editNameBox = editNameBox;
+    }
+
+    @Override
+    @PostConstruct
+    public void initialize() {
+        nameField.setAttribute("placeHolder",
+                               translationService.getTranslation(StunnerWidgetsConstants.NameEditBoxWidgetViewImp_name));
+        super.initialize();
+    }
+
+    @Override
+    public void init(TextEditorBoxView.Presenter presenter) {
+        super.presenter = presenter;
+    }
+
+    @Override
+    public void show(final String name) {
+        nameField.setValue(name);
+        nameField.setTextContent(name);
+        setVisible();
+    }
+
+    @EventHandler("nameField")
+    @SinkNative(Event.ONCHANGE | Event.ONKEYPRESS)
+    public void onChangeName(Event event) {
+        switch (event.getTypeInt()) {
+            case Event.ONCHANGE:
+                presenter.onChangeName(nameField.getValue());
+                break;
+            case Event.ONKEYPRESS:
+                presenter.onKeyPress(event.getKeyCode(),
+                                     false,
+                                     nameField.getValue());
+                break;
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import com.google.gwt.event.dom.client.KeyCodes;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.DefaultTextPropertyProviderImpl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProvider;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TextEditorMultiLineBoxTest {
+
+    public static final String NAME = "name";
+    public static final String MODIFIED_NAME = "modified_name";
+    public static final String ID = "id";
+
+    protected TextEditorMultiLineBox presenter;
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+    @Mock
+    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    @Mock
+    private TextEditorMultiLineBoxView view;
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+    @Mock
+    private Command closeCallback;
+    @Mock
+    private RequiresCommandManager.CommandManagerProvider<AbstractCanvasHandler> commandProvider;
+    @Mock
+    private TextPropertyProviderFactory textPropertyProviderFactory;
+    @Mock
+    private CanvasCommandManager canvasCommandManager;
+    @Mock
+    private Element element;
+    @Mock
+    private Definition definition;
+    @Mock
+    private TextPropertyProvider textPropertyProvider;
+    private Object objectDefinition = new Object();
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void init() {
+        this.textPropertyProvider = new DefaultTextPropertyProviderImpl(definitionUtils,
+                                                                        canvasCommandFactory);
+
+        when(element.getContent()).thenReturn(definition);
+        when(definition.getDefinition()).thenReturn(objectDefinition);
+        when(definitionUtils.getName(objectDefinition)).thenReturn(NAME);
+        when(definitionUtils.getNameIdentifier(objectDefinition)).thenReturn(ID);
+        when(commandProvider.getCommandManager()).thenReturn(canvasCommandManager);
+        when(canvasHandler.getTextPropertyProviderFactory()).thenReturn(textPropertyProviderFactory);
+        when(textPropertyProviderFactory.getProvider(any(Element.class))).thenReturn(textPropertyProvider);
+
+        presenter = new TextEditorMultiLineBox(view);
+
+        presenter.setup();
+
+        verify(view).init(presenter);
+
+        presenter.initialize(canvasHandler,
+                             closeCallback);
+
+        presenter.setCommandManagerProvider(commandProvider);
+
+        presenter.getElement();
+
+        verify(view).getElement();
+
+        presenter.show(element);
+
+        verify(view).show(NAME);
+    }
+
+    @Test
+    public void testSaveByPressingEnter() {
+        presenter.onKeyPress(12,
+                             false,
+                             MODIFIED_NAME);
+
+        verifyNameNotSaved();
+
+        presenter.onKeyPress(KeyCodes.KEY_ENTER,
+                             false,
+                             MODIFIED_NAME);
+
+        verifyNameSaved();
+    }
+
+    @Test
+    public void testSaveByPressingButton() {
+        presenter.onChangeName(MODIFIED_NAME);
+
+        verifyNameNotSaved();
+
+        presenter.onSave();
+
+        verifyNameSaved();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCloseButton() {
+        presenter.onChangeName(MODIFIED_NAME);
+
+        assertEquals(MODIFIED_NAME,
+                     presenter.getNameValue());
+
+        presenter.onClose();
+
+        assertEquals(null,
+                     presenter.getNameValue());
+
+        verify(definitionUtils,
+               never()).getNameIdentifier(objectDefinition);
+        verify(canvasCommandFactory,
+               never()).updatePropertyValue(element,
+                                            ID,
+                                            MODIFIED_NAME);
+
+        verify(commandProvider,
+               never()).getCommandManager();
+        verify(canvasCommandManager,
+               never()).execute(any(),
+                                any());
+
+        verify(view).hide();
+        verify(closeCallback).execute();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void verifyNameNotSaved() {
+        assertEquals(MODIFIED_NAME,
+                     presenter.getNameValue());
+
+        verify(definitionUtils,
+               never()).getNameIdentifier(objectDefinition);
+        verify(canvasCommandFactory,
+               never()).updatePropertyValue(element,
+                                            ID,
+                                            MODIFIED_NAME);
+
+        verify(commandProvider,
+               never()).getCommandManager();
+        verify(canvasCommandManager,
+               never()).execute(any(),
+                                any());
+
+        verify(view,
+               never()).hide();
+        verify(closeCallback,
+               never()).execute();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void verifyNameSaved() {
+        assertEquals(MODIFIED_NAME,
+                     presenter.getNameValue());
+
+        verify(definitionUtils).getNameIdentifier(objectDefinition);
+        verify(canvasCommandFactory).updatePropertyValue(element,
+                                                         ID,
+                                                         MODIFIED_NAME);
+
+        verify(commandProvider).getCommandManager();
+        verify(canvasCommandManager).execute(any(),
+                                             any());
+        verify(view).hide();
+        verify(closeCallback).execute();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxViewTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.user.client.Event;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.dom.CSSStyleDeclaration;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.TextArea;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class TextEditorMultiLineBoxViewTest {
+
+    private static final String NAME = "name";
+
+    @Mock
+    private TextEditorMultiLineBoxView.Presenter presenter;
+
+    @Mock
+    private Event event;
+
+    @Mock
+    private TranslationService translationService;
+
+    @Mock
+    private ClickEvent clickEvent;
+
+    @Mock
+    private Div editNameBox;
+
+    @Mock
+    private TextArea nameField;
+
+    @Mock
+    private HTMLElement htmlElement;
+
+    @Mock
+    private CSSStyleDeclaration style;
+
+    @Mock
+    private HTMLElement element;
+
+    @Mock
+    private Command showCommand;
+
+    @Mock
+    private Command hideCommand;
+
+    @Mock
+    private HTMLElement closeButton;
+
+    @Mock
+    private HTMLElement saveButton;
+
+    private TextEditorMultiLineBoxView tested;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void init() {
+        this.tested = new TextEditorMultiLineBoxView(translationService, editNameBox, nameField, showCommand, hideCommand, closeButton, saveButton);
+        this.tested.init(presenter);
+    }
+
+    @Test
+    public void testOnKeyDownEscEvent() {
+        when(event.getTypeInt()).thenReturn(Event.ONKEYDOWN);
+        when(event.getKeyCode()).thenReturn(KeyCodes.KEY_ESCAPE);
+        tested.editNameBoxEsc(event);
+        verify(presenter,
+               times(1)).onClose();
+    }
+
+    @Test
+    public void testInitialize() {
+        tested.initialize();
+        verify(nameField,
+               times(1)).setAttribute(eq("placeHolder"), anyString());
+    }
+
+    @Test
+    public void testOnMouseOver() {
+        when(event.getTypeInt()).thenReturn(Event.ONMOUSEOVER);
+        tested.editNameBoxEsc(event);
+        verify(editNameBox,
+               times(1)).focus();
+    }
+
+    @Test
+    public void testClickSaveButton() {
+        tested.onSave(clickEvent);
+        verify(presenter,
+               times(1)).onSave();
+    }
+
+    @Test
+    public void testOnChangeNameChangeEvent() {
+        when(event.getTypeInt()).thenReturn(Event.ONCHANGE);
+        tested.onChangeName(event);
+        verify(presenter, times(1)).onChangeName(anyString());
+    }
+
+    @Test
+    public void testOnChangeNameKeyPressEvent() {
+        when(event.getTypeInt()).thenReturn(Event.ONKEYPRESS);
+        tested.onChangeName(event);
+        verify(presenter, times(1)).onKeyPress(anyInt(), eq(false), anyString());
+    }
+
+    @Test
+    public void testClickCloseButton() {
+        tested.onClose(clickEvent);
+        verify(presenter,
+               times(1)).onClose();
+    }
+
+    @Test
+    public void testShow() {
+
+        tested.show(NAME);
+
+        verify(nameField,
+               times(1)).setValue(eq(NAME));
+        verify(nameField,
+               times(1)).setTextContent(eq(NAME));
+
+        verify(nameField,
+               times(1)).setRows(eq(2));
+        verify(nameField,
+               times(1)).setCols(eq(25));
+
+        verify(showCommand, times(1)).execute();
+    }
+
+    @Test
+    public void testHide() {
+        tested.hide();
+        verify(hideCommand, times(1)).execute();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
 
+import com.google.gwt.event.dom.client.KeyCodes;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,48 +41,37 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TextEditorBoxImplTest {
+public class TextEditorSingleLineBoxTest {
 
     public static final String NAME = "name";
     public static final String MODIFIED_NAME = "modified_name";
     public static final String ID = "id";
 
+    protected TextEditorSingleLineBox presenter;
+
     @Mock
     private DefinitionUtils definitionUtils;
-
     @Mock
     private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
-
     @Mock
-    private TextEditorBoxView view;
-
+    private TextEditorMultiLineBoxView view;
     @Mock
     private AbstractCanvasHandler canvasHandler;
-
     @Mock
     private Command closeCallback;
-
     @Mock
     private RequiresCommandManager.CommandManagerProvider<AbstractCanvasHandler> commandProvider;
-
     @Mock
     private TextPropertyProviderFactory textPropertyProviderFactory;
-
     @Mock
     private CanvasCommandManager canvasCommandManager;
-
     @Mock
     private Element element;
-
     @Mock
     private Definition definition;
-
     @Mock
     private TextPropertyProvider textPropertyProvider;
-
     private Object objectDefinition = new Object();
-
-    private TextEditorBoxImpl presenter;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -97,7 +87,7 @@ public class TextEditorBoxImplTest {
         when(canvasHandler.getTextPropertyProviderFactory()).thenReturn(textPropertyProviderFactory);
         when(textPropertyProviderFactory.getProvider(any(Element.class))).thenReturn(textPropertyProvider);
 
-        presenter = new TextEditorBoxImpl(view);
+        presenter = new TextEditorSingleLineBox(view);
 
         presenter.setup();
 
@@ -120,11 +110,13 @@ public class TextEditorBoxImplTest {
     @Test
     public void testSaveByPressingEnter() {
         presenter.onKeyPress(12,
+                             false,
                              MODIFIED_NAME);
 
         verifyNameNotSaved();
 
-        presenter.onKeyPress(13,
+        presenter.onKeyPress(KeyCodes.KEY_ENTER,
+                             false,
                              MODIFIED_NAME);
 
         verifyNameSaved();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxViewTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.user.client.Event;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.dom.CSSStyleDeclaration;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.TextInput;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class TextEditorSingleLineBoxViewTest {
+
+    private static final String NAME = "name";
+
+    @Mock
+    private TextEditorSingleLineBoxView.Presenter presenter;
+
+    @Mock
+    private Event event;
+
+    @Mock
+    private TranslationService translationService;
+
+    @Mock
+    private ClickEvent clickEvent;
+
+    @Mock
+    private Div editNameBox;
+
+    @Mock
+    private TextInput nameField;
+
+    @Mock
+    private HTMLElement htmlElement;
+
+    @Mock
+    private CSSStyleDeclaration style;
+
+    @Mock
+    private HTMLElement element;
+
+    @Mock
+    private Command showCommand;
+
+    @Mock
+    private Command hideCommand;
+
+    @Mock
+    private HTMLElement closeButton;
+
+    @Mock
+    private HTMLElement saveButton;
+
+    private TextEditorSingleLineBoxView tested;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void init() {
+        this.tested = new TextEditorSingleLineBoxView(translationService, editNameBox, nameField, showCommand, hideCommand, closeButton, saveButton);
+        this.tested.init(presenter);
+    }
+
+    @Test
+    public void testOnKeyDownEscEvent() {
+        when(event.getTypeInt()).thenReturn(Event.ONKEYDOWN);
+        when(event.getKeyCode()).thenReturn(KeyCodes.KEY_ESCAPE);
+        tested.editNameBoxEsc(event);
+        verify(presenter,
+               times(1)).onClose();
+    }
+
+    @Test
+    public void testInitialize() {
+
+        tested.initialize();
+        verify(nameField,
+               times(1)).setAttribute(eq("placeHolder"), anyString());
+    }
+
+    @Test
+    public void testOnMouseOver() {
+        when(event.getTypeInt()).thenReturn(Event.ONMOUSEOVER);
+        tested.editNameBoxEsc(event);
+        verify(editNameBox,
+               times(1)).focus();
+    }
+
+    @Test
+    public void testClickSaveButton() {
+        tested.onSave(clickEvent);
+        verify(presenter,
+               times(1)).onSave();
+    }
+
+    @Test
+    public void testOnChangeNameChangeEvent() {
+        when(event.getTypeInt()).thenReturn(Event.ONCHANGE);
+        tested.onChangeName(event);
+        verify(presenter, times(1)).onChangeName(anyString());
+    }
+
+    @Test
+    public void testOnChangeNameKeyPressEvent() {
+        when(event.getTypeInt()).thenReturn(Event.ONKEYPRESS);
+        tested.onChangeName(event);
+        verify(presenter, times(1)).onKeyPress(anyInt(), eq(false), anyString());
+    }
+
+    @Test
+    public void testShow() {
+
+        tested.show(NAME);
+
+        verify(nameField,
+               times(1)).setValue(eq(NAME));
+        verify(nameField,
+               times(1)).setTextContent(eq(NAME));
+
+        verify(showCommand, times(1)).execute();
+    }
+
+    @Test
+    public void testHide() {
+        tested.hide();
+        verify(hideCommand, times(1)).execute();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/DefaultCanvasFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/DefaultCanvasFactory.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.SingleLineTextEditorBox;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.EdgeBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.NodeBuilderControl;
@@ -100,7 +101,7 @@ public class DefaultCanvasFactory
                                 final ManagedInstance<ConnectionAcceptorControl> connectionAcceptorControls,
                                 final ManagedInstance<ContainmentAcceptorControl> containmentAcceptorControls,
                                 final ManagedInstance<DockingAcceptorControl> dockingAcceptorControls,
-                                final ManagedInstance<CanvasInPlaceTextEditorControl> inPlaceTextEditorControls,
+                                final @SingleLineTextEditorBox ManagedInstance<CanvasInPlaceTextEditorControl> inPlaceTextEditorControls,
                                 final @MultipleSelection ManagedInstance<SelectionControl> selectionControls,
                                 final ManagedInstance<LocationControl> locationControls,
                                 final @Default ManagedInstance<ToolboxControl> toolboxControls,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlMultiLine.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlMultiLine.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.components.views.FloatingView;
+import org.kie.workbench.common.stunner.core.graph.Element;
+
+@Dependent
+@MultiLineTextEditorBox
+public class CanvasInPlaceTextEditorControlMultiLine
+        extends AbstractCanvasInPlaceTextEditorControl {
+
+    private final FloatingView<IsWidget> floatingView;
+    private final TextEditorBox<AbstractCanvasHandler, Element> textEditorBox;
+    private final Event<CanvasSelectionEvent> canvasSelectionEvent;
+
+    @Inject
+    public CanvasInPlaceTextEditorControlMultiLine(final FloatingView<IsWidget> floatingView,
+                                                   final @MultiLineTextEditorBox TextEditorBox<AbstractCanvasHandler, Element> textEditorBox,
+                                                   final Event<CanvasSelectionEvent> canvasSelectionEvent) {
+        this.floatingView = floatingView;
+        this.textEditorBox = textEditorBox;
+        this.canvasSelectionEvent = canvasSelectionEvent;
+    }
+
+    @Override
+    protected FloatingView<IsWidget> getFloatingView() {
+        return floatingView;
+    }
+
+    @Override
+    protected TextEditorBox<AbstractCanvasHandler, Element> getTextEditorBox() {
+        return textEditorBox;
+    }
+
+    @Override
+    protected Event<CanvasSelectionEvent> getCanvasSelectionEvent() {
+        return canvasSelectionEvent;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlSingleLine.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlSingleLine.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.components.views.FloatingView;
+import org.kie.workbench.common.stunner.core.graph.Element;
+
+@Dependent
+@SingleLineTextEditorBox
+public class CanvasInPlaceTextEditorControlSingleLine
+        extends AbstractCanvasInPlaceTextEditorControl {
+
+    private final FloatingView<IsWidget> floatingView;
+    private final TextEditorBox<AbstractCanvasHandler, Element> textEditorBox;
+    private final Event<CanvasSelectionEvent> canvasSelectionEvent;
+
+    @Inject
+    public CanvasInPlaceTextEditorControlSingleLine(final FloatingView<IsWidget> floatingView,
+                                                    final @SingleLineTextEditorBox TextEditorBox<AbstractCanvasHandler, Element> textEditorBox,
+                                                    final Event<CanvasSelectionEvent> canvasSelectionEvent) {
+        this.floatingView = floatingView;
+        this.textEditorBox = textEditorBox;
+        this.canvasSelectionEvent = canvasSelectionEvent;
+    }
+
+    @Override
+    protected FloatingView<IsWidget> getFloatingView() {
+        return floatingView;
+    }
+
+    @Override
+    protected TextEditorBox<AbstractCanvasHandler, Element> getTextEditorBox() {
+        return textEditorBox;
+    }
+
+    @Override
+    protected Event<CanvasSelectionEvent> getCanvasSelectionEvent() {
+        return canvasSelectionEvent;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/MultiLineTextEditorBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/MultiLineTextEditorBox.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
+
+import java.lang.annotation.RetentionPolicy;
+
+@java.lang.annotation.Documented
+@java.lang.annotation.Retention(RetentionPolicy.RUNTIME)
+@javax.inject.Qualifier
+public @interface MultiLineTextEditorBox {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/SingleLineTextEditorBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/SingleLineTextEditorBox.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
+
+import java.lang.annotation.RetentionPolicy;
+
+@java.lang.annotation.Documented
+@java.lang.annotation.Retention(RetentionPolicy.RUNTIME)
+@javax.inject.Qualifier
+public @interface SingleLineTextEditorBox {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextEditorBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextEditorBox.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.client.components.actions;
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
 
 import org.jboss.errai.common.client.api.IsElement;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
@@ -22,13 +22,18 @@ import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManag
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.uberfire.mvp.Command;
 
-public interface TextEditorBox<C extends CanvasHandler, E extends Element> extends IsElement,
-                                                                                   RequiresCommandManager<C> {
+public interface TextEditorBox<C extends CanvasHandler, E extends Element>
+        extends IsElement,
+                RequiresCommandManager<C> {
 
     void initialize(final C canvasHandler,
                     final Command closeCallback);
 
     void show(final E element);
 
+    boolean isVisible();
+
     void hide();
 }
+
+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/general/BPMNGeneralSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/general/BPMNGeneralSet.java
@@ -40,7 +40,7 @@ public class BPMNGeneralSet implements BPMNPropertySet,
                                        BPMNBaseInfo {
 
     @Property
-    @FormField
+    @FormField(type = TextAreaFieldType.class)
     private Name name;
 
     @Property
@@ -77,13 +77,13 @@ public class BPMNGeneralSet implements BPMNPropertySet,
         return name;
     }
 
+    public void setName(final Name name) {
+        this.name = name;
+    }
+
     @Override
     public Documentation getDocumentation() {
         return documentation;
-    }
-
-    public void setName(final Name name) {
-        this.name = name;
     }
 
     public void setDocumentation(final Documentation documentation) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/general/TaskGeneralSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/general/TaskGeneralSet.java
@@ -37,7 +37,7 @@ public class TaskGeneralSet implements BPMNPropertySet,
                                        BPMNBaseInfo {
 
     @Property
-    @FormField
+    @FormField(type = TextAreaFieldType.class)
     private Name name;
 
     @Property

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/BPMNCanvasFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/BPMNCanvasFactory.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.DefaultCanvasFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.MultiLineTextEditorBox;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.EdgeBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.NodeBuilderControl;
@@ -75,7 +76,7 @@ public class BPMNCanvasFactory extends DefaultCanvasFactory {
                              final ManagedInstance<ConnectionAcceptorControl> connectionAcceptorControls,
                              final ManagedInstance<ContainmentAcceptorControl> containmentAcceptorControls,
                              final ManagedInstance<DockingAcceptorControl> dockingAcceptorControls,
-                             final ManagedInstance<CanvasInPlaceTextEditorControl> inPlaceTextEditorControls,
+                             final @MultiLineTextEditorBox ManagedInstance<CanvasInPlaceTextEditorControl> inPlaceTextEditorControls,
                              final @MultipleSelection ManagedInstance<SelectionControl> selectionControls,
                              final ManagedInstance<LocationControl> locationControls,
                              final @BPMN ManagedInstance<ToolboxControl> toolboxControls,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/canvas/CaseManagementCanvasFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/canvas/CaseManagementCanvasFactory.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.SingleLineTextEditorBox;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.EdgeBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.NodeBuilderControl;
@@ -88,7 +89,7 @@ public class CaseManagementCanvasFactory
     public CaseManagementCanvasFactory(final ManagedInstance<ConnectionAcceptorControl> connectionAcceptorControls,
                                        final @CaseManagementEditor ManagedInstance<ContainmentAcceptorControl> containmentAcceptorControls,
                                        final ManagedInstance<DockingAcceptorControl> dockingAcceptorControls,
-                                       final ManagedInstance<CanvasInPlaceTextEditorControl> nameEditionControls,
+                                       final @SingleLineTextEditorBox ManagedInstance<CanvasInPlaceTextEditorControl> nameEditionControls,
                                        final @SingleSelection ManagedInstance<SelectionControl> selectionControls,
                                        final @CaseManagementEditor @Observer ManagedInstance<ElementBuilderControl> elementBuilderControls,
                                        final @CaseManagementEditor ManagedInstance<NodeBuilderControl> nodeBuilderControls,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/canvas/CaseManagementCanvasFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/canvas/CaseManagementCanvasFactoryTest.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.cm.client.canvas.controls.containment.Ca
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControlImpl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControlSingleLine;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.EdgeBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.NodeBuilderControl;
@@ -76,7 +76,6 @@ public class CaseManagementCanvasFactoryTest {
     private ManagedInstance<AbstractCanvasHandler> canvasHandlerInstances;
     private ManagedInstance<ControlPointControl> controlPointControls;
 
-
     @Mock
     private Layer layer;
 
@@ -92,7 +91,7 @@ public class CaseManagementCanvasFactoryTest {
         this.connectionAcceptorControls = mockManagedInstance(ConnectionAcceptorControlImpl.class);
         this.containmentAcceptorControls = mockManagedInstance(CaseManagementContainmentAcceptorControlImpl.class);
         this.dockingAcceptorControls = mockManagedInstance(DockingAcceptorControlImpl.class);
-        this.nameEditionControls = mockManagedInstance(CanvasInPlaceTextEditorControlImpl.class);
+        this.nameEditionControls = mockManagedInstance(CanvasInPlaceTextEditorControlSingleLine.class);
         this.selectionControls = mockManagedInstance(SelectionControl.class);
         this.elementBuilderControls = mockManagedInstance(CaseManagementElementBuilderControl.class);
         this.nodeBuilderControls = mockManagedInstance(CaseManagementNodeBuilderControl.class);


### PR DESCRIPTION
Hi  @romartin @hasys ,
inline name edition feature fixed and text editor box layout changed.

For more information [see this ticket](https://issues.jboss.org/browse/JBPM-6777).

Could you please take a look?

Thanks!

