### PR TITLE
JBPM-7156: Stunner - Cancel Activity don't persist after save process

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/Match.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/Match.java
@@ -28,7 +28,7 @@ import org.kie.workbench.common.stunner.core.graph.content.view.View;
  * Creates a pattern matching function.
  * <p>
  * Example usage:
- * <p>
+ *
  * <pre>
  *     // let be T1 a class, and let be T1a, T1b subclasses of T1
  *     // then, let be T2 a class, and let be T2a, T2b subclasses of T2

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/NodeMatch.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/NodeMatch.java
@@ -31,7 +31,7 @@ import org.kie.workbench.common.stunner.core.graph.content.view.View;
  * of a Stunner node.
  * <p>
  * Example usage:
- * <p>
+ *
  * <pre>
  *     // let be T1 a class, and let be T1a, T1b subclasses of T1
  *     // then, let be T2 a class, and let be T2a, T2b subclasses of T2

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/ParsedAssignmentsInfo.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/ParsedAssignmentsInfo.java
@@ -29,7 +29,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.Assignme
  * <p>
  * It has historically been represented through a delimited String.
  * The format of such a String follows the following EBNF:
- * <p>
+ *
  * <pre>
  * AssignmentInfoString ::= InputDeclarations ‘|’ OutputDeclarations ‘|’ Assignments
  * InputDeclarations ::= (Declaration (‘,’ Declaration)*)?
@@ -48,7 +48,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.Assignme
  * <p>
  * <p>
  * The input String follows the following rules:
- * <p>
+ *
  * <pre>
  * |      | in | inSet | out | outSet | assignments |
  * +------+----+-------+-----+--------+-------------+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/events/IntermediateCatchEventConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/events/IntermediateCatchEventConverter.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.IntermediateSignalEventC
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateTimerEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.property.event.error.CancellingErrorEventExecutionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.event.message.CancellingMessageEventExecutionSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.CancellingSignalEventExecutionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.event.timer.CancellingTimerEventExecutionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -54,23 +55,6 @@ public class IntermediateCatchEventConverter {
                 .apply(node).value();
     }
 
