### PR TITLE
[7.7.x] RHPAM-827: Extend test-coverage of toolbar commands

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/AbstractToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/AbstractToolbarCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ClearStatesToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ClearStatesToolbarCommandTest.java
@@ -20,7 +20,7 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearStatesSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,28 +32,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class ClearStatesToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Clear States";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private ClearStatesSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private ClearStatesToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newClearStatesCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.CLEAR_SHAPES)).thenReturn(TEXT);
+        command = new ClearStatesToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        verify(sessionCommandFactory, times(1)).newClearStatesCommand();
+        assertEquals(IconType.BAN, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ClearToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ClearToolbarCommandTest.java
@@ -20,42 +20,45 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class ClearToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Clear toolbar";
+    private static final String ARE_YOU_SURE = "Are you sure?";
+    private static final String OPERATION_CANNOT_BE_REVERTED = "This operation cannot be reverted.";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private ClearSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private ClearToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newClearCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.CLEAR_DIAGRAM)).thenReturn(TEXT);
+        command = new ClearToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
-        assertFalse(command.requiresConfirm());
+        verify(sessionCommandFactory, times(1)).newClearCommand();
+        assertEquals(IconType.ERASER, command.getIcon());
+        assertTrue(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());
+        assertTrue(command.getConfirmMessage().contains(ARE_YOU_SURE));
+        assertTrue(command.getConfirmMessage().contains(OPERATION_CANNOT_BE_REVERTED));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CopyToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CopyToolbarCommandTest.java
@@ -20,40 +20,34 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CopySelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class CopyToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Copy Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private CopySelectionSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private CopyToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
-
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.COPY_SELECTION)).thenReturn(TEXT);
+        command = new CopyToolbarCommand(sessionCommand, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        assertEquals(IconType.COPY, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CutToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CutToolbarCommandTest.java
@@ -20,40 +20,34 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CutSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class CutToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Cut Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private CutSelectionSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private CutToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
-
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.CUT_SELECTION)).thenReturn(TEXT);
+        command = new CutToolbarCommand(sessionCommand, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        assertEquals(IconType.CUT, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/DeleteSelectionToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/DeleteSelectionToolbarCommandTest.java
@@ -20,7 +20,7 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,28 +32,28 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class DeleteSelectionToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Delete Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private DeleteSelectionSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private DeleteSelectionToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newDeleteSelectedElementsCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.DELETE_SELECTION)).thenReturn(TEXT);
+        command = new DeleteSelectionToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
         verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+               times(1)).newDeleteSelectedElementsCommand();
