### PR TITLE
Stunner - @Definition. Support for empty constructor instead of Builder class 

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Association.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Association.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
@@ -41,7 +40,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = EdgeFactory.class, builder = Association.AssociationBuilder.class)
+@Definition(graphFactory = EdgeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 @CanConnect(startRole = "business-knowledge-model", endRole = "text-annotation")
 @CanConnect(startRole = "decision", endRole = "text-annotation")
@@ -60,17 +59,9 @@ public class Association extends Artifact {
         add("association");
     }};
 
-    @NonPortable
-    public static class AssociationBuilder extends BaseNodeBuilder<Association> {
-
-        @Override
-        public Association build() {
-            return new Association(new Id(),
-                                   new org.kie.workbench.common.dmn.api.property.dmn.Description());
-        }
-    }
-
     public Association() {
+        this(new Id(),
+             new org.kie.workbench.common.dmn.api.property.dmn.Description());
     }
 
     public Association(final @MapsTo("id") Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
@@ -44,7 +44,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = BusinessKnowledgeModel.BusinessKnowledgeModelBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class BusinessKnowledgeModel extends DRGElement implements DMNViewDefinition {
 
@@ -86,9 +86,6 @@ public class BusinessKnowledgeModel extends DRGElement implements DMNViewDefinit
              new BackgroundSet(),
              new FontSet(),
              new RectangleDimensionsSet());
-    }
-
-    public BusinessKnowledgeModel() {
     }
 
     public BusinessKnowledgeModel(final @MapsTo("id") Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
@@ -78,20 +77,15 @@ public class BusinessKnowledgeModel extends DRGElement implements DMNViewDefinit
     @Valid
     protected RectangleDimensionsSet dimensionsSet;
 
-    @NonPortable
-    public static class BusinessKnowledgeModelBuilder extends BaseNodeBuilder<BusinessKnowledgeModel> {
-
-        @Override
-        public BusinessKnowledgeModel build() {
-            return new BusinessKnowledgeModel(new Id(),
-                                              new org.kie.workbench.common.dmn.api.property.dmn.Description(),
-                                              new Name(),
-                                              new InformationItem(),
-                                              new FunctionDefinition(),
-                                              new BackgroundSet(),
-                                              new FontSet(),
-                                              new RectangleDimensionsSet());
-        }
+    public BusinessKnowledgeModel() {
+        this(new Id(),
+             new org.kie.workbench.common.dmn.api.property.dmn.Description(),
+             new Name(),
+             new InformationItem(),
+             new FunctionDefinition(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public BusinessKnowledgeModel() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
@@ -44,7 +43,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = DMNDiagram.DMNDiagramBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 @CanContain(roles = {
         "input-data",
@@ -82,19 +81,12 @@ public class DMNDiagram extends DMNModelInstrumentedBase implements DMNViewDefin
     @FormField
     protected RectangleDimensionsSet dimensionsSet;
 
-    @NonPortable
-    public static class DMNDiagramBuilder extends BaseNodeBuilder<DMNDiagram> {
-
-        @Override
-        public DMNDiagram build() {
-            return new DMNDiagram(new Definitions(),
-                                  new BackgroundSet(),
-                                  new FontSet(),
-                                  new RectangleDimensionsSet());
-        }
-    }
-
+    @Override
     public DMNDiagram() {
+        this(new Definitions(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public DMNDiagram(final @MapsTo("definitions") Definitions definitions,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
@@ -81,7 +81,6 @@ public class DMNDiagram extends DMNModelInstrumentedBase implements DMNViewDefin
     @FormField
     protected RectangleDimensionsSet dimensionsSet;
 
-    @Override
     public DMNDiagram() {
         this(new Definitions(),
              new BackgroundSet(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
@@ -49,7 +48,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = Decision.DecisionBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class Decision extends DRGElement implements HasExpression,
                                                     DMNViewDefinition {
@@ -91,25 +90,17 @@ public class Decision extends DRGElement implements HasExpression,
     @Valid
     protected RectangleDimensionsSet dimensionsSet;
 
-    @NonPortable
-    public static class DecisionBuilder extends BaseNodeBuilder<Decision> {
-
-        @Override
-        public Decision build() {
-            return new Decision(new Id(),
-                                new org.kie.workbench.common.dmn.api.property.dmn.Description(),
-                                new Name(),
-                                new Question(),
-                                new AllowedAnswers(),
-                                new InformationItem(),
-                                null,
-                                new BackgroundSet(),
-                                new FontSet(),
-                                new RectangleDimensionsSet());
-        }
-    }
-
     public Decision() {
+        this(new Id(),
+             new org.kie.workbench.common.dmn.api.property.dmn.Description(),
+             new Name(),
+             new Question(),
+             new AllowedAnswers(),
+             new InformationItem(),
+             null,
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public Decision(final @MapsTo("id") Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationRequirement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationRequirement.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.rules.AcyclicDirectedGraphRule;
@@ -39,7 +38,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = EdgeFactory.class, builder = InformationRequirement.InformationRequirementBuilder.class)
+@Definition(graphFactory = EdgeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 @CanConnect(startRole = "decision", endRole = "decision")
 @CanConnect(startRole = "input-data", endRole = "decision")
@@ -56,13 +55,7 @@ public class InformationRequirement extends DMNModelInstrumentedBase {
         add("information-requirement");
     }};
 
-    @NonPortable
-    public static class InformationRequirementBuilder extends BaseNodeBuilder<InformationRequirement> {
-
-        @Override
-        public InformationRequirement build() {
-            return new InformationRequirement();
-        }
+    public InformationRequirement() {
     }
 
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
@@ -45,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = InputData.InputDataBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class InputData extends DRGElement implements DMNViewDefinition {
 
@@ -76,22 +76,14 @@ public class InputData extends DRGElement implements DMNViewDefinition {
     @Valid
     protected RectangleDimensionsSet dimensionsSet;
 
-    @NonPortable
-    public static class InputDataBuilder extends BaseNodeBuilder<InputData> {
-
-        @Override
-        public InputData build() {
-            return new InputData(new Id(),
-                                 new org.kie.workbench.common.dmn.api.property.dmn.Description(),
-                                 new Name(),
-                                 new InformationItem(),
-                                 new BackgroundSet(),
-                                 new FontSet(),
-                                 new RectangleDimensionsSet());
-        }
-    }
-
     public InputData() {
+        this(new Id(),
+                             new org.kie.workbench.common.dmn.api.property.dmn.Description(),
+                             new Name(),
+                             new InformationItem(),
+                             new BackgroundSet(),
+                             new FontSet(),
+                             new RectangleDimensionsSet());
     }
 
     public InputData(final @MapsTo("id") Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
@@ -78,12 +77,12 @@ public class InputData extends DRGElement implements DMNViewDefinition {
 
     public InputData() {
         this(new Id(),
-                             new org.kie.workbench.common.dmn.api.property.dmn.Description(),
-                             new Name(),
-                             new InformationItem(),
-                             new BackgroundSet(),
-                             new FontSet(),
-                             new RectangleDimensionsSet());
+             new org.kie.workbench.common.dmn.api.property.dmn.Description(),
+             new Name(),
+             new InformationItem(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public InputData(final @MapsTo("id") Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeRequirement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeRequirement.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.rules.AcyclicDirectedGraphRule;
@@ -39,7 +38,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = EdgeFactory.class, builder = KnowledgeRequirement.KnowledgeRequirementBuilder.class)
+@Definition(graphFactory = EdgeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 @CanConnect(startRole = "business-knowledge-model", endRole = "decision")
 @CanConnect(startRole = "business-knowledge-model", endRole = "business-knowledge-model")
@@ -56,13 +55,7 @@ public class KnowledgeRequirement extends DMNModelInstrumentedBase {
         add("knowledge-requirement");
     }};
 
-    @NonPortable
-    public static class KnowledgeRequirementBuilder extends BaseNodeBuilder<KnowledgeRequirement> {
-
-        @Override
-        public KnowledgeRequirement build() {
-            return new KnowledgeRequirement();
-        }
+    public KnowledgeRequirement() {
     }
 
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
@@ -48,7 +48,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = KnowledgeSource.KnowledgeSourceBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class KnowledgeSource extends DRGElement implements DMNViewDefinition {
 
@@ -84,22 +84,15 @@ public class KnowledgeSource extends DRGElement implements DMNViewDefinition {
     protected RectangleDimensionsSet dimensionsSet;
 
     @NonPortable
-    public static class KnowledgeSourceBuilder extends BaseNodeBuilder<KnowledgeSource> {
-
-        @Override
-        public KnowledgeSource build() {
-            return new KnowledgeSource(new Id(),
-                                       new org.kie.workbench.common.dmn.api.property.dmn.Description(),
-                                       new Name(),
-                                       new KnowledgeSourceType(),
-                                       new LocationURI(),
-                                       new BackgroundSet(),
-                                       new FontSet(),
-                                       new RectangleDimensionsSet());
-        }
-    }
-
     public KnowledgeSource() {
+        this(new Id(),
+             new org.kie.workbench.common.dmn.api.property.dmn.Description(),
+             new Name(),
+             new KnowledgeSourceType(),
+             new LocationURI(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public KnowledgeSource(final @MapsTo("id") Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
@@ -83,7 +82,6 @@ public class KnowledgeSource extends DRGElement implements DMNViewDefinition {
     @Valid
     protected RectangleDimensionsSet dimensionsSet;
 
-    @NonPortable
     public KnowledgeSource() {
         this(new Id(),
              new org.kie.workbench.common.dmn.api.property.dmn.Description(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
@@ -46,7 +46,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class TextAnnotation extends Artifact implements DMNViewDefinition {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
@@ -47,7 +46,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = TextAnnotation.TextAnnotationBuilder.class)
+@FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class TextAnnotation extends Artifact implements DMNViewDefinition {
 
@@ -80,22 +79,14 @@ public class TextAnnotation extends Artifact implements DMNViewDefinition {
     @FormField(afterElement = "fontSet")
     protected RectangleDimensionsSet dimensionsSet;
 
-    @NonPortable
-    public static class TextAnnotationBuilder extends BaseNodeBuilder<TextAnnotation> {
-
-        @Override
-        public TextAnnotation build() {
-            return new TextAnnotation(new Id(),
-                                      new org.kie.workbench.common.dmn.api.property.dmn.Description(),
-                                      new Text(),
-                                      new TextFormat(),
-                                      new BackgroundSet(),
-                                      new FontSet(),
-                                      new RectangleDimensionsSet());
-        }
-    }
-
     public TextAnnotation() {
+        this(new Id(),
+             new org.kie.workbench.common.dmn.api.property.dmn.Description(),
+             new Text(),
+             new TextFormat(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public TextAnnotation(final @MapsTo("id") Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -200,7 +200,7 @@ public class DMNMarshallerTest {
                 // Please note this is different from the stunner jbpm test which this dmn test is based on
                 Graph graph = (Graph) dmnGraphFactory.build(uuid,
                                                             DMN_DEF_SET_ID);
-                DMNDiagram model = new DMNDiagram.DMNDiagramBuilder().build();
+                DMNDiagram model = new DMNDiagram();
                 Node node = viewNodeFactory.build(uuid,
                                                   model);
                 graph.addNode(node);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/Definition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/Definition.java
@@ -32,5 +32,6 @@ public @interface Definition {
 
     Class<? extends ElementFactory> graphFactory();
 
+    @Deprecated
     Class<? extends Builder<?>> builder() default VoidBuilder.class;
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
@@ -54,6 +54,7 @@ import org.kie.workbench.common.stunner.core.definition.builder.VoidBuilder;
 import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 import org.kie.workbench.common.stunner.core.definition.property.PropertyType;
 import org.kie.workbench.common.stunner.core.processors.definition.BindableDefinitionAdapterGenerator;
+import org.kie.workbench.common.stunner.core.processors.definition.TypeConstructor;
 import org.kie.workbench.common.stunner.core.processors.definitionset.BindableDefinitionSetAdapterGenerator;
 import org.kie.workbench.common.stunner.core.processors.definitionset.DefinitionSetProxyGenerator;
 import org.kie.workbench.common.stunner.core.processors.factory.ModelFactoryGenerator;
@@ -663,7 +664,7 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
 
     private void processDefinitionModelBuilder(final Element e,
                                                final String className,
-                                               final Map<String, String> processingContextMap) {
+                                               final Map<String, TypeConstructor> processingContextMap) {
         Definition definitionAnn = e.getAnnotation(Definition.class);
         TypeMirror bMirror = null;
         try {
@@ -674,7 +675,10 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
         if (null != bMirror && !VoidBuilder.class.getName().equals(bMirror.toString())) {
             String fqcn = bMirror.toString();
             processingContextMap.put(className,
-                                     fqcn);
+                                     TypeConstructor.builder(fqcn));
+        } else {
+            processingContextMap.put(className,
+                                     TypeConstructor.builder(className));
         }
     }
 
@@ -1220,7 +1224,8 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
             if (size > 0) {
                 final Map<String, String> buildersMap = new LinkedHashMap<>();
                 if (!processingContext.getDefinitionAnnotations().getBuilderFieldNames().isEmpty()) {
-                    buildersMap.putAll(processingContext.getDefinitionAnnotations().getBuilderFieldNames());
+                    processingContext.getDefinitionAnnotations().getBuilderFieldNames().forEach(
+                            (key, value) -> buildersMap.put(key, value.representation()));
                 }
                 if (!processingContext.getDefSetAnnotations().getBuilderFieldNames().isEmpty()) {
                     buildersMap.putAll(processingContext.getDefSetAnnotations().getBuilderFieldNames());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
@@ -678,13 +678,13 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
                                      TypeConstructor.builder(fqcn));
         } else {
             processingContextMap.put(className,
-                                     TypeConstructor.builder(className));
+                                     TypeConstructor.constructor(className));
         }
     }
 
     private void processDefinitionSetModelBuilder(final Element e,
                                                   final String className,
-                                                  final Map<String, String> processingContextMap) {
+                                                  final Map<String, TypeConstructor> processingContextMap) {
         DefinitionSet definitionAnn = e.getAnnotation(DefinitionSet.class);
         TypeMirror bMirror = null;
         try {
@@ -695,7 +695,7 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
         if (null != bMirror && !VoidBuilder.class.getName().equals(bMirror.toString())) {
             String fqcn = bMirror.toString();
             processingContextMap.put(className,
-                                     fqcn);
+                                     TypeConstructor.builder(fqcn));
         }
     }
 
@@ -1228,7 +1228,8 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
                             (key, value) -> buildersMap.put(key, value.representation()));
                 }
                 if (!processingContext.getDefSetAnnotations().getBuilderFieldNames().isEmpty()) {
-                    buildersMap.putAll(processingContext.getDefSetAnnotations().getBuilderFieldNames());
+                    processingContext.getDefSetAnnotations().getBuilderFieldNames().forEach(
+                            (key, value) -> buildersMap.put(key, value.representation()));
                 }
                 // Ensure visible on both backend and client sides.
                 final String packageName = getGeneratedPackageName() + ".definition.factory";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
@@ -1225,11 +1225,11 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
                 final Map<String, String> buildersMap = new LinkedHashMap<>();
                 if (!processingContext.getDefinitionAnnotations().getBuilderFieldNames().isEmpty()) {
                     processingContext.getDefinitionAnnotations().getBuilderFieldNames().forEach(
-                            (key, value) -> buildersMap.put(key, value.representation()));
+                            (key, value) -> buildersMap.put(key, value.toCode()));
                 }
                 if (!processingContext.getDefSetAnnotations().getBuilderFieldNames().isEmpty()) {
                     processingContext.getDefSetAnnotations().getBuilderFieldNames().forEach(
-                            (key, value) -> buildersMap.put(key, value.representation()));
+                            (key, value) -> buildersMap.put(key, value.toCode()));
                 }
                 // Ensure visible on both backend and client sides.
                 final String packageName = getGeneratedPackageName() + ".definition.factory";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/ProcessingDefinitionAnnotations.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/ProcessingDefinitionAnnotations.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.kie.workbench.common.stunner.core.processors.definition.TypeConstructor;
+
 public class ProcessingDefinitionAnnotations {
 
     private final Map<String, String> baseTypes = new HashMap<>();
@@ -31,7 +33,7 @@ public class ProcessingDefinitionAnnotations {
     private final Map<String, String> titleFieldNames = new HashMap<>();
     private final Map<String, String> categoryFieldNames = new HashMap<>();
     private final Map<String, String> descriptionFieldNames = new HashMap<>();
-    private final Map<String, String> builderFieldNames = new HashMap<>();
+    private final Map<String, TypeConstructor> builderFieldNames = new HashMap<>();
     private final Map<String, String[]> shapeDefs = new HashMap<>();
 
     public Map<String, String> getBaseTypes() {
@@ -70,7 +72,7 @@ public class ProcessingDefinitionAnnotations {
         return descriptionFieldNames;
     }
 
-    public Map<String, String> getBuilderFieldNames() {
+    public Map<String, TypeConstructor> getBuilderFieldNames() {
         return builderFieldNames;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/ProcessingDefinitionSetAnnotations.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/ProcessingDefinitionSetAnnotations.java
@@ -21,11 +21,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.kie.workbench.common.stunner.core.processors.definition.TypeConstructor;
+
 public class ProcessingDefinitionSetAnnotations {
 
     private final Map<String, String> descriptionFieldNames = new HashMap<>();
     private final Set<String> definitionIds = new HashSet<>();
-    private final Map<String, String> builderFieldNames = new HashMap<>();
+    private final Map<String, TypeConstructor> builderFieldNames = new HashMap<>();
     private final Map<String, String> graphTypes = new HashMap<>();
     private final Map<String, String> qualifiers = new HashMap<>();
     private boolean hasShapeSet = false;
@@ -38,7 +40,7 @@ public class ProcessingDefinitionSetAnnotations {
         return definitionIds;
     }
 
-    public Map<String, String> getBuilderFieldNames() {
+    public Map<String, TypeConstructor> getBuilderFieldNames() {
         return builderFieldNames;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definition/TypeConstructor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definition/TypeConstructor.java
@@ -18,7 +18,7 @@ package org.kie.workbench.common.stunner.core.processors.definition;
 
 public interface TypeConstructor {
 
-    String representation();
+    String toCode();
 
     static TypeConstructor builder(String builderClass) {
         return () -> String.format("new %s().build()", builderClass);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definition/TypeConstructor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definition/TypeConstructor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.processors.definition;
+
+public interface TypeConstructor {
+
+    String representation();
+
+    static TypeConstructor builder(String builderClass) {
+        return () -> String.format("new %s().build()", builderClass);
+    }
+
+    static TypeConstructor constructor(String className) {
+        return () -> String.format("new %s()", className);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definitionset/DefinitionSetProxyGenerator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definitionset/DefinitionSetProxyGenerator.java
@@ -53,7 +53,7 @@ public class DefinitionSetProxyGenerator extends AbstractAdapterGenerator {
                  defSetClassName);
         String builder = "new " + defSetClassName + "()";
         if (null != buildersMap && !buildersMap.isEmpty()) {
-            builder = buildersMap.get(defSetClassName).representation();
+            builder = buildersMap.get(defSetClassName).toCode();
         }
 
         // Builder.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definitionset/DefinitionSetProxyGenerator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definitionset/DefinitionSetProxyGenerator.java
@@ -24,6 +24,7 @@ import javax.annotation.processing.Messager;
 import org.kie.workbench.common.stunner.core.definition.DefinitionSetProxy;
 import org.kie.workbench.common.stunner.core.processors.AbstractAdapterGenerator;
 import org.kie.workbench.common.stunner.core.processors.ProcessingEntity;
+import org.kie.workbench.common.stunner.core.processors.definition.TypeConstructor;
 import org.uberfire.annotations.processors.exceptions.GenerationException;
 
 public class DefinitionSetProxyGenerator extends AbstractAdapterGenerator {
@@ -36,7 +37,7 @@ public class DefinitionSetProxyGenerator extends AbstractAdapterGenerator {
     public StringBuffer generate(final String packageName,
                                  final String className,
                                  final ProcessingEntity definitionSetProcessedEntity,
-                                 final Map<String, String> buildersMap,
+                                 final Map<String, TypeConstructor> buildersMap,
                                  final Messager messager) throws GenerationException {
         String defSetClassName = definitionSetProcessedEntity.getClassName();
         Map<String, Object> root = new HashMap<String, Object>();
@@ -52,10 +53,7 @@ public class DefinitionSetProxyGenerator extends AbstractAdapterGenerator {
                  defSetClassName);
         String builder = "new " + defSetClassName + "()";
         if (null != buildersMap && !buildersMap.isEmpty()) {
-            String builderClass = buildersMap.get(defSetClassName);
-            if (null != builderClass && builderClass.trim().length() > 0) {
-                builder = "new " + builderClass + "().build()";
-            }
+            builder = buildersMap.get(defSetClassName).representation();
         }
 
         // Builder.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/resources/org/kie/workbench/common/stunner/core/processors/factory/templates/ModelFactory.ftl
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/resources/org/kie/workbench/common/stunner/core/processors/factory/templates/ModelFactory.ftl
@@ -48,7 +48,7 @@ public class ${className} extends ${parentClassName}<Object> {
 
             if ( ${builder.className}.class.equals( clazz ) ) {
 
-                return new ${builder.methodName}().build();
+                return ${builder.methodName};
 
             }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.variables.Proce
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
@@ -73,12 +71,12 @@ public class AdHocSubprocess
 
     public AdHocSubprocess() {
         this(new BPMNGeneralSet("Sub-process"),
-                        new BackgroundSet(),
-                        new FontSet(),
-                        new RectangleDimensionsSet(),
-                        new SimulationSet(),
-                        new AdHocSubprocessTaskExecutionSet(),
-                        new ProcessData());
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet(),
+             new SimulationSet(),
+             new AdHocSubprocessTaskExecutionSet(),
+             new ProcessData());
     }
 
     public AdHocSubprocess(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
@@ -51,7 +51,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Bindable
 @CanContain(roles = {"cm_activity", "cm_stage", "IntermediateEventsMorph", "GatewaysMorph"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
-@Definition(graphFactory = NodeFactory.class, builder = AdHocSubprocess.AdHocSubprocessBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseSubprocess.class)
 @FormDefinition(
         startElement = "general",
@@ -71,22 +71,14 @@ public class AdHocSubprocess
     @Valid
     private ProcessData processData;
 
-    @NonPortable
-    public static class AdHocSubprocessBuilder implements Builder<AdHocSubprocess> {
-
-        @Override
-        public AdHocSubprocess build() {
-            return new AdHocSubprocess(new BPMNGeneralSet("Sub-process"),
-                                       new BackgroundSet(),
-                                       new FontSet(),
-                                       new RectangleDimensionsSet(),
-                                       new SimulationSet(),
-                                       new AdHocSubprocessTaskExecutionSet(),
-                                       new ProcessData());
-        }
-    }
-
     public AdHocSubprocess() {
+        this(new BPMNGeneralSet("Sub-process"),
+                        new BackgroundSet(),
+                        new FontSet(),
+                        new RectangleDimensionsSet(),
+                        new SimulationSet(),
+                        new AdHocSubprocessTaskExecutionSet(),
+                        new ProcessData());
     }
 
     public AdHocSubprocess(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -48,7 +46,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = BPMNDiagramImpl.BPMNDiagramBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @CanContain(roles = {"all"})
 @FormDefinition(
         startElement = "diagramSet",
@@ -87,24 +85,16 @@ public class BPMNDiagramImpl implements BPMNDiagram {
         add("diagram");
     }};
 
-    @NonPortable
-    public static class BPMNDiagramBuilder implements Builder<BPMNDiagramImpl> {
-
-        public static final Double WIDTH = 950d;
-        public static final Double HEIGHT = 950d;
-
-        @Override
-        public BPMNDiagramImpl build() {
-            return new BPMNDiagramImpl(new DiagramSet(),
-                                       new ProcessData(),
-                                       new BackgroundSet(),
-                                       new FontSet(),
-                                       new RectangleDimensionsSet(WIDTH,
-                                                                  HEIGHT));
-        }
-    }
+    public static final Double WIDTH = 950d;
+    public static final Double HEIGHT = 950d;
 
     public BPMNDiagramImpl() {
+        this(new DiagramSet(),
+             new ProcessData(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet(WIDTH,
+                                        HEIGHT));
     }
 
     public BPMNDiagramImpl(final @MapsTo("diagramSet") DiagramSet diagramSet,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseConnector.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseConnector.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
@@ -31,7 +30,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 public abstract class BaseConnector implements BPMNViewDefinition {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseConnector.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseConnector.java
@@ -51,13 +51,9 @@ public abstract class BaseConnector implements BPMNViewDefinition {
     @PropertySet
     protected FontSet fontSet;
 
-    @NonPortable
-    static abstract class BaseConnectorBuilder<T extends BaseConnector> implements Builder<BaseConnector> {
-
-        public static final transient String COLOR = "#000000";
-        public static final transient String BORDER_COLOR = "#000000";
-        public static final Double BORDER_SIZE = 1d;
-    }
+    public static final transient String COLOR = "#000000";
+    public static final transient String BORDER_COLOR = "#000000";
+    public static final Double BORDER_SIZE = 1d;
 
     @Labels
     protected final Set<String> labels = new HashSet<String>() {{

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BusinessRuleTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BusinessRuleTask.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -40,7 +39,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.task.TaskTypes;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
 import org.kie.workbench.common.stunner.core.util.HashUtil;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BusinessRuleTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BusinessRuleTask.java
@@ -50,7 +50,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = BusinessRuleTask.BusinessRuleTaskBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @CanDock(roles = {"IntermediateEventOnActivityBoundary"})
 @Morph(base = BaseTask.class)
 @FormDefinition(
@@ -73,15 +73,6 @@ public class BusinessRuleTask extends BaseTask implements DataIOModel {
     )
     @Valid
     protected DataIOSet dataIOSet;
-
-    @NonPortable
-    public static class BusinessRuleTaskBuilder implements Builder<BusinessRuleTask> {
-
-        @Override
-        public BusinessRuleTask build() {
-            return new BusinessRuleTask();
-        }
-    }
 
     public BusinessRuleTask() {
         this(new TaskGeneralSet(new Name("Task"),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -39,7 +38,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.variables.Proce
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
@@ -50,7 +48,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = EmbeddedSubprocess.EmbeddedSubprocessBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseSubprocess.class)
 @CanContain(roles = {"all"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
@@ -60,23 +58,6 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)}
 )
 public class EmbeddedSubprocess extends BaseSubprocess implements DataIOModel {
-
-    @NonPortable
-    public static class EmbeddedSubprocessBuilder implements Builder<EmbeddedSubprocess> {
-
-        // TODO: It should use #FAFAFA as bg_color, rather than other subprocesses...
-        @Override
-        public EmbeddedSubprocess build() {
-            return new EmbeddedSubprocess(
-                    new BPMNGeneralSet("Sub-process"),
-                    new BackgroundSet(),
-                    new FontSet(),
-                    new RectangleDimensionsSet(),
-                    new SimulationSet(),
-                    new EmbeddedSubprocessExecutionSet(),
-                    new ProcessData());
-        }
-    }
 
     @PropertySet
     @FormField(afterElement = "general")
@@ -89,7 +70,14 @@ public class EmbeddedSubprocess extends BaseSubprocess implements DataIOModel {
     private ProcessData processData;
 
     public EmbeddedSubprocess() {
-        super();
+        this(
+                new BPMNGeneralSet("Sub-process"),
+                new BackgroundSet(),
+                new FontSet(),
+                new RectangleDimensionsSet(),
+                new SimulationSet(),
+                new EmbeddedSubprocessExecutionSet(),
+                new ProcessData());
     }
 
     public EmbeddedSubprocess(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndErrorEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndErrorEvent.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -36,7 +35,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -45,7 +43,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = EndErrorEvent.EndNoneEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseEndEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -63,21 +61,13 @@ public class EndErrorEvent extends BaseEndEvent {
     @FormField(afterElement = "executionSet")
     protected DataIOSet dataIOSet;
 
-    @NonPortable
-    public static class EndNoneEventBuilder implements Builder<EndErrorEvent> {
-
-        @Override
-        public EndErrorEvent build() {
-            return new EndErrorEvent(new BPMNGeneralSet(""),
-                                     new BackgroundSet(),
-                                     new FontSet(),
-                                     new CircleDimensionSet(new Radius()),
-                                     new ErrorEventExecutionSet(),
-                                     new DataIOSet());
-        }
-    }
-
     public EndErrorEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new ErrorEventExecutionSet(),
+             new DataIOSet());
     }
 
     public EndErrorEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndMessageEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndMessageEvent.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -139,5 +137,4 @@ public class EndMessageEvent extends BaseEndEvent {
         }
         return false;
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndMessageEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndMessageEvent.java
@@ -47,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = EndMessageEvent.EndMessageEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseEndEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -66,6 +66,12 @@ public class EndMessageEvent extends BaseEndEvent {
     protected DataIOSet dataIOSet;
 
     public EndMessageEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new MessageEventExecutionSet(),
+             new DataIOSet());
     }
 
     public EndMessageEvent(final @MapsTo("general") BPMNGeneralSet general,
@@ -134,17 +140,4 @@ public class EndMessageEvent extends BaseEndEvent {
         return false;
     }
 
-    @NonPortable
-    public static class EndMessageEventBuilder implements Builder<EndMessageEvent> {
-
-        @Override
-        public EndMessageEvent build() {
-            return new EndMessageEvent(new BPMNGeneralSet(""),
-                                       new BackgroundSet(),
-                                       new FontSet(),
-                                       new CircleDimensionSet(new Radius()),
-                                       new MessageEventExecutionSet(),
-                                       new DataIOSet());
-        }
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndNoneEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndNoneEvent.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.bpmn.definition;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -30,7 +29,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.SubFormFieldInitializer.COLLAPSIBLE_CONTAINER;
@@ -38,7 +36,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = EndNoneEvent.EndNoneEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseEndEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -47,19 +45,11 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 )
 public class EndNoneEvent extends BaseEndEvent {
 
-    @NonPortable
-    public static class EndNoneEventBuilder implements Builder<EndNoneEvent> {
-
-        @Override
-        public EndNoneEvent build() {
-            return new EndNoneEvent(new BPMNGeneralSet(""),
-                                    new BackgroundSet(),
-                                    new FontSet(),
-                                    new CircleDimensionSet(new Radius()));
-        }
-    }
-
     public EndNoneEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()));
     }
 
     public EndNoneEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndSignalEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndSignalEvent.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -47,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = EndSignalEvent.EndSignalEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseEndEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -66,6 +64,12 @@ public class EndSignalEvent extends BaseEndEvent {
     protected DataIOSet dataIOSet;
 
     public EndSignalEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new ScopedSignalEventExecutionSet(),
+             new DataIOSet());
     }
 
     public EndSignalEvent(final @MapsTo("general") BPMNGeneralSet general,
@@ -124,21 +128,7 @@ public class EndSignalEvent extends BaseEndEvent {
                     Objects.equals(executionSet, other.executionSet) &&
                     Objects.equals(dataIOSet, other.dataIOSet) &&
                     Objects.equals(labels, other.labels);
-            }
-        return false;
-    }
-
-    @NonPortable
-    public static class EndSignalEventBuilder implements Builder<EndSignalEvent> {
-
-        @Override
-        public EndSignalEvent build() {
-            return new EndSignalEvent(new BPMNGeneralSet(""),
-                                      new BackgroundSet(),
-                                      new FontSet(),
-                                      new CircleDimensionSet(new Radius()),
-                                      new ScopedSignalEventExecutionSet(),
-                                      new DataIOSet());
         }
+        return false;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndTerminateEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EndTerminateEvent.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.bpmn.definition;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -30,7 +29,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.SubFormFieldInitializer.COLLAPSIBLE_CONTAINER;
@@ -38,7 +36,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = EndTerminateEvent.EndTerminateEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseEndEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -47,19 +45,11 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 )
 public class EndTerminateEvent extends BaseEndEvent {
 
-    @NonPortable
-    public static class EndTerminateEventBuilder implements Builder<EndTerminateEvent> {
-
-        @Override
-        public EndTerminateEvent build() {
-            return new EndTerminateEvent(new BPMNGeneralSet(""),
-                                         new BackgroundSet(),
-                                         new FontSet(),
-                                         new CircleDimensionSet(new Radius()));
-        }
-    }
-
     public EndTerminateEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()));
     }
 
     public EndTerminateEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EventSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EventSubprocess.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.variables.Proce
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
@@ -49,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = EventSubprocess.EventSubprocessBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseSubprocess.class)
 @CanContain(roles = {"all"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
@@ -72,7 +70,13 @@ public class EventSubprocess extends BaseSubprocess {
     private ProcessData processData;
 
     public EventSubprocess() {
-        super();
+        this(new BPMNGeneralSet("Event Sub-process"),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet(),
+             new SimulationSet(),
+             new EventSubprocessExecutionSet(),
+             new ProcessData());
     }
 
     public EventSubprocess(final @MapsTo("general") BPMNGeneralSet general,
@@ -132,21 +136,5 @@ public class EventSubprocess extends BaseSubprocess {
                     Objects.equals(labels, other.labels);
         }
         return false;
-    }
-
-    @NonPortable
-    public static class EventSubprocessBuilder implements Builder<EventSubprocess> {
-
-        @Override
-        public EventSubprocess build() {
-            return new EventSubprocess(
-                    new BPMNGeneralSet("Event Sub-process"),
-                    new BackgroundSet(),
-                    new FontSet(),
-                    new RectangleDimensionsSet(),
-                    new SimulationSet(),
-                    new EventSubprocessExecutionSet(),
-                    new ProcessData());
-        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ExclusiveGateway.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ExclusiveGateway.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -37,7 +36,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -46,7 +44,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = ExclusiveGateway.ExclusiveGatewayBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseGateway.class)
 @FormDefinition(
         startElement = "general",
@@ -62,20 +60,12 @@ public class ExclusiveGateway extends BaseGateway {
     @Valid
     private GatewayExecutionSet executionSet;
 
-    @NonPortable
-    public static class ExclusiveGatewayBuilder implements Builder<ExclusiveGateway> {
-
-        @Override
-        public ExclusiveGateway build() {
-            return new ExclusiveGateway(new BPMNGeneralSet(""),
-                                        new BackgroundSet(),
-                                        new FontSet(),
-                                        new CircleDimensionSet(new Radius()),
-                                        new GatewayExecutionSet());
-        }
-    }
-
     public ExclusiveGateway() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new GatewayExecutionSet());
     }
 
     public ExclusiveGateway(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/InclusiveGateway.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/InclusiveGateway.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -37,7 +36,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -46,7 +44,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = InclusiveGateway.InclusiveGatewayBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseGateway.class)
 @FormDefinition(
         startElement = "general",
@@ -60,20 +58,12 @@ public class InclusiveGateway extends BaseGateway {
     @Valid
     private GatewayExecutionSet executionSet;
 
-    @NonPortable
-    public static class InclusiveGatewayBuilder implements Builder<InclusiveGateway> {
-
-        @Override
-        public InclusiveGateway build() {
-            return new InclusiveGateway(new BPMNGeneralSet(""),
-                                        new BackgroundSet(),
-                                        new FontSet(),
-                                        new CircleDimensionSet(new Radius()),
-                                        new GatewayExecutionSet());
-        }
-    }
-
     public InclusiveGateway() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new GatewayExecutionSet());
     }
 
     public InclusiveGateway(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateErrorEventCatching.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateErrorEventCatching.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -36,7 +35,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -45,7 +43,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = IntermediateErrorEventCatching.IntermediateErrorEventCatchingBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseCatchingIntermediateEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -64,21 +62,13 @@ public class IntermediateErrorEventCatching extends BaseCatchingIntermediateEven
     @Valid
     protected DataIOSet dataIOSet;
 
-    @NonPortable
-    public static class IntermediateErrorEventCatchingBuilder implements Builder<IntermediateErrorEventCatching> {
-
-        @Override
-        public IntermediateErrorEventCatching build() {
-            return new IntermediateErrorEventCatching(new BPMNGeneralSet(""),
-                                                      new BackgroundSet(),
-                                                      new FontSet(),
-                                                      new CircleDimensionSet(new Radius()),
-                                                      new DataIOSet(),
-                                                      new CancellingErrorEventExecutionSet());
-        }
-    }
-
     public IntermediateErrorEventCatching() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new DataIOSet(),
+             new CancellingErrorEventExecutionSet());
     }
 
     public IntermediateErrorEventCatching(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateMessageEventCatching.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateMessageEventCatching.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -47,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseCatchingIntermediateEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -67,6 +65,12 @@ public class IntermediateMessageEventCatching extends BaseCatchingIntermediateEv
     protected DataIOSet dataIOSet;
 
     public IntermediateMessageEventCatching() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new DataIOSet(),
+             new CancellingMessageEventExecutionSet());
     }
 
     public IntermediateMessageEventCatching(final @MapsTo("general") BPMNGeneralSet general,
@@ -133,19 +137,5 @@ public class IntermediateMessageEventCatching extends BaseCatchingIntermediateEv
                     Objects.equals(labels, other.labels);
         }
         return false;
-    }
-
-    @NonPortable
-    public static class IntermediateMessageEventCatchingBuilder implements Builder<IntermediateMessageEventCatching> {
-
-        @Override
-        public IntermediateMessageEventCatching build() {
-            return new IntermediateMessageEventCatching(new BPMNGeneralSet(""),
-                                                        new BackgroundSet(),
-                                                        new FontSet(),
-                                                        new CircleDimensionSet(new Radius()),
-                                                        new DataIOSet(),
-                                                        new CancellingMessageEventExecutionSet());
-        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateMessageEventThrowing.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateMessageEventThrowing.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -47,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseThrowingIntermediateEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -61,21 +59,13 @@ public class IntermediateMessageEventThrowing extends BaseThrowingIntermediateEv
     @Valid
     protected MessageEventExecutionSet executionSet;
 
-    @NonPortable
-    public static class IntermediateMessageEventThrowingBuilder implements Builder<IntermediateMessageEventThrowing> {
-
-        @Override
-        public IntermediateMessageEventThrowing build() {
-            return new IntermediateMessageEventThrowing(new BPMNGeneralSet(""),
-                                                        new DataIOSet(),
-                                                        new BackgroundSet(),
-                                                        new FontSet(),
-                                                        new CircleDimensionSet(new Radius()),
-                                                        new MessageEventExecutionSet());
-        }
-    }
-
     public IntermediateMessageEventThrowing() {
+        this(new BPMNGeneralSet(""),
+             new DataIOSet(),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new MessageEventExecutionSet());
     }
 
     public IntermediateMessageEventThrowing(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateSignalEventCatching.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateSignalEventCatching.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -36,7 +35,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -45,7 +43,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = IntermediateSignalEventCatching.IntermediateSignalEventCatchingBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseCatchingIntermediateEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -64,21 +62,13 @@ public class IntermediateSignalEventCatching extends BaseCatchingIntermediateEve
     @Valid
     protected DataIOSet dataIOSet;
 
-    @NonPortable
-    public static class IntermediateSignalEventCatchingBuilder implements Builder<IntermediateSignalEventCatching> {
-
-        @Override
-        public IntermediateSignalEventCatching build() {
-            return new IntermediateSignalEventCatching(new BPMNGeneralSet(""),
-                                                       new BackgroundSet(),
-                                                       new FontSet(),
-                                                       new CircleDimensionSet(new Radius()),
-                                                       new DataIOSet(),
-                                                       new CancellingSignalEventExecutionSet());
-        }
-    }
-
     public IntermediateSignalEventCatching() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new DataIOSet(),
+             new CancellingSignalEventExecutionSet());
     }
 
     public IntermediateSignalEventCatching(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateSignalEventThrowing.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateSignalEventThrowing.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -36,7 +35,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -45,7 +43,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = IntermediateSignalEventThrowing.IntermediateSignalEventThrowingBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseThrowingIntermediateEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -59,21 +57,13 @@ public class IntermediateSignalEventThrowing extends BaseThrowingIntermediateEve
     @Valid
     protected ScopedSignalEventExecutionSet executionSet;
 
-    @NonPortable
-    public static class IntermediateSignalEventThrowingBuilder implements Builder<IntermediateSignalEventThrowing> {
-
-        @Override
-        public IntermediateSignalEventThrowing build() {
-            return new IntermediateSignalEventThrowing(new BPMNGeneralSet(""),
-                                                       new DataIOSet(),
-                                                       new BackgroundSet(),
-                                                       new FontSet(),
-                                                       new CircleDimensionSet(new Radius()),
-                                                       new ScopedSignalEventExecutionSet());
-        }
-    }
-
     public IntermediateSignalEventThrowing() {
+        this(new BPMNGeneralSet(""),
+             new DataIOSet(),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new ScopedSignalEventExecutionSet());
     }
 
     public IntermediateSignalEventThrowing(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateTimerEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateTimerEvent.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -35,7 +34,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGen
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -44,7 +42,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = IntermediateTimerEvent.IntermediateTimerEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseCatchingIntermediateEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -58,20 +56,12 @@ public class IntermediateTimerEvent extends BaseCatchingIntermediateEvent {
     @Valid
     protected CancellingTimerEventExecutionSet executionSet;
 
-    @NonPortable
-    public static class IntermediateTimerEventBuilder implements Builder<IntermediateTimerEvent> {
-
-        @Override
-        public IntermediateTimerEvent build() {
-            return new IntermediateTimerEvent(new BPMNGeneralSet(""),
-                                              new BackgroundSet(),
-                                              new FontSet(),
-                                              new CircleDimensionSet(new Radius()),
-                                              new CancellingTimerEventExecutionSet());
-        }
-    }
-
     public IntermediateTimerEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new CancellingTimerEventExecutionSet());
     }
 
     public IntermediateTimerEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/Lane.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/Lane.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -37,7 +36,6 @@ import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.util.HashUtil;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/Lane.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/Lane.java
@@ -47,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = Lane.LaneBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @CanContain(roles = {"lane_child"})
 @FormDefinition(
         startElement = "general",
@@ -83,19 +83,11 @@ public class Lane implements BPMNViewDefinition {
         add("cm_nop");
     }};
 
-    @NonPortable
-    public static class LaneBuilder implements Builder<Lane> {
-
-        @Override
-        public Lane build() {
-            return new Lane(new BPMNGeneralSet("Lane"),
-                            new BackgroundSet(),
-                            new FontSet(),
-                            new RectangleDimensionsSet());
-        }
-    }
-
     public Lane() {
+        this(new BPMNGeneralSet("Lane"),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public Lane(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/MultipleInstanceSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/MultipleInstanceSubprocess.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.variables.Proce
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
@@ -51,7 +49,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Bindable
 @CanContain(roles = {"all"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
-@Definition(graphFactory = NodeFactory.class, builder = MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseSubprocess.class)
 
 @FormDefinition(
@@ -76,6 +74,13 @@ public class MultipleInstanceSubprocess extends BaseSubprocess {
     private ProcessData processData;
 
     public MultipleInstanceSubprocess() {
+        this(new BPMNGeneralSet("Multiple Instance Sub-process"),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet(),
+             new SimulationSet(),
+             new MultipleInstanceSubprocessTaskExecutionSet(),
+             new ProcessData());
     }
 
     public MultipleInstanceSubprocess(final @MapsTo("general") BPMNGeneralSet general,
@@ -84,8 +89,7 @@ public class MultipleInstanceSubprocess extends BaseSubprocess {
                                       final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet,
                                       final @MapsTo("simulationSet") SimulationSet simulationSet,
                                       final @MapsTo("executionSet") MultipleInstanceSubprocessTaskExecutionSet executionSet,
-                                      final @MapsTo("processData") ProcessData processData
-    ) {
+                                      final @MapsTo("processData") ProcessData processData) {
         super(general,
               backgroundSet,
               fontSet,
@@ -129,21 +133,5 @@ public class MultipleInstanceSubprocess extends BaseSubprocess {
                     Objects.equals(labels, other.labels);
         }
         return false;
-    }
-
-    @NonPortable
-    public static class MultipleInstanceSubprocessBuilder implements Builder<MultipleInstanceSubprocess> {
-
-        @Override
-        public MultipleInstanceSubprocess build() {
-            return new MultipleInstanceSubprocess(
-                    new BPMNGeneralSet("Multiple Instance Sub-process"),
-                    new BackgroundSet(),
-                    new FontSet(),
-                    new RectangleDimensionsSet(),
-                    new SimulationSet(),
-                    new MultipleInstanceSubprocessTaskExecutionSet(),
-                    new ProcessData());
-        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/NoneTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/NoneTask.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -38,7 +37,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.task.TaskTypes;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -48,7 +46,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = NoneTask.NoneTaskBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @CanDock(roles = {"IntermediateEventOnActivityBoundary"})
 @Morph(base = BaseTask.class)
 @FormDefinition(
@@ -61,15 +59,6 @@ public class NoneTask extends BaseTask {
     @PropertySet
     @Valid
     protected EmptyTaskExecutionSet executionSet;
-
-    @NonPortable
-    public static class NoneTaskBuilder implements Builder<NoneTask> {
-
-        @Override
-        public NoneTask build() {
-            return new NoneTask();
-        }
-    }
 
     public NoneTask() {
         this(new TaskGeneralSet(new Name("Task"),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ParallelGateway.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ParallelGateway.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.bpmn.definition;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -30,7 +29,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.SubFormFieldInitializer.COLLAPSIBLE_CONTAINER;
@@ -38,7 +36,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = ParallelGateway.ParallelGatewayBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseGateway.class)
 @FormDefinition(
         startElement = "general",
@@ -47,19 +45,11 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 )
 public class ParallelGateway extends BaseGateway {
 
-    @NonPortable
-    public static class ParallelGatewayBuilder implements Builder<ParallelGateway> {
-
-        @Override
-        public ParallelGateway build() {
-            return new ParallelGateway(new BPMNGeneralSet(""),
-                                       new BackgroundSet(),
-                                       new FontSet(),
-                                       new CircleDimensionSet(new Radius()));
-        }
-    }
-
     public ParallelGateway() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()));
     }
 
     public ParallelGateway(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ReusableSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ReusableSubprocess.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -37,7 +36,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.task.ReusableSu
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -47,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = ReusableSubprocess.ReusableSubprocessBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseSubprocess.class)
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
 @FormDefinition(
@@ -71,24 +69,14 @@ public class ReusableSubprocess extends BaseSubprocess implements DataIOModel {
     @Valid
     protected DataIOSet dataIOSet;
 
-    @NonPortable
-    public static class ReusableSubprocessBuilder implements Builder<ReusableSubprocess> {
-
-        @Override
-        public ReusableSubprocess build() {
-            return new ReusableSubprocess(
-                    new BPMNGeneralSet("Sub-process"),
-                    new ReusableSubprocessTaskExecutionSet(),
-                    new DataIOSet(),
-                    new BackgroundSet(),
-                    new FontSet(),
-                    new RectangleDimensionsSet(),
-                    new SimulationSet());
-        }
-    }
-
     public ReusableSubprocess() {
-        super();
+        this(new BPMNGeneralSet("Sub-process"),
+             new ReusableSubprocessTaskExecutionSet(),
+             new DataIOSet(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet(),
+             new SimulationSet());
     }
 
     public ReusableSubprocess(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ScriptTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ScriptTask.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -39,7 +38,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.task.TaskTypes;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -49,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = ScriptTask.ScriptTaskBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @CanDock(roles = {"IntermediateEventOnActivityBoundary"})
 @Morph(base = BaseTask.class)
 @FormDefinition(
@@ -65,15 +63,6 @@ public class ScriptTask extends BaseTask {
     )
     @Valid
     protected ScriptTaskExecutionSet executionSet;
-
-    @NonPortable
-    public static class ScriptTaskBuilder implements Builder<ScriptTask> {
-
-        @Override
-        public ScriptTask build() {
-            return new ScriptTask();
-        }
-    }
 
     public ScriptTask() {
         this(new TaskGeneralSet(new Name("Task"),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -46,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = EdgeFactory.class, builder = SequenceFlow.SequenceFlowBuilder.class)
+@Definition(graphFactory = EdgeFactory.class)
 // *** Connection rules for sequence flows ****
 @CanConnect(startRole = "sequence_start", endRole = "sequence_end")
 @CanConnect(startRole = "choreography_sequence_start", endRole = "choreography_sequence_end")
@@ -82,21 +81,13 @@ public class SequenceFlow extends BaseConnector {
     @Valid
     protected SequenceFlowExecutionSet executionSet;
 
-    @NonPortable
-    public static class SequenceFlowBuilder extends BaseConnectorBuilder<SequenceFlow> {
-
-        @Override
-        public SequenceFlow build() {
-            return new SequenceFlow(new BPMNGeneralSet(),
-                                    new SequenceFlowExecutionSet(),
-                                    new BackgroundSet(COLOR,
-                                                      BORDER_COLOR,
-                                                      BORDER_SIZE),
-                                    new FontSet());
-        }
-    }
-
     public SequenceFlow() {
+        this(new BPMNGeneralSet(),
+             new SequenceFlowExecutionSet(),
+             new BackgroundSet(COLOR,
+                               BORDER_COLOR,
+                               BORDER_SIZE),
+             new FontSet());
     }
 
     public SequenceFlow(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartErrorEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartErrorEvent.java
@@ -46,7 +46,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = StartErrorEvent.StartErrorEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseStartEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -65,22 +65,14 @@ public class StartErrorEvent extends BaseStartEvent {
     @Valid
     protected DataIOSet dataIOSet;
 
-    @NonPortable
-    public static class StartErrorEventBuilder implements Builder<StartErrorEvent> {
-
-        @Override
-        public StartErrorEvent build() {
-            return new StartErrorEvent(new BPMNGeneralSet(""),
-                                       new BackgroundSet(),
-                                       new FontSet(),
-                                       new CircleDimensionSet(new Radius()),
-                                       new SimulationAttributeSet(),
-                                       new DataIOSet(),
-                                       new InterruptingErrorEventExecutionSet());
-        }
-    }
-
     public StartErrorEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new SimulationAttributeSet(),
+             new DataIOSet(),
+             new InterruptingErrorEventExecutionSet());
     }
 
     public StartErrorEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartErrorEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartErrorEvent.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -37,7 +36,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.Simu
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartMessageEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartMessageEvent.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -40,7 +39,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.Simu
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -49,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = StartMessageEvent.StartMessageEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseStartEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -69,6 +67,13 @@ public class StartMessageEvent extends BaseStartEvent implements DataIOModel {
     protected DataIOSet dataIOSet;
 
     public StartMessageEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new SimulationAttributeSet(),
+             new DataIOSet(),
+             new InterruptingMessageEventExecutionSet());
     }
 
     public StartMessageEvent(final @MapsTo("general") BPMNGeneralSet general,
@@ -138,21 +143,5 @@ public class StartMessageEvent extends BaseStartEvent implements DataIOModel {
                     Objects.equals(labels, other.labels);
         }
         return false;
-    }
-
-    @NonPortable
-    public static class StartMessageEventBuilder implements Builder<StartMessageEvent> {
-
-        @Override
-        public StartMessageEvent build() {
-            return new StartMessageEvent(new BPMNGeneralSet(""),
-                                         new BackgroundSet(),
-                                         new FontSet(),
-                                         new CircleDimensionSet(new Radius()),
-                                         new SimulationAttributeSet(),
-                                         new DataIOSet(),
-                                         new InterruptingMessageEventExecutionSet()
-            );
-        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartNoneEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartNoneEvent.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import java.util.Objects;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -35,7 +34,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.Simu
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -44,7 +42,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = StartNoneEvent.StartNoneEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseStartEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -56,21 +54,13 @@ public class StartNoneEvent extends BaseStartEvent {
     @Property
     private IsInterrupting isInterrupting = new IsInterrupting(true);
 
-    @NonPortable
-    public static class StartNoneEventBuilder implements Builder<StartNoneEvent> {
-
-        @Override
-        public StartNoneEvent build() {
-            return new StartNoneEvent(new BPMNGeneralSet(""),
-                                      new BackgroundSet(),
-                                      new FontSet(),
-                                      new CircleDimensionSet(new Radius()),
-                                      new SimulationAttributeSet(),
-                                      new IsInterrupting(true));
-        }
-    }
-
     public StartNoneEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new SimulationAttributeSet(),
+             new IsInterrupting(true));
     }
 
     public StartNoneEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartSignalEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartSignalEvent.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -37,7 +36,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.Simu
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -46,7 +44,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = StartSignalEvent.StartSignalEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseStartEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -65,22 +63,14 @@ public class StartSignalEvent extends BaseStartEvent {
     @Valid
     protected DataIOSet dataIOSet;
 
-    @NonPortable
-    public static class StartSignalEventBuilder implements Builder<StartSignalEvent> {
-
-        @Override
-        public StartSignalEvent build() {
-            return new StartSignalEvent(new BPMNGeneralSet(""),
-                                        new BackgroundSet(),
-                                        new FontSet(),
-                                        new CircleDimensionSet(new Radius()),
-                                        new SimulationAttributeSet(),
-                                        new DataIOSet(),
-                                        new InterruptingSignalEventExecutionSet());
-        }
-    }
-
     public StartSignalEvent() {
+        this(new BPMNGeneralSet(""),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new SimulationAttributeSet(),
+             new DataIOSet(),
+             new InterruptingSignalEventExecutionSet());
     }
 
     public StartSignalEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartTimerEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartTimerEvent.java
@@ -45,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = StartTimerEvent.StartTimerEventBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseStartEvent.class)
 @FormDefinition(
         startElement = "general",
@@ -59,21 +59,13 @@ public class StartTimerEvent extends BaseStartEvent {
     @Valid
     protected InterruptingTimerEventExecutionSet executionSet;
 
-    @NonPortable
-    public static class StartTimerEventBuilder implements Builder<StartTimerEvent> {
-
-        @Override
-        public StartTimerEvent build() {
-            return new StartTimerEvent(new BPMNGeneralSet(""),
-                                       new BackgroundSet(),
-                                       new FontSet(),
-                                       new CircleDimensionSet(new Radius()),
-                                       new SimulationAttributeSet(),
-                                       new InterruptingTimerEventExecutionSet());
-        }
-    }
-
     public StartTimerEvent() {
+        this((new BPMNGeneralSet("")),
+             new BackgroundSet(),
+             new FontSet(),
+             new CircleDimensionSet(new Radius()),
+             new SimulationAttributeSet(),
+             new InterruptingTimerEventExecutionSet());
     }
 
     public StartTimerEvent(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartTimerEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/StartTimerEvent.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -36,7 +35,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.Simu
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/UserTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/UserTask.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -40,7 +39,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.task.UserTaskEx
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.Morph;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanDock;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -50,7 +48,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = UserTask.UserTaskBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @CanDock(roles = {"IntermediateEventOnActivityBoundary"})
 @Morph(base = BaseTask.class)
 @FormDefinition(
@@ -66,15 +64,6 @@ public class UserTask extends BaseTask implements DataIOModel {
     )
     @Valid
     protected UserTaskExecutionSet executionSet;
-
-    @NonPortable
-    public static class UserTaskBuilder implements Builder<UserTask> {
-
-        @Override
-        public UserTask build() {
-            return new UserTask();
-        }
-    }
 
     public UserTask() {
         this(new TaskGeneralSet(new Name("Task"),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/dimensions/CircleDimensionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/dimensions/CircleDimensionSet.java
@@ -48,6 +48,7 @@ public class CircleDimensionSet implements BPMNPropertySet {
     protected Radius radius;
 
     public CircleDimensionSet() {
+        this(new Radius());
     }
 
     public CircleDimensionSet(final @MapsTo("radius") Radius radius) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/HashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/HashCodeAndEqualityTest.java
@@ -693,14 +693,14 @@ public class HashCodeAndEqualityTest {
                                                 new CircleDimensionSet(),
                                                 new SimulationAttributeSet(),
                                                 new IsInterrupting()))
-                .addFalseCase(new StartNoneEvent(),
+                .addTrueCase(new StartNoneEvent(),
                               new StartNoneEvent(new BPMNGeneralSet(),
                                                  new BackgroundSet(),
                                                  new FontSet(),
                                                  new CircleDimensionSet(),
                                                  new SimulationAttributeSet(),
                                                  new IsInterrupting()))
-                .addFalseCase(new StartNoneEvent(new BPMNGeneralSet(),
+                .addTrueCase(new StartNoneEvent(new BPMNGeneralSet(),
                                                  new BackgroundSet(),
                                                  new FontSet(),
                                                  new CircleDimensionSet(),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/HashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/HashCodeAndEqualityTest.java
@@ -94,10 +94,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testAdHocSubprocessEquals() {
-        AdHocSubprocess.AdHocSubprocessBuilder builder = new AdHocSubprocess.AdHocSubprocessBuilder();
-        AdHocSubprocess a = builder.build();
-        builder = new AdHocSubprocess.AdHocSubprocessBuilder();
-        AdHocSubprocess b = builder.build();
+        AdHocSubprocess a = new AdHocSubprocess();
+        AdHocSubprocess b = new AdHocSubprocess();;
         assertEquals(a,
                      b);
         assertEquals(new AdHocSubprocess(),
@@ -108,20 +106,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testAdHocSubprocessHashCode() {
-        AdHocSubprocess.AdHocSubprocessBuilder builder = new AdHocSubprocess.AdHocSubprocessBuilder();
-        AdHocSubprocess a = builder.build();
-        builder = new AdHocSubprocess.AdHocSubprocessBuilder();
-        AdHocSubprocess b = builder.build();
+        AdHocSubprocess a = new AdHocSubprocess();
+        AdHocSubprocess b = new AdHocSubprocess();;
         assertTrue(a.hashCode() == b.hashCode());
         assertTrue(new AdHocSubprocess().hashCode() == new AdHocSubprocess().hashCode());
     }
 
     @Test
     public void testBPMNDiagramImplEquals() {
-        BPMNDiagramImpl.BPMNDiagramBuilder builder = new BPMNDiagramImpl.BPMNDiagramBuilder();
-        BPMNDiagramImpl a = builder.build();
-        builder = new BPMNDiagramImpl.BPMNDiagramBuilder();
-        BPMNDiagramImpl b = builder.build();
+        BPMNDiagramImpl a = new BPMNDiagramImpl();
+        BPMNDiagramImpl b = new BPMNDiagramImpl();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -130,20 +124,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testBPMNDiagramImplHashCode() {
-        BPMNDiagramImpl.BPMNDiagramBuilder builder = new BPMNDiagramImpl.BPMNDiagramBuilder();
-        BPMNDiagramImpl a = builder.build();
-        builder = new BPMNDiagramImpl.BPMNDiagramBuilder();
-        BPMNDiagramImpl b = builder.build();
+        BPMNDiagramImpl a = new BPMNDiagramImpl();
+        BPMNDiagramImpl b = new BPMNDiagramImpl();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testBusinessRuleTaskEquals() {
-        BusinessRuleTask.BusinessRuleTaskBuilder builder = new BusinessRuleTask.BusinessRuleTaskBuilder();
-        BusinessRuleTask a = builder.build();
-        builder = new BusinessRuleTask.BusinessRuleTaskBuilder();
-        BusinessRuleTask b = builder.build();
+        BusinessRuleTask a = new BusinessRuleTask();
+        BusinessRuleTask b = new BusinessRuleTask();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -152,20 +142,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testBusinessRuleTaskHashCode() {
-        BusinessRuleTask.BusinessRuleTaskBuilder builder = new BusinessRuleTask.BusinessRuleTaskBuilder();
-        BusinessRuleTask a = builder.build();
-        builder = new BusinessRuleTask.BusinessRuleTaskBuilder();
-        BusinessRuleTask b = builder.build();
+        BusinessRuleTask a = new BusinessRuleTask();
+        BusinessRuleTask b = new BusinessRuleTask();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testEndNoneEventEquals() {
-        EndNoneEvent.EndNoneEventBuilder builder = new EndNoneEvent.EndNoneEventBuilder();
-        EndNoneEvent a = builder.build();
-        builder = new EndNoneEvent.EndNoneEventBuilder();
-        EndNoneEvent b = builder.build();
+        BusinessRuleTask a = new BusinessRuleTask();
+        BusinessRuleTask b = new BusinessRuleTask();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -174,20 +160,17 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testEndNoneEventHashCode() {
-        EndNoneEvent.EndNoneEventBuilder builder = new EndNoneEvent.EndNoneEventBuilder();
-        EndNoneEvent a = builder.build();
-        builder = new EndNoneEvent.EndNoneEventBuilder();
-        EndNoneEvent b = builder.build();
+        BusinessRuleTask a = new BusinessRuleTask();
+        BusinessRuleTask b = new BusinessRuleTask();
+
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testEndTerminateEventEquals() {
-        EndTerminateEvent.EndTerminateEventBuilder builder = new EndTerminateEvent.EndTerminateEventBuilder();
-        EndTerminateEvent a = builder.build();
-        builder = new EndTerminateEvent.EndTerminateEventBuilder();
-        EndTerminateEvent b = builder.build();
+        EndTerminateEvent a = new EndTerminateEvent();
+        EndTerminateEvent b = new EndTerminateEvent();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -196,10 +179,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testEndTerminateEventHashCode() {
-        EndTerminateEvent.EndTerminateEventBuilder builder = new EndTerminateEvent.EndTerminateEventBuilder();
-        EndTerminateEvent a = builder.build();
-        builder = new EndTerminateEvent.EndTerminateEventBuilder();
-        EndTerminateEvent b = builder.build();
+        EndTerminateEvent a = new EndTerminateEvent();
+        EndTerminateEvent b = new EndTerminateEvent();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
@@ -223,23 +204,19 @@ public class HashCodeAndEqualityTest {
         final DataIOSet C_DATA_SET = new DataIOSet(new AssignmentsInfo(ASSIGNMENT_INFO));
         final DataIOSet D_DATA_SET = new DataIOSet(new AssignmentsInfo("Other value"));
 
-        EndSignalEvent.EndSignalEventBuilder builder = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent a = builder.build();
+        EndSignalEvent a = new EndSignalEvent();
         a.setExecutionSet(A_EXECUTION_SET);
         a.setDataIOSet(A_DATA_SET);
 
-        builder = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent b = builder.build();
+        EndSignalEvent b = new EndSignalEvent();
         b.setExecutionSet(B_EXECUTION_SET);
         b.setDataIOSet(B_DATA_SET);
 
-        builder = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent c = builder.build();
+        EndSignalEvent c = new EndSignalEvent();
         c.setExecutionSet(C_EXECUTION_SET);
         c.setDataIOSet(C_DATA_SET);
 
-        builder = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent d = builder.build();
+        EndSignalEvent d = new EndSignalEvent();
         d.setExecutionSet(D_EXECUTION_SET);
         d.setDataIOSet(D_DATA_SET);
 
@@ -272,18 +249,15 @@ public class HashCodeAndEqualityTest {
         assertNotEquals(b,
                         a);
 
-        EndMessageEvent.EndMessageEventBuilder builderMessage = new EndMessageEvent.EndMessageEventBuilder();
-        EndMessageEvent e = builderMessage.build();
+        EndMessageEvent e = new EndMessageEvent();
         assertNotEquals(a,
                         e);
     }
 
     @Test
     public void testEndSignalEventHashCode() {
-        EndSignalEvent.EndSignalEventBuilder builder = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent a = builder.build();
-        builder = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent b = builder.build();
+        EndSignalEvent a = new EndSignalEvent();
+        EndSignalEvent b = new EndSignalEvent();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
@@ -302,23 +276,19 @@ public class HashCodeAndEqualityTest {
         final DataIOSet C_DATA_SET = new DataIOSet(new AssignmentsInfo(ASSIGNMENT_INFO));
         final DataIOSet D_DATA_SET = new DataIOSet(new AssignmentsInfo("Other value"));
 
-        EndMessageEvent.EndMessageEventBuilder builder = new EndMessageEvent.EndMessageEventBuilder();
-        EndMessageEvent a = builder.build();
+        EndMessageEvent a = new EndMessageEvent();
         a.setExecutionSet(A_EXECUTION_SET);
         a.setDataIOSet(A_DATA_SET);
 
-        builder = new EndMessageEvent.EndMessageEventBuilder();
-        EndMessageEvent b = builder.build();
+        EndMessageEvent b = new EndMessageEvent();
         b.setExecutionSet(B_EXECUTION_SET);
         b.setDataIOSet(B_DATA_SET);
 
-        builder = new EndMessageEvent.EndMessageEventBuilder();
-        EndMessageEvent c = builder.build();
+        EndMessageEvent c = new EndMessageEvent();
         c.setExecutionSet(C_EXECUTION_SET);
         c.setDataIOSet(C_DATA_SET);
 
-        builder = new EndMessageEvent.EndMessageEventBuilder();
-        EndMessageEvent d = builder.build();
+        EndMessageEvent d = new EndMessageEvent();
         d.setExecutionSet(D_EXECUTION_SET);
         d.setDataIOSet(D_DATA_SET);
 
@@ -359,28 +329,23 @@ public class HashCodeAndEqualityTest {
         assertNotEquals(a,
                         d);
 
-        EndSignalEvent.EndSignalEventBuilder builderSignal = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent e = builderSignal.build();
+        EndSignalEvent e = new EndSignalEvent();
         assertNotEquals(a,
                         e);
     }
 
     @Test
     public void testEndMessageEventHashCode() {
-        EndMessageEvent.EndMessageEventBuilder builder = new EndMessageEvent.EndMessageEventBuilder();
-        EndMessageEvent a = builder.build();
-        builder = new EndMessageEvent.EndMessageEventBuilder();
-        EndMessageEvent b = builder.build();
+        EndMessageEvent a = new EndMessageEvent();
+        EndMessageEvent b = new EndMessageEvent();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testExclusiveDatabasedGatewayEquals() {
-        ExclusiveGateway.ExclusiveGatewayBuilder builder = new ExclusiveGateway.ExclusiveGatewayBuilder();
-        ExclusiveGateway a = builder.build();
-        builder = new ExclusiveGateway.ExclusiveGatewayBuilder();
-        ExclusiveGateway b = builder.build();
+        ExclusiveGateway a = new ExclusiveGateway();
+        ExclusiveGateway b = new ExclusiveGateway();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -389,20 +354,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testExclusiveDatabasedGatewayHashCode() {
-        ExclusiveGateway.ExclusiveGatewayBuilder builder = new ExclusiveGateway.ExclusiveGatewayBuilder();
-        ExclusiveGateway a = builder.build();
-        builder = new ExclusiveGateway.ExclusiveGatewayBuilder();
-        ExclusiveGateway b = builder.build();
+        ExclusiveGateway a = new ExclusiveGateway();
+        ExclusiveGateway b = new ExclusiveGateway();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testIntermediateTimerEventEquals() {
-        IntermediateTimerEvent.IntermediateTimerEventBuilder builder = new IntermediateTimerEvent.IntermediateTimerEventBuilder();
-        IntermediateTimerEvent a = builder.build();
-        builder = new IntermediateTimerEvent.IntermediateTimerEventBuilder();
-        IntermediateTimerEvent b = builder.build();
+        IntermediateTimerEvent a = new IntermediateTimerEvent();
+        IntermediateTimerEvent b = new IntermediateTimerEvent();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -411,10 +372,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void IntermediateMessageEventThrowingHashCode() {
-        IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder builder = new IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder();
-        IntermediateMessageEventThrowing a = builder.build();
-        builder = new IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder();
-        IntermediateMessageEventThrowing b = builder.build();
+        IntermediateMessageEventThrowing a = new IntermediateMessageEventThrowing();
+        IntermediateMessageEventThrowing b = new IntermediateMessageEventThrowing();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
@@ -433,23 +392,19 @@ public class HashCodeAndEqualityTest {
         final DataIOSet C_DATA_SET = new DataIOSet(new AssignmentsInfo(ASSIGNMENT_INFO));
         final DataIOSet D_DATA_SET = new DataIOSet(new AssignmentsInfo("Other value"));
 
-        IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder builder = new IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder();
-        IntermediateMessageEventThrowing a = builder.build();
+        IntermediateMessageEventThrowing a = new IntermediateMessageEventThrowing();
         a.setExecutionSet(A_EXECUTION_SET);
         a.setDataIOSet(A_DATA_SET);
 
-        builder = new IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder();
-        IntermediateMessageEventThrowing b = builder.build();
+        IntermediateMessageEventThrowing b = new IntermediateMessageEventThrowing();
         b.setExecutionSet(B_EXECUTION_SET);
         b.setDataIOSet(B_DATA_SET);
 
-        builder = new IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder();
-        IntermediateMessageEventThrowing c = builder.build();
+        IntermediateMessageEventThrowing c = new IntermediateMessageEventThrowing();
         c.setExecutionSet(C_EXECUTION_SET);
         c.setDataIOSet(C_DATA_SET);
 
-        builder = new IntermediateMessageEventThrowing.IntermediateMessageEventThrowingBuilder();
-        IntermediateMessageEventThrowing d = builder.build();
+        IntermediateMessageEventThrowing d = new IntermediateMessageEventThrowing();
         d.setExecutionSet(D_EXECUTION_SET);
         d.setDataIOSet(D_DATA_SET);
 
@@ -494,18 +449,15 @@ public class HashCodeAndEqualityTest {
         assertNotEquals(a,
                         d);
 
-        EndSignalEvent.EndSignalEventBuilder builderSignal = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent e = builderSignal.build();
+        EndSignalEvent e = new EndSignalEvent();
         assertNotEquals(a,
                         e);
     }
 
     @Test
     public void IntermediateMessageEventCatchingHashCode() {
-        IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder builder = new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder();
-        IntermediateMessageEventCatching a = builder.build();
-        builder = new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder();
-        IntermediateMessageEventCatching b = builder.build();
+        IntermediateMessageEventCatching a = new IntermediateMessageEventCatching();
+        IntermediateMessageEventCatching b = new IntermediateMessageEventCatching();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
@@ -528,23 +480,19 @@ public class HashCodeAndEqualityTest {
         final DataIOSet C_DATA_SET = new DataIOSet(new AssignmentsInfo(ASSIGNMENT_INFO));
         final DataIOSet D_DATA_SET = new DataIOSet(new AssignmentsInfo("Other value"));
 
-        IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder builder = new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder();
-        IntermediateMessageEventCatching a = builder.build();
+        IntermediateMessageEventCatching a = new IntermediateMessageEventCatching();
         a.setExecutionSet(A_EXECUTION_SET);
         a.setDataIOSet(A_DATA_SET);
 
-        builder = new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder();
-        IntermediateMessageEventCatching b = builder.build();
+        IntermediateMessageEventCatching b = new IntermediateMessageEventCatching();
         b.setExecutionSet(B_EXECUTION_SET);
         b.setDataIOSet(B_DATA_SET);
 
-        builder = new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder();
-        IntermediateMessageEventCatching c = builder.build();
+        IntermediateMessageEventCatching c = new IntermediateMessageEventCatching();
         c.setExecutionSet(C_EXECUTION_SET);
         c.setDataIOSet(C_DATA_SET);
 
-        builder = new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder();
-        IntermediateMessageEventCatching d = builder.build();
+        IntermediateMessageEventCatching d = new IntermediateMessageEventCatching();
         d.setExecutionSet(D_EXECUTION_SET);
         d.setDataIOSet(D_DATA_SET);
 
@@ -589,28 +537,23 @@ public class HashCodeAndEqualityTest {
         assertNotEquals(a,
                         d);
 
-        EndSignalEvent.EndSignalEventBuilder builderSignal = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent e = builderSignal.build();
+        EndSignalEvent e = new EndSignalEvent();
         assertNotEquals(a,
                         e);
     }
 
     @Test
     public void testIntermediateTimerEventHashCode() {
-        IntermediateTimerEvent.IntermediateTimerEventBuilder builder = new IntermediateTimerEvent.IntermediateTimerEventBuilder();
-        IntermediateTimerEvent a = builder.build();
-        builder = new IntermediateTimerEvent.IntermediateTimerEventBuilder();
-        IntermediateTimerEvent b = builder.build();
+        IntermediateTimerEvent a = new IntermediateTimerEvent();
+        IntermediateTimerEvent b = new IntermediateTimerEvent();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testLaneEquals() {
-        Lane.LaneBuilder builder = new Lane.LaneBuilder();
-        Lane a = builder.build();
-        builder = new Lane.LaneBuilder();
-        Lane b = builder.build();
+        Lane a = new Lane();
+        Lane b = new Lane();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -619,20 +562,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testLaneHashCode() {
-        Lane.LaneBuilder builder = new Lane.LaneBuilder();
-        Lane a = builder.build();
-        builder = new Lane.LaneBuilder();
-        Lane b = builder.build();
+        Lane a = new Lane();
+        Lane b = new Lane();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testNoneTaskEquals() {
-        NoneTask.NoneTaskBuilder builder = new NoneTask.NoneTaskBuilder();
-        NoneTask a = builder.build();
-        builder = new NoneTask.NoneTaskBuilder();
-        NoneTask b = builder.build();
+        NoneTask a = new NoneTask();
+        NoneTask b = new NoneTask();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -641,20 +580,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testNoneTaskHashCode() {
-        NoneTask.NoneTaskBuilder builder = new NoneTask.NoneTaskBuilder();
-        NoneTask a = builder.build();
-        builder = new NoneTask.NoneTaskBuilder();
-        NoneTask b = builder.build();
+        NoneTask a = new NoneTask();
+        NoneTask b = new NoneTask();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testParallelGatewayEquals() {
-        ParallelGateway.ParallelGatewayBuilder builder = new ParallelGateway.ParallelGatewayBuilder();
-        ParallelGateway a = builder.build();
-        builder = new ParallelGateway.ParallelGatewayBuilder();
-        ParallelGateway b = builder.build();
+        ParallelGateway a = new ParallelGateway();
+        ParallelGateway b = new ParallelGateway();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -663,20 +598,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testParallelGatewayHashCode() {
-        ParallelGateway.ParallelGatewayBuilder builder = new ParallelGateway.ParallelGatewayBuilder();
-        ParallelGateway a = builder.build();
-        builder = new ParallelGateway.ParallelGatewayBuilder();
-        ParallelGateway b = builder.build();
+        ParallelGateway a = new ParallelGateway();
+        ParallelGateway b = new ParallelGateway();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testReusableSubprocessEquals() {
-        ReusableSubprocess.ReusableSubprocessBuilder builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess a = builder.build();
-        builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess b = builder.build();
+        ReusableSubprocess a = new ReusableSubprocess();
+        ReusableSubprocess b = new ReusableSubprocess();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -685,20 +616,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testReusableSubprocessHashCode() {
-        ReusableSubprocess.ReusableSubprocessBuilder builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess a = builder.build();
-        builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess b = builder.build();
+        ReusableSubprocess a = new ReusableSubprocess();
+        ReusableSubprocess b = new ReusableSubprocess();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testEventSubprocessEquals() {
-        EventSubprocess.EventSubprocessBuilder builder = new EventSubprocess.EventSubprocessBuilder();
-        EventSubprocess a = builder.build();
-        builder = new EventSubprocess.EventSubprocessBuilder();
-        EventSubprocess b = builder.build();
+        EventSubprocess a = new EventSubprocess();
+        EventSubprocess b = new EventSubprocess();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -707,20 +634,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testEventSubprocessHashCode() {
-        EventSubprocess.EventSubprocessBuilder builder = new EventSubprocess.EventSubprocessBuilder();
-        EventSubprocess a = builder.build();
-        builder = new EventSubprocess.EventSubprocessBuilder();
-        EventSubprocess b = builder.build();
+        EventSubprocess a = new EventSubprocess();
+        EventSubprocess b = new EventSubprocess();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testScriptTaskEquals() {
-        ScriptTask.ScriptTaskBuilder builder = new ScriptTask.ScriptTaskBuilder();
-        ScriptTask a = builder.build();
-        builder = new ScriptTask.ScriptTaskBuilder();
-        ScriptTask b = builder.build();
+        ScriptTask a = new ScriptTask();
+        ScriptTask b = new ScriptTask();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -729,20 +652,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testScriptTaskHashCode() {
-        ScriptTask.ScriptTaskBuilder builder = new ScriptTask.ScriptTaskBuilder();
-        ScriptTask a = builder.build();
-        builder = new ScriptTask.ScriptTaskBuilder();
-        ScriptTask b = builder.build();
+        ScriptTask a = new ScriptTask();
+        ScriptTask b = new ScriptTask();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testSequenceFlowEquals() {
-        SequenceFlow.SequenceFlowBuilder builder = new SequenceFlow.SequenceFlowBuilder();
-        SequenceFlow a = builder.build();
-        builder = new SequenceFlow.SequenceFlowBuilder();
-        SequenceFlow b = builder.build();
+        SequenceFlow a = new SequenceFlow();
+        SequenceFlow b = new SequenceFlow();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -751,10 +670,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testSequenceFlowHashCode() {
-        SequenceFlow.SequenceFlowBuilder builder = new SequenceFlow.SequenceFlowBuilder();
-        SequenceFlow a = builder.build();
-        builder = new SequenceFlow.SequenceFlowBuilder();
-        SequenceFlow b = builder.build();
+        SequenceFlow a = new SequenceFlow();
+        SequenceFlow b = new SequenceFlow();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
@@ -795,10 +712,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testStartSignalEventEquals() {
-        StartSignalEvent.StartSignalEventBuilder builder = new StartSignalEvent.StartSignalEventBuilder();
-        StartSignalEvent a = builder.build();
-        builder = new StartSignalEvent.StartSignalEventBuilder();
-        StartSignalEvent b = builder.build();
+        StartSignalEvent a = new StartSignalEvent();
+        StartSignalEvent b = new StartSignalEvent();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -807,10 +722,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testStartSignalEventHashCode() {
-        StartSignalEvent.StartSignalEventBuilder builder = new StartSignalEvent.StartSignalEventBuilder();
-        StartSignalEvent a = builder.build();
-        builder = new StartSignalEvent.StartSignalEventBuilder();
-        StartSignalEvent b = builder.build();
+        StartSignalEvent a = new StartSignalEvent();
+        StartSignalEvent b = new StartSignalEvent();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
@@ -833,23 +746,19 @@ public class HashCodeAndEqualityTest {
         final DataIOSet C_DATA_SET = new DataIOSet(new AssignmentsInfo(ASSIGNMENT_INFO));
         final DataIOSet D_DATA_SET = new DataIOSet(new AssignmentsInfo("Other value"));
 
-        StartMessageEvent.StartMessageEventBuilder builder = new StartMessageEvent.StartMessageEventBuilder();
-        StartMessageEvent a = builder.build();
+        StartMessageEvent a = new StartMessageEvent();
         a.setExecutionSet(A_EXECUTION_SET);
         a.setDataIOSet(A_DATA_SET);
 
-        builder = new StartMessageEvent.StartMessageEventBuilder();
-        StartMessageEvent b = builder.build();
+        StartMessageEvent b = new StartMessageEvent();
         b.setExecutionSet(B_EXECUTION_SET);
         b.setDataIOSet(B_DATA_SET);
 
-        builder = new StartMessageEvent.StartMessageEventBuilder();
-        StartMessageEvent c = builder.build();
+        StartMessageEvent c = new StartMessageEvent();
         c.setExecutionSet(C_EXECUTION_SET);
         c.setDataIOSet(C_DATA_SET);
 
-        builder = new StartMessageEvent.StartMessageEventBuilder();
-        StartMessageEvent d = builder.build();
+        StartMessageEvent d = new StartMessageEvent();
         d.setExecutionSet(D_EXECUTION_SET);
         d.setDataIOSet(D_DATA_SET);
 
@@ -894,28 +803,23 @@ public class HashCodeAndEqualityTest {
         assertNotEquals(a,
                         d);
 
-        EndSignalEvent.EndSignalEventBuilder builderSignal = new EndSignalEvent.EndSignalEventBuilder();
-        EndSignalEvent e = builderSignal.build();
+        EndSignalEvent e = new EndSignalEvent();
         assertNotEquals(a,
                         e);
     }
 
     @Test
     public void testStartMessageEventHashCode() {
-        StartMessageEvent.StartMessageEventBuilder builder = new StartMessageEvent.StartMessageEventBuilder();
-        StartMessageEvent a = builder.build();
-        builder = new StartMessageEvent.StartMessageEventBuilder();
-        StartMessageEvent b = builder.build();
+        StartMessageEvent a = new StartMessageEvent();
+        StartMessageEvent b = new StartMessageEvent();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testStartTimerEventEquals() {
-        StartTimerEvent.StartTimerEventBuilder builder = new StartTimerEvent.StartTimerEventBuilder();
-        StartTimerEvent a = builder.build();
-        builder = new StartTimerEvent.StartTimerEventBuilder();
-        StartTimerEvent b = builder.build();
+        StartTimerEvent a = new StartTimerEvent();
+        StartTimerEvent b = new StartTimerEvent();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -924,20 +828,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testStartTimerEventHashCode() {
-        StartTimerEvent.StartTimerEventBuilder builder = new StartTimerEvent.StartTimerEventBuilder();
-        StartTimerEvent a = builder.build();
-        builder = new StartTimerEvent.StartTimerEventBuilder();
-        StartTimerEvent b = builder.build();
+        StartTimerEvent a = new StartTimerEvent();
+        StartTimerEvent b = new StartTimerEvent();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testUserTaskEquals() {
-        UserTask.UserTaskBuilder builder = new UserTask.UserTaskBuilder();
-        UserTask a = builder.build();
-        builder = new UserTask.UserTaskBuilder();
-        UserTask b = builder.build();
+        UserTask a = new UserTask();
+        UserTask b = new UserTask();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -946,20 +846,16 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testUserTaskHashCode() {
-        UserTask.UserTaskBuilder builder = new UserTask.UserTaskBuilder();
-        UserTask a = builder.build();
-        builder = new UserTask.UserTaskBuilder();
-        UserTask b = builder.build();
+        UserTask a = new UserTask();
+        UserTask b = new UserTask();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }
 
     @Test
     public void testEmbeddedSubprocessEquals() {
-        EmbeddedSubprocess.EmbeddedSubprocessBuilder builder = new EmbeddedSubprocess.EmbeddedSubprocessBuilder();
-        EmbeddedSubprocess a = builder.build();
-        builder = new EmbeddedSubprocess.EmbeddedSubprocessBuilder();
-        EmbeddedSubprocess b = builder.build();
+        EmbeddedSubprocess a = new EmbeddedSubprocess();
+        EmbeddedSubprocess b = new EmbeddedSubprocess();
         assertEquals(a,
                      b);
         assertEquals(new EmbeddedSubprocess(),
@@ -970,10 +866,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testEmbeddedSubprocessHashCode() {
-        EmbeddedSubprocess.EmbeddedSubprocessBuilder builder = new EmbeddedSubprocess.EmbeddedSubprocessBuilder();
-        EmbeddedSubprocess a = builder.build();
-        builder = new EmbeddedSubprocess.EmbeddedSubprocessBuilder();
-        EmbeddedSubprocess b = builder.build();
+        EmbeddedSubprocess a = new EmbeddedSubprocess();
+        EmbeddedSubprocess b = new EmbeddedSubprocess();
         assertEquals(a.hashCode(),
                      b.hashCode());
         assertEquals(new EmbeddedSubprocess().hashCode(),
@@ -1115,47 +1009,37 @@ public class HashCodeAndEqualityTest {
         final ProcessData A_PROCESS_DATA = new ProcessData(new ProcessVariables(PROCESS_DATA));
         final ProcessData B_PROCESS_DATA = new ProcessData(new ProcessVariables("Other value"));
 
-        MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess a = builder.build();
+        MultipleInstanceSubprocess a = new MultipleInstanceSubprocess();
         a.setExecutionSet(A_EXECUTION_SET);
         a.setProcessData(A_PROCESS_DATA);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess b = builder.build();
+        MultipleInstanceSubprocess b = new MultipleInstanceSubprocess();
         b.setExecutionSet(B_EXECUTION_SET);
         b.setProcessData(A_PROCESS_DATA);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess c = builder.build();
+        MultipleInstanceSubprocess c = new MultipleInstanceSubprocess();
         c.setExecutionSet(C_EXECUTION_SET);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess d = builder.build();
+        MultipleInstanceSubprocess d = new MultipleInstanceSubprocess();
         d.setExecutionSet(D_EXECUTION_SET);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess e = builder.build();
+        MultipleInstanceSubprocess e = new MultipleInstanceSubprocess();
         e.setExecutionSet(E_EXECUTION_SET);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess f = builder.build();
+        MultipleInstanceSubprocess f = new MultipleInstanceSubprocess();
         f.setExecutionSet(F_EXECUTION_SET);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess g = builder.build();
+        MultipleInstanceSubprocess g = new MultipleInstanceSubprocess();
         g.setExecutionSet(G_EXECUTION_SET);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess h = builder.build();
-        g.setExecutionSet(H_EXECUTION_SET);
+        MultipleInstanceSubprocess h = new MultipleInstanceSubprocess();
+        h.setExecutionSet(H_EXECUTION_SET);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess i = builder.build();
-        g.setExecutionSet(I_EXECUTION_SET);
+        MultipleInstanceSubprocess i = new MultipleInstanceSubprocess();
+        i.setExecutionSet(I_EXECUTION_SET);
 
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess j = builder.build();
-        g.setExecutionSet(J_EXECUTION_SET);
+        MultipleInstanceSubprocess j = new MultipleInstanceSubprocess();
+        j.setExecutionSet(J_EXECUTION_SET);
 
         assertEquals(a,
                      a);
@@ -1212,18 +1096,15 @@ public class HashCodeAndEqualityTest {
         assertNotEquals(b,
                         a);
 
-        MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder builderMessage = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess k = builderMessage.build();
+        MultipleInstanceSubprocess k = new MultipleInstanceSubprocess();
         assertNotEquals(a,
                         k);
     }
 
     @Test
     public void testMultipleInstanceSubprocessHashCode() {
-        MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess a = builder.build();
-        builder = new MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder();
-        MultipleInstanceSubprocess b = builder.build();
+        MultipleInstanceSubprocess a = new MultipleInstanceSubprocess();
+        MultipleInstanceSubprocess b = new MultipleInstanceSubprocess();
         assertEquals(a.hashCode(),
                      b.hashCode());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/connectors/SequenceFlowPriorityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/connectors/SequenceFlowPriorityTest.java
@@ -108,7 +108,7 @@ public class SequenceFlowPriorityTest {
     @Test
     public void testSequenceFlowPriorityValid() {
         for (String test : PRIORITY_VALID) {
-            SequenceFlow sequenceFlow = new SequenceFlow.SequenceFlowBuilder().build();
+            SequenceFlow sequenceFlow = new SequenceFlow();
             sequenceFlow.getExecutionSet().setPriority(new Priority(test));
             Set<ConstraintViolation<SequenceFlow>> violations = this.validator.validate(sequenceFlow);
             assertTrue(violations.isEmpty());
@@ -118,7 +118,7 @@ public class SequenceFlowPriorityTest {
     @Test
     public void testSequenceFlowPriorityInvalid() {
         for (String test : PRIORITY_INVALID) {
-            SequenceFlow sequenceFlow = new SequenceFlow.SequenceFlowBuilder().build();
+            SequenceFlow sequenceFlow = new SequenceFlow();
             sequenceFlow.getExecutionSet().setPriority(new Priority(test));
             Set<ConstraintViolation<SequenceFlow>> violations = this.validator.validate(sequenceFlow);
             assertEquals(1,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/BPMNDiagramTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/BPMNDiagramTest.java
@@ -58,7 +58,7 @@ public class BPMNDiagramTest {
     }
 
     public BPMNDiagramImpl createValidBpmnDiagram() {
-        BPMNDiagramImpl BPMNDiagramImpl = new BPMNDiagramImpl.BPMNDiagramBuilder().build();
+        BPMNDiagramImpl BPMNDiagramImpl = new BPMNDiagramImpl();
         DiagramSet diagramSet = BPMNDiagramImpl.getDiagramSet();
         diagramSet.setName(new Name(NAME_VALID));
         diagramSet.setId(new Id(ID_VALID));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ExclusiveGatewayTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ExclusiveGatewayTest.java
@@ -46,7 +46,7 @@ public class ExclusiveGatewayTest {
 
     @Test
     public void testExclusiveDatabasedGatewayNameValid() {
-        ExclusiveGateway exclusiveGateway = new ExclusiveGateway.ExclusiveGatewayBuilder().build();
+        ExclusiveGateway exclusiveGateway = new ExclusiveGateway();
         exclusiveGateway.getGeneral().setName(new Name(NAME_VALID));
         Set<ConstraintViolation<ExclusiveGateway>> violations = this.validator.validate(exclusiveGateway);
         assertTrue(violations.isEmpty());
@@ -54,7 +54,7 @@ public class ExclusiveGatewayTest {
 
     @Test
     public void testExclusiveDatabasedGatewayNameEmpty() {
-        ExclusiveGateway exclusiveGateway = new ExclusiveGateway.ExclusiveGatewayBuilder().build();
+        ExclusiveGateway exclusiveGateway = new ExclusiveGateway();
         exclusiveGateway.getGeneral().setName(new Name(""));
         Set<ConstraintViolation<ExclusiveGateway>> violations = this.validator.validate(exclusiveGateway);
         assertTrue(violations.isEmpty());
@@ -62,7 +62,7 @@ public class ExclusiveGatewayTest {
 
     @Test
     public void testExclusiveDatabasedGatewayExecutionSet() {
-        ExclusiveGateway exclusiveGateway = new ExclusiveGateway.ExclusiveGatewayBuilder().build();
+        ExclusiveGateway exclusiveGateway = new ExclusiveGateway();
         exclusiveGateway.setExecutionSet(new GatewayExecutionSet());
         Set<ConstraintViolation<ExclusiveGateway>> violations = this.validator.validate(exclusiveGateway);
         assertTrue(violations.isEmpty());
@@ -70,7 +70,7 @@ public class ExclusiveGatewayTest {
 
     @Test
     public void testExclusiveDatabasedGatewayExecutionSetWithDefaultRoute() {
-        ExclusiveGateway exclusiveGateway = new ExclusiveGateway.ExclusiveGatewayBuilder().build();
+        ExclusiveGateway exclusiveGateway = new ExclusiveGateway();
         exclusiveGateway.setExecutionSet(new GatewayExecutionSet(DEFAULT_ROUTE_VALID));
         Set<ConstraintViolation<ExclusiveGateway>> violations = this.validator.validate(exclusiveGateway);
         assertTrue(violations.isEmpty());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/InclusiveGatewayTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/InclusiveGatewayTest.java
@@ -46,7 +46,7 @@ public class InclusiveGatewayTest {
 
     @Test
     public void testInclusiveDatabasedGatewayNameValid() {
-        InclusiveGateway inclusiveGateway = new InclusiveGateway.InclusiveGatewayBuilder().build();
+        InclusiveGateway inclusiveGateway = new InclusiveGateway();
         inclusiveGateway.getGeneral().setName(new Name(NAME_VALID));
         Set<ConstraintViolation<InclusiveGateway>> violations = this.validator.validate(inclusiveGateway);
         assertTrue(violations.isEmpty());
@@ -54,7 +54,7 @@ public class InclusiveGatewayTest {
 
     @Test
     public void testInclusiveDatabasedGatewayNameEmpty() {
-        InclusiveGateway inclusiveGateway = new InclusiveGateway.InclusiveGatewayBuilder().build();
+        InclusiveGateway inclusiveGateway = new InclusiveGateway();
         inclusiveGateway.getGeneral().setName(new Name(NAME_VALID));
         Set<ConstraintViolation<InclusiveGateway>> violations = this.validator.validate(inclusiveGateway);
         assertTrue(violations.isEmpty());
@@ -62,7 +62,7 @@ public class InclusiveGatewayTest {
 
     @Test
     public void testInclusiveDatabasedGatewayExecutionSet() {
-        InclusiveGateway inclusiveGateway = new InclusiveGateway.InclusiveGatewayBuilder().build();
+        InclusiveGateway inclusiveGateway = new InclusiveGateway();
         inclusiveGateway.setExecutionSet(new GatewayExecutionSet());
         Set<ConstraintViolation<InclusiveGateway>> violations = this.validator.validate(inclusiveGateway);
         assertTrue(violations.isEmpty());
@@ -70,7 +70,7 @@ public class InclusiveGatewayTest {
 
     @Test
     public void testInclusiveDatabasedGatewayExecutionSetWithDefaultRoute() {
-        InclusiveGateway inclusiveGateway = new InclusiveGateway.InclusiveGatewayBuilder().build();
+        InclusiveGateway inclusiveGateway = new InclusiveGateway();
         inclusiveGateway.setExecutionSet(new GatewayExecutionSet(DEFAULT_ROUTE_VALID));
         Set<ConstraintViolation<InclusiveGateway>> violations = this.validator.validate(inclusiveGateway);
         assertTrue(violations.isEmpty());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ParallelGatewayTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ParallelGatewayTest.java
@@ -44,7 +44,7 @@ public class ParallelGatewayTest {
 
     @Test
     public void testParallelDatabasedGatewayNameValid() {
-        ParallelGateway parallelGateway = new ParallelGateway.ParallelGatewayBuilder().build();
+        ParallelGateway parallelGateway = new ParallelGateway();
         parallelGateway.getGeneral().setName(new Name(NAME_VALID));
         Set<ConstraintViolation<ParallelGateway>> violations = this.validator.validate(parallelGateway);
         assertTrue(violations.isEmpty());
@@ -52,7 +52,7 @@ public class ParallelGatewayTest {
 
     @Test
     public void testParallelDatabasedGatewayNameEmpty() {
-        ParallelGateway parallelGateway = new ParallelGateway.ParallelGatewayBuilder().build();
+        ParallelGateway parallelGateway = new ParallelGateway();
         parallelGateway.getGeneral().setName(new Name(""));
         Set<ConstraintViolation<ParallelGateway>> violations = this.validator.validate(parallelGateway);
         assertTrue(violations.isEmpty());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/StartNoneEventTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/StartNoneEventTest.java
@@ -77,7 +77,7 @@ public class StartNoneEventTest {
 
     @Test
     public void testStartNoneEventNameValid() {
-        StartNoneEvent startNoneEvent = new StartNoneEvent.StartNoneEventBuilder().build();
+        StartNoneEvent startNoneEvent = new StartNoneEvent();
         startNoneEvent.getGeneral().setName(new Name(NAME_VALID));
         Set<ConstraintViolation<StartNoneEvent>> violations = this.validator.validate(startNoneEvent);
         assertTrue(violations.isEmpty());
@@ -85,7 +85,7 @@ public class StartNoneEventTest {
 
     @Test
     public void testStartNoneEventNameEmpty() {
-        StartNoneEvent startNoneEvent = new StartNoneEvent.StartNoneEventBuilder().build();
+        StartNoneEvent startNoneEvent = new StartNoneEvent();
         startNoneEvent.getGeneral().setName(new Name(""));
         Set<ConstraintViolation<StartNoneEvent>> violations = this.validator.validate(startNoneEvent);
         assertTrue(violations.isEmpty());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/UserTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/UserTaskTest.java
@@ -94,7 +94,7 @@ public class UserTaskTest {
 
     @Test
     public void testUserTaskTaskNameValid() {
-        UserTask userTask = new UserTask.UserTaskBuilder().build();
+        UserTask userTask = new UserTask();
         userTask.getExecutionSet().setTaskName(new TaskName(TASK_NAME_VALID));
         Set<ConstraintViolation<UserTask>> violations = this.validator.validate(userTask);
         assertTrue(violations.isEmpty());
@@ -102,7 +102,7 @@ public class UserTaskTest {
 
     @Test
     public void testUserTaskTaskNameInvalid() {
-        UserTask userTask = new UserTask.UserTaskBuilder().build();
+        UserTask userTask = new UserTask();
         userTask.getExecutionSet().setTaskName(new TaskName(TASK_NAME_INVALID));
         Set<ConstraintViolation<UserTask>> violations = this.validator.validate(userTask);
         assertEquals(1,
@@ -111,7 +111,7 @@ public class UserTaskTest {
 
     @Test
     public void testUserTaskNameValid() {
-        UserTask userTask = new UserTask.UserTaskBuilder().build();
+        UserTask userTask = new UserTask();
         userTask.getGeneral().setName(new Name(TASK_NAME_VALID));
         Set<ConstraintViolation<UserTask>> violations = this.validator.validate(userTask);
         assertTrue(violations.isEmpty());
@@ -119,7 +119,7 @@ public class UserTaskTest {
 
     @Test
     public void testUserTaskNameEmpty() {
-        UserTask userTask = new UserTask.UserTaskBuilder().build();
+        UserTask userTask = new UserTask();
         userTask.getGeneral().setName(new Name(""));
         Set<ConstraintViolation<UserTask>> violations = this.validator.validate(userTask);
         assertTrue(violations.isEmpty());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
@@ -92,7 +92,7 @@ public class ConditionalComboBoxFieldRendererTest {
   public void init() throws Exception {
     resetMocks();
 
-    EmbeddedSubprocess embeddedSubprocess = new EmbeddedSubprocess.EmbeddedSubprocessBuilder().build();
+    EmbeddedSubprocess embeddedSubprocess = new EmbeddedSubprocess();
     OnEntryAction onEntryAction = embeddedSubprocess.getExecutionSet().getOnEntryAction();
     OnExitAction onExitAction = embeddedSubprocess.getExecutionSet().getOnExitAction();
 
@@ -137,7 +137,7 @@ public class ConditionalComboBoxFieldRendererTest {
   public void initWithDefinitionSet() throws Exception {
     resetMocks();
 
-    SequenceFlow sequenceFlow = new SequenceFlow.SequenceFlowBuilder().build();
+    SequenceFlow sequenceFlow = new SequenceFlow();
     SequenceFlowExecutionSet sequenceFlowExecutionSet = sequenceFlow.getExecutionSet();
     ConditionExpression conditionExpression = sequenceFlowExecutionSet.getConditionExpression();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/test/java/org/kie/workbench/common/stunner/bpmn/project/factory/impl/BPMNProjectDiagramFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/test/java/org/kie/workbench/common/stunner/bpmn/project/factory/impl/BPMNProjectDiagramFactoryTest.java
@@ -75,7 +75,7 @@ public class BPMNProjectDiagramFactoryTest {
 
     @Before
     public void setup() {
-        diagram = new BPMNDiagramImpl.BPMNDiagramBuilder().build();
+        diagram = new BPMNDiagramImpl();
         View<BPMNDiagram> diagramNodeContent = new ViewImpl<>(diagram,
                                                                          bounds);
         graphNodes.add(diagramNode);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNViewHandlersTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNViewHandlersTest.java
@@ -45,7 +45,7 @@ public class BPMNViewHandlersTest {
     public void testFontHandler() {
         final FontHandler<BPMNViewDefinition, ShapeView> fontHandler =
                 new BPMNShapeViewHandlers.FontHandlerBuilder<>().build();
-        final StartNoneEvent bean = new StartNoneEvent.StartNoneEventBuilder().build();
+        final StartNoneEvent bean = new StartNoneEvent();
         bean.getFontSet().getFontColor().setValue("fontColor");
         bean.getFontSet().getFontFamily().setValue("fontFamily");
         bean.getFontSet().getFontSize().setValue(12d);
@@ -64,7 +64,7 @@ public class BPMNViewHandlersTest {
     public void testViewHandler() {
         final ViewAttributesHandler<BPMNViewDefinition, ShapeView> fontHandler =
                 new BPMNShapeViewHandlers.ViewAttributesHandlerBuilder<>().build();
-        final StartNoneEvent bean = new StartNoneEvent.StartNoneEventBuilder().build();
+        final StartNoneEvent bean = new StartNoneEvent();
         bean.getBackgroundSet().getBgColor().setValue("bgColor");
         bean.getBackgroundSet().getBorderColor().setValue("borderColor");
         bean.getBackgroundSet().getBorderSize().setValue(5d);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/EventCancelActivityViewHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/EventCancelActivityViewHandlerTest.java
@@ -46,7 +46,7 @@ public class EventCancelActivityViewHandlerTest extends EventViewHandlerTestBase
     @SuppressWarnings("unchecked")
     public void testHandleTimerIsNotCancel() {
         final IntermediateTimerEvent bean =
-                new IntermediateTimerEvent.IntermediateTimerEventBuilder().build();
+                new IntermediateTimerEvent();
         bean.getExecutionSet().getCancelActivity().setValue(false);
         tested.handle(bean, view);
         verify(prim1).setAlpha(eq(0d));
@@ -57,7 +57,7 @@ public class EventCancelActivityViewHandlerTest extends EventViewHandlerTestBase
     @SuppressWarnings("unchecked")
     public void testHandleTimerIsCancel() {
         final IntermediateTimerEvent bean =
-                new IntermediateTimerEvent.IntermediateTimerEventBuilder().build();
+                new IntermediateTimerEvent();
 
         bean.getExecutionSet().getCancelActivity().setValue(true);
         tested.handle(bean, view);
@@ -70,7 +70,7 @@ public class EventCancelActivityViewHandlerTest extends EventViewHandlerTestBase
     @SuppressWarnings("unchecked")
     public void testHandleSignalIsNotCancel() {
         final IntermediateSignalEventCatching bean =
-                new IntermediateSignalEventCatching.IntermediateSignalEventCatchingBuilder().build();
+                new IntermediateSignalEventCatching();
 
         bean.getExecutionSet().getCancelActivity().setValue(false);
         tested.handle(bean, view);
@@ -83,7 +83,7 @@ public class EventCancelActivityViewHandlerTest extends EventViewHandlerTestBase
     @SuppressWarnings("unchecked")
     public void testHandleSignalIsCancel() {
         final IntermediateSignalEventCatching bean =
-                new IntermediateSignalEventCatching.IntermediateSignalEventCatchingBuilder().build();
+                new IntermediateSignalEventCatching();
 
         bean.getExecutionSet().getCancelActivity().setValue(true);
         tested.handle(bean, view);
@@ -96,7 +96,7 @@ public class EventCancelActivityViewHandlerTest extends EventViewHandlerTestBase
     @SuppressWarnings("unchecked")
     public void testHandleMessageIsNotCancel() {
         final IntermediateMessageEventCatching bean =
-                new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder().build();
+                new IntermediateMessageEventCatching();
 
         bean.getExecutionSet().getCancelActivity().setValue(false);
         tested.handle(bean, view);
@@ -109,7 +109,7 @@ public class EventCancelActivityViewHandlerTest extends EventViewHandlerTestBase
     @SuppressWarnings("unchecked")
     public void testHandleMessageIsCancel() {
         final IntermediateMessageEventCatching bean =
-                new IntermediateMessageEventCatching.IntermediateMessageEventCatchingBuilder().build();
+                new IntermediateMessageEventCatching();
 
         bean.getExecutionSet().getCancelActivity().setValue(true);
         tested.handle(bean, view);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/EventInterruptingViewHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/EventInterruptingViewHandlerTest.java
@@ -45,7 +45,7 @@ public class EventInterruptingViewHandlerTest extends EventViewHandlerTestBase {
     @Test
     @SuppressWarnings("unchecked")
     public void testHandleTimerIsNotInterrupting() {
-        final StartTimerEvent bean = new StartTimerEvent.StartTimerEventBuilder().build();
+        final StartTimerEvent bean = new StartTimerEvent();
         bean.getExecutionSet().getIsInterrupting().setValue(false);
         tested.handle(bean, view);
         verify(prim1).setAlpha(eq(0d));
@@ -55,7 +55,7 @@ public class EventInterruptingViewHandlerTest extends EventViewHandlerTestBase {
     @Test
     @SuppressWarnings("unchecked")
     public void testHandleTimerIsInterrupting() {
-        final StartTimerEvent bean = new StartTimerEvent.StartTimerEventBuilder().build();
+        final StartTimerEvent bean = new StartTimerEvent();
         bean.getExecutionSet().getIsInterrupting().setValue(true);
         tested.handle(bean, view);
         verify(prim1).setAlpha(eq(1d));
@@ -65,7 +65,7 @@ public class EventInterruptingViewHandlerTest extends EventViewHandlerTestBase {
     @Test
     @SuppressWarnings("unchecked")
     public void testHandleMessageEventIsNotInterrupting() {
-        final StartMessageEvent bean = new StartMessageEvent.StartMessageEventBuilder().build();
+        final StartMessageEvent bean = new StartMessageEvent();
         bean.getExecutionSet().getIsInterrupting().setValue(false);
         tested.handle(bean, view);
         verify(prim1).setAlpha(eq(0d));
@@ -75,7 +75,7 @@ public class EventInterruptingViewHandlerTest extends EventViewHandlerTestBase {
     @Test
     @SuppressWarnings("unchecked")
     public void testHandleMessageEventIsInterrupting() {
-        final StartMessageEvent bean = new StartMessageEvent.StartMessageEventBuilder().build();
+        final StartMessageEvent bean = new StartMessageEvent();
         bean.getExecutionSet().getIsInterrupting().setValue(true);
         tested.handle(bean, view);
         verify(prim1).setAlpha(eq(1d));
@@ -85,7 +85,7 @@ public class EventInterruptingViewHandlerTest extends EventViewHandlerTestBase {
     @Test
     @SuppressWarnings("unchecked")
     public void testHandleSignalEventIsNotInterrupting() {
-        final StartSignalEvent bean = new StartSignalEvent.StartSignalEventBuilder().build();
+        final StartSignalEvent bean = new StartSignalEvent();
         bean.getExecutionSet().getIsInterrupting().setValue(false);
         tested.handle(bean, view);
         verify(prim1).setAlpha(eq(0d));
@@ -95,7 +95,7 @@ public class EventInterruptingViewHandlerTest extends EventViewHandlerTestBase {
     @Test
     @SuppressWarnings("unchecked")
     public void testHandleSignalEventIsInterrupting() {
-        final StartSignalEvent bean = new StartSignalEvent.StartSignalEventBuilder().build();
+        final StartSignalEvent bean = new StartSignalEvent();
         bean.getExecutionSet().getIsInterrupting().setValue(true);
         tested.handle(bean, view);
         verify(prim1).setAlpha(eq(1d));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/CaseManagementDiagram.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/CaseManagementDiagram.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -40,7 +39,6 @@ import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -50,7 +48,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = CaseManagementDiagram.CaseManagementDiagramBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @CanContain(roles = {"cm_stage", "cm_nop"})
 @FormDefinition(
         startElement = "diagramSet",
@@ -93,20 +91,12 @@ public class CaseManagementDiagram implements BPMNDiagram {
         add("diagram");
     }};
 
-    @NonPortable
-    public static class CaseManagementDiagramBuilder implements Builder<CaseManagementDiagram> {
-
-        @Override
-        public CaseManagementDiagram build() {
-            return new CaseManagementDiagram(new DiagramSet(""),
-                                             new ProcessData(),
-                                             new BackgroundSet(),
-                                             new FontSet(),
-                                             new RectangleDimensionsSet());
-        }
-    }
-
     public CaseManagementDiagram() {
+        this(new DiagramSet(""),
+             new ProcessData(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet());
     }
 
     public CaseManagementDiagram(final @MapsTo("diagramSet") DiagramSet diagramSet,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/ReusableSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/ReusableSubprocess.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.cm.definition;
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -37,7 +36,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.Simu
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.ReusableSubprocessTaskExecutionSet;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
-import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -46,7 +44,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class, builder = ReusableSubprocess.ReusableSubprocessBuilder.class)
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(
         startElement = "general",
         policy = FieldPolicy.ONLY_MARKED,
@@ -72,24 +70,14 @@ public class ReusableSubprocess extends BaseSubprocess implements DataIOModel {
     @Valid
     protected DataIOSet dataIOSet;
 
-    @NonPortable
-    public static class ReusableSubprocessBuilder implements Builder<ReusableSubprocess> {
-
-        @Override
-        public ReusableSubprocess build() {
-            return new ReusableSubprocess(
-                    new BPMNGeneralSet("Subprocess"),
-                    new ReusableSubprocessTaskExecutionSet(),
-                    new DataIOSet(),
-                    new BackgroundSet(),
-                    new FontSet(),
-                    new RectangleDimensionsSet(),
-                    new SimulationSet());
-        }
-    }
-
     public ReusableSubprocess() {
-        super();
+        this(new BPMNGeneralSet("Subprocess"),
+             new ReusableSubprocessTaskExecutionSet(),
+             new DataIOSet(),
+             new BackgroundSet(),
+             new FontSet(),
+             new RectangleDimensionsSet(),
+             new SimulationSet());
     }
 
     public ReusableSubprocess(final @MapsTo("general") BPMNGeneralSet general,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/test/java/org/kie/workbench/common/stunner/cm/definition/HashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/test/java/org/kie/workbench/common/stunner/cm/definition/HashCodeAndEqualityTest.java
@@ -26,10 +26,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testCaseManagementDiagramEquals() {
-        CaseManagementDiagram.CaseManagementDiagramBuilder builder = new CaseManagementDiagram.CaseManagementDiagramBuilder();
-        CaseManagementDiagram a = builder.build();
-        builder = new CaseManagementDiagram.CaseManagementDiagramBuilder();
-        CaseManagementDiagram b = builder.build();
+        CaseManagementDiagram a = new CaseManagementDiagram();
+        CaseManagementDiagram b = new CaseManagementDiagram();
         assertEquals(a,
                      b);
         assertFalse(a.equals(19));
@@ -38,19 +36,15 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testCaseManagementDiagramHashCode() {
-        CaseManagementDiagram.CaseManagementDiagramBuilder builder = new CaseManagementDiagram.CaseManagementDiagramBuilder();
-        CaseManagementDiagram a = builder.build();
-        builder = new CaseManagementDiagram.CaseManagementDiagramBuilder();
-        CaseManagementDiagram b = builder.build();
+        CaseManagementDiagram a = new CaseManagementDiagram();
+        CaseManagementDiagram b = new CaseManagementDiagram();
         assertTrue(a.hashCode() == b.hashCode());
     }
 
     @Test
     public void testReusableSubprocessEquals() {
-        ReusableSubprocess.ReusableSubprocessBuilder builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess a = builder.build();
-        builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess b = builder.build();
+        ReusableSubprocess a = new ReusableSubprocess();
+        ReusableSubprocess b = new ReusableSubprocess();
         assertFalse(a.equals(19));
         assertFalse(a.equals(null));
         assertEquals(a,
@@ -59,10 +53,8 @@ public class HashCodeAndEqualityTest {
 
     @Test
     public void testReusableSubprocessHashCode() {
-        ReusableSubprocess.ReusableSubprocessBuilder builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess a = builder.build();
-        builder = new ReusableSubprocess.ReusableSubprocessBuilder();
-        ReusableSubprocess b = builder.build();
+        ReusableSubprocess a = new ReusableSubprocess();
+        ReusableSubprocess b = new ReusableSubprocess();
         assertTrue(a.hashCode() - b.hashCode() == 0);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/test/java/org/kie/workbench/common/stunner/cm/util/CaseManagementUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/test/java/org/kie/workbench/common/stunner/cm/util/CaseManagementUtilsTest.java
@@ -45,7 +45,7 @@ public class CaseManagementUtilsTest {
         final Graph graph = new GraphImpl<>("uuid",
                                             new GraphNodeStoreImpl());
         final Node node = new NodeImpl<Definition>("node-uuid");
-        final CaseManagementDiagram content = new CaseManagementDiagram.CaseManagementDiagramBuilder().build();
+        final CaseManagementDiagram content = new CaseManagementDiagram();
         node.setContent(new DefinitionImpl<>(content));
 
         graph.addNode(node);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeDefFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeDefFactoryTest.java
@@ -117,22 +117,22 @@ public class CaseManagementShapeDefFactoryTest {
         assertNotNull(nullShape);
         assertTrue(nullShape instanceof NullShape);
 
-        final Shape diagramShape = tested.newShape(new CaseManagementDiagram.CaseManagementDiagramBuilder().build(),
+        final Shape diagramShape = tested.newShape(new CaseManagementDiagram(),
                                                    new CaseManagementDiagramShapeDef());
         assertNotNull(diagramShape);
         assertTrue(diagramShape instanceof CMContainerShape);
 
-        final Shape subprocessShape = tested.newShape(new AdHocSubprocess.AdHocSubprocessBuilder().build(),
+        final Shape subprocessShape = tested.newShape(new AdHocSubprocess(),
                                                       new CaseManagementSubprocessShapeDef());
         assertNotNull(subprocessShape);
         assertTrue(subprocessShape instanceof CMContainerShape);
 
-        final Shape activityShape = tested.newShape(new UserTask.UserTaskBuilder().build(),
+        final Shape activityShape = tested.newShape(new UserTask(),
                                                     new CaseManagementTaskShapeDef());
         assertNotNull(activityShape);
         assertTrue(activityShape instanceof ActivityShape);
 
-        final Shape activityShape2 = tested.newShape(new ReusableSubprocess.ReusableSubprocessBuilder().build(),
+        final Shape activityShape2 = tested.newShape(new ReusableSubprocess(),
                                                      new CaseManagementReusableSubprocessTaskShapeDef());
         assertNotNull(activityShape2);
         assertTrue(activityShape2 instanceof ActivityShape);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeFactoryTest.java
@@ -184,98 +184,98 @@ public class CaseManagementShapeFactoryTest {
 
     @Test
     public void checkCMDiagram() {
-        assertShapeConstruction(new CaseManagementDiagram.CaseManagementDiagramBuilder().build(),
+        assertShapeConstruction(new CaseManagementDiagram(),
                                 (shape) -> {
                                     assertNotNull(shape.getShapeView());
                                     assertTrue(shape instanceof CMContainerShape);
                                     assertTrue(shape.getShapeView() instanceof DiagramView);
                                     assertTrue(((AbstractElementShape) shape).getShapeDefinition() instanceof CaseManagementDiagramShapeDef);
                                 });
-        assertShapeGlyph(new CaseManagementDiagram.CaseManagementDiagramBuilder().build());
+        assertShapeGlyph(new CaseManagementDiagram());
     }
 
     @Test
     public void checkLane() {
-        assertShapeConstruction(new Lane.LaneBuilder().build(),
+        assertShapeConstruction(new Lane(),
                                 nullAssertions);
-        assertShapeGlyph(new Lane.LaneBuilder().build());
+        assertShapeGlyph(new Lane());
     }
 
     @Test
     public void checkNoneTask() {
-        assertShapeConstruction(new NoneTask.NoneTaskBuilder().build(),
+        assertShapeConstruction(new NoneTask(),
                                 activityAssertions);
-        assertShapeGlyph(new NoneTask.NoneTaskBuilder().build());
+        assertShapeGlyph(new NoneTask());
     }
 
     @Test
     public void checkUserTask() {
-        assertShapeConstruction(new UserTask.UserTaskBuilder().build(),
+        assertShapeConstruction(new UserTask(),
                                 activityAssertions);
-        assertShapeGlyph(new UserTask.UserTaskBuilder().build());
+        assertShapeGlyph(new UserTask());
     }
 
     @Test
     public void checkBusinessRuleTask() {
-        assertShapeConstruction(new BusinessRuleTask.BusinessRuleTaskBuilder().build(),
+        assertShapeConstruction(new BusinessRuleTask(),
                                 activityAssertions);
-        assertShapeGlyph(new BusinessRuleTask.BusinessRuleTaskBuilder().build());
+        assertShapeGlyph(new BusinessRuleTask());
     }
 
     @Test
     public void checkStartNoneEvent() {
-        assertShapeConstruction(new StartNoneEvent.StartNoneEventBuilder().build(),
+        assertShapeConstruction(new StartNoneEvent(),
                                 nullAssertions);
-        assertShapeGlyph(new StartNoneEvent.StartNoneEventBuilder().build());
+        assertShapeGlyph(new StartNoneEvent());
     }
 
     @Test
     public void checkEndNoneEvent() {
-        assertShapeConstruction(new EndNoneEvent.EndNoneEventBuilder().build(),
+        assertShapeConstruction(new EndNoneEvent(),
                                 nullAssertions);
-        assertShapeGlyph(new EndNoneEvent.EndNoneEventBuilder().build());
+        assertShapeGlyph(new EndNoneEvent());
     }
 
     @Test
     public void checkEndTerminateEvent() {
-        assertShapeConstruction(new EndTerminateEvent.EndTerminateEventBuilder().build(),
+        assertShapeConstruction(new EndTerminateEvent(),
                                 nullAssertions);
-        assertShapeGlyph(new EndTerminateEvent.EndTerminateEventBuilder().build());
+        assertShapeGlyph(new EndTerminateEvent());
     }
 
     @Test
     public void checkParallelGateway() {
-        assertShapeConstruction(new ParallelGateway.ParallelGatewayBuilder().build(),
+        assertShapeConstruction(new ParallelGateway(),
                                 nullAssertions);
-        assertShapeGlyph(new ParallelGateway.ParallelGatewayBuilder().build());
+        assertShapeGlyph(new ParallelGateway());
     }
 
     @Test
     public void checkExclusiveDatabasedGateway() {
-        assertShapeConstruction(new ExclusiveGateway.ExclusiveGatewayBuilder().build(),
+        assertShapeConstruction(new ExclusiveGateway(),
                                 nullAssertions);
-        assertShapeGlyph(new ExclusiveGateway.ExclusiveGatewayBuilder().build());
+        assertShapeGlyph(new ExclusiveGateway());
     }
 
     @Test
     public void checkAdHocSubprocess() {
-        assertShapeConstruction(new AdHocSubprocess.AdHocSubprocessBuilder().build(),
+        assertShapeConstruction(new AdHocSubprocess(),
                                 stageAssertions);
-        assertShapeGlyph(new AdHocSubprocess.AdHocSubprocessBuilder().build());
+        assertShapeGlyph(new AdHocSubprocess());
     }
 
     @Test
     public void checkReusableSubprocess() {
-        assertShapeConstruction(new ReusableSubprocess.ReusableSubprocessBuilder().build(),
+        assertShapeConstruction(new ReusableSubprocess(),
                                 reusableSubprocessActivityAssertions);
-        assertShapeGlyph(new ReusableSubprocess.ReusableSubprocessBuilder().build());
+        assertShapeGlyph(new ReusableSubprocess());
     }
 
     @Test
     public void checkSequenceFlow() {
-        assertShapeConstruction(new SequenceFlow.SequenceFlowBuilder().build(),
+        assertShapeConstruction(new SequenceFlow(),
                                 connectorAssertions);
-        assertShapeGlyph(new SequenceFlow.SequenceFlowBuilder().build());
+        assertShapeGlyph(new SequenceFlow());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
The change adds support for omitting an explicit `builder = ` by generating code for the empty constructor. Both runtime (`TestScopeModelFactory`) and compile time (annotation processor) support is provided.

@romartin Shall I link a new Jira for this?