-    private PropertyWriter timerEvent(Node<View<IntermediateTimerEvent>, ?> n) {
-        CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.getFlowElement().setId(n.getUUID());
-
-        IntermediateTimerEvent definition = n.getContent().getDefinition();
-
-        BPMNGeneralSet general = definition.getGeneral();
-        p.setName(general.getName().getValue());
-        p.setDocumentation(general.getDocumentation().getValue());
-
-        CancellingTimerEventExecutionSet executionSet = definition.getExecutionSet();
-        p.addTimer(executionSet.getTimerSettings());
-
-        p.setBounds(n.getContent().getBounds());
-        return p;
-    }
-
     private PropertyWriter errorEvent(Node<View<IntermediateErrorEventCatching>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
         p.getFlowElement().setId(n.getUUID());
@@ -85,6 +69,7 @@ public class IntermediateCatchEventConverter {
                 definition.getDataIOSet().getAssignmentsinfo());
 
         CancellingErrorEventExecutionSet executionSet = definition.getExecutionSet();
+        p.setCancelActivity(executionSet.getCancelActivity().getValue());
         p.addError(executionSet.getErrorRef());
 
         p.setBounds(n.getContent().getBounds());
@@ -104,7 +89,27 @@ public class IntermediateCatchEventConverter {
         p.setAssignmentsInfo(
                 definition.getDataIOSet().getAssignmentsinfo());
 
+        CancellingSignalEventExecutionSet executionSet = definition.getExecutionSet();
+        p.setCancelActivity(executionSet.getCancelActivity().getValue());
         p.addSignal(definition.getExecutionSet().getSignalRef());
+
+        p.setBounds(n.getContent().getBounds());
+        return p;
+    }
+
+    private PropertyWriter timerEvent(Node<View<IntermediateTimerEvent>, ?> n) {
+        CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
+        p.getFlowElement().setId(n.getUUID());
+
+        IntermediateTimerEvent definition = n.getContent().getDefinition();
+
+        BPMNGeneralSet general = definition.getGeneral();
+        p.setName(general.getName().getValue());
+        p.setDocumentation(general.getDocumentation().getValue());
+
+        CancellingTimerEventExecutionSet executionSet = definition.getExecutionSet();
+        p.setCancelActivity(executionSet.getCancelActivity().getValue());
+        p.addTimer(executionSet.getTimerSettings());
 
         p.setBounds(n.getContent().getBounds());
         return p;
@@ -124,7 +129,7 @@ public class IntermediateCatchEventConverter {
                 definition.getDataIOSet().getAssignmentsinfo());
 
         CancellingMessageEventExecutionSet executionSet = definition.getExecutionSet();
-
+        p.setCancelActivity(executionSet.getCancelActivity().getValue());
         p.addMessage(executionSet.getMessageRef());
 
         p.setBounds(n.getContent().getBounds());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/BoundaryEventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/BoundaryEventPropertyWriter.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.pro
 
 import org.eclipse.bpmn2.BoundaryEvent;
 import org.eclipse.bpmn2.EventDefinition;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.dc;
 
@@ -29,6 +30,12 @@ public class BoundaryEventPropertyWriter extends CatchEventPropertyWriter {
         super(event, variableScope);
         this.event = event;
     }
+
+    @Override
+    public void setCancelActivity(Boolean value) {
+        CustomAttribute.boundarycaForEvent.of(flowElement).set(value);
+    }
+
 
     public void setParentActivity(ActivityPropertyWriter parent) {
         org.eclipse.dd.dc.Bounds parentBounds =

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/BoundaryEventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/BoundaryEventPropertyWriter.java
@@ -36,7 +36,6 @@ public class BoundaryEventPropertyWriter extends CatchEventPropertyWriter {
         CustomAttribute.boundarycaForEvent.of(flowElement).set(value);
     }
 
-
     public void setParentActivity(ActivityPropertyWriter parent) {
         org.eclipse.dd.dc.Bounds parentBounds =
                 getParentActivityBounds(parent.getShape().getBounds());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.pro
 import bpsim.ElementParameters;
 import org.eclipse.bpmn2.CatchEvent;
 import org.eclipse.bpmn2.EventDefinition;
-import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.ParsedAssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.SimulationAttributeSets;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
@@ -70,6 +70,6 @@ public class CatchEventPropertyWriter extends EventPropertyWriter {
     }
 
     public void setCancelActivity(Boolean value) {
-        CustomAttribute.boundarycaForEvent.of(flowElement).set(value);
+        // this only makes sense for boundary events: ignore
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.pro
 import bpsim.ElementParameters;
 import org.eclipse.bpmn2.CatchEvent;
 import org.eclipse.bpmn2.EventDefinition;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.ParsedAssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.SimulationAttributeSets;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
@@ -66,5 +67,9 @@ public class CatchEventPropertyWriter extends EventPropertyWriter {
     @Override
     public void addEventDefinition(EventDefinition eventDefinition) {
         this.event.getEventDefinitions().add(eventDefinition);
+    }
+
+    public void setCancelActivity(Boolean value) {
+        CustomAttribute.boundarycaForEvent.of(flowElement).set(value);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/DefinitionResolver.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/DefinitionResolver.java
@@ -42,12 +42,12 @@ import org.eclipse.emf.ecore.util.FeatureMap;
  * Because the Stunner model aggregates different aspects of a node,
  * while the Eclipse model keeps them in separate sections, we use this
  * object to access such aspects, namely
- * <p>
+ *
  * <ul>
  * <li>shapes</li>
  * <li>simulation parameters</li>
  * </ul>.
- * <p>
+ *
  * <em>signal</em> concern is due to a bug in current Eclipse BPMN2 implementation,
  * which is outdated w.r.t. upstream.
  */
@@ -86,7 +86,7 @@ public class DefinitionResolver {
      * Message, Error, Timer resolution, is that Message, Error, Timer
      * instances are usually attached to the events that refer them,
      * so that we can do:
-     * <p>
+     *
      * <code><pre>
      *     Message mySignal = myEvent.getMessageRef()
      * </pre></code>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/events/IntermediateCatchEventConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/events/IntermediateCatchEventConverter.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.TypedFactoryMana
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.BpmnNode;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.CatchEventPropertyReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.EventDefinitionReader;
-import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.EventPropertyReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.PropertyReaderFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateErrorEventCatching;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateMessageEventCatching;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/events/IntermediateCatchEventConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/events/IntermediateCatchEventConverter.java
@@ -114,7 +114,7 @@ public class IntermediateCatchEventConverter {
         Node<View<IntermediateErrorEventCatching>, Edge> node = factoryManager.newNode(nodeId, IntermediateErrorEventCatching.class);
 
         IntermediateErrorEventCatching definition = node.getContent().getDefinition();
-        EventPropertyReader p = propertyReaderFactory.of(event);
+        CatchEventPropertyReader p = propertyReaderFactory.of(event);
 
         definition.setGeneral(new BPMNGeneralSet(
                 new Name(p.getName()),
@@ -144,7 +144,7 @@ public class IntermediateCatchEventConverter {
         Node<View<IntermediateSignalEventCatching>, Edge> node = factoryManager.newNode(nodeId, IntermediateSignalEventCatching.class);
 
         IntermediateSignalEventCatching definition = node.getContent().getDefinition();
-        EventPropertyReader p = propertyReaderFactory.of(event);
+        CatchEventPropertyReader p = propertyReaderFactory.of(event);
 
         definition.setGeneral(new BPMNGeneralSet(
                 new Name(p.getName()),
@@ -174,7 +174,7 @@ public class IntermediateCatchEventConverter {
         Node<View<IntermediateTimerEvent>, Edge> node = factoryManager.newNode(nodeId, IntermediateTimerEvent.class);
 
         IntermediateTimerEvent definition = node.getContent().getDefinition();
-        EventPropertyReader p = propertyReaderFactory.of(event);
+        CatchEventPropertyReader p = propertyReaderFactory.of(event);
 
         definition.setGeneral(new BPMNGeneralSet(
                 new Name(p.getName()),
@@ -200,7 +200,7 @@ public class IntermediateCatchEventConverter {
         Node<View<IntermediateMessageEventCatching>, Edge> node = factoryManager.newNode(nodeId, IntermediateMessageEventCatching.class);
 
         IntermediateMessageEventCatching definition = node.getContent().getDefinition();
-        EventPropertyReader p = propertyReaderFactory.of(event);
+        CatchEventPropertyReader p = propertyReaderFactory.of(event);
 
         definition.setGeneral(new BPMNGeneralSet(
                 new Name(p.getName()),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/events/IntermediateCatchEventConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/events/IntermediateCatchEventConverter.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.Match;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.TypedFactoryManager;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.BpmnNode;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.CatchEventPropertyReader;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.EventDefinitionReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.EventPropertyReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.PropertyReaderFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateErrorEventCatching;
@@ -126,7 +127,7 @@ public class IntermediateCatchEventConverter {
 
         definition.setExecutionSet(new CancellingErrorEventExecutionSet(
                 new CancelActivity(p.isCancelActivity()),
-                new ErrorRef(e.getErrorRef().getErrorCode())
+                new ErrorRef(EventDefinitionReader.errorRefOf(e))
         ));
 
         node.getContent().setBounds(p.getBounds());
@@ -212,7 +213,7 @@ public class IntermediateCatchEventConverter {
 
         definition.setExecutionSet(new CancellingMessageEventExecutionSet(
                 new CancelActivity(p.isCancelActivity()),
-                new MessageRef(e.getMessageRef().getName())
+                new MessageRef(EventDefinitionReader.messageRefOf(e))
         ));
 
         node.getContent().setBounds(p.getBounds());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/BasePropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/BasePropertyReader.java
@@ -131,5 +131,4 @@ public abstract class BasePropertyReader {
         org.eclipse.dd.dc.Bounds bounds = shape.getBounds();
         return new RectangleDimensionsSet((double) bounds.getWidth(), (double) bounds.getHeight());
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/BoundaryEventPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/BoundaryEventPropertyReader.java
@@ -30,6 +30,7 @@ public class BoundaryEventPropertyReader extends CatchEventPropertyReader {
         super(el, plane, definitionResolver);
     }
 
+    @Override
     public boolean isCancelActivity() {
         return CustomAttribute.boundarycaForBoundaryEvent.of(element).get();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CatchEventPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CatchEventPropertyReader.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.eclipse.bpmn2.CatchEvent;
 import org.eclipse.bpmn2.EventDefinition;
 import org.eclipse.bpmn2.di.BPMNPlane;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.DefinitionResolver;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
 
@@ -34,6 +35,12 @@ public class CatchEventPropertyReader extends EventPropertyReader {
         super(catchEvent, plane, definitionResolver, EventPropertyReader.getSignalRefId(catchEvent.getEventDefinitions()));
         this.catchEvent = catchEvent;
     }
+
+    public boolean isCancelActivity() {
+        // return default value (only used in boundary)
+        return true;
+    }
+
 
     @Override
     public AssignmentsInfo getAssignmentsInfo() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CatchEventPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CatchEventPropertyReader.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.eclipse.bpmn2.CatchEvent;
 import org.eclipse.bpmn2.EventDefinition;
 import org.eclipse.bpmn2.di.BPMNPlane;
-import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.DefinitionResolver;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CatchEventPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CatchEventPropertyReader.java
@@ -41,7 +41,6 @@ public class CatchEventPropertyReader extends EventPropertyReader {
         return true;
     }
 
-
     @Override
     public AssignmentsInfo getAssignmentsInfo() {
         return AssignmentsInfos.of(
@@ -60,5 +59,4 @@ public class CatchEventPropertyReader extends EventPropertyReader {
         result.addAll(eventDefinitionRefs);
         return result;
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/EventPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/EventPropertyReader.java
@@ -58,10 +58,6 @@ public abstract class EventPropertyReader extends FlowElementPropertyReader {
 
     public abstract AssignmentsInfo getAssignmentsInfo();
 
-    public boolean isCancelActivity() {
-        return CustomAttribute.boundarycaForEvent.of(element).get();
-    }
-
     public TimerSettingsValue getTimerSettings(TimerEventDefinition eventDefinition) {
         TimerSettingsValue timerSettingsValue = new TimerSettings().getValue();
         toFormalExpression(eventDefinition.getTimeCycle()).ifPresent(timeCycle -> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/EventPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/EventPropertyReader.java
@@ -26,7 +26,6 @@ import org.eclipse.bpmn2.FormalExpression;
 import org.eclipse.bpmn2.SignalEventDefinition;
 import org.eclipse.bpmn2.TimerEventDefinition;
 import org.eclipse.bpmn2.di.BPMNPlane;
-import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.DefinitionResolver;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/GatewayPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/GatewayPropertyReader.java
@@ -30,5 +30,4 @@ public class GatewayPropertyReader extends FlowElementPropertyReader {
     public String getDefaultRoute() {
         return CustomAttribute.dg.of(element).get();
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/LanePropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/LanePropertyReader.java
@@ -25,5 +25,4 @@ public class LanePropertyReader extends BasePropertyReader {
     public LanePropertyReader(Lane el, BPMNPlane plane, BPMNShape shape) {
         super(el, plane, shape);
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ThrowEventPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ThrowEventPropertyReader.java
@@ -52,5 +52,4 @@ public class ThrowEventPropertyReader extends EventPropertyReader {
         result.addAll(eventDefinitionRefs);
         return result;
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/StartEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/StartEvent.java
@@ -50,14 +50,6 @@ public abstract class StartEvent<T extends BaseStartEvent> extends BPMNDiagramMa
 
     protected DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller = null;
 
-    @Parameterized.Parameters
-    public static List<Object[]> marshallers() {
-        return Arrays.asList(new Object[][]{
-                // New (un)marshaller is disabled for now due to found incompleteness
-                {OLD}, {NEW}
-        });
-    }
-
     StartEvent(Marshaller marshallerType) {
         super.init();
         switch (marshallerType) {
@@ -68,6 +60,14 @@ public abstract class StartEvent<T extends BaseStartEvent> extends BPMNDiagramMa
                 marshaller = newMarshaller;
                 break;
         }
+    }
+
+    @Parameterized.Parameters
+    public static List<Object[]> marshallers() {
+        return Arrays.asList(new Object[][]{
+                // New (un)marshaller is disabled for now due to found incompleteness
+                {OLD}, {NEW}
+        });
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/intermediate/CatchingIntermediateEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/intermediate/CatchingIntermediateEvent.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.stunner.core.graph.content.definition.Definition
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller.NEW;
 import static org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller.OLD;
 
 @RunWith(Parameterized.class)
@@ -54,8 +55,7 @@ public abstract class CatchingIntermediateEvent<T extends BaseCatchingIntermedia
     @Parameterized.Parameters
     public static List<Object[]> marshallers() {
         return Arrays.asList(new Object[][]{
-                // New (un)marshaller is disabled for now due to found incompleteness
-                {OLD}//, {NEW}
+                {OLD}, {NEW}
         });
     }
 
@@ -71,7 +71,6 @@ public abstract class CatchingIntermediateEvent<T extends BaseCatchingIntermedia
         }
     }
 
-    @Ignore
     @Test
     public void testMigration() throws Exception {
         Diagram<Graph, Metadata> oldDiagram = Unmarshalling.unmarshall(oldMarshaller, getBpmnCatchingIntermediateEventFilePath());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/intermediate/CatchingIntermediateEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/intermediate/CatchingIntermediateEvent.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshallin
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -52,13 +51,6 @@ public abstract class CatchingIntermediateEvent<T extends BaseCatchingIntermedia
 
     protected DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller = null;
 
-    @Parameterized.Parameters
-    public static List<Object[]> marshallers() {
-        return Arrays.asList(new Object[][]{
-                {OLD}, {NEW}
-        });
-    }
-
     CatchingIntermediateEvent(Marshaller marshallerType) {
         super.init();
         switch (marshallerType) {
@@ -69,6 +61,13 @@ public abstract class CatchingIntermediateEvent<T extends BaseCatchingIntermedia
                 marshaller = newMarshaller;
                 break;
         }
+    }
+
+    @Parameterized.Parameters
+    public static List<Object[]> marshallers() {
+        return Arrays.asList(new Object[][]{
+                {OLD}, {NEW}
+        });
     }
 
     @Test


### PR DESCRIPTION
@hasys @LuboTerifaj @romartin I'm fixing this but facing an issue

in `catchingIntermediateMessageEvents.bpmn` we have 

    <bpmn2:intermediateCatchEvent id="D9C771AC-6C9D-459F-960F-B3361B75228D" drools:boundaryca="false" name="">

Please notice cancel activity is false.

new marshallers are parsing `cancelActivity == false` (in my view, correctly)
old marshallers are parsing `cancelActivity == true`

that's not what the BPMN file says. So, who's wrong, and why?