### PR TITLE
JBPM-7031: Stunner - Disable doing operation in view mode

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
@@ -197,6 +197,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.workbench.stunner</groupId>
+      <artifactId>kie-wb-common-stunner-project-client</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtils.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.client.widgets.menu;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.ButtonGroup;
 import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
@@ -83,6 +84,26 @@ public class MenuUtils {
             @Override
             public Widget asWidget() {
                 return button;
+            }
+        };
+    }
+
+    public static HasEnabledIsWidget buildHasEnabledWidget(final ButtonGroup buttonGroup,
+                                                           final Button button) {
+        return new HasEnabledIsWidget() {
+            @Override
+            public void setEnabled(boolean enabled) {
+                button.setEnabled(enabled);
+            }
+
+            @Override
+            public boolean isEnabled() {
+                return button.isEnabled();
+            }
+
+            @Override
+            public Widget asWidget() {
+                return buttonGroup;
             }
         };
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtilsTest.java
@@ -19,6 +19,8 @@ package org.kie.workbench.common.stunner.client.widgets.menu;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.ButtonGroup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +45,12 @@ public class MenuUtilsTest {
 
     @Mock
     private Widget widget;
+
+    @Mock
+    private Button button;
+
+    @Mock
+    private ButtonGroup buttonGroup;
 
     @Before
     public void setUp() {
@@ -79,5 +87,24 @@ public class MenuUtilsTest {
 
         menuItem.setEnabled(false);
         assertFalse(menuItem.isEnabled());
+    }
+
+    @Test
+    public void testBuildItemWithButtonGroup() {
+        final MenuUtils.HasEnabledIsWidget wrappedButtonGroup = MenuUtils.buildHasEnabledWidget(buttonGroup, button);
+        final BaseMenuCustom menuItem = (BaseMenuCustom) MenuUtils.buildItem(wrappedButtonGroup);
+        assertEquals(buttonGroup,
+                     menuItem.build());
+
+        menuItem.setEnabled(true);
+        verify(button,
+               times(1)).setEnabled(true);
+
+        menuItem.setEnabled(false);
+        verify(button,
+               times(1)).setEnabled(false);
+
+        when(button.isEnabled()).thenReturn(true);
+        assertTrue(menuItem.isEnabled());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorMenuItemsBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorMenuItemsBuilder.java
@@ -239,16 +239,18 @@ public class ProjectDiagramEditorMenuItemsBuilder {
             addClickHandler(event -> exportBPMNCommand.execute());
         }});
 
-        final IsWidget group = new ButtonGroup() {{
-            add(new Button() {{
-                setToggleCaret(true);
-                setDataToggle(Toggle.DROPDOWN);
-                setIcon(IconType.DOWNLOAD);
-                setSize(ButtonSize.SMALL);
-                setTitle(translationService.getValue(StunnerProjectClientConstants.DOWNLOAD_DIAGRAM));
-            }});
-            add(menu);
+        final Button button = new Button() {{
+            setToggleCaret(true);
+            setDataToggle(Toggle.DROPDOWN);
+            setIcon(IconType.DOWNLOAD);
+            setSize(ButtonSize.SMALL);
+            setTitle(translationService.getValue(StunnerProjectClientConstants.DOWNLOAD_DIAGRAM));
         }};
+        final IsWidget group = MenuUtils.buildHasEnabledWidget(new ButtonGroup() {{
+                                                                   add(button);
+                                                                   add(menu);
+                                                               }},
+                                                               button);
         return buildItem(group);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
+import org.kie.workbench.common.stunner.core.client.session.ClientReadOnlySession;
 import org.kie.workbench.common.stunner.core.client.session.ClientSessionFactory;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearStatesSessionCommand;
@@ -54,6 +55,7 @@ import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSes
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientReadOnlySession;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramFocusEvent;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramLoseFocusEvent;
 import org.kie.workbench.common.stunner.project.client.screens.ProjectMessagesListener;
@@ -98,7 +100,7 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class AbstractProjectDiagramEditorTest {
 
-    private static final String TITLE = "title";
+    protected static final String TITLE = "title";
 
     @Mock
     protected ProjectDiagram diagram;
@@ -221,13 +223,19 @@ public class AbstractProjectDiagramEditorTest {
     protected ExportToSvgSessionCommand exportToSvgSessionCommand;
 
     @Mock
-    protected SessionPresenter sessionPresenter;
+    protected SessionPresenter fullSessionPresenter;
+
+    @Mock
+    protected SessionPresenter readOnlySessionPresenter;
 
     @Mock
     protected SessionPresenter.View sessionPresenterView;
 
     @Mock
     protected AbstractClientFullSession clientFullSession;
+
+    @Mock
+    protected AbstractClientReadOnlySession clientReadOnlySession;
 
     @Mock
     protected ObservablePath filePath;
@@ -238,11 +246,47 @@ public class AbstractProjectDiagramEditorTest {
     @Mock
     protected OverviewWidgetPresenter overviewWidget;
 
-    @Captor
-    private ArgumentCaptor<Consumer<ClientFullSession>> clientSessionConsumerCaptor;
+    @Mock
+    protected MenuItem clearItem;
+
+    @Mock
+    protected MenuItem visitGraphItem;
+
+    @Mock
+    protected MenuItem switchGridItem;
+
+    @Mock
+    protected MenuItem deleteSelectionItem;
+
+    @Mock
+    protected MenuItem undoItem;
+
+    @Mock
+    protected MenuItem redoItem;
+
+    @Mock
+    protected MenuItem validateItem;
+
+    @Mock
+    protected MenuItem exportsItem;
+
+    @Mock
+    protected MenuItem pasteItem;
+
+    @Mock
+    protected MenuItem copyItem;
+
+    @Mock
+    protected MenuItem cutItem;
 
     @Captor
-    private ArgumentCaptor<SessionPresenter.SessionPresenterCallback> clientSessionPresenterCallbackCaptor;
+    protected ArgumentCaptor<Consumer<ClientFullSession>> clientFullSessionConsumerCaptor;
+
+    @Captor
+    protected ArgumentCaptor<Consumer<ClientReadOnlySession>> clientReadOnlySessionConsumerCaptor;
+
+    @Captor
+    protected ArgumentCaptor<SessionPresenter.SessionPresenterCallback> clientSessionPresenterCallbackCaptor;
 
     abstract class ClientResourceTypeMock implements ClientResourceType {
 
@@ -270,28 +314,35 @@ public class AbstractProjectDiagramEditorTest {
         doReturn(pasteSelectionSessionCommand).when(sessionCommandFactory).newPasteSelectionCommand();
         doReturn(cutSelectionSessionCommand).when(sessionCommandFactory).newCutSelectionCommand();
 
-        when(sessionPresenterFactory.newPresenterEditor()).thenReturn(sessionPresenter);
-        when(sessionPresenter.getInstance()).thenReturn(clientFullSession);
-        when(sessionPresenter.withToolbar(anyBoolean())).thenReturn(sessionPresenter);
-        when(sessionPresenter.withPalette(anyBoolean())).thenReturn(sessionPresenter);
-        when(sessionPresenter.displayNotifications(any(Predicate.class))).thenReturn(sessionPresenter);
-        when(sessionPresenter.getView()).thenReturn(sessionPresenterView);
+        when(sessionPresenterFactory.newPresenterEditor()).thenReturn(fullSessionPresenter);
+        when(fullSessionPresenter.getInstance()).thenReturn(clientFullSession);
+        when(fullSessionPresenter.withToolbar(anyBoolean())).thenReturn(fullSessionPresenter);
+        when(fullSessionPresenter.withPalette(anyBoolean())).thenReturn(fullSessionPresenter);
+        when(fullSessionPresenter.displayNotifications(any(Predicate.class))).thenReturn(fullSessionPresenter);
+        when(fullSessionPresenter.getView()).thenReturn(sessionPresenterView);
 
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newClearItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newVisitGraphItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newSwitchGridItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newDeleteSelectionItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newUndoItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newRedoItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newValidateItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newExportsItem(any(Command.class),
-                                                                                    any(Command.class),
-                                                                                    any(Command.class),
-                                                                                    any(Command.class),
-                                                                                    any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newPasteItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newCopyItem(any(Command.class));
-        doReturn(mock(MenuItem.class)).when(projectMenuItemsBuilder).newCutItem(any(Command.class));
+        when(sessionPresenterFactory.newPresenterViewer()).thenReturn(readOnlySessionPresenter);
+        when(readOnlySessionPresenter.getInstance()).thenReturn(clientReadOnlySession);
+        when(readOnlySessionPresenter.withToolbar(anyBoolean())).thenReturn(readOnlySessionPresenter);
+        when(readOnlySessionPresenter.withPalette(anyBoolean())).thenReturn(readOnlySessionPresenter);
+        when(readOnlySessionPresenter.displayNotifications(any(Predicate.class))).thenReturn(readOnlySessionPresenter);
+        when(readOnlySessionPresenter.getView()).thenReturn(sessionPresenterView);
+
+        when(projectMenuItemsBuilder.newClearItem(any(Command.class))).thenReturn(clearItem);
+        when(projectMenuItemsBuilder.newVisitGraphItem(any(Command.class))).thenReturn(visitGraphItem);
+        when(projectMenuItemsBuilder.newSwitchGridItem(any(Command.class))).thenReturn(switchGridItem);
+        when(projectMenuItemsBuilder.newDeleteSelectionItem(any(Command.class))).thenReturn(deleteSelectionItem);
+        when(projectMenuItemsBuilder.newUndoItem(any(Command.class))).thenReturn(undoItem);
+        when(projectMenuItemsBuilder.newRedoItem(any(Command.class))).thenReturn(redoItem);
+        when(projectMenuItemsBuilder.newValidateItem(any(Command.class))).thenReturn(validateItem);
+        when(projectMenuItemsBuilder.newExportsItem(any(Command.class),
+                                                    any(Command.class),
+                                                    any(Command.class),
+                                                    any(Command.class),
+                                                    any(Command.class))).thenReturn(exportsItem);
+        when(projectMenuItemsBuilder.newPasteItem(any(Command.class))).thenReturn(pasteItem);
+        when(projectMenuItemsBuilder.newCopyItem(any(Command.class))).thenReturn(copyItem);
+        when(projectMenuItemsBuilder.newCutItem(any(Command.class))).thenReturn(cutItem);
 
         when(alertsButtonMenuItemBuilder.build()).thenReturn(alertsButtonMenuItem);
         when(versionRecordManager.getPathToLatest()).thenReturn(filePath);
@@ -415,25 +466,25 @@ public class AbstractProjectDiagramEditorTest {
         when(metadata.getTitle()).thenReturn(TITLE);
         when(metadata.getOverview()).thenReturn(overview);
         when(sessionManager.getSessionFactory(eq(metadata), eq(ClientFullSession.class))).thenReturn(clientSessionFactory);
-        when(sessionPresenterFactory.newPresenterEditor()).thenReturn(sessionPresenter);
 
         presenter.open(diagram);
 
         verify(view).showLoading();
         verify(presenter).setOriginalHash(anyInt());
+        verify(presenter).destroySession();
 
         verify(clientSessionFactory).newSession(eq(metadata),
-                                                clientSessionConsumerCaptor.capture());
+                                                clientFullSessionConsumerCaptor.capture());
 
-        final Consumer<ClientFullSession> clientSessionConsumer = clientSessionConsumerCaptor.getValue();
-        clientSessionConsumer.accept(clientFullSession);
+        final Consumer<ClientFullSession> clientFullSessionConsumer = clientFullSessionConsumerCaptor.getValue();
+        clientFullSessionConsumer.accept(clientFullSession);
 
         verify(view).setWidget(eq(sessionPresenterView));
-        verify(sessionPresenter).withToolbar(eq(false));
-        verify(sessionPresenter).withPalette(eq(true));
-        verify(sessionPresenter).open(eq(diagram),
-                                      eq(clientFullSession),
-                                      clientSessionPresenterCallbackCaptor.capture());
+        verify(fullSessionPresenter).withToolbar(eq(false));
+        verify(fullSessionPresenter).withPalette(eq(true));
+        verify(fullSessionPresenter).open(eq(diagram),
+                                          eq(clientFullSession),
+                                          clientSessionPresenterCallbackCaptor.capture());
 
         final SessionPresenter.SessionPresenterCallback clientSessionPresenterCallback = clientSessionPresenterCallbackCaptor.getValue();
         clientSessionPresenterCallback.onSuccess();
@@ -449,13 +500,66 @@ public class AbstractProjectDiagramEditorTest {
                                         any(com.google.gwt.user.client.Command.class));
 
         verify(presenter).onDiagramLoad();
+
+        assertEquals(fullSessionPresenter,
+                     presenter.getSessionPresenter());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOpenReadOnly() {
+        final ProjectMetadata metadata = mock(ProjectMetadata.class);
+        final Overview overview = mock(Overview.class);
+        final ClientSessionFactory clientSessionFactory = mock(ClientSessionFactory.class);
+
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getTitle()).thenReturn(TITLE);
+        when(metadata.getOverview()).thenReturn(overview);
+        when(sessionManager.getSessionFactory(eq(metadata), eq(ClientReadOnlySession.class))).thenReturn(clientSessionFactory);
+
+        doReturn(true).when(presenter).isReadOnly();
+        presenter.open(diagram);
+
+        verify(view).showLoading();
+        verify(presenter).setOriginalHash(anyInt());
+        verify(presenter).destroySession();
+
+        verify(clientSessionFactory).newSession(eq(metadata),
+                                                clientReadOnlySessionConsumerCaptor.capture());
+
+        final Consumer<ClientReadOnlySession> clientReadOnlySessionConsumer = clientReadOnlySessionConsumerCaptor.getValue();
+        clientReadOnlySessionConsumer.accept(clientFullSession);
+
+        verify(view).setWidget(eq(sessionPresenterView));
+        verify(readOnlySessionPresenter).withToolbar(eq(false));
+        verify(readOnlySessionPresenter).withPalette(eq(false));
+        verify(readOnlySessionPresenter).open(eq(diagram),
+                                              eq(clientFullSession),
+                                              clientSessionPresenterCallbackCaptor.capture());
+
+        final SessionPresenter.SessionPresenterCallback clientSessionPresenterCallback = clientSessionPresenterCallbackCaptor.getValue();
+        clientSessionPresenterCallback.onSuccess();
+
+        verify(view).hideBusyIndicator();
+
+        //Verify Overview widget was setup. It'd be nice to just verify(presenter).resetEditorPages(..) but it is protected
+        verify(overviewWidget).setContent(eq(overview),
+                                          eq(filePath));
+        verify(kieView).clear();
+        verify(kieView).addMainEditorPage(eq(view));
+        verify(kieView).addOverviewPage(eq(overviewWidget),
+                                        any(com.google.gwt.user.client.Command.class));
+
+        verify(presenter).onDiagramLoad();
+
+        assertEquals(readOnlySessionPresenter,
+                     presenter.getSessionPresenter());
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testCloseEditor() {
-        SessionPresenter sessionPresenter = mock(SessionPresenter.class);
-        presenter.setSessionPresenter(sessionPresenter);
+        presenter.setFullSessionPresenter(fullSessionPresenter);
         presenter.doClose();
         verify(clearStatesSessionCommand, times(1)).unbind();
         verify(switchGridSessionCommand, times(1)).unbind();
@@ -472,7 +576,43 @@ public class AbstractProjectDiagramEditorTest {
         verify(copySelectionSessionCommand, times(1)).unbind();
         verify(pasteSelectionSessionCommand, times(1)).unbind();
         verify(cutSelectionSessionCommand, times(1)).unbind();
-        verify(sessionPresenter, never()).clear();
-        verify(sessionPresenter, times(1)).destroy();
+        verify(fullSessionPresenter, never()).clear();
+        verify(fullSessionPresenter, times(1)).destroy();
+    }
+
+    @Test
+    public void testInitialiseMenuBarStateForSession_Enabled() {
+        presenter.initialiseMenuBarStateForSession(true);
+
+        verify(clearItem).setEnabled(true);
+        verify(visitGraphItem).setEnabled(true);
+        verify(switchGridItem).setEnabled(true);
+        verify(validateItem).setEnabled(true);
+        verify(exportsItem).setEnabled(true);
+
+        verify(deleteSelectionItem).setEnabled(false);
+        verify(undoItem).setEnabled(false);
+        verify(redoItem).setEnabled(false);
+        verify(copyItem).setEnabled(false);
+        verify(cutItem).setEnabled(false);
+        verify(pasteItem).setEnabled(false);
+    }
+
+    @Test
+    public void testInitialiseMenuBarStateForSession_Disabled() {
+        presenter.initialiseMenuBarStateForSession(false);
+
+        verify(clearItem).setEnabled(false);
+        verify(visitGraphItem).setEnabled(false);
+        verify(switchGridItem).setEnabled(false);
+        verify(validateItem).setEnabled(false);
+        verify(exportsItem).setEnabled(false);
+
+        verify(deleteSelectionItem).setEnabled(false);
+        verify(undoItem).setEnabled(false);
+        verify(redoItem).setEnabled(false);
+        verify(copyItem).setEnabled(false);
+        verify(cutItem).setEnabled(false);
+        verify(pasteItem).setEnabled(false);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -451,8 +451,10 @@ public class AbstractProjectDiagramEditorTest {
         String title = "testDiagram";
 
         String formattedTitle = presenter.formatTitle(title);
+        String suffix = getResourceType().getSuffix();
+        String shortName = getResourceType().getShortName();
         assertEquals(formattedTitle,
-                     "testDiagram.bpmn - Business Process");
+                     "testDiagram." + suffix + " - " + shortName);
     }
 
     @Test
@@ -528,13 +530,13 @@ public class AbstractProjectDiagramEditorTest {
                                                 clientReadOnlySessionConsumerCaptor.capture());
 
         final Consumer<ClientReadOnlySession> clientReadOnlySessionConsumer = clientReadOnlySessionConsumerCaptor.getValue();
-        clientReadOnlySessionConsumer.accept(clientFullSession);
+        clientReadOnlySessionConsumer.accept(clientReadOnlySession);
 
         verify(view).setWidget(eq(sessionPresenterView));
         verify(readOnlySessionPresenter).withToolbar(eq(false));
         verify(readOnlySessionPresenter).withPalette(eq(false));
         verify(readOnlySessionPresenter).open(eq(diagram),
-                                              eq(clientFullSession),
+                                              eq(clientReadOnlySession),
                                               clientSessionPresenterCallbackCaptor.capture());
 
         final SessionPresenter.SessionPresenterCallback clientSessionPresenterCallback = clientSessionPresenterCallbackCaptor.getValue();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
@@ -36,7 +36,16 @@ import org.kie.workbench.common.stunner.core.client.session.ClientFullSession;
 import org.kie.workbench.common.stunner.core.client.session.ClientSessionFactory;
 import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearStatesSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CopySelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CutSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToBpmnSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToJpgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPdfSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToSvgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
@@ -82,6 +91,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -142,25 +152,52 @@ public class ProjectDiagramEditorTest {
     private ProjectDiagramEditorMenuItemsBuilder menuItemsBuilder;
 
     @Mock
-    private VisitGraphSessionCommand sessionVisitGraphCommand;
+    private ClearStatesSessionCommand clearStatesSessionCommand;
 
     @Mock
-    private SwitchGridSessionCommand sessionSwitchGridCommand;
+    private SwitchGridSessionCommand switchGridSessionCommand;
 
     @Mock
-    private ClearSessionCommand sessionClearCommand;
+    private VisitGraphSessionCommand visitGraphSessionCommand;
 
     @Mock
-    private DeleteSelectionSessionCommand sessionDeleteSelectionCommand;
+    private ClearSessionCommand clearSessionCommand;
 
     @Mock
-    private UndoSessionCommand sessionUndoCommand;
+    private DeleteSelectionSessionCommand deleteSelectionSessionCommand;
 
     @Mock
-    private RedoSessionCommand sessionRedoCommand;
+    private UndoSessionCommand undoSessionCommand;
 
     @Mock
-    private ValidateSessionCommand sessionValidateCommand;
+    private RedoSessionCommand redoSessionCommand;
+
+    @Mock
+    private ValidateSessionCommand validateSessionCommand;
+
+    @Mock
+    private ExportToPngSessionCommand exportToPngSessionCommand;
+
+    @Mock
+    private ExportToJpgSessionCommand exportToJpgSessionCommand;
+
+    @Mock
+    private ExportToPdfSessionCommand exportToPdfSessionCommand;
+
+    @Mock
+    private ExportToBpmnSessionCommand exportToBpmnSessionCommand;
+
+    @Mock
+    private CopySelectionSessionCommand copySelectionSessionCommand;
+
+    @Mock
+    private PasteSelectionSessionCommand pasteSelectionSessionCommand;
+
+    @Mock
+    private CutSelectionSessionCommand cutSelectionSessionCommand;
+
+    @Mock
+    private ExportToSvgSessionCommand exportToSvgSessionCommand;
 
     @Mock
     private ClientFullSessionImpl fullSession;
@@ -214,13 +251,22 @@ public class ProjectDiagramEditorTest {
     public void setup() {
         VersionRecordManager versionRecordManagerMock = versionRecordManager;
         when(versionRecordManager.getCurrentPath()).thenReturn(path);
-        when(sessionCommandFactory.newClearCommand()).thenReturn(sessionClearCommand);
-        when(sessionCommandFactory.newVisitGraphCommand()).thenReturn(sessionVisitGraphCommand);
-        when(sessionCommandFactory.newSwitchGridCommand()).thenReturn(sessionSwitchGridCommand);
-        when(sessionCommandFactory.newDeleteSelectedElementsCommand()).thenReturn(sessionDeleteSelectionCommand);
-        when(sessionCommandFactory.newUndoCommand()).thenReturn(sessionUndoCommand);
-        when(sessionCommandFactory.newRedoCommand()).thenReturn(sessionRedoCommand);
-        when(sessionCommandFactory.newValidateCommand()).thenReturn(sessionValidateCommand);
+        doReturn(clearStatesSessionCommand).when(sessionCommandFactory).newClearStatesCommand();
+        doReturn(switchGridSessionCommand).when(sessionCommandFactory).newSwitchGridCommand();
+        doReturn(visitGraphSessionCommand).when(sessionCommandFactory).newVisitGraphCommand();
+        doReturn(clearSessionCommand).when(sessionCommandFactory).newClearCommand();
+        doReturn(deleteSelectionSessionCommand).when(sessionCommandFactory).newDeleteSelectedElementsCommand();
+        doReturn(undoSessionCommand).when(sessionCommandFactory).newUndoCommand();
+        doReturn(redoSessionCommand).when(sessionCommandFactory).newRedoCommand();
+        doReturn(validateSessionCommand).when(sessionCommandFactory).newValidateCommand();
+        doReturn(exportToPngSessionCommand).when(sessionCommandFactory).newExportToPngSessionCommand();
+        doReturn(exportToJpgSessionCommand).when(sessionCommandFactory).newExportToJpgSessionCommand();
+        doReturn(exportToSvgSessionCommand).when(sessionCommandFactory).newExportToSvgSessionCommand();
+        doReturn(exportToPdfSessionCommand).when(sessionCommandFactory).newExportToPdfSessionCommand();
+        doReturn(exportToBpmnSessionCommand).when(sessionCommandFactory).newExportToBpmnSessionCommand();
+        doReturn(copySelectionSessionCommand).when(sessionCommandFactory).newCopySelectionCommand();
+        doReturn(pasteSelectionSessionCommand).when(sessionCommandFactory).newPasteSelectionCommand();
+        doReturn(cutSelectionSessionCommand).when(sessionCommandFactory).newCutSelectionCommand();
         when(presenterFactory.newPresenterEditor()).thenReturn(presenter);
         when(clientSessionManager.getCurrentSession()).thenReturn(fullSession);
         when(clientSessionManager.getSessionFactory(metadata,
@@ -267,7 +313,7 @@ public class ProjectDiagramEditorTest {
             }
         };
         tested.init();
-        tested.setSessionPresenter(presenter);
+        tested.setFullSessionPresenter(presenter);
 
         when(translationService.getValue(anyString())).thenAnswer(i -> i.getArguments()[0]);
     }
@@ -277,19 +323,19 @@ public class ProjectDiagramEditorTest {
     public void testInit() {
         verify(view,
                times(1)).init(eq(tested));
-        verify(sessionVisitGraphCommand,
+        verify(visitGraphSessionCommand,
                times(0)).bind(eq(fullSession));
-        verify(sessionSwitchGridCommand,
+        verify(switchGridSessionCommand,
                times(0)).bind(eq(fullSession));
-        verify(sessionClearCommand,
+        verify(clearSessionCommand,
                times(0)).bind(eq(fullSession));
-        verify(sessionDeleteSelectionCommand,
+        verify(deleteSelectionSessionCommand,
                times(0)).bind(eq(fullSession));
-        verify(sessionUndoCommand,
+        verify(undoSessionCommand,
                times(0)).bind(eq(fullSession));
-        verify(sessionRedoCommand,
+        verify(redoSessionCommand,
                times(0)).bind(eq(fullSession));
-        verify(sessionValidateCommand,
+        verify(validateSessionCommand,
                times(0)).bind(eq(fullSession));
     }
 
@@ -297,7 +343,7 @@ public class ProjectDiagramEditorTest {
     @SuppressWarnings("unchecked")
     public void testValidateBeforeSave() {
         tested.save();
-        verify(sessionValidateCommand,
+        verify(validateSessionCommand,
                times(1)).execute(any(ClientSessionCommand.Callback.class));
     }
 
@@ -419,7 +465,7 @@ public class ProjectDiagramEditorTest {
         doAnswer(i -> {
             ((ClientSessionCommand.Callback) i.getArguments()[0]).onSuccess();
             return null;
-        }).when(sessionValidateCommand).execute(any(ClientSessionCommand.Callback.class));
+        }).when(validateSessionCommand).execute(any(ClientSessionCommand.Callback.class));
 
         tested.onSave();
 
@@ -433,7 +479,7 @@ public class ProjectDiagramEditorTest {
         doAnswer(i -> {
             ((ClientSessionCommand.Callback) i.getArguments()[0]).onSuccess();
             return null;
-        }).when(sessionValidateCommand).execute(any(ClientSessionCommand.Callback.class));
+        }).when(validateSessionCommand).execute(any(ClientSessionCommand.Callback.class));
 
         tested.onSave();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
@@ -70,6 +70,7 @@ import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
 @Dependent
@@ -87,6 +88,9 @@ public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramR
     private boolean isMigrating = false;
 
     private final PopupUtil popupUtil;
+
+    private final MenuItem formsGenerationMenuItem;
+    private final MenuItem migrateMenuItem;
 
     @Inject
     public BPMNDiagramEditor(final View view,
@@ -133,6 +137,11 @@ public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramR
         this.bpmnDiagramEditorMenuItemsBuilder = bpmnDiagramEditorMenuItemsBuilder;
         this.migrateDiagramEvent = migrateDiagramEvent;
         this.popupUtil = popupUtil;
+
+        this.formsGenerationMenuItem = bpmnDiagramEditorMenuItemsBuilder.newFormsGenerationMenuItem(() -> executeFormsCommand(GenerateProcessFormsSessionCommand.class),
+                                                                                                    () -> executeFormsCommand(GenerateDiagramFormsSessionCommand.class),
+                                                                                                    () -> executeFormsCommand(GenerateSelectedFormsSessionCommand.class));
+        this.migrateMenuItem = bpmnDiagramEditorMenuItemsBuilder.newMigrateMenuItem(this::onMigrate);
     }
 
     @OnStartup
@@ -140,6 +149,13 @@ public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramR
                           final PlaceRequest place) {
         super.doStartUp(path,
                         place);
+    }
+
+    @Override
+    protected void initialiseMenuBarStateForSession(final boolean enabled) {
+        super.initialiseMenuBarStateForSession(enabled);
+        formsGenerationMenuItem.setEnabled(enabled);
+        migrateMenuItem.setEnabled(enabled);
     }
 
     @Override
@@ -159,10 +175,8 @@ public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramR
     protected void makeAdditionalStunnerMenus(final FileMenuBuilder fileMenuBuilder) {
         super.makeAdditionalStunnerMenus(fileMenuBuilder);
         fileMenuBuilder
-                .addNewTopLevelMenu(bpmnDiagramEditorMenuItemsBuilder.newFormsGenerationMenuItem(() -> executeFormsCommand(GenerateProcessFormsSessionCommand.class),
-                                                                                                 () -> executeFormsCommand(GenerateDiagramFormsSessionCommand.class),
-                                                                                                 () -> executeFormsCommand(GenerateSelectedFormsSessionCommand.class)))
-                .addNewTopLevelMenu(bpmnDiagramEditorMenuItemsBuilder.newMigrateMenuItem(this::onMigrate));
+                .addNewTopLevelMenu(formsGenerationMenuItem)
+                .addNewTopLevelMenu(migrateMenuItem);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorMenuItemsBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorMenuItemsBuilder.java
@@ -46,17 +46,17 @@ public class BPMNDiagramEditorMenuItemsBuilder {
     }
 
     public MenuItem newMigrateMenuItem(final Command migrateCommand) {
-        return MenuUtils.buildItem(
-                new Button() {{
-                    setSize(ButtonSize.SMALL);
-                    setText(translationService.getValue(BPMNClientConstants.EditorMigrateActionMenu));
-                    addClickHandler(clickEvent -> migrateCommand.execute());
-                }});
+        final MenuUtils.HasEnabledIsWidget buttonWrapper = MenuUtils.buildHasEnabledWidget(new Button() {{
+            setSize(ButtonSize.SMALL);
+            setText(translationService.getValue(BPMNClientConstants.EditorMigrateActionMenu));
+            addClickHandler(clickEvent -> migrateCommand.execute());
+        }});
+        return MenuUtils.buildItem(buttonWrapper);
     }
 
     public MenuItem newFormsGenerationMenuItem(final Command generateProcessForm,
-                                        final Command generateAllForms,
-                                        final Command generateSelectedForms) {
+                                               final Command generateAllForms,
+                                               final Command generateSelectedForms) {
         final DropDownMenu menu = new DropDownMenu() {{
             setPull(Pull.RIGHT);
         }};
@@ -79,16 +79,19 @@ public class BPMNDiagramEditorMenuItemsBuilder {
             setTitle(translationService.getValue(BPMNClientConstants.EditorGenerateSelectionForms));
             addClickHandler(event -> generateSelectedForms.execute());
         }});
-        final IsWidget group = new ButtonGroup() {{
-            add(new Button() {{
-                setToggleCaret(true);
-                setDataToggle(Toggle.DROPDOWN);
-                setIcon(IconType.LIST_ALT);
-                setSize(ButtonSize.SMALL);
-                setTitle(translationService.getValue(BPMNClientConstants.EditorFormGenerationTitle));
-            }});
-            add(menu);
+
+        final Button button = new Button() {{
+            setToggleCaret(true);
+            setDataToggle(Toggle.DROPDOWN);
+            setIcon(IconType.LIST_ALT);
+            setSize(ButtonSize.SMALL);
+            setTitle(translationService.getValue(BPMNClientConstants.EditorFormGenerationTitle));
         }};
-        return  MenuUtils.buildItem(group);
+        final IsWidget group = MenuUtils.buildHasEnabledWidget(new ButtonGroup() {{
+                                                                   add(button);
+                                                                   add(menu);
+                                                               }},
+                                                               button);
+        return MenuUtils.buildItem(group);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorTest.java
@@ -48,6 +48,7 @@ import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.menu.MenuItem;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -104,6 +105,12 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     @Mock
     private AbstractCanvasHandler canvasHandler;
 
+    @Mock
+    private MenuItem formsGenerationMenuItem;
+
+    @Mock
+    private MenuItem migrateMenuItem;
+
     private ArgumentCaptor<Command> commandCaptor;
 
     private ArgumentCaptor<BPMNMigrateDiagramEvent> migrateDiagramEventCaptor;
@@ -137,6 +144,9 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         when(translationService.getValue(BPMNClientConstants.EditorMigrateActionWarning)).thenReturn(MIGRATE_ACTION_WARNING);
         when(translationService.getValue(BPMNClientConstants.EditorMigrateAction)).thenReturn(MIGRATE_ACTION);
         when(translationService.getValue(BPMNClientConstants.EditorMigrateConfirmAction)).thenReturn(MIGRATE_CONFIRM_ACTION);
+
+        when(bpmnDiagramEditorMenuItemsBuilder.newFormsGenerationMenuItem(any(Command.class), any(Command.class), any(Command.class))).thenReturn(formsGenerationMenuItem);
+        when(bpmnDiagramEditorMenuItemsBuilder.newMigrateMenuItem(any(Command.class))).thenReturn(migrateMenuItem);
 
         super.setUp();
     }
@@ -181,7 +191,6 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                 versionRecordManager = BPMNDiagramEditorTest.this.versionRecordManager;
                 alertsButtonMenuItemBuilder = BPMNDiagramEditorTest.this.alertsButtonMenuItemBuilder;
                 place = BPMNDiagramEditorTest.this.currentPlace;
-                presenter = BPMNDiagramEditorTest.this.sessionPresenter;
                 kieView = BPMNDiagramEditorTest.this.kieView;
                 overviewWidget = BPMNDiagramEditorTest.this.overviewWidget;
             }
@@ -192,6 +201,7 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                 //avoid GWT log initialization.
             }
         });
+
         return diagramEditor;
     }
 
@@ -225,6 +235,7 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         ObservablePath currentPath = mock(ObservablePath.class);
         when(versionRecordManager.getCurrentPath()).thenReturn(currentPath);
         doReturn(true).when(diagramEditor).isDirty(any(Integer.class));
+        doReturn(fullSessionPresenter).when(diagramEditor).getSessionPresenter();
 
         diagramEditor.onMigrate();
         verify(popupUtil,
@@ -269,5 +280,21 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         verify(generateDiagramFormsSessionCommand, times(1)).unbind();
         verify(generateProcessFormsSessionCommand, times(1)).unbind();
         verify(generateSelectedFormsSessionCommand, times(1)).unbind();
+    }
+
+    @Override
+    public void testInitialiseMenuBarStateForSession_Enabled() {
+        super.testInitialiseMenuBarStateForSession_Enabled();
+
+        verify(formsGenerationMenuItem).setEnabled(true);
+        verify(migrateMenuItem).setEnabled(true);
+    }
+
+    @Override
+    public void testInitialiseMenuBarStateForSession_Disabled() {
+        super.testInitialiseMenuBarStateForSession_Disabled();
+
+        verify(formsGenerationMenuItem).setEnabled(false);
+        verify(migrateMenuItem).setEnabled(false);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-7031

@romartin I tried endlessly to only have one "open" method and cast the ```SessionPresenter``` but could not find a way to do it; so had to (unhappily) settle for what you see in the PR (two ```SessionPresenter```'s, one for "full" and another for "read-only").... if you can explain how to cast I'll more than happily update to use a single ```openSession(..)``` method!