### PR TITLE
[7.7.x] RHPAM-845 (JBPM-7129) - Stunner - Allow optional size constraints for shapes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlersTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlersTest.java
@@ -68,9 +68,10 @@ public class DMNViewHandlersTest {
         handler.handle(view,
                        shape);
 
-        verify(shape).setSizeConstraints(eq(Width.MIN),
-                                         eq(Height.MIN),
-                                         eq(Width.MAX),
-                                         eq(Height.MAX));
+        verify(shape).setMinWidth(eq(Width.MIN));
+        verify(shape).setMaxWidth(eq(Width.MAX));
+        verify(shape).setMinHeight(eq(Height.MIN));
+        verify(shape).setMaxHeight(eq(Height.MAX));
+
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresContainerShapeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresContainerShapeView.java
@@ -63,9 +63,4 @@ public class WiresContainerShapeView<T extends WiresContainerShapeView>
         this.getChildren().forEach(WiresContainerShapeView::destroy);
         super.preDestroy();
     }
-
-    @SuppressWarnings("unchecked")
-    protected T cast() {
-        return (T) this;
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeView.java
@@ -22,7 +22,6 @@ import com.ait.lienzo.client.core.shape.Shape;
 import com.ait.lienzo.client.core.shape.wires.ControlHandleList;
 import com.ait.lienzo.client.core.shape.wires.IControlHandle;
 import com.ait.lienzo.client.core.shape.wires.WiresShapeControlHandleList;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.ViewEventHandlerManager;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresScalableContainer;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
@@ -105,19 +104,31 @@ public class DecoratedShapeView<T extends WiresShapeViewExt>
                              width,
                              height);
         refresh();
-        return (T) this;
+        return cast();
     }
 
     @Override
