### PR TITLE
JBPM-5902 Stunner - Integration with the jBPM validations API

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/NotificationMessageUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/NotificationMessageUtils.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
 import org.kie.workbench.common.stunner.core.validation.ModelBeanViolation;
 import org.kie.workbench.common.stunner.core.validation.Violation;
 
@@ -68,6 +69,12 @@ public class NotificationMessageUtils {
                 + violation.getMessage();
     }
 
+    public static String getDomainValidationMessage(final ClientTranslationService translationService,
+                                                    final DomainViolation violation) {
+        return getViolationTypeMessage(violation) +
+                violation.getMessage();
+    }
+
     private static String getViolationTypeMessage(final Violation violation) {
         return "(" + violation.getViolationType() + ") ";
     }
@@ -86,7 +93,8 @@ public class NotificationMessageUtils {
         // Bean & graph structure resulting messages.
         final Collection<ModelBeanViolation> modelViolations = elementViolation.getModelViolations();
         final Collection<RuleViolation> graphViolations = elementViolation.getGraphViolations();
-        final boolean skip = modelViolations.isEmpty() && graphViolations.isEmpty();
+        final Collection<DomainViolation> domainViolations = elementViolation.getDomainViolations();
+        final boolean skip = modelViolations.isEmpty() && graphViolations.isEmpty() && domainViolations.isEmpty();
         if (!skip) {
             final StringBuilder message = new StringBuilder()
                     .append(OPEN_BRA)
@@ -96,10 +104,13 @@ public class NotificationMessageUtils {
                     .append(CLOSE_BRA).append(NEW_LINE);
             modelViolations
                     .forEach(v -> message.append(getBeanValidationMessage(translationService,
-                                                                          v)).append(NEW_LINE));
+                                                                                            v)).append(NEW_LINE));
             graphViolations
                     .forEach(v -> message.append(getRuleValidationMessage(translationService,
-                                                                          v)).append(NEW_LINE));
+                                                                                            v)).append(NEW_LINE));
+            domainViolations
+                    .forEach(v -> message.append("BPMN ").append(getDomainValidationMessage(translationService,
+                                                                                            v)).append(NEW_LINE));
             return message.toString();
         }
         return "";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/DiagramElementViolation.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/DiagramElementViolation.java
@@ -26,16 +26,21 @@ public interface DiagramElementViolation<V extends GraphElementViolation> extend
     /**
      * The violation's root element UUID.
      */
-    public String getUUID();
+    String getUUID();
 
     /**
      * Returns the resulting violations produced by the graph structure validation, if any.
      */
-    public Collection<V> getGraphViolations();
+    Collection<V> getGraphViolations();
 
     /**
      * Returns the resulting violations produced by the validation for the different beans
      * present in the graph structure, if any.
      */
