### PR TITLE
AF-1151: Project's pom.xml file is not validated before saving

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
@@ -424,4 +424,7 @@ public class LibraryConstants {
 
     @TranslationKey(defaultValue = "")
     public static final String GitUrlFailedToBeCopiedToClipboard = "GitUrlFailedToBeCopiedToClipboard";
+
+    @TranslationKey(defaultValue = "")
+    public static final String InvalidPom = "InvalidPom";
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/PomEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/PomEditor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.library.client.util;
+
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import elemental2.dom.DomGlobal;
+import org.guvnor.common.services.project.client.type.POMResourceType;
+import org.jboss.errai.common.client.api.Caller;
+import org.kie.workbench.common.screens.defaulteditor.client.editor.KieTextEditorPresenter;
+import org.kie.workbench.common.screens.defaulteditor.client.editor.KieTextEditorView;
+import org.kie.workbench.common.services.shared.validation.ValidationService;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.annotations.WorkbenchEditor;
+import org.uberfire.client.annotations.WorkbenchMenu;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.promise.Promises;
+import org.uberfire.ext.widgets.common.client.ace.AceEditorMode;
+import org.uberfire.lifecycle.OnStartup;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.menu.Menus;
+
+@WorkbenchEditor(
+        identifier = "PomEditor",
+        supportedTypes = {POMResourceType.class},
+        priority = 2)
+
+public class PomEditor extends KieTextEditorPresenter {
+
+    private final Promises promises;
+
+    private final Caller<ValidationService> validationService;
+
+    @Inject
+    public PomEditor(final KieTextEditorView baseView,
+                     final Promises promises,
+                     final Caller<ValidationService> validationService) {
+
+        super(baseView);
+        this.promises = promises;
+        this.validationService = validationService;
+    }
+
+    @OnStartup
+    public void onStartup(final ObservablePath path,
+                          final PlaceRequest place) {
+        super.onStartup(path, place);
+    }
+
+    @Override
+    protected void save(final String commitMessage) {
+        promises.promisify(validationService, s -> {
+            Path path = getPathSupplier().get();Ω
+            String content = getContentSupplier().get();
+            return s.validateForSave(path, content);
+        }).then(errors -> {
+
+            if (errors.isEmpty()) {
+                super.save(commitMessage);
+            } else {
+                DomGlobal.console.info("Error!");
+            }
+
+            return promises.resolve();
+        });
+    }
+
+    @WorkbenchPartTitle
+    public String getTitleText() {
+        return super.getTitleText();
+    }
+
+    @WorkbenchPartTitleDecoration
+    public IsWidget getTitle() {
+        return super.getTitle();
+    }
+
+    @WorkbenchPartView
+    public IsWidget asWidget() {
+        return super.getWidget();
+    }
+
+    @Override
+    protected Command onValidate() {
+        return super.onValidate();
+    }
+
+    @WorkbenchMenu
+    public Menus getMenus() {
+        return menus;
+    }
+
+    @Override
+    public AceEditorMode getAceEditorMode() {
+        return AceEditorMode.XML;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/PomEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/PomEditor.java
@@ -57,25 +57,24 @@ import static org.uberfire.workbench.events.NotificationEvent.NotificationType.E
         identifier = "PomEditor",
         supportedTypes = {POMResourceType.class},
         priority = 2)
-
 public class PomEditor extends KieTextEditorPresenter {
 
-    private Caller<PomEditorService> pomEditorService;
-    private ConflictingRepositoriesPopup conflictingRepositoriesPopup;
-
-    @Inject
-    public Event<NotificationEvent> notificationEvent;
-
-    @Inject
-    public TranslationService translationService;
+    private final Caller<PomEditorService> pomEditorService;
+    private final ConflictingRepositoriesPopup conflictingRepositoriesPopup;
+    public final Event<NotificationEvent> notificationEvent;
+    public final TranslationService translationService;
 
     @Inject
     public PomEditor(final KieTextEditorView baseView,
                      final Caller<PomEditorService> pomEditorService,
-                     final ConflictingRepositoriesPopup conflictingRepositoriesPopup) {
+                     final ConflictingRepositoriesPopup conflictingRepositoriesPopup,
+                     final Event<NotificationEvent> notificationEvent,
+                     final TranslationService translationService) {
         super(baseView);
         this.pomEditorService = pomEditorService;
         this.conflictingRepositoriesPopup = conflictingRepositoriesPopup;
+        this.notificationEvent = notificationEvent;
+        this.translationService = translationService;
     }
 
     @OnStartup

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/Library.properties
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/Library.properties
@@ -443,3 +443,4 @@ CloseUnsavedProjectAssetsInfoMessage=The following assets will have their change
 CloseUnsavedProjectAssetsQuestionMessage=Do you want to proceed anyway?
 GitUrlSuccessfullyCopiedToClipboard=Git URL copied to clipboard!
 GitUrlFailedToBeCopiedToClipboard=Git URL couldn't be copied to the clipboard because this browser does not support it
+InvalidPom=POM is invalid. There's an error at line {0} column {1}.

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/PomEditorTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/PomEditorTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.library.client.util;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.enterprise.event.Event;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.client.repositories.ConflictingRepositoriesPopup;
+import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.model.MavenRepositoryMetadata;
+import org.guvnor.common.services.project.service.DeploymentMode;
+import org.guvnor.common.services.project.service.GAVAlreadyExistsException;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.defaulteditor.client.editor.KieTextEditorView;
+import org.kie.workbench.common.screens.projecteditor.service.PomEditorService;
+import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
+import org.kie.workbench.common.widgets.metadata.client.widget.OverviewWidgetPresenter;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class PomEditorTest {
+
+    @Mock
+    private KieTextEditorView view;
+
+    @Mock
+    private PomEditorService service;
+
+    @Mock
+    private ConflictingRepositoriesPopup conflictingRepositoriesPopup;
+
+    @Mock
+    private Path pomPath;
+
+    @Mock
+    private PlaceRequest placeRequest;
+
+    @Mock
+    private BusyIndicatorView mockBusyIndicatorView;
+
+    @Mock
+    private VersionRecordManager mockVersionRecordManager;
+
+    @Mock
+    private OverviewWidgetPresenter overviewWidgetPresenter;
+
+    private Event<NotificationEvent> mockNotificationEvent = new EventSourceMock<NotificationEvent>() {
+        @Override
+        public void fire(final NotificationEvent event) {
+            //Do nothing. Default implementation throws an Exception.
+        }
+    };
+
+    private PomEditor presenter;
+
+    private String pomXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+            "<modelVersion>4.0.0</modelVersion>\n" +
+            "<groupId>groupId</groupId>\n" +
+            "<artifactId>artifactId</artifactId>\n" +
+            "<version>0.0.1</version>\n" +
+            "<name>name</name>\n" +
+            "<description>description</description>\n" +
+            "</project>";
+
+    private String comment = "comment";
+
+    private GAV gav = new GAV("groupId",
+                              "artifactId",
+                              "0.0.1");
+
+    @Before
+    public void setup() {
+        presenter = new PomEditor(view,
+                                  new CallerMock<>(service),
+                                  conflictingRepositoriesPopup) {
+            {
+                //Yuck, yuck, yuck... the class hierarchy is really a mess
+                busyIndicatorView = mockBusyIndicatorView;
+                versionRecordManager = mockVersionRecordManager;
+                overviewWidget = overviewWidgetPresenter;
+                notification = mockNotificationEvent;
+            }
+        };
+        when(view.getContent()).thenReturn(pomXml);
+    }
+
+    @Test
+    public void testSaveNonClashingGAV() {
+        presenter.save(comment);
+
+        verify(service,
+               times(1)).save(any(ObservablePath.class),
+                              eq(pomXml),
+                              any(Metadata.class),
+                              eq(comment),
+                              eq(DeploymentMode.VALIDATED));
+        verify(view,
+               times(1)).showBusyIndicator(eq(CommonConstants.INSTANCE.Saving()));
+        verify(view,
+               times(1)).hideBusyIndicator();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSaveClashingGAV() {
+        final GAVAlreadyExistsException gae = new GAVAlreadyExistsException(gav,
+                                                                            Collections.<MavenRepositoryMetadata>emptySet());
+        doThrow(gae).when(service).save(any(ObservablePath.class),
+                                        eq(pomXml),
+                                        any(Metadata.class),
+                                        eq(comment),
+                                        eq(DeploymentMode.VALIDATED));
+
+        presenter.save(comment);
+
+        verify(service,
+               times(1)).save(any(ObservablePath.class),
+                              eq(pomXml),
+                              any(Metadata.class),
+                              eq(comment),
+                              eq(DeploymentMode.VALIDATED));
+        verify(view,
+               times(1)).showBusyIndicator(eq(CommonConstants.INSTANCE.Saving()));
+        verify(view,
+               times(1)).hideBusyIndicator();
+
+        final ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass(Command.class);
+
+        verify(conflictingRepositoriesPopup,
+               times(1)).setContent(eq(gav),
+                                    any(Set.class),
+                                    commandArgumentCaptor.capture());
+        verify(conflictingRepositoriesPopup,
+               times(1)).show();
+
+        assertNotNull(commandArgumentCaptor.getValue());
+
+        //Emulate User electing to force save
+        commandArgumentCaptor.getValue().execute();
+
+        verify(service,
+               times(1)).save(any(ObservablePath.class),
+                              eq(pomXml),
+                              any(Metadata.class),
+                              eq(comment),
+                              eq(DeploymentMode.FORCED));
+        //We attempted to save the POM twice
+        verify(view,
+               times(2)).showBusyIndicator(eq(CommonConstants.INSTANCE.Saving()));
+        //We hid the BusyPopup 1 x per save attempt
+        verify(view,
+               times(2)).hideBusyIndicator();
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/src/main/java/org/kie/workbench/common/screens/projecteditor/model/InvalidPomException.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/src/main/java/org/kie/workbench/common/screens/projecteditor/model/InvalidPomException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class InvalidPomException extends RuntimeException {
+
+    private int lineNumber = 0;
+    private int columnNumber = 0;
+
+    public InvalidPomException() {
+        super();
+    }
+
+    public InvalidPomException(final int lineNumber,
+                               final int columnNumber) {
+
+        super("Invalid POM.");
+        this.lineNumber = lineNumber;
+        this.columnNumber = columnNumber;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public int getColumnNumber() {
+        return columnNumber;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/main/java/org/kie/workbench/common/screens/projecteditor/backend/server/PomEditorServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/main/java/org/kie/workbench/common/screens/projecteditor/backend/server/PomEditorServiceImpl.java
@@ -41,6 +41,7 @@ import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.bus.server.annotations.Service;
 import org.kie.workbench.common.screens.defaulteditor.service.DefaultEditorContent;
 import org.kie.workbench.common.screens.defaulteditor.service.DefaultEditorService;
+import org.kie.workbench.common.screens.projecteditor.model.InvalidPomException;
 import org.kie.workbench.common.screens.projecteditor.service.PomEditorService;
 import org.kie.workbench.common.services.shared.project.KieModule;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
@@ -152,12 +153,10 @@ public class PomEditorServiceImpl implements PomEditorService {
             if (pom.getGav().equals(module.getPom().getGav())) {
                 return;
             }
-        } catch (IOException ioe) {
-            logger.warn("Unable to load pom.xml. It is therefore impossible to ascertain GAV.",
-                        ioe);
-        } catch (XmlPullParserException pe) {
-            logger.warn("Unable to load pom.xml. It is therefore impossible to ascertain GAV.",
-                        pe);
+        } catch (final XmlPullParserException e) {
+            throw new InvalidPomException(e.getLineNumber(), e.getColumnNumber());
+        } catch (final IOException e) {
+            logger.warn("Unable to load pom.xml. It is therefore impossible to ascertain GAV.",e);
         }
 
         // Check is the POM's GAV resolves to any pre-existing artifacts.

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/callbacks/CommandWithThrowableDrivenErrorCallback.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/callbacks/CommandWithThrowableDrivenErrorCallback.java
@@ -30,6 +30,7 @@ import org.uberfire.mvp.ParameterizedCommand;
  */
 public class CommandWithThrowableDrivenErrorCallback extends HasBusyIndicatorDefaultErrorCallback {
 
+    @FunctionalInterface
     public interface CommandWithThrowable extends ParameterizedCommand<Throwable> {
 
     }


### PR DESCRIPTION
This PR brings back the `PomEditor` class that was removed along with the implementation of the new Settings screen. More than that, this editor now contains a save validation and displays a friendly message when errors occur.

![ezgif-2-bfbbb02672](https://user-images.githubusercontent.com/1584568/38277374-91710c3e-376e-11e8-867e-06958e594d65.gif)

