### PR TITLE
JBPM 6491 - [Stunner] Improve usability and user experience when using connectors

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeAction.java
@@ -147,10 +147,12 @@ public class CreateNodeAction extends AbstractToolboxAction {
                                                                targetNode))
                         .deferCommand(() -> addEdge(canvasHandler,
                                                     sourceNode,
+                                                    targetNode,
                                                     connector))
                         .deferCommand(() -> setEdgeTarget(canvasHandler,
                                                           connector,
-                                                          targetNode));
+                                                          targetNode,
+                                                          sourceNode));
 
         final CommandResult result =
                 sessionCommandManager.execute(canvasHandler,
@@ -178,19 +180,21 @@ public class CreateNodeAction extends AbstractToolboxAction {
 
     private CanvasCommand<AbstractCanvasHandler> addEdge(final AbstractCanvasHandler canvasHandler,
                                                          final Node<View<?>, Edge> sourceNode,
+                                                         final Node<View<?>, Edge> targetNode,
                                                          final Edge<? extends ViewConnector<?>, Node> connector) {
         return canvasCommandFactory.addConnector(sourceNode,
                                                  connector,
-                                                 MagnetConnection.Builder.forElement(sourceNode),
+                                                 MagnetConnection.Builder.forElement(sourceNode, targetNode),
                                                  canvasHandler.getDiagram().getMetadata().getShapeSetId());
     }
 
     private CanvasCommand<AbstractCanvasHandler> setEdgeTarget(final AbstractCanvasHandler canvasHandler,
                                                                final Edge<? extends ViewConnector<?>, Node> connector,
-                                                               final Node<View<?>, Edge> targetNode) {
+                                                               final Node<View<?>, Edge> targetNode,
+                                                               final Node<View<?>, Edge> sourceNode) {
         return canvasCommandFactory.setTargetNode(targetNode,
                                                   connector,
-                                                  MagnetConnection.Builder.forElement(targetNode));
+                                                  MagnetConnection.Builder.forElement(targetNode, sourceNode));
     }
 
     private CanvasCommand<AbstractCanvasHandler> addNode(final AbstractCanvasHandler canvasHandler,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeActionTest.java
@@ -48,6 +48,7 @@ import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
@@ -58,6 +59,7 @@ import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyString;
@@ -170,9 +172,9 @@ public class CreateNodeActionTest {
                                            new BoundImpl(100d,
                                                          100d)));
         when(targetNodeContent.getBounds())
-                .thenReturn(new BoundsImpl(new BoundImpl(0d,
+                .thenReturn(new BoundsImpl(new BoundImpl(10d,
                                                          0d),
-                                           new BoundImpl(100d,
+                                           new BoundImpl(200d,
                                                          100d)));
         when(clientFactoryManager.newElement(anyString(),
                                              eq(EDGE_ID)))
@@ -257,5 +259,10 @@ public class CreateNodeActionTest {
         final CanvasSelectionEvent eCaptured = eventArgumentCaptor.getValue();
         assertEquals(TARGET_NODE_UUID,
                      eCaptured.getIdentifiers().iterator().next());
+
+        assertTrue(addConnectorCommand.getConnection() instanceof MagnetConnection);
+        assertEquals(((MagnetConnection) addConnectorCommand.getConnection()).getMagnetIndex().getAsInt(), MagnetConnection.MAGNET_RIGHT);
+        assertTrue(setTargetNodeCommand.getConnection() instanceof MagnetConnection);
+        assertEquals(((MagnetConnection) setTargetNodeCommand.getConnection()).getMagnetIndex().getAsInt(), MagnetConnection.MAGNET_LEFT);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnection.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnection.java
@@ -16,10 +16,13 @@
 
 package org.kie.workbench.common.stunner.core.graph.content.view;
 
+import java.util.Objects;
+
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
@@ -28,6 +31,8 @@ import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull
 public class MagnetConnection extends DiscreteConnection {
 
     public static final int MAGNET_CENTER = 0;
+    public static final int MAGNET_RIGHT = 2;
+    public static final int MAGNET_LEFT = 4;
 
     private Point2D location;
     private Boolean auto;
@@ -38,6 +43,10 @@ public class MagnetConnection extends DiscreteConnection {
                      auto);
         this.location = location;
         this.auto = auto;
+    }
+
+    private MagnetConnection(int index) {
+        setIndex(index);
     }
 
     public MagnetConnection setLocation(final Point2D location) {
@@ -146,10 +155,15 @@ public class MagnetConnection extends DiscreteConnection {
                     new Point2D(width / 2,
                                 height / 2) :
                     null;
-            final MagnetConnection center = new MagnetConnection(at,
-                                                                 false);
-            center.setIndex(MAGNET_CENTER);
-            return center;
+            return new MagnetConnection(MAGNET_CENTER).setLocation(at).setAuto(false);
+        }
+
+        public static MagnetConnection forElement(final Element<? extends View<?>> element, final Element<? extends View<?>> connectedTo) {
+            final Point2D elementPosition = GraphUtils.getPosition(element.getContent());
+            final Point2D connectedToPosition = (Objects.nonNull(connectedTo) ? GraphUtils.getPosition(connectedTo.getContent()) : elementPosition);
+            final int index = (elementPosition.getX() > connectedToPosition.getX() ? MAGNET_LEFT : MAGNET_RIGHT);
+            return new MagnetConnection(index).setAuto(false);
         }
     }
 }
+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnectionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnectionTest.java
@@ -16,19 +16,42 @@
 
 package org.kie.workbench.common.stunner.core.graph.content.view;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MagnetConnectionTest {
+
+    @Mock
+    private Element element;
+
+    @Mock
+    private Element element2;
+
+    @Mock
+    private View<?> content;
+    @Mock
+    private View<?> content2;
+
+    @Before
+    public void setUp() {
+        BoundsImpl bounds = new BoundsImpl(new BoundImpl(10d,
+                                                         20d),
+                                           new BoundImpl(100d,
+                                                         200d));
+        when(element.getContent()).thenReturn(content);
+        when(content.getBounds()).thenReturn(bounds);
+    }
 
     @Test
     public void testForLocation() {
@@ -45,14 +68,6 @@ public class MagnetConnectionTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testForElement() {
-        Element element = mock(Element.class);
-        View<?> content = mock(View.class);
-        BoundsImpl bounds = new BoundsImpl(new BoundImpl(10d,
-                                                         20d),
-                                           new BoundImpl(100d,
-                                                         200d));
-        when(element.getContent()).thenReturn(content);
-        when(content.getBounds()).thenReturn(bounds);
         MagnetConnection m1 = MagnetConnection.Builder.forElement(element);
 
         assertEquals(45,
@@ -62,6 +77,40 @@ public class MagnetConnectionTest {
                      m1.getLocation().getY(),
                      0);
         assertEquals(MagnetConnection.MAGNET_CENTER,
+                     m1.getMagnetIndex().getAsInt());
+        assertFalse(m1.isAuto());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testForElementWithReferenceRight() {
+        BoundsImpl bounds2 = new BoundsImpl(new BoundImpl(20d,
+                                                          30d),
+                                            new BoundImpl(200d,
+                                                          300d));
+        when(element2.getContent()).thenReturn(content2);
+        when(content2.getBounds()).thenReturn(bounds2);
+
+        MagnetConnection m1 = MagnetConnection.Builder.forElement(element, element2);
+        assertNull(m1.getLocation());
+        assertEquals(MagnetConnection.MAGNET_RIGHT,
+                     m1.getMagnetIndex().getAsInt());
+        assertFalse(m1.isAuto());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testForElementWithReferenceLeft() {
+        BoundsImpl bounds2 = new BoundsImpl(new BoundImpl(5d,
+                                                          10d),
+                                            new BoundImpl(200d,
+                                                          300d));
+        when(element2.getContent()).thenReturn(content2);
+        when(content2.getBounds()).thenReturn(bounds2);
+
+        MagnetConnection m1 = MagnetConnection.Builder.forElement(element, element2);
+        assertNull(m1.getLocation());
+        assertEquals(MagnetConnection.MAGNET_LEFT,
                      m1.getMagnetIndex().getAsInt());
         assertFalse(m1.isAuto());
     }


### PR DESCRIPTION
When creating sequence flows using gateways, now the default magnet assigned to the nodes consider the position to choose left or right magnet index. This is a quick win, maybe it can have more detailed rules to assign default connectors considering other restrictions, IMO this should be specified and handled on a new JIRA, after the release. WDYT ?
@romartin 
@LuboTerifaj 

Thanks.