-    public Collection<ModelBeanViolation> getModelViolations();
+    Collection<ModelBeanViolation> getModelViolations();
+
+    /**
+     * Returns the domain (BPMN, DMN, CM...) violations produced by a diagram validation.
+     */
+    Collection<DomainViolation> getDomainViolations();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/DomainValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/DomainValidator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.validation;
+
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+
+/**
+ * Base validator type for Domain (BPMN, DMN, Case Management ...).
+ */
+public interface DomainValidator extends Validator<Diagram, DomainViolation> {
+
+    String getDefinitionSetId();
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/DomainViolation.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/DomainViolation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.validation;
+
+public interface DomainViolation extends Violation {
+
+    /**
+     * The violation's message.
+     */
+    String getMessage();
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/ValidationService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/validation/ValidationService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.validation;
+
+import java.util.Collection;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+@Remote
+public interface ValidationService {
+
+    Collection<DiagramElementViolation<RuleViolation>> validate(Diagram diagram);
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/pom.xml
@@ -178,6 +178,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/service/ValidationServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/service/ValidationServiceImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.service;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
+import org.kie.workbench.common.stunner.core.validation.DomainValidator;
+import org.kie.workbench.common.stunner.core.validation.ValidationService;
+import org.kie.workbench.common.stunner.core.validation.impl.ElementViolationImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+@Service
+public class ValidationServiceImpl implements ValidationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ValidationServiceImpl.class.getName());
+
+    private final Instance<DomainValidator> validators;
+
+    protected ValidationServiceImpl() {
+        this(null);
+    }
+
+    @Inject
+    public ValidationServiceImpl(Instance<DomainValidator> validators) {
+        this.validators = validators;
+    }
+
+    @Override
+    public Collection<DiagramElementViolation<RuleViolation>> validate(Diagram diagram) {
+        final Collection<DiagramElementViolation<RuleViolation>> violations = new HashSet<>();
+        //handle domain violations (BPMN, DMN, CM...)
+        domainValidation(diagram, v -> violations.add(v));
+        return violations;
+    }
+
+    private void domainValidation(Diagram diagram, Consumer<DiagramElementViolation<RuleViolation>> callback) {
+        StreamSupport.stream(validators.spliterator(), false)
+                .filter(validator -> Objects.equals(validator.getDefinitionSetId(), diagram.getMetadata().getDefinitionSetId()))
+                .findFirst()
+                .ifPresent(validator -> validator.validate(diagram, domainViolations ->
+                        callback.accept(new ElementViolationImpl.Builder()
+                                                .setUuid(diagram.getGraph().getUUID())
+                                                .setDomainViolations(domainViolations)
+                                                .build())));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/service/ValidationServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/service/ValidationServiceImplTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.service;
+
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.Instance;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.core.util.UUID;
+import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
+import org.kie.workbench.common.stunner.core.validation.DomainValidator;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValidationServiceImplTest {
+
+    public static final String DEF_SET_ID = "defSetId";
+
+    private ValidationServiceImpl validationService;
+
+    @Mock
+    private Instance<DomainValidator> validators;
+
+    @Mock
+    private DomainValidator domainValidator;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
+    private DomainViolation domainViolation;
+
+    @Mock
+    private Graph graph;
+
+    private static final String GRAPH_UUID = UUID.uuid();
+
+    @Before
+    public void setUp() {
+        when(validators.spliterator()).thenReturn(Arrays.asList(domainValidator).spliterator());
+        when(domainValidator.getDefinitionSetId()).thenReturn(DEF_SET_ID);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getDefinitionSetId()).thenReturn(DEF_SET_ID);
+        when(diagram.getGraph()).thenReturn(graph);
+        when(graph.getUUID()).thenReturn(GRAPH_UUID);
+        when(domainViolation.getViolationType()).thenReturn(Violation.Type.ERROR);
+        validationService = new ValidationServiceImpl(validators);
+    }
+
+    @Test
+    public void validate() {
+        final List<DomainViolation> domainViolationList = Arrays.asList(domainViolation);
+        final Collection<DiagramElementViolation<RuleViolation>> violations = validationService.validate(diagram);
+        final ArgumentCaptor<Consumer> argumentCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(domainValidator).validate(eq(diagram), argumentCaptor.capture());
+        verify(diagram).getMetadata();
+        verify(metadata).getDefinitionSetId();
+        argumentCaptor.getValue().accept(domainViolationList);
+        assertEquals(violations.stream()
+                             .map(DiagramElementViolation::getDomainViolations)
+                             .flatMap(v -> v.stream())
+                             .collect(Collectors.toList()),
+                     domainViolationList);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/validation/canvas/CanvasDiagramValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/validation/canvas/CanvasDiagramValidator.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.core.client.validation.canvas;
 
 import java.util.Collection;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -75,7 +76,7 @@ public class CanvasDiagramValidator<H extends AbstractCanvasHandler> {
         final boolean[] valid = {true};
         elementViolations
                 .forEach(v -> {
-                    if (!checkViolation(canvasHandler,
+                    if (checkViolation(canvasHandler,
                                         v)) {
                         valid[0] = false;
                     }
@@ -94,15 +95,10 @@ public class CanvasDiagramValidator<H extends AbstractCanvasHandler> {
 
     private boolean checkViolation(final H canvasHandler,
                                    final DiagramElementViolation<RuleViolation> elementViolation) {
-        final boolean[] valid = {true};
-        elementViolation.getGraphViolations()
-                .forEach(v -> {
-                    if (applyViolation(canvasHandler,
-                                       v)) {
-                        valid[0] = false;
-                    }
-                });
-        return valid[0];
+        return Stream.concat(elementViolation.getGraphViolations().stream(),
+                             elementViolation.getDomainViolations().stream())
+                .filter(v -> v instanceof RuleViolation)
+                .anyMatch(v -> applyViolation(canvasHandler, (RuleViolation) v));
     }
 
     private boolean applyViolation(final H canvasHandler,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/validation/ClientDiagramValidatorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/validation/ClientDiagramValidatorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.validation;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessor;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessorImpl;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.core.util.UUID;
+import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
+import org.kie.workbench.common.stunner.core.validation.ModelValidator;
+import org.kie.workbench.common.stunner.core.validation.ValidationService;
+import org.kie.workbench.common.stunner.core.validation.impl.ElementViolationImpl;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.CallerMock;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientDiagramValidatorTest {
+
+    private ClientDiagramValidator clientDiagramValidator;
+
+    @Mock
+    private TreeWalkTraverseProcessor treeWalkTraverseProcessor;
+
+    @Mock
+    private ModelValidator modelValidator;
+
+    @Mock
+    private ValidationService validationService;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    private TestingGraphMockHandler graphTestHandler;
+
+    private String uuid = UUID.uuid();
+
+    private ElementViolationImpl backendViolation;
+
+    @Before
+    public void setUp() throws Exception {
+        this.graphTestHandler = new TestingGraphMockHandler();
+        treeWalkTraverseProcessor = new TreeWalkTraverseProcessorImpl();
+        backendViolation = new ElementViolationImpl.Builder().setUuid(uuid).build();
+        Collection<DiagramElementViolation<RuleViolation>> violations = Arrays.asList(backendViolation);
+        when(diagram.getName()).thenReturn("Test diagram");
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(validationService.validate(diagram)).thenReturn(violations);
+        clientDiagramValidator = new ClientDiagramValidator(graphTestHandler.definitionManager, graphTestHandler.ruleManager,
+                                                            treeWalkTraverseProcessor, modelValidator, new CallerMock<>(validationService));
+    }
+
+    @Test
+    public void validate() {
+        when(diagram.getGraph()).thenReturn(graphTestHandler.graph);
+        clientDiagramValidator.validate(diagram, result -> assertTrue(result.stream().anyMatch(v -> Objects.equals(backendViolation, v))));
+        verify(validationService).validate(diagram);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/AbstractDiagramValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/AbstractDiagramValidator.java
@@ -83,17 +83,18 @@ public abstract class AbstractDiagramValidator
             if (bean.isPresent()) {
                 // If the underlying bean is a Definition, it accomplishes JSR303 validations.
                 modelValidator.validate(bean.get(),
-                                        modelViolations -> {
-                                            violations.get().add(
-                                                    ElementViolationImpl.Builder.build(element.getUUID(),
-                                                                                       ruleViolations,
-                                                                                       modelViolations)
-                                            );
-                                        });
+                                        modelViolations ->
+                                                violations.get().add(new ElementViolationImpl.Builder()
+                                                                             .setUuid(element.getUUID())
+                                                                             .setGraphViolations(ruleViolations)
+                                                                             .setModelViolations(modelViolations)
+                                                                             .build()));
             } else {
                 // Otherwise, no need not perform bean validation.
-                violations.get().add(ElementViolationImpl.Builder.build(element.getUUID(),
-                                                                        ruleViolations));
+                violations.get().add(new ElementViolationImpl.Builder()
+                                             .setUuid(element.getUUID())
+                                             .setGraphViolations(ruleViolations)
+                                             .build());
             }
         };
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/ElementViolationImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/ElementViolationImpl.java
@@ -19,13 +19,17 @@ package org.kie.workbench.common.stunner.core.validation.impl;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
 import org.kie.workbench.common.stunner.core.validation.ModelBeanViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
 
 @Portable
 public final class ElementViolationImpl
@@ -34,15 +38,18 @@ public final class ElementViolationImpl
     private final String uuid;
     private final Collection<RuleViolation> graphViolations;
     private final Collection<ModelBeanViolation> modelViolations;
+    private final Collection<DomainViolation> domainViolations;
     private final Type type;
 
-    private ElementViolationImpl(final @MapsTo("uuid") String uuid,
-                                 final @MapsTo("graphViolations") Collection<RuleViolation> graphViolations,
-                                 final @MapsTo("modelViolations") Collection<ModelBeanViolation> modelViolations,
-                                 final @MapsTo("type") Type type) {
+    ElementViolationImpl(final @MapsTo("uuid") String uuid,
+                         final @MapsTo("graphViolations") Collection<RuleViolation> graphViolations,
+                         final @MapsTo("modelViolations") Collection<ModelBeanViolation> modelViolations,
+                         final @MapsTo("domainViolations") Collection<DomainViolation> domainViolations,
+                         final @MapsTo("type") Type type) {
         this.uuid = uuid;
         this.graphViolations = graphViolations;
         this.modelViolations = modelViolations;
+        this.domainViolations = domainViolations;
         this.type = type;
     }
 
@@ -62,6 +69,11 @@ public final class ElementViolationImpl
     }
 
     @Override
+    public Collection<DomainViolation> getDomainViolations() {
+        return domainViolations;
+    }
+
+    @Override
     public Type getViolationType() {
         return type;
     }
@@ -69,23 +81,46 @@ public final class ElementViolationImpl
     @NonPortable
     public static class Builder {
 
-        public static ElementViolationImpl build(final String uuid,
-                                                 final Collection<RuleViolation> graphViolations) {
-            return build(uuid,
-                         graphViolations,
-                         Collections.emptyList());
+        private String uuid;
+        private Collection<RuleViolation> graphViolations = Collections.emptyList();
+        private Collection<ModelBeanViolation> modelViolations = Collections.emptyList();
+        private Collection<DomainViolation> domainViolations = Collections.emptyList();
+        private Violation.Type type;
+
+        public Builder setUuid(String uuid) {
+            this.uuid = uuid;
+            return this;
         }
 
-        public static ElementViolationImpl build(final String uuid,
-                                                 final Collection<RuleViolation> graphViolations,
-                                                 final Collection<ModelBeanViolation> modelViolations) {
-            return new ElementViolationImpl(uuid,
-                                            graphViolations,
-                                            modelViolations,
-                                            ValidationUtils.getMaxSeverity(new LinkedHashSet<org.kie.workbench.common.stunner.core.validation.Violation>() {{
-                                                addAll(graphViolations);
-                                                addAll(modelViolations);
-                                            }}));
+        public Builder setGraphViolations(Collection<RuleViolation> graphViolations) {
+            this.graphViolations = graphViolations;
+            return this;
+        }
+
+        public Builder setModelViolations(Collection<ModelBeanViolation> modelViolations) {
+            this.modelViolations = modelViolations;
+            return this;
+        }
+
+        public Builder setDomainViolations(Collection<DomainViolation> domainViolations) {
+            this.domainViolations = domainViolations;
+            return this;
+        }
+
+        public Builder setType(Violation.Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public ElementViolationImpl build() {
+            if (Objects.isNull(type)) {
+                setType(ValidationUtils.getMaxSeverity(new LinkedHashSet<org.kie.workbench.common.stunner.core.validation.Violation>() {{
+                    Optional.ofNullable(graphViolations).ifPresent(v -> addAll(v));
+                    Optional.ofNullable(modelViolations).ifPresent(v -> addAll(v));
+                    Optional.ofNullable(domainViolations).ifPresent(v -> addAll(v));
+                }}));
+            }
+            return new ElementViolationImpl(uuid, graphViolations, modelViolations, domainViolations, type);
         }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/ElementViolationImplBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/ElementViolationImplBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.validation.impl;
+
+import java.util.Collection;
+
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+import org.kie.workbench.common.stunner.core.validation.ModelBeanViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+
+public class ElementViolationImplBuilder {
+
+    private String uuid;
+    private Collection<RuleViolation> graphViolations;
+    private Collection<ModelBeanViolation> modelViolations;
+    private Collection<DomainViolation> domainViolations;
+    private Violation.Type type;
+
+    public ElementViolationImplBuilder setUuid(String uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    public ElementViolationImplBuilder setGraphViolations(Collection<RuleViolation> graphViolations) {
+        this.graphViolations = graphViolations;
+        return this;
+    }
+
+    public ElementViolationImplBuilder setModelViolations(Collection<ModelBeanViolation> modelViolations) {
+        this.modelViolations = modelViolations;
+        return this;
+    }
+
+    public ElementViolationImplBuilder setDomainViolations(Collection<DomainViolation> domainViolations) {
+        this.domainViolations = domainViolations;
+        return this;
+    }
+
+    public ElementViolationImplBuilder setType(Violation.Type type) {
+        this.type = type;
+        return this;
+    }
+
+    public ElementViolationImpl createElementViolationImpl() {
+        return new ElementViolationImpl(uuid, graphViolations, modelViolations, domainViolations, type);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.backend.service;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.DiagramImpl;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.service.DiagramService;
+import org.kie.workbench.common.stunner.project.diagram.ProjectDiagram;
+import org.kie.workbench.common.stunner.project.diagram.ProjectMetadata;
+import org.kie.workbench.common.stunner.project.diagram.impl.ProjectDiagramImpl;
+import org.kie.workbench.common.stunner.project.service.ProjectDiagramService;
+import org.uberfire.backend.vfs.Path;
+
+@ApplicationScoped
+@Service
+public class DelegateDiagramService implements DiagramService {
+
+    private final ProjectDiagramService projectDiagramService;
+
+    @Inject
+    public DelegateDiagramService(final ProjectDiagramService projectDiagramService) {
+        this.projectDiagramService = projectDiagramService;
+    }
+
+    private Diagram convert(ProjectDiagram projectDiagram) {
+        final DiagramImpl diagram = new DiagramImpl(projectDiagram.getName(), projectDiagram.getMetadata());
+        diagram.setGraph(projectDiagram.getGraph());
+        return diagram;
+    }
+
+    private ProjectDiagram convert(Diagram<Graph, Metadata> diagram) {
+        if (!ProjectMetadata.class.isInstance(diagram.getMetadata())) {
+            throw new IllegalStateException("The Metadata is supposed to be a ProjectMetadata for diagram " + diagram.getName());
+        }
+        return new ProjectDiagramImpl(diagram.getName(), diagram.getGraph(), ProjectMetadata.class.cast(diagram.getMetadata()));
+    }
+
+    @Override
+    public Diagram<Graph, Metadata> getDiagramByPath(Path path) {
+        return convert(projectDiagramService.getDiagramByPath(path));
+    }
+
+    @Override
+    public boolean accepts(Path path) {
+        return projectDiagramService.accepts(path);
+    }
+
+    @Override
+    public Path create(Path path, String name, String defSetId) {
+        return projectDiagramService.create(path, name, defSetId);
+    }
+
+    @Override
+    public Metadata saveOrUpdate(Diagram<Graph, Metadata> diagram) {
+        return projectDiagramService.saveOrUpdate(convert(diagram));
+    }
+
+    @Override
+    public boolean delete(Diagram<Graph, Metadata> diagram) {
+        return projectDiagramService.delete(convert(diagram));
+    }
+
+    @Override
+    public String getRawContent(Diagram<Graph, Metadata> diagram) {
+        return projectDiagramService.getRawContent(convert(diagram));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.workbench.common.stunner.project.backend.service;
 
 import org.junit.Before;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramServiceTest.java
@@ -1,0 +1,126 @@
+package org.kie.workbench.common.stunner.project.backend.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.project.diagram.ProjectDiagram;
+import org.kie.workbench.common.stunner.project.diagram.ProjectMetadata;
+import org.kie.workbench.common.stunner.project.service.ProjectDiagramService;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DelegateDiagramServiceTest {
+
+    public static final String NAME = "diagram";
+    public static final String DEF_ID = "defId";
+    public static final String CONTENT = "content";
+    private DelegateDiagramService delegateDiagramService;
+
+    @Mock
+    private ProjectDiagramService projectDiagramService;
+
+    @Mock
+    private Path path;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private ProjectMetadata projectMetadata;
+
+    @Mock
+    private Graph graph;
+
+    @Captor
+    private ArgumentCaptor<ProjectDiagram> projectDiagramArgumentCaptor;
+
+    @Mock
+    private ProjectDiagram projectDiagram;
+
+    @Before
+    public void setUp() throws Exception {
+        when(diagram.getMetadata()).thenReturn(projectMetadata);
+        when(diagram.getGraph()).thenReturn(graph);
+        when(diagram.getName()).thenReturn(NAME);
+        when(projectDiagramService.getDiagramByPath(path)).thenReturn(projectDiagram);
+        when(projectDiagram.getGraph()).thenReturn(graph);
+        when(projectDiagram.getName()).thenReturn(NAME);
+        when(projectDiagram.getMetadata()).thenReturn(projectMetadata);
+        when(projectDiagramService.getDiagramByPath(path)).thenReturn(projectDiagram);
+        when(projectDiagramService.accepts(path)).thenReturn(true);
+        when(projectDiagramService.create(path, NAME, DEF_ID)).thenReturn(path);
+        when(projectDiagramService.saveOrUpdate(any(ProjectDiagram.class))).thenReturn(projectMetadata);
+        when(projectDiagramService.delete(any(ProjectDiagram.class))).thenReturn(true);
+        when(projectDiagramService.getRawContent(any(ProjectDiagram.class))).thenReturn(CONTENT);
+        delegateDiagramService = new DelegateDiagramService(projectDiagramService);
+    }
+
+    @Test
+    public void getDiagramByPath() {
+        Diagram<Graph, Metadata> diagram = delegateDiagramService.getDiagramByPath(path);
+        verify(projectDiagramService).getDiagramByPath(path);
+        assertEqualDiagram(diagram);
+    }
+
+    @Test
+    public void accepts() {
+        boolean accepts = delegateDiagramService.accepts(path);
+        verify(projectDiagramService).accepts(path);
+        assertTrue(accepts);
+    }
+
+    @Test
+    public void create() {
+        Path createdPath = delegateDiagramService.create(this.path, NAME, DEF_ID);
+        verify(projectDiagramService).create(this.path, NAME, DEF_ID);
+        assertEquals(createdPath, path);
+    }
+
+    @Test
+    public void saveOrUpdate() {
+        Metadata metadata = delegateDiagramService.saveOrUpdate(diagram);
+        verify(projectDiagramService).saveOrUpdate(projectDiagramArgumentCaptor.capture());
+        assertEqualDiagram(projectDiagramArgumentCaptor.getValue());
+        assertEquals(metadata, projectMetadata);
+    }
+
+    @Test
+    public void delete() {
+        boolean deleted = delegateDiagramService.delete(diagram);
+        verify(projectDiagramService).delete(projectDiagramArgumentCaptor.capture());
+        assertEqualDiagram(projectDiagramArgumentCaptor.getValue());
+        assertTrue(deleted);
+    }
+
+    private void assertEqualDiagram(ProjectDiagram projectDiagram) {
+        assertEquals(projectDiagram.getName(), NAME);
+        assertEquals(projectDiagram.getGraph(), graph);
+        assertEquals(projectDiagram.getMetadata(), projectMetadata);
+    }
+
+    private void assertEqualDiagram(Diagram<Graph, Metadata> diagram) {
+        assertEquals(diagram.getName(), NAME);
+        assertEquals(diagram.getGraph(), graph);
+        assertEquals(diagram.getMetadata(), projectMetadata);
+    }
+
+    @Test
+    public void getRawContent() {
+        String rawContent = delegateDiagramService.getRawContent(diagram);
+        verify(projectDiagramService).getRawContent(projectDiagramArgumentCaptor.capture());
+        assertEquals(rawContent, CONTENT);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -723,7 +723,7 @@ public class AbstractProjectDiagramEditorTest {
         verify(validateSessionCommand).execute(validationCallbackCaptor.capture());
 
         final Collection<DiagramElementViolation<RuleViolation>> violations = new ArrayList<>();
-        violations.add(ElementViolationImpl.Builder.build("UUID", Collections.singletonList(new BoundsExceededViolation(mock(Bounds.class)))));
+        violations.add(new ElementViolationImpl.Builder().setUuid("UUID").setGraphViolations(Collections.singletonList(new BoundsExceededViolation(mock(Bounds.class)))).build());
         final ClientSessionCommand.Callback validationCallback = validationCallbackCaptor.getValue();
         validationCallback.onError(violations);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNValidator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.validation;
+
+import org.kie.workbench.common.stunner.core.validation.DomainValidator;
+
+public interface BPMNValidator extends DomainValidator {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNViolation.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNViolation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.validation;
+
+import java.util.Optional;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.stunner.core.rule.violations.AbstractRuleViolation;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+
+@Portable
+public class BPMNViolation extends AbstractRuleViolation implements DomainViolation {
+
+    private String message;
+
+    BPMNViolation() {
+    }
+
+    public BPMNViolation(@MapsTo("message") String message, @MapsTo("type") Type type) {
+        super(type);
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public Optional<Object[]> getArguments() {
+        return Optional.of(new Object[]{message});
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnApi.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnApi.gwt.xml
@@ -25,6 +25,7 @@
   <inherits name="org.kie.workbench.common.stunner.core.StunnerClientApi"/>
   <inherits name="org.kie.workbench.common.stunner.shapes.StunnerShapesApi"/>
 
+  <source path="validation"/>
   <source path="definition"/>
   <source path="factory"/>
   <source path="forms"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImpl.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.validation;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.drools.core.xml.SemanticModules;
+import org.jbpm.bpmn2.xml.BPMNDISemanticModule;
+import org.jbpm.bpmn2.xml.BPMNSemanticModule;
+import org.jbpm.compiler.xml.XmlProcessReader;
+import org.jbpm.ruleflow.core.validation.RuleFlowProcessValidator;
+import org.kie.api.definition.process.Process;
+import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
+import org.kie.workbench.common.stunner.bpmn.validation.BPMNValidator;
+import org.kie.workbench.common.stunner.bpmn.validation.BPMNViolation;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.service.DiagramService;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+@ApplicationScoped
+public class BPMNValidatorImpl implements BPMNValidator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BPMNValidatorImpl.class);
+    private final DiagramService diagramService;
+    private SemanticModules modules;
+
+    @Inject
+    public BPMNValidatorImpl(final DiagramService diagramService) {
+        this.diagramService = diagramService;
+    }
+
+    @PostConstruct
+    protected void init() {
+        modules = new SemanticModules();
+        modules.addSemanticModule(new BPMNSemanticModule());
+        modules.addSemanticModule(new BPMNDISemanticModule());
+    }
+
+    @Override
+    public void validate(Diagram diagram, Consumer<Collection<DomainViolation>> resultConsumer) {
+        String rawContent = diagramService.getRawContent(diagram);
+        if (Objects.nonNull(rawContent)) {
+            resultConsumer.accept(validate(rawContent).stream().collect(Collectors.toSet()));
+            return;
+        }
+
+        resultConsumer.accept(Collections.emptyList());
+    }
+
+    protected Collection<BPMNViolation> validate(String serializedProcess) {
+        try {
+            List<Process> processes = parseProcess(serializedProcess);
+            if (Objects.isNull(processes) || processes.size() == 0) {
+                return Collections.emptyList();
+            }
+
+            return processes.stream()
+                    .distinct()
+                    .map(process -> RuleFlowProcessValidator.getInstance().validateProcess(process))
+                    .flatMap(processValidationErrors -> Stream.of(processValidationErrors))
+                    .filter(Objects::nonNull)
+                    .map(error -> new BPMNViolation(error.getMessage(), Violation.Type.ERROR))
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            LOG.error("Error parsing process", e);
+            return Arrays.asList(new BPMNViolation(e.getMessage(), Violation.Type.ERROR));
+        }
+    }
+
+    private List<Process> parseProcess(String serializedProcess) throws SAXException, IOException {
+        return new XmlProcessReader(modules, getClass().getClassLoader()).read(new StringReader(serializedProcess));
+    }
+
+    @Override
+    public String getDefinitionSetId() {
+        return BPMNDefinitionSet.class.getName();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImpl.java
@@ -96,7 +96,7 @@ public class BPMNValidatorImpl implements BPMNValidator {
                     .map(process -> RuleFlowProcessValidator.getInstance().validateProcess(process))
                     .flatMap(processValidationErrors -> Stream.of(processValidationErrors))
                     .filter(Objects::nonNull)
-                    .map(error -> new BPMNViolation(error.getMessage(), Violation.Type.ERROR))
+                    .map(error -> new BPMNViolation(error.getMessage(), Violation.Type.WARNING))
                     .collect(Collectors.toSet());
         } catch (SAXException | IOException e) {
             LOG.error("Error parsing process", e);
@@ -108,7 +108,7 @@ public class BPMNValidatorImpl implements BPMNValidator {
     }
 
     private List<BPMNViolation> getBpmnViolationsFromException(Supplier<String> message) {
-        return Arrays.asList(new BPMNViolation(message.get(), Violation.Type.ERROR));
+        return Arrays.asList(new BPMNViolation(message.get(), Violation.Type.WARNING));
     }
 
     private List<Process> parseProcess(String serializedProcess) throws SAXException, IOException {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.validation;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
+import org.kie.workbench.common.stunner.bpmn.validation.BPMNViolation;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.service.DiagramService;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BPMNValidatorImplTest {
+
+    private static final String BPMN_NO_END = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/validation/no-end.bpmn";
+    private static final String BPMN_VALID = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/validation/valid.bpmn";
+
+    private BPMNValidatorImpl bpmnValidador;
+
+    @Mock
+    private DiagramService diagramService;
+
+    @Mock
+    private Diagram diagram;
+
+    @Before
+    public void setUp() {
+        bpmnValidador = new BPMNValidatorImpl(diagramService);
+        bpmnValidador.init();
+    }
+
+    private InputStream loadStream(String path) {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+    }
+
+    @Test
+    public void validateSerialized() {
+        Collection<BPMNViolation> violations = bpmnValidador.validate(getSerializedProcess(BPMN_VALID));
+        assertTrue(violations.isEmpty());
+    }
+
+    private String getSerializedProcess(String path) {
+        try {
+            return IOUtils.toString(loadStream(path), "UTF-8");
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Test
+    public void validateWithViolation() {
+        when(diagramService.getRawContent(diagram)).thenReturn(getSerializedProcess(BPMN_NO_END));
+        bpmnValidador.validate(diagram, result -> {
+            assertNotNull(result);
+            assertEquals(result.size(), 2);
+            assertTrue(result.stream().map(Violation::getViolationType).allMatch(t -> Violation.Type.ERROR.equals(t)));
+        });
+    }
+
+    @Test
+    public void validateNoViolations() {
+        when(diagramService.getRawContent(diagram)).thenReturn(getSerializedProcess(BPMN_VALID));
+        bpmnValidador.validate(diagram, result -> {
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        });
+    }
+
+    @Test
+    public void getDefinitionSetId() {
+        assertEquals(bpmnValidador.getDefinitionSetId(), BPMNDefinitionSet.class.getName());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImplTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
 import org.kie.workbench.common.stunner.bpmn.validation.BPMNViolation;
+import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.service.DiagramService;
 import org.kie.workbench.common.stunner.core.validation.Violation;
@@ -96,6 +97,6 @@ public class BPMNValidatorImplTest {
 
     @Test
     public void getDefinitionSetId() {
-        assertEquals(bpmnValidador.getDefinitionSetId(), BPMNDefinitionSet.class.getName());
+        assertEquals(bpmnValidador.getDefinitionSetId(), BindableAdapterUtils.getDefinitionId(BPMNDefinitionSet.class));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImplTest.java
@@ -82,7 +82,7 @@ public class BPMNValidatorImplTest {
         bpmnValidador.validate(diagram, result -> {
             assertNotNull(result);
             assertEquals(result.size(), 2);
-            assertTrue(result.stream().map(Violation::getViolationType).allMatch(t -> Violation.Type.ERROR.equals(t)));
+            assertTrue(result.stream().map(Violation::getViolationType).allMatch(t -> Violation.Type.WARNING.equals(t)));
         });
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/validation/no-end.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/validation/no-end.bpmn
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_OzyHAT2EEei9g4A3RC9ZVw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="src.old" drools:packageName="com.myteam.tiago" drools:version="1.0" name="old" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_33F8E9A8-5245-403E-BBDA-633AD423549E</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_C2BA288A-0B62-4920-A6D4-254A69C3285D" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Task_1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task_1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_33F8E9A8-5245-403E-BBDA-633AD423549E</bpmn2:incoming>
+      <bpmn2:ioSpecification id="_Ozz8MD2EEei9g4A3RC9ZVw">
+        <bpmn2:dataInput id="_C2BA288A-0B62-4920-A6D4-254A69C3285D_SkippableInputX" name="Skippable"/>
+        <bpmn2:inputSet id="_Ozz8MT2EEei9g4A3RC9ZVw">
+          <bpmn2:dataInputRefs>_C2BA288A-0B62-4920-A6D4-254A69C3285D_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_Ozz8Mj2EEei9g4A3RC9ZVw"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_Ozz8Mz2EEei9g4A3RC9ZVw">
+        <bpmn2:targetRef>_C2BA288A-0B62-4920-A6D4-254A69C3285D_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_Ozz8ND2EEei9g4A3RC9ZVw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_Ozz8NT2EEei9g4A3RC9ZVw">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_Ozz8Nj2EEei9g4A3RC9ZVw">_C2BA288A-0B62-4920-A6D4-254A69C3285D_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_33F8E9A8-5245-403E-BBDA-633AD423549E" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_C2BA288A-0B62-4920-A6D4-254A69C3285D"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_Ozz8Nz2EEei9g4A3RC9ZVw">
+    <bpmndi:BPMNPlane id="_Ozz8OD2EEei9g4A3RC9ZVw" bpmnElement="src.old">
+      <bpmndi:BPMNShape id="_Ozz8OT2EEei9g4A3RC9ZVw" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_Ozz8Oj2EEei9g4A3RC9ZVw" bpmnElement="_C2BA288A-0B62-4920-A6D4-254A69C3285D">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_Ozz8Oz2EEei9g4A3RC9ZVw" bpmnElement="_33F8E9A8-5245-403E-BBDA-633AD423549E" sourceElement="_Ozz8OT2EEei9g4A3RC9ZVw" targetElement="_Ozz8Oj2EEei9g4A3RC9ZVw">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_Oz0jQD2EEei9g4A3RC9ZVw" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_33F8E9A8-5245-403E-BBDA-633AD423549E" id="_Oz0jQT2EEei9g4A3RC9ZVw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_C2BA288A-0B62-4920-A6D4-254A69C3285D" id="_Oz0jQj2EEei9g4A3RC9ZVw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_Oz0jQz2EEei9g4A3RC9ZVw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_OzyHAT2EEei9g4A3RC9ZVw</bpmn2:source>
+    <bpmn2:target>_OzyHAT2EEei9g4A3RC9ZVw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/validation/valid.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/validation/valid.bpmn
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_KkuasD2GEei9g4A3RC9ZVw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="__346882DD-549F-4D11-BD0B-ECCA55A0F047_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:process id="src.old" drools:packageName="com.myteam.tiago" drools:version="1.0" name="old" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_3ECD0288-C518-4654-B9F6-814A9870A562</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_346882DD-549F-4D11-BD0B-ECCA55A0F047" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Task_1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task_1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_3ECD0288-C518-4654-B9F6-814A9870A562</bpmn2:incoming>
+      <bpmn2:outgoing>_DE5A45FD-2807-4E01-9D8C-C3249F8C8D96</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_KkuasT2GEei9g4A3RC9ZVw">
+        <bpmn2:dataInput id="_346882DD-549F-4D11-BD0B-ECCA55A0F047_TaskNameInputX" drools:dtype="String" itemSubjectRef="__346882DD-549F-4D11-BD0B-ECCA55A0F047_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_346882DD-549F-4D11-BD0B-ECCA55A0F047_SkippableInputX" name="Skippable"/>
+        <bpmn2:inputSet id="_Kkuasj2GEei9g4A3RC9ZVw">
+          <bpmn2:dataInputRefs>_346882DD-549F-4D11-BD0B-ECCA55A0F047_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_346882DD-549F-4D11-BD0B-ECCA55A0F047_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_KkvBwD2GEei9g4A3RC9ZVw"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_KkvBwT2GEei9g4A3RC9ZVw">
+        <bpmn2:targetRef>_346882DD-549F-4D11-BD0B-ECCA55A0F047_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_KkvBwj2GEei9g4A3RC9ZVw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_KkvBwz2GEei9g4A3RC9ZVw"><![CDATA[Task]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_KkvBxD2GEei9g4A3RC9ZVw">_346882DD-549F-4D11-BD0B-ECCA55A0F047_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_KkvBxT2GEei9g4A3RC9ZVw">
+        <bpmn2:targetRef>_346882DD-549F-4D11-BD0B-ECCA55A0F047_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_KkvBxj2GEei9g4A3RC9ZVw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_KkvBxz2GEei9g4A3RC9ZVw">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_KkvByD2GEei9g4A3RC9ZVw">_346882DD-549F-4D11-BD0B-ECCA55A0F047_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_3ECD0288-C518-4654-B9F6-814A9870A562" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_346882DD-549F-4D11-BD0B-ECCA55A0F047"/>
+    <bpmn2:endEvent id="_22E71B83-E16E-46FE-BB8F-DBFC3891653B" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_DE5A45FD-2807-4E01-9D8C-C3249F8C8D96</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_DE5A45FD-2807-4E01-9D8C-C3249F8C8D96" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_346882DD-549F-4D11-BD0B-ECCA55A0F047" targetRef="_22E71B83-E16E-46FE-BB8F-DBFC3891653B"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_KkvByT2GEei9g4A3RC9ZVw">
+    <bpmndi:BPMNPlane id="_KkvByj2GEei9g4A3RC9ZVw" bpmnElement="src.old">
+      <bpmndi:BPMNShape id="_KkvByz2GEei9g4A3RC9ZVw" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_KkvBzD2GEei9g4A3RC9ZVw" bpmnElement="_346882DD-549F-4D11-BD0B-ECCA55A0F047">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_KkvBzT2GEei9g4A3RC9ZVw" bpmnElement="_22E71B83-E16E-46FE-BB8F-DBFC3891653B">
+        <dc:Bounds height="28.0" width="28.0" x="340.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_KkvBzj2GEei9g4A3RC9ZVw" bpmnElement="_3ECD0288-C518-4654-B9F6-814A9870A562" sourceElement="_KkvByz2GEei9g4A3RC9ZVw" targetElement="_KkvBzD2GEei9g4A3RC9ZVw">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_Kkvo0D2GEei9g4A3RC9ZVw" bpmnElement="_DE5A45FD-2807-4E01-9D8C-C3249F8C8D96" sourceElement="_KkvBzD2GEei9g4A3RC9ZVw" targetElement="_KkvBzT2GEei9g4A3RC9ZVw">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="354.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_Kkvo0T2GEei9g4A3RC9ZVw" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_346882DD-549F-4D11-BD0B-ECCA55A0F047" id="_Kkvo0j2GEei9g4A3RC9ZVw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_22E71B83-E16E-46FE-BB8F-DBFC3891653B" id="_Kkvo0z2GEei9g4A3RC9ZVw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DE5A45FD-2807-4E01-9D8C-C3249F8C8D96" id="_Kkvo1D2GEei9g4A3RC9ZVw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_Kkvo1T2GEei9g4A3RC9ZVw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_3ECD0288-C518-4654-B9F6-814A9870A562" id="_Kkvo1j2GEei9g4A3RC9ZVw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_KkuasD2GEei9g4A3RC9ZVw</bpmn2:source>
+    <bpmn2:target>_KkuasD2GEei9g4A3RC9ZVw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -609,6 +609,11 @@
 
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
+      <artifactId>kie-wb-common-stunner-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-processors</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -609,11 +609,6 @@
 
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
-      <artifactId>kie-wb-common-stunner-backend</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-processors</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Now, the **BPMN** validation is applied to the diagram and consolidated with the Graph and Model validations that already existed. The validations alerts keep the same template for messages just appending the new validation messages.
The BPMN validation is based on the **jBPM** implementation in the same way as the old designer does.
It was created a `DomainValidator` interface that represents the validator of the diagram domain, for instance: BPMN, CM, DMN... for now only the BPMN is implemented, but if necessary it is prepared to insert other validators to other domains.
The DomainValidators are executed on backend, while the Graph and Model are still executed on client side.

@romartin 
@LuboTerifaj 