### PR TITLE
JBPM-6822: Stunner - make notifications more user friendly

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
@@ -174,34 +174,35 @@ public class SessionPresenterView extends Composite
 
     @Override
     public SessionPresenterView showError(final String message) {
-        settings.setType(NotifyType.DANGER);
-        showNotification("Error",
-                         buildHtmlEscapedText(message),
-                         IconType.CLOSE);
+
+        getSettings().setType(kieNotificationCssClass(NotifyType.DANGER));
+        showNotification("Error", message, IconType.EXCLAMATION_CIRCLE);
+
         return this;
     }
 
     @Override
     public SessionPresenter.View showWarning(final String message) {
-        settings.setType(NotifyType.WARNING);
-        showNotification("Warning",
-                         buildHtmlEscapedText(message),
-                         IconType.CLOSE);
+
+        getSettings().setType(kieNotificationCssClass(NotifyType.WARNING));
+        showNotification("Warning", message, IconType.EXCLAMATION_TRIANGLE);
+
         return this;
     }
 
     @Override
     public SessionPresenterView showMessage(final String message) {
-        settings.setType(NotifyType.SUCCESS);
-        showNotification("Info",
-                         buildHtmlEscapedText(message),
-                         IconType.STICKY_NOTE);
+
+        getSettings().setType(kieNotificationCssClass(NotifyType.SUCCESS));
+        showNotification("Info", message, IconType.INFO_CIRCLE);
+
         return this;
     }
 
