### PR TITLE
BAQE-400: Remove unused imports (fix)

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImpl.java
@@ -26,7 +26,6 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresShapeView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasHandlerRegistrationControl;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/CanvasViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/CanvasViewTest.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.stunner.client.widgets.canvas.view;
 
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.Scene;
-import com.ait.lienzo.client.core.shape.wires.WiresContainer;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresDockingControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
@@ -36,7 +35,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPositionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPositionCommandTest.java
@@ -36,11 +36,9 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -170,7 +168,7 @@ public class UpdateElementPositionCommandTest extends AbstractGraphCommandTest {
     }
 
     @Test
-    public void testExecuteDockedNode(){
+    public void testExecuteDockedNode() {
         ArgumentCaptor<Bounds> boundsArgumentCaptor = ArgumentCaptor.forClass(Bounds.class);
         this.tested = new UpdateElementPositionCommand(dockedNode, new Point2D(600d, 600d));
         final CommandResult<RuleViolation> result = tested.execute(graphCommandExecutionContext);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
-import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
@@ -101,7 +100,7 @@ public class GraphUtilsTest {
     }
 
     @Test
-    public void isDockedNodeTest(){
+    public void isDockedNodeTest() {
         assertTrue(GraphUtils.isDockedNode(graphInstance.dockedNode));
         assertFalse(GraphUtils.isDockedNode(graphInstance.startNode));
         assertFalse(GraphUtils.isDockedNode(graphInstance.intermNode));
@@ -109,7 +108,7 @@ public class GraphUtilsTest {
     }
 
     @Test
-    public void getDockedNodesTest(){
+    public void getDockedNodesTest() {
         List<Node> dockedNodes = GraphUtils.getDockedNodes(graphInstance.intermNode);
         assertEquals(dockedNodes.size(), 1);
         assertEquals(dockedNodes.get(0), graphInstance.dockedNode);


### PR DESCRIPTION
Hey @jomarko @tiagodolphine @manstis 

Sorry after merging a few PRs together the full build got broken due to some `unused imports` check failed. Here is the fix. 

Thanks!