+        assertEquals(IconType.TRASH_O, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToBpmnToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToBpmnToolbarCommandTest.java
@@ -17,15 +17,16 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToBpmnSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,27 +35,28 @@ import static org.mockito.Mockito.when;
 public class ExportToBpmnToolbarCommandTest
         extends AbstractToolbarCommandTest {
 
-    private static final String CAPTION = "CAPTION";
-
-    @Mock
-    private SessionCommandFactory sessionCommandFactory;
+    private static final String TEXT = "Export BPMN";
 
     @Mock
     private ExportToBpmnSessionCommand sessionCommand;
 
-    @Test
-    public void testExport() {
+    private ExportToBpmnToolbarCommand command;
+
+    @Before
+    public void setUp() throws Exception {
         when(sessionCommandFactory.newExportToBpmnSessionCommand()).thenReturn(sessionCommand);
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_BPMN)).thenReturn(CAPTION);
-        final ExportToBpmnToolbarCommand tested = new ExportToBpmnToolbarCommand(sessionCommandFactory,
-                                                                                 translationService);
+
+        when(translationService.getValue(CoreTranslationMessages.EXPORT_BPMN)).thenReturn(TEXT);
+        command = new ExportToBpmnToolbarCommand(sessionCommandFactory, translationService);
+    }
+
+    @Test
+    public void testInstance() {
         verify(sessionCommandFactory,
                times(1)).newExportToBpmnSessionCommand();
-        assertEquals(IconType.FILE_TEXT_O,
-                     tested.getIcon());
-        assertEquals(CAPTION,
-                     tested.getCaption());
-        assertEquals(CAPTION,
-                     tested.getTooltip());
+        assertEquals(IconType.FILE_TEXT_O, command.getIcon());
+        assertFalse(command.requiresConfirm());
+        assertEquals(TEXT, command.getCaption());
+        assertEquals(TEXT, command.getTooltip());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToJpgToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToJpgToolbarCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,36 +17,45 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToJpgSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToJpgToolbarCommandTest extends AbstractToolbarCommandTest{
+public class ExportToJpgToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    @Mock
-    private SessionCommandFactory sessionCommandFactory;
+    private static final String TEXT = "Export JPEG";
 
     @Mock
     private ExportToJpgSessionCommand sessionCommand;
 
-    @Test
-    public void testExport() {
+    private ExportToJpgToolbarCommand command;
+
+    @Before
+    public void setUp() throws Exception {
         when(sessionCommandFactory.newExportToJpgSessionCommand()).thenReturn(sessionCommand);
-        final ExportToJpgToolbarCommand tested = new ExportToJpgToolbarCommand(sessionCommandFactory, translationService);
+
+        when(translationService.getValue(CoreTranslationMessages.EXPORT_JPG)).thenReturn(TEXT);
+        command = new ExportToJpgToolbarCommand(sessionCommandFactory, translationService);
+    }
+
+    @Test
+    public void testInstance() {
         verify(sessionCommandFactory,
                times(1)).newExportToJpgSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O,
-                     tested.getIcon());
-        assertNull(tested.getCaption());
+        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        assertFalse(command.requiresConfirm());
+        assertEquals(TEXT, command.getCaption());
+        assertEquals(TEXT, command.getTooltip());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPdfToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPdfToolbarCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,33 +17,45 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPdfSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.SessionCommandFactory;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPdfToolbarCommandTest extends AbstractToolbarCommandTest{
+public class ExportToPdfToolbarCommandTest extends AbstractToolbarCommandTest {
+
+    private static final String TEXT = "Export PDF";
 
     @Mock
     private ExportToPdfSessionCommand sessionCommand;
 
-    @Test
-    public void testExport() {
+    private ExportToPdfToolbarCommand command;
+
+    @Before
+    public void setUp() throws Exception {
         when(sessionCommandFactory.newExportToPdfSessionCommand()).thenReturn(sessionCommand);
-        final ExportToPdfToolbarCommand tested = new ExportToPdfToolbarCommand(sessionCommandFactory, translationService);
+
+        when(translationService.getValue(CoreTranslationMessages.EXPORT_PDF)).thenReturn(TEXT);
+        command = new ExportToPdfToolbarCommand(sessionCommandFactory, translationService);
+    }
+
+    @Test
+    public void testInstance() {
         verify(sessionCommandFactory,
                times(1)).newExportToPdfSessionCommand();
-        assertEquals(IconType.FILE_PDF_O,
-                     tested.getIcon());
-        assertNull(tested.getCaption());
+        assertEquals(IconType.FILE_PDF_O, command.getIcon());
+        assertFalse(command.requiresConfirm());
+        assertEquals(TEXT, command.getCaption());
+        assertEquals(TEXT, command.getTooltip());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToSvgToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToSvgToolbarCommandTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ExportToSvgToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "text";
+    private static final String TEXT = "Export SVG";
 
     private ExportToSvgToolbarCommand command;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/PasteToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/PasteToolbarCommandTest.java
@@ -20,40 +20,34 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class PasteToolbarCommandTest extends AbstractToolbarCommandTest {
 
     private static final String TEXT = "Export PNG";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private PasteSelectionSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private PasteToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
-
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.PASTE_SELECTION)).thenReturn(TEXT);
+        command = new PasteToolbarCommand(sessionCommand, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        assertEquals(IconType.PASTE, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/RedoToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/RedoToolbarCommandTest.java
@@ -16,11 +16,12 @@
 
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
+import org.gwtbootstrap3.client.ui.constants.IconRotate;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,28 +33,28 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class RedoToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Redo Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private RedoSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private RedoToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newRedoCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.REDO)).thenReturn(TEXT);
+        command = new RedoToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        verify(sessionCommandFactory, times(1)).newRedoCommand();
+        assertEquals(IconType.UNDO, command.getIcon());
+        assertEquals(IconRotate.ROTATE_180, command.getIconRotate());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SwitchGridToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SwitchGridToolbarCommandTest.java
@@ -20,7 +20,7 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,30 +32,35 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class SwitchGridToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Redo Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private SwitchGridSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private SwitchGridToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newSwitchGridCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.SWITCH_GRID)).thenReturn(TEXT);
+        command = new SwitchGridToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        verify(sessionCommandFactory, times(1)).newSwitchGridCommand();
+        assertEquals(IconType.TH, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());
+    }
+
+    @Test
+    public void testDoDestroy() {
+        command.doDestroy();
+        verify(sessionCommand, times(1)).unbind();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/UndoToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/UndoToolbarCommandTest.java
@@ -20,7 +20,7 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,28 +32,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class UndoToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Redo Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private UndoSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private UndoToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newUndoCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.UNDO)).thenReturn(TEXT);
+        command = new UndoToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        verify(sessionCommandFactory, times(1)).newUndoCommand();
+        assertEquals(IconType.UNDO, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ValidateToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ValidateToolbarCommandTest.java
@@ -20,7 +20,7 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,28 +32,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class ValidateToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Redo Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private ValidateSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private ValidateToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newValidateCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.VALIDATE)).thenReturn(TEXT);
+        command = new ValidateToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        verify(sessionCommandFactory, times(1)).newValidateCommand();
+        assertEquals(IconType.CHECK, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/VisitGraphToolbarCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/VisitGraphToolbarCommandTest.java
@@ -20,7 +20,7 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,28 +32,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportToPngToolbarCommandTest extends AbstractToolbarCommandTest {
+public class VisitGraphToolbarCommandTest extends AbstractToolbarCommandTest {
 
-    private static final String TEXT = "Export PNG";
+    private static final String TEXT = "Redo Toolbar";
 
     @Mock
-    private ExportToPngSessionCommand sessionCommand;
+    private VisitGraphSessionCommand sessionCommand;
 
-    private ExportToPngToolbarCommand command;
+    private VisitGraphToolbarCommand command;
 
     @Before
     public void setUp() throws Exception {
-        when(sessionCommandFactory.newExportToPngSessionCommand()).thenReturn(sessionCommand);
+        when(sessionCommandFactory.newVisitGraphCommand()).thenReturn(sessionCommand);
 
-        when(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)).thenReturn(TEXT);
-        command = new ExportToPngToolbarCommand(sessionCommandFactory, translationService);
+        when(translationService.getValue(CoreTranslationMessages.VISIT_GRAPH)).thenReturn(TEXT);
+        command = new VisitGraphToolbarCommand(sessionCommandFactory, translationService);
     }
 
     @Test
     public void testInstance() {
-        verify(sessionCommandFactory,
-               times(1)).newExportToPngSessionCommand();
-        assertEquals(IconType.FILE_IMAGE_O, command.getIcon());
+        verify(sessionCommandFactory, times(1)).newVisitGraphCommand();
+        assertEquals(IconType.AUTOMOBILE, command.getIcon());
         assertFalse(command.requiresConfirm());
         assertEquals(TEXT, command.getCaption());
         assertEquals(TEXT, command.getTooltip());


### PR DESCRIPTION
cherry-picks #1587 

Add unit test for each toolbar command and
verify instance of these commands are correctly created.