### PR TITLE
DROOLS-2436: Fix wrong diagram's name match condition.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/DiagramLookupServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/DiagramLookupServiceImpl.java
@@ -83,7 +83,7 @@ public class DiagramLookupServiceImpl
                               final Diagram<Graph, Metadata> item) {
         final Map<String, String> criteriaMap = AbstractCriteriaLookupManager.parseCriteria(criteria);
         final String name = criteriaMap.get(DiagramLookupRequest.CRITERIA_NAME);
-        if (null != name && name.trim().length() > 9) {
+        if (null != name && name.trim().length() > 0) {
             return name.equals(item.getName());
         }
         return true;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/test/java/org/kie/workbench/common/stunner/backend/service/DiagramLookupServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/test/java/org/kie/workbench/common/stunner/backend/service/DiagramLookupServiceImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.backend.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.lookup.diagram.DiagramLookupRequest;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiagramLookupServiceImplTest {
+
+    private static final String NAME = "name1";
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private DiagramServiceImpl diagramService;
+
+    @Mock
+    private Diagram<Graph, Metadata> diagram;
+
+    private DiagramLookupServiceImpl tested;
+
+    @Before
+    public void setup() {
+        when(diagram.getName()).thenReturn(NAME);
+        tested = new DiagramLookupServiceImpl(ioService,
+                                              diagramService);
+    }
+
+    @Test
+    public void testMatches() {
+        String criteria = DiagramLookupRequest.CRITERIA_NAME + "=" + NAME;
+        String criteria1 = DiagramLookupRequest.CRITERIA_NAME + "=" + "name2";
+        String criteria2 = "";
+        assertTrue(tested.matches(criteria, diagram));
+        assertFalse(tested.matches(criteria1, diagram));
+        assertTrue(tested.matches(criteria2, diagram));
+    }
+}


### PR DESCRIPTION
Hey @manstis  @jomarko 

Fixed the issue on the diagram's name matching condition. 

See [DROOLS-2436](https://issues.jboss.org/browse/DROOLS-2436)

Sorry it was my fault, added a small test at least for this. 

@manstis Thanks for pointing out the root issue, this way things are easier... :+1:  

Thanks!
