### PR TITLE
JBPM-7129: Stunner - Allow optional size constraints for shapes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlersTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlersTest.java
@@ -68,9 +68,10 @@ public class DMNViewHandlersTest {
         handler.handle(view,
                        shape);
 
-        verify(shape).setSizeConstraints(eq(Width.MIN),
-                                         eq(Height.MIN),
-                                         eq(Width.MAX),
-                                         eq(Height.MAX));
+        verify(shape).setMinWidth(eq(Width.MIN));
+        verify(shape).setMaxWidth(eq(Width.MAX));
+        verify(shape).setMinHeight(eq(Height.MIN));
+        verify(shape).setMaxHeight(eq(Height.MAX));
+
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresContainerShapeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresContainerShapeView.java
@@ -63,9 +63,4 @@ public class WiresContainerShapeView<T extends WiresContainerShapeView>
         this.getChildren().forEach(WiresContainerShapeView::destroy);
         super.preDestroy();
     }
-
-    @SuppressWarnings("unchecked")
-    protected T cast() {
-        return (T) this;
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeView.java
@@ -22,7 +22,6 @@ import com.ait.lienzo.client.core.shape.Shape;
 import com.ait.lienzo.client.core.shape.wires.ControlHandleList;
 import com.ait.lienzo.client.core.shape.wires.IControlHandle;
 import com.ait.lienzo.client.core.shape.wires.WiresShapeControlHandleList;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.ViewEventHandlerManager;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresScalableContainer;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
@@ -105,19 +104,31 @@ public class DecoratedShapeView<T extends WiresShapeViewExt>
                              width,
                              height);
         refresh();
-        return (T) this;
+        return cast();
     }
 
     @Override
