### PR TITLE
JBPM-7134: Stunner - Do not notify User about no commands to redo

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
@@ -64,14 +64,16 @@ public class CopySelectionSessionCommand extends AbstractSelectionAwareSessionCo
     }
 
     protected void onKeyDownEvent(final Key... keys) {
-        handleCtrlC(keys);
+        if (isEnabled()) {
+            handleCtrlC(keys);
+        }
     }
 
-    private void handleCtrlC(Key[] keys) {
+    private void handleCtrlC(final Key[] keys) {
         if (doKeysMatch(keys,
                         Key.CONTROL,
                         Key.C)) {
-            this.execute(newDefaultCallback("Error while trying to copy selected items."));
+            this.execute();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CutSelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CutSelectionSessionCommand.java
@@ -76,14 +76,16 @@ public class CutSelectionSessionCommand extends AbstractSelectionAwareSessionCom
     }
 
     protected void onKeyDownEvent(final Key... keys) {
-        handleCtrlX(keys);
+        if (isEnabled()) {
+            handleCtrlX(keys);
+        }
     }
 
-    private void handleCtrlX(Key[] keys) {
+    private void handleCtrlX(final Key[] keys) {
         if (doKeysMatch(keys,
                         Key.CONTROL,
                         Key.X)) {
-            this.execute(newDefaultCallback("Error while trying to cut selected items."));
+            this.execute();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommand.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
 import java.util.Collection;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -26,7 +25,6 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementsClearEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
@@ -43,6 +41,7 @@ import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.graph.Element;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import static org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher.doKeysMatch;
 
 /**
  * This session command obtains the selected elements on session and executes a delete operation for each one.
@@ -111,22 +110,16 @@ public class DeleteSelectionSessionCommand extends AbstractSelectionAwareSession
         }
     }
 
-    void onKeyDownEvent(final KeyboardEvent.Key... keys) {
-        if (KeysMatcher.doKeysMatch(keys,
-                                    KeyboardEvent.Key.DELETE)) {
-            DeleteSelectionSessionCommand.this.execute(new Callback<ClientRuntimeError>() {
-                @Override
-                public void onSuccess() {
-                    // Nothing to do.
-                }
+    protected void onKeyDownEvent(final KeyboardEvent.Key... keys) {
+        if (isEnabled()) {
+            handleDelete(keys);
+        }
+    }
 
-                @Override
-                public void onError(final ClientRuntimeError error) {
-                    LOGGER.log(Level.SEVERE,
-                               "Error while trying to delete selected items. Message=[" + error.toString() + "]",
-                               error.getThrowable());
-                }
-            });
+    private void handleDelete(final KeyboardEvent.Key... keys) {
+        if (doKeysMatch(keys,
+                        KeyboardEvent.Key.DELETE)) {
+            this.execute();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
@@ -105,12 +105,16 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<C
     }
 
     void onKeyDownEvent(final Key... keys) {
-        handleCtrlV(keys);
+        if (isEnabled()) {
+            handleCtrlV(keys);
+        }
     }
 
-    private void handleCtrlV(Key[] keys) {
-        if (doKeysMatch(keys, Key.CONTROL, Key.V)) {
-            this.execute(newDefaultCallback("Error while trying to paste selected items. Message="));
+    private void handleCtrlV(final Key[] keys) {
+        if (doKeysMatch(keys,
+                        Key.CONTROL,
+                        Key.V)) {
+            this.execute();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
@@ -21,7 +21,6 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -36,6 +35,7 @@ import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.command.util.RedoCommandHandler;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import static org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher.doKeysMatch;
 
 @Dependent
 public class RedoSessionCommand extends AbstractClientSessionCommand<ClientFullSession> {
@@ -59,18 +59,22 @@ public class RedoSessionCommand extends AbstractClientSessionCommand<ClientFullS
     @Override
     public void bind(final ClientFullSession session) {
         super.bind(session);
-        session.getKeyboardControl().addKeyShortcutCallback(keys -> {
-            if (isRedoShortcut(keys)) {
-                RedoSessionCommand.this.execute();
-            }
-        });
+        session.getKeyboardControl().addKeyShortcutCallback(this::onKeyDownEvent);
     }
 
-    private boolean isRedoShortcut(final KeyboardEvent.Key... keys) {
-        return KeysMatcher.doKeysMatch(keys,
-                                       KeyboardEvent.Key.CONTROL,
-                                       KeyboardEvent.Key.SHIFT,
-                                       KeyboardEvent.Key.Z);
+    void onKeyDownEvent(final KeyboardEvent.Key... keys) {
+        if (isEnabled()) {
+            handleCtrlShiftZ(keys);
+        }
+    }
+
+    private void handleCtrlShiftZ(final KeyboardEvent.Key[] keys) {
+        if (doKeysMatch(keys,
+                        KeyboardEvent.Key.CONTROL,
+                        KeyboardEvent.Key.SHIFT,
+                        KeyboardEvent.Key.Z)) {
+            this.execute();
+        }
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
@@ -23,7 +23,6 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -36,6 +35,7 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import static org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher.doKeysMatch;
 
 @Dependent
 public class UndoSessionCommand extends AbstractClientSessionCommand<ClientFullSession> {
@@ -55,17 +55,21 @@ public class UndoSessionCommand extends AbstractClientSessionCommand<ClientFullS
     @Override
     public void bind(final ClientFullSession session) {
         super.bind(session);
-        session.getKeyboardControl().addKeyShortcutCallback(keys -> {
-            if (isUndoShortcut(keys)) {
-                UndoSessionCommand.this.execute();
-            }
-        });
+        session.getKeyboardControl().addKeyShortcutCallback(this::onKeyDownEvent);
     }
 
-    private boolean isUndoShortcut(final KeyboardEvent.Key... keys) {
-        return KeysMatcher.doKeysMatch(keys,
-                                       KeyboardEvent.Key.CONTROL,
-                                       KeyboardEvent.Key.Z);
+    void onKeyDownEvent(final KeyboardEvent.Key... keys) {
+        if (isEnabled()) {
+            handleCtrlZ(keys);
+        }
+    }
+
+    private void handleCtrlZ(final KeyboardEvent.Key[] keys) {
+        if (doKeysMatch(keys,
+                        KeyboardEvent.Key.CONTROL,
+                        KeyboardEvent.Key.Z)) {
+            this.execute();
+        }
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
@@ -36,6 +36,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -82,6 +83,8 @@ public abstract class BaseSessionCommandKeyboardTest {
     @Test
     @SuppressWarnings("unchecked")
     public void checkRespondsToExpectedKeys() {
+        doReturn(true).when(command).isEnabled();
+
         command.bind(session);
 
         verify(keyboardControl,
@@ -92,6 +95,22 @@ public abstract class BaseSessionCommandKeyboardTest {
 
         verify(command,
                times(1)).execute(any(ClientSessionCommand.Callback.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkDoesNotRespondToExpectedKeysWhenDisabled() {
+        doReturn(false).when(command).isEnabled();
+
+        command.bind(session);
+
+        verify(keyboardControl,
+               times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(getExpectedKeys());
+
+        verify(command, never()).execute(any(ClientSessionCommand.Callback.class));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 
@@ -84,7 +85,7 @@ public class RedoCommandHandler<C extends Command> {
     public CommandResult<?> execute(final Object context,
                                     final CommandManager commandManager) {
         if (registry.isEmpty()) {
-            throw new IllegalStateException("Not possible to execute a command: no commands to redo.");
+            return GraphCommandResultBuilder.SUCCESS;
         }
 
         final C last = registry.peek();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandlerTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 import org.kie.workbench.common.stunner.core.registry.impl.CommandRegistryImpl;
@@ -33,8 +34,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -101,7 +105,7 @@ public class RedoCommandHandlerTest {
                                 eq(command1));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void testExecuteOnNull() {
         Object obj = mock(Object.class);
@@ -110,8 +114,10 @@ public class RedoCommandHandlerTest {
         when(commandRegistry.isEmpty()).thenReturn(true);
 
         tested = new RedoCommandHandler(registryFactory);
-        tested.execute(obj,
-                       manager);
+
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     tested.execute(obj, manager));
+        verify(manager, never()).execute(anyObject(), any(Command.class));
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-7134

I removed the use of ```IllegalStateException``` in ```RedoCommandHandler``` however also made all the ```AbstractSelectionAwareSessionCommand``` implementations only invoke the command in response to a keys match **if** the command itself is **enabled**. This IMO is a better fix than simply not throwing the exception.