-    public T setSizeConstraints(final double minWidth,
-                                final double minHeight,
-                                final double maxWidth,
-                                final double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
-        return (T) this;
+    public T setMinWidth(Double minWidth) {
+        getPath().setMinWidth(minWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMaxWidth(Double maxWidth) {
+        getPath().setMaxWidth(maxWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMinHeight(Double minHeight) {
+        getPath().setMinHeight(minHeight);
+        return cast();
+    }
+
+    @Override
+    public T setMaxHeight(Double maxHeight) {
+        getPath().setMaxHeight(maxHeight);
+        return cast();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -428,7 +428,7 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     }
 
     @SuppressWarnings("unchecked")
-    private T cast() {
+    protected T cast() {
         return (T) this;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasRadiusView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasRadiusView.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.shapes.client.view;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasRadius;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
@@ -31,14 +30,21 @@ public abstract class AbstractHasRadiusView<T extends AbstractHasRadiusView> ext
     }
 
     @Override
-    public T setRadiusConstraints(double minRadius, double maxRadius) {
+    public T setMinRadius(Double minRadius) {
         double minDiameter = minRadius * 2;
+
+        getPath().setMinWidth(minDiameter)
+                .setMinHeight(minDiameter);
+
+        return cast();
+    }
+
+    @Override
+    public T setMaxRadius(Double maxRadius) {
         double maxDiameter = maxRadius * 2;
 
-        getPath().setSizeConstraints(new BoundingBox(minDiameter,
-                                                     minDiameter,
-                                                     maxDiameter,
-                                                     maxDiameter));
+        getPath().setMaxWidth(maxDiameter)
+                .setMaxHeight(maxDiameter);
 
         return cast();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasSizeView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/src/main/java/org/kie/workbench/common/stunner/shapes/client/view/AbstractHasSizeView.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.shapes.client.view;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
@@ -31,11 +30,26 @@ public abstract class AbstractHasSizeView<T extends AbstractHasSizeView> extends
     }
 
     @Override
-    public T setSizeConstraints(double minWidth, double minHeight, double maxWidth, double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
+    public T setMinWidth(Double minWidth) {
+        getPath().setMaxHeight(minWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMaxWidth(Double maxWidth) {
+        getPath().setMaxHeight(maxWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMinHeight(Double minHeight) {
+        getPath().setMaxHeight(minHeight);
+        return cast();
+    }
+
+    @Override
+    public T setMaxHeight(Double maxHeight) {
+        getPath().setMaxHeight(maxHeight);
         return cast();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasRadius.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasRadius.java
@@ -20,6 +20,7 @@ public interface HasRadius<T> {
 
     T setRadius(final double radius);
 
-    T setRadiusConstraints(final double minRadius,
-                           final double maxRadius);
+    T setMinRadius(final Double minRadius);
+
+    T setMaxRadius(final Double maxRadius);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasSize.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasSize.java
@@ -21,8 +21,8 @@ public interface HasSize<T> {
     T setSize(final double width,
               final double height);
 
-    T setSizeConstraints(final double minWidth,
-                         final double minHeight,
-                         final double maxWidth,
-                         final double maxHeight);
+    T setMinWidth (final Double minWidth);
+    T setMaxWidth (final Double maxWidth);
+    T setMinHeight (final Double minHeight);
+    T setMaxHeight (final Double maxHeight);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
@@ -75,18 +75,33 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
             final Double beanWidth = widthProvider.apply(bean);
             final Double beanHeight = heightProvider.apply(bean);
             final double width = null != beanWidth ? beanWidth : boundsWidth;
-            final double minWidth = minWidthProvider.apply(bean);
-            final double maxWidth = maxWidthProvider.apply(bean);
             final double height = null != beanHeight ? beanHeight : boundsHeight;
-            final double minHeight = minHeightProvider.apply(bean);
-            final double maxHeight = maxHeightProvider.apply(bean);
+            final Double minWidth = minWidthProvider.apply(bean);
+            final Double maxWidth = maxWidthProvider.apply(bean);
+            final Double minHeight = minHeightProvider.apply(bean);
+            final Double maxHeight = maxHeightProvider.apply(bean);
+
+            HasSize hasSizeView = (HasSize)view;
+
             if (width > 0 && height > 0) {
-                ((HasSize) view).setSize(width, height);
-            }
-            if (minWidth > 0 && minHeight > 0 && maxWidth > 0 && maxHeight > 0) {
-                ((HasSize) view).setSizeConstraints(minWidth, minHeight, maxWidth, maxHeight);
+                hasSizeView.setSize(width, height);
             }
 
+            if (isValidSizeConstraint(minWidth)) {
+                hasSizeView.setMinWidth(minWidth);
+            }
+
+            if (isValidSizeConstraint(maxWidth)) {
+                hasSizeView.setMaxWidth(maxWidth);
+            }
+
+            if (isValidSizeConstraint(minHeight)) {
+                hasSizeView.setMinHeight(minHeight);
+            }
+
+            if (isValidSizeConstraint(maxHeight)) {
+                hasSizeView.setMaxHeight(maxHeight);
+            }
         }
         if (view instanceof HasRadius) {
             final Double beanRadius = radiusProvider.apply(bean);
@@ -94,15 +109,32 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
                     (boundsWidth > boundsHeight ?
                         boundsWidth / 2 :
                         boundsHeight / 2);
-            final double minRadius = minRadiusProvider.apply(bean);
-            final double maxRadius = maxRadiusProvider.apply(bean);
+            final Double minRadius = minRadiusProvider.apply(bean);
+            final Double maxRadius = maxRadiusProvider.apply(bean);
             if (radius > 0) {
                 ((HasRadius) view).setRadius(radius);
             }
-            if (minRadius > 0 && maxRadius > 0) {
-                ((HasRadius) view).setRadiusConstraints(minRadius, maxRadius);
+
+            if (isValidSizeConstraint(minRadius)) {
+                ((HasRadius) view).setMinRadius(minRadius);
+            }
+
+            if (isValidSizeConstraint(maxRadius)) {
+                ((HasRadius) view).setMaxRadius(maxRadius);
             }
         }
+    }
+
+    private static boolean isValidSizeConstraint(Double value) {
+        if (value == null) {
+            return true;
+        }
+
+        if (value > 0) {
+            return true;
+        }
+
+        return false;
     }
 
     public static class Builder<W, V extends ShapeView> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
@@ -125,8 +125,12 @@ public class ShapeViewExtStub
     }
 
     @Override
-    public Object setRadiusConstraints(final double minRadius,
-                                       final double maxRadius) {
+    public Object setMinRadius(Double minRadius) {
+        return this;
+    }
+
+    @Override
+    public Object setMaxRadius(Double maxRadius) {
         return this;
     }
 
@@ -137,10 +141,22 @@ public class ShapeViewExtStub
     }
 
     @Override
-    public Object setSizeConstraints(final double minWidth,
-                                     final double minHeight,
-                                     final double maxWidth,
-                                     final double maxHeight) {
+    public Object setMinWidth(Double minWidth) {
+        return this;
+    }
+
+    @Override
+    public Object setMaxWidth(Double minWidth) {
+        return this;
+    }
+
+    @Override
+    public Object setMinHeight(Double minWidth) {
+        return this;
+    }
+
+    @Override
+    public Object setMaxHeight(Double minWidth) {
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/SizeHandlerTest.java
@@ -27,6 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -97,21 +98,53 @@ public class SizeHandlerTest {
         final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, never()).setSizeConstraints(anyDouble(), anyDouble(), anyDouble(), anyDouble());
+        verify(view, never()).setMinWidth(anyDouble());
+        verify(view, never()).setMaxWidth(anyDouble());
+        verify(view, never()).setMinHeight(anyDouble());
+        verify(view, never()).setMaxHeight(anyDouble());
+
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minWidth(o -> -10d)
+                .maxWidth(o -> -10d)
+                .minHeight(o -> -100d)
+                .maxHeight(o -> -100d)
+                .build();
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, never()).setMinWidth(anyDouble());
+        verify(view, never()).setMaxWidth(anyDouble());
+        verify(view, never()).setMinHeight(anyDouble());
+        verify(view, never()).setMaxHeight(anyDouble());
     }
 
     @Test
     public void testHandleValidSizeConstraints() {
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minWidth(o -> null)
+                .maxWidth(o -> null)
+                .minHeight(o -> null)
+                .maxHeight(o -> null)
+                .build();
+        final Object bean = mock(Object.class);
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, times(1)).setMinWidth(isNull(Double.class));
+        verify(view, times(1)).setMaxWidth(isNull(Double.class));
+        verify(view, times(1)).setMinHeight(isNull(Double.class));
+        verify(view, times(1)).setMaxHeight(isNull(Double.class));
+
         tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
                 .minWidth(o -> 10d)
                 .maxWidth(o -> 100d)
                 .minHeight(o -> 10d)
                 .maxHeight(o -> 100d)
                 .build();
-        final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, times(1)).setSizeConstraints(10d, 10d, 100d, 100d);
+        verify(view, times(1)).setMinWidth(10d);
+        verify(view, times(1)).setMaxWidth(100d);
+        verify(view, times(1)).setMinHeight(10d);
+        verify(view, times(1)).setMaxHeight(100d);
     }
 
     @Test
@@ -123,18 +156,38 @@ public class SizeHandlerTest {
         final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, never()).setRadiusConstraints(anyDouble(), anyDouble());
+        verify(view, never()).setMinRadius(anyDouble());
+        verify(view, never()).setMaxRadius(anyDouble());
+
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minRadius(o -> -10d)
+                .maxRadius(o -> -100d)
+                .build();
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, never()).setMinRadius(anyDouble());
+        verify(view, never()).setMaxRadius(anyDouble());
     }
 
     @Test
     public void testHandleValidRadiusConstraints() {
         tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
-                .minRadius(o -> 10d)
-                .maxRadius(o -> 100d)
+                .minRadius(o -> null)
+                .maxRadius(o -> null)
                 .build();
         final Object bean = mock(Object.class);
         tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
 
-        verify(view, times(1)).setRadiusConstraints(10d, 100d);
+        verify(view, times(1)).setMinRadius(isNull(Double.class));
+        verify(view, times(1)).setMaxRadius(isNull(Double.class));
+
+        tested = new SizeHandler.Builder<Object, ShapeViewExtStub>()
+                .minRadius(o -> 10d)
+                .maxRadius(o -> 100d)
+                .build();
+        tested.handle(new ViewImpl<>(bean, BoundsImpl.build()), view);
+
+        verify(view, times(1)).setMinRadius(10d);
+        verify(view, times(1)).setMaxRadius(100d);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/AbstractCaseManagementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/AbstractCaseManagementShape.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
@@ -92,14 +91,26 @@ public abstract class AbstractCaseManagementShape<T extends WiresContainerShapeV
     }
 
     @Override
-    public T setSizeConstraints(final double minWidth,
-                                final double minHeight,
-                                final double maxWidth,
-                                final double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
+    public T setMinWidth(Double minWidth) {
+        getPath().setMinWidth(minWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMaxWidth(Double maxWidth) {
+        getPath().setMaxWidth(maxWidth);
+        return cast();
+    }
+
+    @Override
+    public T setMinHeight(Double minHeight) {
+        getPath().setMinHeight(minHeight);
+        return cast();
+    }
+
+    @Override
+    public T setMaxHeight(Double maxHeight) {
+        getPath().setMaxHeight(maxHeight);
         return cast();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/MockCaseManagementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/MockCaseManagementShape.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.cm.client.wires;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresContainerShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 
@@ -41,18 +40,6 @@ public class MockCaseManagementShape extends AbstractCaseManagementShape<WiresCo
     @Override
     public WiresContainerShapeView setSize(double width,
                                            double height) {
-        return this;
-    }
-
-    @Override
-    public WiresContainerShapeView setSizeConstraints(final double minWidth,
-                                                      final double minHeight,
-                                                      final double maxWidth,
-                                                      final double maxHeight) {
-        getPath().setSizeConstraints(new BoundingBox(minWidth,
-                                                     minHeight,
-                                                     maxWidth,
-                                                     maxHeight));
         return this;
     }
 }


### PR DESCRIPTION
Issue:
[RHPAM-845](https://issues.jboss.org/browse/RHPAM-845)
[JBPM-7129](https://issues.jboss.org/browse/JBPM-7129) 

Cherry-pick:
commit fbd29158037907e593a4656e0686b26941570e81

**This PR depends on kiegroup/lienzo-core.**

**7.7.x Branch PR's:**
kiegroup/kie-wb-common
[_this one_](https://github.com/kiegroup/kie-wb-common/pull/1677)
kiegroup/lienzo-core:
https://github.com/kiegroup/lienzo-core/pull/20
kiegroup/lienzo-tests
https://github.com/kiegroup/lienzo-tests/pull/16

**Master PR's:**
_kiegroup/kie-wb-common_
https://github.com/kiegroup/kie-wb-common/pull/1641
_kiegroup/lienzo-core:_
https://github.com/kiegroup/lienzo-core/pull/18
_kiegroup/lienzo-tests_
https://github.com/kiegroup/lienzo-tests/pull/14

@romartin 