-    private void showNotification(final String title,
-                                  final String message,
-                                  final IconType icon) {
+    void showNotification(final String title,
+                          final String message,
+                          final IconType icon) {
+
         Notify.notify(title,
                       buildHtmlEscapedText(message),
                       icon,
@@ -229,7 +230,15 @@ public class SessionPresenterView extends Composite
         this.removeFromParent();
     }
 
+    NotifySettings getSettings() {
+        return settings;
+    }
+
     private static String buildHtmlEscapedText(final String message) {
         return new SafeHtmlBuilder().appendEscapedLines(message).toSafeHtml().asString();
+    }
+
+    private String kieNotificationCssClass(final NotifyType notifyType) {
+        return notifyType.getCssName() + " kie-session-notification";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.java
@@ -35,6 +35,7 @@ import org.gwtbootstrap3.extras.notify.client.constants.NotifyType;
 import org.gwtbootstrap3.extras.notify.client.ui.Notify;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.ForEvent;
@@ -44,6 +45,10 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.session.Sessio
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasFocusedShapeEvent;
 import org.kie.workbench.common.stunner.core.client.components.palette.PaletteDefinition;
 import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
+
+import static org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants.SessionPresenterView_Error;
+import static org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants.SessionPresenterView_Info;
+import static org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants.SessionPresenterView_Warning;
 
 // TODO: i18n.
 @Dependent
@@ -73,6 +78,9 @@ public class SessionPresenterView extends Composite
     @Inject
     @DataField
     private SessionContainer sessionContainer;
+
+    @Inject
+    private TranslationService translationService;
 
     private final NotifySettings settings = NotifySettings.newSettings();
 
@@ -176,7 +184,7 @@ public class SessionPresenterView extends Composite
     public SessionPresenterView showError(final String message) {
 
         getSettings().setType(kieNotificationCssClass(NotifyType.DANGER));
-        showNotification("Error", message, IconType.EXCLAMATION_CIRCLE);
+        showNotification(translate(SessionPresenterView_Error), message, IconType.EXCLAMATION_CIRCLE);
 
         return this;
     }
@@ -185,7 +193,7 @@ public class SessionPresenterView extends Composite
     public SessionPresenter.View showWarning(final String message) {
 
         getSettings().setType(kieNotificationCssClass(NotifyType.WARNING));
-        showNotification("Warning", message, IconType.EXCLAMATION_TRIANGLE);
+        showNotification(translate(SessionPresenterView_Warning), message, IconType.EXCLAMATION_TRIANGLE);
 
         return this;
     }
@@ -194,7 +202,7 @@ public class SessionPresenterView extends Composite
     public SessionPresenterView showMessage(final String message) {
 
         getSettings().setType(kieNotificationCssClass(NotifyType.SUCCESS));
-        showNotification("Info", message, IconType.INFO_CIRCLE);
+        showNotification(translate(SessionPresenterView_Info), message, IconType.INFO_CIRCLE);
 
         return this;
     }
@@ -232,6 +240,14 @@ public class SessionPresenterView extends Composite
 
     NotifySettings getSettings() {
         return settings;
+    }
+
+    TranslationService getTranslationService() {
+        return translationService;
+    }
+
+    private String translate(final String translationKey) {
+        return getTranslationService().getTranslation(translationKey);
     }
 
     private static String buildHtmlEscapedText(final String message) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.less
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterView.less
@@ -56,3 +56,19 @@
     width: 100%;
     height: 100%;
 }
+
+.kie-session-notification {
+    padding: 1rem 2rem 2rem;
+
+    [data-notify="title"] {
+        font-weight: 700;
+        color: rgba(0, 0, 0, 0.75);
+        padding-left: 0.5rem;
+    }
+
+    [data-notify="message"] {
+        display: block;
+        padding: 0;
+        margin-top: 0.5rem;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.java
@@ -34,4 +34,13 @@ public interface StunnerWidgetsConstants {
 
     @TranslationKey(defaultValue = "")
     public static String NameEditBoxWidgetViewImp_name = "NameEditBoxWidgetViewImpl.name";
+
+    @TranslationKey(defaultValue = "")
+    public static String SessionPresenterView_Error = "SessionPresenterView.Error";
+
+    @TranslationKey(defaultValue = "")
+    public static String SessionPresenterView_Warning = "SessionPresenterView.Warning";
+
+    @TranslationKey(defaultValue = "")
+    public static String SessionPresenterView_Info = "SessionPresenterView.Info";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
@@ -3,3 +3,6 @@ DefinitionPaletteGroupWidgetViewImpl.showLess=Less
 NameEditBoxWidgetViewImpl.save=Save
 NameEditBoxWidgetViewImpl.close=Close
 NameEditBoxWidgetViewImpl.name=Name
+SessionPresenterView.Error=Error
+SessionPresenterView.Warning=Warning
+SessionPresenterView.Info=Info

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
@@ -26,6 +26,7 @@ import com.google.gwt.event.dom.client.ContextMenuHandler;
 import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
 import org.junit.Before;
@@ -206,5 +207,47 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
 
         verify(element).setScrollLeft(eventX);
         verify(element).setScrollTop(eventY);
+    }
+
+    @Test
+    public void testShowError() {
+
+        final SessionPresenterView view = spy(new SessionPresenterView());
+        final String message = "Hello<br />World";
+
+        when(view.getSettings()).thenReturn(settings);
+
+        view.showError(message);
+
+        verify(settings).setType("danger kie-session-notification");
+        verify(view).showNotification("Error", message, IconType.EXCLAMATION_CIRCLE);
+    }
+
+    @Test
+    public void testShowWarning() {
+
+        final SessionPresenterView view = spy(new SessionPresenterView());
+        final String message = "Hello<br />World";
+
+        when(view.getSettings()).thenReturn(settings);
+
+        view.showWarning(message);
+
+        verify(settings).setType("warning kie-session-notification");
+        verify(view).showNotification("Warning", message, IconType.EXCLAMATION_TRIANGLE);
+    }
+
+    @Test
+    public void testShowMessage() {
+
+        final SessionPresenterView view = spy(new SessionPresenterView());
+        final String message = "Hello<br />World";
+
+        when(view.getSettings()).thenReturn(settings);
+
+        view.showMessage(message);
+
+        verify(settings).setType("success kie-session-notification");
+        verify(view).showNotification("Info", message, IconType.INFO_CIRCLE);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionPresenterViewTest.java
@@ -29,6 +29,7 @@ import com.google.gwtmockito.WithClassesToStub;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +39,9 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Canva
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertNotNull;
+import static org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants.SessionPresenterView_Error;
+import static org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants.SessionPresenterView_Info;
+import static org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants.SessionPresenterView_Warning;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -86,6 +90,9 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
 
     @Mock
     private com.google.gwt.dom.client.Style paletteStyle;
+
+    @Mock
+    private TranslationService translationService;
 
     @Before
     public void setup() throws Exception {
@@ -214,13 +221,16 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
 
         final SessionPresenterView view = spy(new SessionPresenterView());
         final String message = "Hello<br />World";
+        final String error = "Error";
 
+        when(translationService.getTranslation(SessionPresenterView_Error)).thenReturn(error);
+        when(view.getTranslationService()).thenReturn(translationService);
         when(view.getSettings()).thenReturn(settings);
 
         view.showError(message);
 
         verify(settings).setType("danger kie-session-notification");
-        verify(view).showNotification("Error", message, IconType.EXCLAMATION_CIRCLE);
+        verify(view).showNotification(error, message, IconType.EXCLAMATION_CIRCLE);
     }
 
     @Test
@@ -228,13 +238,16 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
 
         final SessionPresenterView view = spy(new SessionPresenterView());
         final String message = "Hello<br />World";
+        final String warning = "Warning";
 
+        when(translationService.getTranslation(SessionPresenterView_Warning)).thenReturn(warning);
+        when(view.getTranslationService()).thenReturn(translationService);
         when(view.getSettings()).thenReturn(settings);
 
         view.showWarning(message);
 
         verify(settings).setType("warning kie-session-notification");
-        verify(view).showNotification("Warning", message, IconType.EXCLAMATION_TRIANGLE);
+        verify(view).showNotification(warning, message, IconType.EXCLAMATION_TRIANGLE);
     }
 
     @Test
@@ -242,12 +255,15 @@ public class SessionPresenterViewTest extends AbstractCanvasHandlerViewerTest {
 
         final SessionPresenterView view = spy(new SessionPresenterView());
         final String message = "Hello<br />World";
+        final String info = "Info";
 
+        when(translationService.getTranslation(SessionPresenterView_Info)).thenReturn(info);
+        when(view.getTranslationService()).thenReturn(translationService);
         when(view.getSettings()).thenReturn(settings);
 
         view.showMessage(message);
 
         verify(settings).setType("success kie-session-notification");
-        verify(view).showNotification("Info", message, IconType.INFO_CIRCLE);
+        verify(view).showNotification(info, message, IconType.INFO_CIRCLE);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-6822

Before:
<img width="1738" alt="before" src="https://user-images.githubusercontent.com/1079279/38758527-c3ffcd76-3f47-11e8-9b0c-2cce46ccdec4.png">

After:
<img width="1834" alt="after" src="https://user-images.githubusercontent.com/1079279/38759072-69ec59e6-3f4a-11e8-9e9b-01588440b64a.png">

---

@manstis I considered your [comment](https://issues.jboss.org/browse/JBPM-6822?focusedCommentId=13558096&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13558096), and I checked how easy would be to re-use the existing `NotificationEvent`. This seemed so easy that I quickly tried it, but some scenarios like [this one](https://www.dropbox.com/s/9vrbkvii2525cej/b1.gif?dl=0) became a little buggy ([see](https://www.dropbox.com/s/kj9itf4yau695ym/b2.gif?dl=0) the warning notification). Thus I preferred to follow @romartin's suggestion and fix only the HTML characters.