-    public T setSizeConstraints(final double minWidth,
-                                final double minHeight,
-                                final double maxWidth,
-                                final double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
-        return (T) this;
+    public T setMinWidth(Double minWidth) {
+        getPath().setMinWidth(minWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMaxWidth(Double maxWidth) {
+        getPath().setMaxWidth(maxWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMinHeight(Double minHeight) {
+        getPath().setMinHeight(minHeight);
+        return cast();
+    }
+
+    @Override
+    public T setMaxHeight(Double maxHeight) {
+        getPath().setMaxHeight(maxHeight);
+        return cast();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -424,7 +424,7 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     }
 
     @SuppressWarnings("unchecked")
-    private T cast() {
+    protected T cast() {
         return (T) this;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasRadiusView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasRadiusView.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.shapes.client.view;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasRadius;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
@@ -35,10 +34,10 @@ public abstract class AbstractHasRadiusView<T extends AbstractHasRadiusView> ext
         double minDiameter = minRadius * 2;
         double maxDiameter = maxRadius * 2;
 
-        getPath().setSizeConstraints(new BoundingBox(minDiameter,
-                                                     minDiameter,
-                                                     maxDiameter,
-                                                     maxDiameter));
+        getPath().setMinWidth(minDiameter)
+                 .setMaxWidth(maxDiameter)
+                 .setMinHeight(minDiameter)
+                 .setMaxHeight(maxDiameter);
 
         return cast();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasRadiusView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasRadiusView.java
@@ -30,14 +30,21 @@ public abstract class AbstractHasRadiusView<T extends AbstractHasRadiusView> ext
     }
 
     @Override
-    public T setRadiusConstraints(double minRadius, double maxRadius) {
+    public T setMinRadius(Double minRadius) {
         double minDiameter = minRadius * 2;
-        double maxDiameter = maxRadius * 2;
 
         getPath().setMinWidth(minDiameter)
-                 .setMaxWidth(maxDiameter)
-                 .setMinHeight(minDiameter)
-                 .setMaxHeight(maxDiameter);
+                .setMinHeight(minDiameter);
+
+        return cast();
+    }
+
+    @Override
+    public T setMaxRadius(Double maxRadius) {
+        double maxDiameter = maxRadius * 2;
+
+        getPath().setMaxWidth(maxDiameter)
+                .setMaxHeight(maxDiameter);
 
         return cast();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasSizeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasSizeView.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.shapes.client.view;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
@@ -31,11 +30,26 @@ public abstract class AbstractHasSizeView<T extends AbstractHasSizeView> extends
     }
 
     @Override
-    public T setSizeConstraints(double minWidth, double minHeight, double maxWidth, double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
+    public T setMinWidth(Double minWidth) {
+        getPath().setMaxHeight(minWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMaxWidth(Double maxWidth) {
+        getPath().setMaxHeight(maxWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMinHeight(Double minHeight) {
+        getPath().setMaxHeight(minHeight);
+        return cast();
+    }
+
+    @Override
+    public T setMaxHeight(Double maxHeight) {
+        getPath().setMaxHeight(maxHeight);
         return cast();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasRadius.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasRadius.java
@@ -20,6 +20,7 @@ public interface HasRadius<T> {
 
     T setRadius(final double radius);
 
-    T setRadiusConstraints(final double minRadius,
-                           final double maxRadius);
+    T setMinRadius(final Double minRadius);
+
+    T setMaxRadius(final Double maxRadius);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasSize.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasSize.java
@@ -21,8 +21,8 @@ public interface HasSize<T> {
     T setSize(final double width,
               final double height);
 
-    T setSizeConstraints(final double minWidth,
-                         final double minHeight,
-                         final double maxWidth,
-                         final double maxHeight);
+    T setMinWidth (final Double minWidth);
+    T setMaxWidth (final Double maxWidth);
+    T setMinHeight (final Double minHeight);
+    T setMaxHeight (final Double maxHeight);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
@@ -87,19 +87,19 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
                 hasSizeView.setSize(width, height);
             }
 
-            if (isValidSize(minWidth)) {
+            if (isValidSizeConstraint(minWidth)) {
                 hasSizeView.setMinWidth(minWidth);
             }
 
-            if (isValidSize(maxWidth)) {
+            if (isValidSizeConstraint(maxWidth)) {
                 hasSizeView.setMaxWidth(maxWidth);
             }
 
-            if (isValidSize(minHeight)) {
+            if (isValidSizeConstraint(minHeight)) {
                 hasSizeView.setMinHeight(minHeight);
             }
 
-            if (isValidSize(maxHeight)) {
+            if (isValidSizeConstraint(maxHeight)) {
                 hasSizeView.setMaxHeight(maxHeight);
             }
         }
@@ -109,23 +109,28 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
                     (boundsWidth > boundsHeight ?
                         boundsWidth / 2 :
                         boundsHeight / 2);
-            final double minRadius = minRadiusProvider.apply(bean);
-            final double maxRadius = maxRadiusProvider.apply(bean);
+            final Double minRadius = minRadiusProvider.apply(bean);
+            final Double maxRadius = maxRadiusProvider.apply(bean);
             if (radius > 0) {
                 ((HasRadius) view).setRadius(radius);
             }
-            if (minRadius > 0 && maxRadius > 0) {
-                ((HasRadius) view).setRadiusConstraints(minRadius, maxRadius);
+
+            if (isValidSizeConstraint(minRadius)) {
+                ((HasRadius) view).setMinRadius(minRadius);
+            }
+
+            if (isValidSizeConstraint(maxRadius)) {
+                ((HasRadius) view).setMaxRadius(maxRadius);
             }
         }
     }
 
-    private static boolean isValidSize(Double value) {
+    private static boolean isValidSizeConstraint(Double value) {
         if (value == null) {
             return true;
         }
 
-        if (value < 0) {
+        if (value > 0) {
             return true;
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
@@ -75,18 +75,33 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
             final Double beanWidth = widthProvider.apply(bean);
             final Double beanHeight = heightProvider.apply(bean);
             final double width = null != beanWidth ? beanWidth : boundsWidth;
-            final double minWidth = minWidthProvider.apply(bean);
-            final double maxWidth = maxWidthProvider.apply(bean);
             final double height = null != beanHeight ? beanHeight : boundsHeight;
-            final double minHeight = minHeightProvider.apply(bean);
-            final double maxHeight = maxHeightProvider.apply(bean);
+            final Double minWidth = minWidthProvider.apply(bean);
+            final Double maxWidth = maxWidthProvider.apply(bean);
+            final Double minHeight = minHeightProvider.apply(bean);
+            final Double maxHeight = maxHeightProvider.apply(bean);
+
+            HasSize hasSizeView = (HasSize)view;
+
             if (width > 0 && height > 0) {
-                ((HasSize) view).setSize(width, height);
-            }
-            if (minWidth > 0 && minHeight > 0 && maxWidth > 0 && maxHeight > 0) {
-                ((HasSize) view).setSizeConstraints(minWidth, minHeight, maxWidth, maxHeight);
+                hasSizeView.setSize(width, height);
             }
 
+            if (minWidth == null || minWidth > 0) {
+                hasSizeView.setMinWidth(minWidth);
+            }
+
+            if (maxWidth == null || maxWidth > 0) {
+                hasSizeView.setMaxWidth(maxWidth);
+            }
+
+            if (minHeight == null || minHeight > 0) {
+                hasSizeView.setMinHeight(minHeight);
+            }
+
+            if (maxHeight == null || maxHeight > 0) {
+                hasSizeView.setMaxHeight(maxHeight);
+            }
         }
         if (view instanceof HasRadius) {
             final Double beanRadius = radiusProvider.apply(bean);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
@@ -87,19 +87,19 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
                 hasSizeView.setSize(width, height);
             }
 
-            if (minWidth == null || minWidth > 0) {
+            if (isValidSize(minWidth)) {
                 hasSizeView.setMinWidth(minWidth);
             }
 
-            if (maxWidth == null || maxWidth > 0) {
+            if (isValidSize(maxWidth)) {
                 hasSizeView.setMaxWidth(maxWidth);
             }
 
-            if (minHeight == null || minHeight > 0) {
+            if (isValidSize(minHeight)) {
                 hasSizeView.setMinHeight(minHeight);
             }
 
-            if (maxHeight == null || maxHeight > 0) {
+            if (isValidSize(maxHeight)) {
                 hasSizeView.setMaxHeight(maxHeight);
             }
         }
@@ -118,6 +118,18 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
                 ((HasRadius) view).setRadiusConstraints(minRadius, maxRadius);
             }
         }
+    }
+
+    private static boolean isValidSize(Double value) {
+        if (value == null) {
+            return true;
+        }
+
+        if (value < 0) {
+            return true;
+        }
+
+        return false;
     }
 
     public static class Builder<W, V extends ShapeView> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
@@ -135,10 +135,22 @@ public class ShapeViewExtStub
     }
 
     @Override
-    public Object setSizeConstraints(final double minWidth,
-                                     final double minHeight,
-                                     final double maxWidth,
-                                     final double maxHeight) {
+    public Object setMinWidth(Double minWidth) {
+        return this;
+    }
+
+    @Override
+    public Object setMaxWidth(Double minWidth) {
+        return this;
+    }
+
+    @Override
+    public Object setMinHeight(Double minWidth) {
+        return this;
+    }
+
+    @Override
+    public Object setMaxHeight(Double minWidth) {
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
@@ -123,8 +123,12 @@ public class ShapeViewExtStub
     }
 
     @Override
-    public Object setRadiusConstraints(final double minRadius,
-                                       final double maxRadius) {
+    public Object setMinRadius(Double minRadius) {
+        return this;
+    }
+
+    @Override
+    public Object setMaxRadius(Double maxRadius) {
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
@@ -25,7 +25,6 @@ import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
@@ -97,7 +97,10 @@ public class SizeHandlerTest {
         final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, never()).setSizeConstraints(anyDouble(), anyDouble(), anyDouble(), anyDouble());
+        verify(view, never()).setMinWidth(anyDouble());
+        verify(view, never()).setMaxWidth(anyDouble());
+        verify(view, never()).setMinHeight(anyDouble());
+        verify(view, never()).setMaxHeight(anyDouble());
     }
 
     @Test
@@ -111,7 +114,10 @@ public class SizeHandlerTest {
         final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, times(1)).setSizeConstraints(10d, 10d, 100d, 100d);
+        verify(view, times(1)).setMinWidth(10d);
+        verify(view, times(1)).setMaxWidth(100d);
+        verify(view, times(1)).setMinHeight(10d);
+        verify(view, times(1)).setMaxHeight(100d);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
@@ -25,8 +25,10 @@ import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -101,17 +103,43 @@ public class SizeHandlerTest {
         verify(view, never()).setMaxWidth(anyDouble());
         verify(view, never()).setMinHeight(anyDouble());
         verify(view, never()).setMaxHeight(anyDouble());
+
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minWidth(o -> -10d)
+                .maxWidth(o -> -10d)
+                .minHeight(o -> -100d)
+                .maxHeight(o -> -100d)
+                .build();
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, never()).setMinWidth(anyDouble());
+        verify(view, never()).setMaxWidth(anyDouble());
+        verify(view, never()).setMinHeight(anyDouble());
+        verify(view, never()).setMaxHeight(anyDouble());
     }
 
     @Test
     public void testHandleValidSizeConstraints() {
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minWidth(o -> null)
+                .maxWidth(o -> null)
+                .minHeight(o -> null)
+                .maxHeight(o -> null)
+                .build();
+        final Object bean = mock(Object.class);
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, times(1)).setMinWidth(isNull(Double.class));
+        verify(view, times(1)).setMaxWidth(isNull(Double.class));
+        verify(view, times(1)).setMinHeight(isNull(Double.class));
+        verify(view, times(1)).setMaxHeight(isNull(Double.class));
+
         tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
                 .minWidth(o -> 10d)
                 .maxWidth(o -> 100d)
                 .minHeight(o -> 10d)
                 .maxHeight(o -> 100d)
                 .build();
-        final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
         verify(view, times(1)).setMinWidth(10d);
@@ -129,18 +157,38 @@ public class SizeHandlerTest {
         final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, never()).setRadiusConstraints(anyDouble(), anyDouble());
+        verify(view, never()).setMinRadius(anyDouble());
+        verify(view, never()).setMaxRadius(anyDouble());
+
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minRadius(o -> -10d)
+                .maxRadius(o -> -100d)
+                .build();
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, never()).setMinRadius(anyDouble());
+        verify(view, never()).setMaxRadius(anyDouble());
     }
 
     @Test
     public void testHandleValidRadiusConstraints() {
         tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
-                .minRadius(o -> 10d)
-                .maxRadius(o -> 100d)
+                .minRadius(o -> null)
+                .maxRadius(o -> null)
                 .build();
         final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, times(1)).setRadiusConstraints(10d, 100d);
+        verify(view, times(1)).setMinRadius(isNull(Double.class));
+        verify(view, times(1)).setMaxRadius(isNull(Double.class));
+
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minRadius(o -> 10d)
+                .maxRadius(o -> 100d)
+                .build();
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, times(1)).setMinRadius(10d);
+        verify(view, times(1)).setMaxRadius(100d);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/AbstractCaseManagementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/AbstractCaseManagementShape.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
@@ -92,14 +91,26 @@ public abstract class AbstractCaseManagementShape<T extends WiresContainerShapeV
     }
 
     @Override
-    public T setSizeConstraints(final double minWidth,
-                                final double minHeight,
-                                final double maxWidth,
-                                final double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
+    public T setMinWidth(Double minWidth) {
+        getPath().setMinWidth(minWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMaxWidth(Double maxWidth) {
+        getPath().setMaxWidth(maxWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMinHeight(Double minHeight) {
+        getPath().setMinHeight(minHeight);
+        return cast();
+    }
+
+    @Override
+    public T setMaxHeight(Double maxHeight) {
+        getPath().setMaxHeight(maxHeight);
         return cast();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/MockCaseManagementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/MockCaseManagementShape.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.cm.client.wires;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 
@@ -41,18 +40,6 @@ public class MockCaseManagementShape extends AbstractCaseManagementShape<WiresCo
     @Override
     public WiresContainerShapeView setSize(double width,
                                            double height) {
-        return this;
-    }
-
-    @Override
-    public WiresContainerShapeView setSizeConstraints(final double minWidth,
-                                                      final double minHeight,
-                                                      final double maxWidth,
-                                                      final double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
         return this;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-7129

AbstractMultiPathPartShapes now support adding min or max Constraints.
You can set minWidth, max Width, minHeight, maxHeight independent from
each other. For example you can set the minWidth for a shape and leave
all other constraints blank. Blank constraints will be ignored.

All this PR's are related to this task:
lienzo-core:
https://github.com/kiegroup/lienzo-core/pull/18

lienzo-tests:
https://github.com/kiegroup/lienzo-tests/pull/14

kie-wb-common
This PR