### PR TITLE
JBPM-7181: Stunner - When change name widget disappear by timeout all changes made are lost

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateAttributeAnimationHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateAttributeAnimationHandler.java
@@ -137,7 +137,7 @@ public class ShapeStateAttributeAnimationHandler<V extends LienzoShapeView>
                     public void onClose(final IAnimation animation,
                                         final IAnimationHandle handle) {
                         super.onClose(animation, handle);
-                        if (!animationHandle.isRunning()) {
+                        if (null != animationHandle && !animationHandle.isRunning()) {
                             setAnimationHandle(null);
                             completeCallback.execute();
                         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateAttributeAnimationHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateAttributeAnimationHandlerTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import com.ait.lienzo.client.core.animation.AnimationCallback;
 import com.ait.lienzo.client.core.animation.AnimationProperties;
 import com.ait.lienzo.client.core.animation.AnimationTweener;
+import com.ait.lienzo.client.core.animation.IAnimation;
 import com.ait.lienzo.client.core.animation.IAnimationHandle;
 import com.ait.lienzo.client.core.shape.Shape;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
@@ -30,12 +31,14 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.LienzoShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ShapeStateAttributesFactory;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -82,6 +85,20 @@ public class ShapeStateAttributeAnimationHandlerTest {
         tested.reset();
         verify(animationHandle, times(1)).stop();
         assertEquals(ShapeState.NONE, tested.getShapeState());
+    }
+
+    @Test
+    public void testApplyStateAnimationWithResetBeforeAnimationCompletes() {
+        final ArgumentCaptor<AnimationCallback> animationCallbackCaptor = ArgumentCaptor.forClass(AnimationCallback.class);
+        tested.applyState(ShapeState.SELECTED);
+        verify(shape, times(1)).animate(any(AnimationTweener.class),
+                                        any(AnimationProperties.class),
+                                        anyDouble(),
+                                        animationCallbackCaptor.capture());
+        tested.reset();
+
+        final AnimationCallback animationCallback = animationCallbackCaptor.getValue();
+        animationCallback.onClose(mock(IAnimation.class), mock(IAnimationHandle.class));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/AbstractTextEditorBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/AbstractTextEditorBox.java
@@ -83,6 +83,13 @@ public abstract class AbstractTextEditorBox implements TextEditorBoxView.Present
     // TODO: Check command result.
     @Override
     public void onSave() {
+        flush();
+        getView().hide();
+        fireCloseCallback();
+    }
+
+    @Override
+    public void flush() {
         if (null != this.value) {
             final TextPropertyProvider textPropertyProvider = textPropertyProviderFactory.getProvider(element);
             textPropertyProvider.setText(canvasHandler,
@@ -90,8 +97,6 @@ public abstract class AbstractTextEditorBox implements TextEditorBoxView.Present
                                          element,
                                          value);
         }
-        getView().hide();
-        fireCloseCallback();
     }
 
     @Override
@@ -130,6 +135,16 @@ public abstract class AbstractTextEditorBox implements TextEditorBoxView.Present
         this.value = value;
         // Enter key produces save.
         if ((KeyCodes.KEY_ENTER == keyCode) && (!shiftKeyPressed)) {
+            onSave();
+        }
+    }
+
+    @Override
+    public void onKeyDown(final int keyCode,
+                          final String value) {
+        this.value = value;
+        // Tab key produces save.
+        if (KeyCodes.KEY_TAB == keyCode) {
             onSave();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/AbstractTextEditorBoxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/AbstractTextEditorBoxView.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Event;
@@ -108,5 +109,9 @@ public abstract class AbstractTextEditorBoxView<T extends TextEditorBoxView.Pres
     @EventHandler("closeButton")
     public void onClose(ClickEvent clickEvent) {
         presenter.onClose();
+    }
+
+    protected void scheduleDeferredCommand(final Scheduler.ScheduledCommand command) {
+        Scheduler.get().scheduleDeferred(command);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBoxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorBoxView.java
@@ -41,6 +41,9 @@ public interface TextEditorBoxView extends UberElement<TextEditorBoxView.Present
                         final boolean shiftKeyPressed,
                         final String value);
 
+        void onKeyDown(final int keyCode,
+                       final String value);
+
         String getNameValue();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxView.java
@@ -84,7 +84,7 @@ public class TextEditorMultiLineBoxView
     }
 
     @EventHandler("nameField")
-    @SinkNative(Event.ONCHANGE | Event.ONKEYPRESS)
+    @SinkNative(Event.ONCHANGE | Event.ONKEYPRESS | Event.ONKEYDOWN)
     public void onChangeName(Event event) {
         switch (event.getTypeInt()) {
             case Event.ONCHANGE:
@@ -95,6 +95,9 @@ public class TextEditorMultiLineBoxView
                                      event.getShiftKey(),
                                      nameField.getValue());
                 break;
+            case Event.ONKEYDOWN:
+                //Defer processing of KeyDownEvent until after KeyPress has been processed as we write the value to the Presenter from the TextArea.
+                scheduleDeferredCommand(() -> presenter.onKeyDown(event.getKeyCode(), nameField.getValue()));
         }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxView.java
@@ -83,7 +83,7 @@ public class TextEditorSingleLineBoxView
     }
 
     @EventHandler("nameField")
-    @SinkNative(Event.ONCHANGE | Event.ONKEYPRESS)
+    @SinkNative(Event.ONCHANGE | Event.ONKEYPRESS | Event.ONKEYDOWN)
     public void onChangeName(Event event) {
         switch (event.getTypeInt()) {
             case Event.ONCHANGE:
@@ -94,6 +94,9 @@ public class TextEditorSingleLineBoxView
                                      false,
                                      nameField.getValue());
                 break;
+            case Event.ONKEYDOWN:
+                //Defer processing of KeyDownEvent until after KeyPress has been processed as we write the value to the Presenter from the TextInput.
+                scheduleDeferredCommand(() -> presenter.onKeyDown(event.getKeyCode(), nameField.getValue()));
         }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBoxTest.java
@@ -123,6 +123,19 @@ public class TextEditorMultiLineBoxTest {
     }
 
     @Test
+    public void testSaveByPressingTab() {
+        presenter.onKeyDown(KeyCodes.KEY_T,
+                            MODIFIED_NAME);
+
+        verifyNameNotSaved();
+
+        presenter.onKeyDown(KeyCodes.KEY_TAB,
+                            MODIFIED_NAME);
+
+        verifyNameSaved();
+    }
+
+    @Test
     public void testSaveByPressingButton() {
         presenter.onChangeName(MODIFIED_NAME);
 
@@ -131,6 +144,15 @@ public class TextEditorMultiLineBoxTest {
         presenter.onSave();
 
         verifyNameSaved();
+    }
+
+    @Test
+    public void testFlush() {
+        presenter.onChangeName(MODIFIED_NAME);
+
+        presenter.flush();
+
+        verifyNameFlushed();
     }
 
     @Test
@@ -187,8 +209,14 @@ public class TextEditorMultiLineBoxTest {
                never()).execute();
     }
 
-    @SuppressWarnings("unchecked")
     protected void verifyNameSaved() {
+        verifyNameFlushed();
+        verify(view).hide();
+        verify(closeCallback).execute();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void verifyNameFlushed() {
         assertEquals(MODIFIED_NAME,
                      presenter.getNameValue());
 
@@ -200,7 +228,5 @@ public class TextEditorMultiLineBoxTest {
         verify(commandProvider).getCommandManager();
         verify(canvasCommandManager).execute(any(),
                                              any());
-        verify(view).hide();
-        verify(closeCallback).execute();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxTest.java
@@ -123,6 +123,19 @@ public class TextEditorSingleLineBoxTest {
     }
 
     @Test
+    public void testSaveByPressingTab() {
+        presenter.onKeyDown(KeyCodes.KEY_T,
+                            MODIFIED_NAME);
+
+        verifyNameNotSaved();
+
+        presenter.onKeyDown(KeyCodes.KEY_TAB,
+                            MODIFIED_NAME);
+
+        verifyNameSaved();
+    }
+
+    @Test
     public void testSaveByPressingButton() {
         presenter.onChangeName(MODIFIED_NAME);
 
@@ -131,6 +144,15 @@ public class TextEditorSingleLineBoxTest {
         presenter.onSave();
 
         verifyNameSaved();
+    }
+
+    @Test
+    public void testFlush() {
+        presenter.onChangeName(MODIFIED_NAME);
+
+        presenter.flush();
+
+        verifyNameFlushed();
     }
 
     @Test
@@ -187,8 +209,14 @@ public class TextEditorSingleLineBoxTest {
                never()).execute();
     }
 
-    @SuppressWarnings("unchecked")
     protected void verifyNameSaved() {
+        verifyNameFlushed();
+        verify(view).hide();
+        verify(closeCallback).execute();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void verifyNameFlushed() {
         assertEquals(MODIFIED_NAME,
                      presenter.getNameValue());
 
@@ -200,7 +228,5 @@ public class TextEditorSingleLineBoxTest {
         verify(commandProvider).getCommandManager();
         verify(canvasCommandManager).execute(any(),
                                              any());
-        verify(view).hide();
-        verify(closeCallback).execute();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBoxViewTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Event;
@@ -31,9 +32,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,8 +90,13 @@ public class TextEditorSingleLineBoxViewTest {
     @Before
     @SuppressWarnings("unchecked")
     public void init() {
-        this.tested = new TextEditorSingleLineBoxView(translationService, editNameBox, nameField, showCommand, hideCommand, closeButton, saveButton);
+        this.tested = spy(new TextEditorSingleLineBoxView(translationService, editNameBox, nameField, showCommand, hideCommand, closeButton, saveButton));
         this.tested.init(presenter);
+
+        doAnswer(i -> {
+            ((Scheduler.ScheduledCommand) i.getArguments()[0]).execute();
+            return null;
+        }).when(tested).scheduleDeferredCommand(any(Scheduler.ScheduledCommand.class));
     }
 
     @Test
@@ -102,7 +110,6 @@ public class TextEditorSingleLineBoxViewTest {
 
     @Test
     public void testInitialize() {
-
         tested.initialize();
         verify(nameField,
                times(1)).setAttribute(eq("placeHolder"), anyString());
@@ -125,21 +132,32 @@ public class TextEditorSingleLineBoxViewTest {
 
     @Test
     public void testOnChangeNameChangeEvent() {
+        when(nameField.getValue()).thenReturn(NAME);
         when(event.getTypeInt()).thenReturn(Event.ONCHANGE);
         tested.onChangeName(event);
-        verify(presenter, times(1)).onChangeName(anyString());
+        verify(presenter, times(1)).onChangeName(eq(NAME));
     }
 
     @Test
     public void testOnChangeNameKeyPressEvent() {
+        when(nameField.getValue()).thenReturn(NAME);
         when(event.getTypeInt()).thenReturn(Event.ONKEYPRESS);
+        when(event.getKeyCode()).thenReturn(KeyCodes.KEY_A);
         tested.onChangeName(event);
-        verify(presenter, times(1)).onKeyPress(anyInt(), eq(false), anyString());
+        verify(presenter, times(1)).onKeyPress(eq(KeyCodes.KEY_A), eq(false), eq(NAME));
+    }
+
+    @Test
+    public void testOnChangeNameKeyDownEvent() {
+        when(nameField.getValue()).thenReturn(NAME);
+        when(event.getTypeInt()).thenReturn(Event.ONKEYDOWN);
+        when(event.getKeyCode()).thenReturn(KeyCodes.KEY_A);
+        tested.onChangeName(event);
+        verify(presenter, times(1)).onKeyDown(eq(KeyCodes.KEY_A), eq(NAME));
     }
 
     @Test
     public void testShow() {
-
         tested.show(NAME);
 
         verify(nameField,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControl.java
@@ -20,6 +20,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -27,6 +28,8 @@ import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasHandlerRegistrationControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher;
 import org.kie.workbench.common.stunner.core.client.canvas.event.CanvasFocusedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasShapeRemovedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.components.views.FloatingView;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
@@ -53,12 +56,13 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
         extends AbstractCanvasHandlerRegistrationControl<AbstractCanvasHandler>
         implements CanvasInPlaceTextEditorControl<AbstractCanvasHandler, AbstractClientFullSession, Element> {
 
-    private static final int FLOATING_VIEW_TIMEOUT = 3000;
-    private static final double SHAPE_EDIT_ALPHA = 0.2d;
+    static final int FLOATING_VIEW_TIMEOUT = 3000;
+    static final double SHAPE_EDIT_ALPHA = 0.2d;
+    static final double SHAPE_NOT_EDIT_ALPHA = 1.0d;
 
     private String uuid;
 
-    private final Command floatingHideCallback = AbstractCanvasInPlaceTextEditorControl.this::hide;
+    private final Command hideFloatingViewOnTimeoutCommand = this::flush;
 
     protected abstract FloatingView<IsWidget> getFloatingView();
 
@@ -89,9 +93,13 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
 
         getFloatingView()
                 .hide()
-                .setHideCallback(floatingHideCallback)
+                .setHideCallback(hideFloatingViewOnTimeoutCommand)
                 .setTimeOut(FLOATING_VIEW_TIMEOUT)
-                .add(ElementWrapperWidget.getWidget(getTextEditorBox().getElement()));
+                .add(wrapTextEditorBoxElement(getTextEditorBox().getElement()));
+    }
+
+    protected IsWidget wrapTextEditorBoxElement(final HTMLElement element) {
+        return ElementWrapperWidget.getWidget(element);
     }
 
     @Override
@@ -115,30 +123,32 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
                                                     clickHandler);
                         registerHandler(shape.getUUID(),
                                         clickHandler);
-                        // Change mouse cursor, if shape supports it.
-                        if (hasEventHandlers.supports(ViewEventType.TEXT_ENTER) &&
-                                hasEventHandlers.supports(ViewEventType.TEXT_EXIT)) {
-                            final TextEnterHandler enterHandler = new TextEnterHandler() {
-                                @Override
-                                public void handle(TextEnterEvent event) {
-                                    canvasHandler.getAbstractCanvas().getView().setCursor(AbstractCanvas.Cursors.TEXT);
-                                }
-                            };
-                            hasEventHandlers.addHandler(ViewEventType.TEXT_ENTER,
-                                                        enterHandler);
-                            registerHandler(shape.getUUID(),
-                                            enterHandler);
-                            final TextExitHandler exitHandler = new TextExitHandler() {
-                                @Override
-                                public void handle(TextExitEvent event) {
-                                    canvasHandler.getAbstractCanvas().getView().setCursor(AbstractCanvas.Cursors.AUTO);
-                                }
-                            };
-                            hasEventHandlers.addHandler(ViewEventType.TEXT_EXIT,
-                                                        exitHandler);
-                            registerHandler(shape.getUUID(),
-                                            exitHandler);
-                        }
+                    }
+
+                    // Change mouse cursor, if shape supports it.
+                    if (hasEventHandlers.supports(ViewEventType.TEXT_ENTER)) {
+                        final TextEnterHandler enterHandler = new TextEnterHandler() {
+                            @Override
+                            public void handle(TextEnterEvent event) {
+                                canvasHandler.getAbstractCanvas().getView().setCursor(AbstractCanvas.Cursors.TEXT);
+                            }
+                        };
+                        hasEventHandlers.addHandler(ViewEventType.TEXT_ENTER,
+                                                    enterHandler);
+                        registerHandler(shape.getUUID(),
+                                        enterHandler);
+                    }
+                    if (hasEventHandlers.supports(ViewEventType.TEXT_EXIT)) {
+                        final TextExitHandler exitHandler = new TextExitHandler() {
+                            @Override
+                            public void handle(TextExitEvent event) {
+                                canvasHandler.getAbstractCanvas().getView().setCursor(AbstractCanvas.Cursors.AUTO);
+                            }
+                        };
+                        hasEventHandlers.addHandler(ViewEventType.TEXT_EXIT,
+                                                    exitHandler);
+                        registerHandler(shape.getUUID(),
+                                        exitHandler);
                     }
                 }
             }
@@ -150,7 +160,7 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
                                                                                                           final double x,
                                                                                                           final double y) {
         if (getTextEditorBox().isVisible()) {
-            this.hide();
+            flush();
         }
         this.uuid = item.getUUID();
         enableShapeEdit();
@@ -211,7 +221,7 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
         final Shape<?> shape = getShape(this.uuid);
         if (null != shape) {
             final HasTitle hasTitle = (HasTitle) shape.getShapeView();
-            final double alpha = editMode ? SHAPE_EDIT_ALPHA : 1d;
+            final double alpha = editMode ? SHAPE_EDIT_ALPHA : SHAPE_NOT_EDIT_ALPHA;
             shape.getShapeView().setFillAlpha(alpha);
             hasTitle.setTitleAlpha(alpha);
             getCanvas().draw();
@@ -240,9 +250,26 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
         }
     }
 
+    void onCanvasClearSelectionEvent(final @Observes CanvasClearSelectionEvent event) {
+        checkNotNull("event",
+                     event);
+        flush();
+    }
+
+    void onCanvasShapeRemovedEvent(final @Observes CanvasShapeRemovedEvent event) {
+        checkNotNull("event",
+                     event);
+        flush();
+    }
+
     void onCanvasFocusedEvent(final @Observes CanvasFocusedEvent canvasFocusedEvent) {
         checkNotNull("canvasFocusedEvent",
                      canvasFocusedEvent);
+        flush();
+    }
+
+    void flush() {
+        getTextEditorBox().flush();
         hide();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextEditorBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextEditorBox.java
@@ -34,6 +34,8 @@ public interface TextEditorBox<C extends CanvasHandler, E extends Element>
     boolean isVisible();
 
     void hide();
+
+    void flush();
 }
 
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/views/FloatingWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/views/FloatingWidgetView.java
@@ -175,7 +175,7 @@ public class FloatingWidgetView implements FloatingView<IsWidget> {
             timer = new Timer() {
                 @Override
                 public void run() {
-                    FloatingWidgetView.this.doHide();
+                    FloatingWidgetView.this.hide();
                 }
             };
             timer.schedule(timeout);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.event.CanvasFocusedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasShapeRemovedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
+import org.kie.workbench.common.stunner.core.client.components.views.FloatingView;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractClientFullSession;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasEventHandlers;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextDoubleClickEvent;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextDoubleClickHandler;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextEnterEvent;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextEnterHandler;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitEvent;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitHandler;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class AbstractCanvasInPlaceTextEditorControlTest<C extends AbstractCanvasInPlaceTextEditorControl> {
+
+    private static final String UUID = "uuid";
+
+    private static final double X = 10.0;
+
+    private static final double Y = 20.0;
+
+    @Mock
+    protected FloatingView<IsWidget> floatingView;
+
+    @Mock
+    protected TextEditorBox<AbstractCanvasHandler, Element> textEditorBox;
+
+    @Mock
+    protected HTMLElement textEditBoxElement;
+
+    @Mock
+    protected IsWidget textEditBoxWidget;
+
+    @Mock
+    protected EventSourceMock<CanvasSelectionEvent> canvasSelectionEvent;
+
+    @Mock
+    protected AbstractClientFullSession session;
+
+    @Mock
+    protected KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
+
+    @Mock
+    protected AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    protected Canvas canvas;
+
+    @Mock
+    protected AbstractCanvas abstractCanvas;
+
+    @Mock
+    protected AbstractCanvas.View abstractCanvasView;
+
+    @Mock
+    protected Element element;
+
+    @Mock
+    protected Shape shape;
+
+    @Mock
+    protected TestShapeView testShapeView;
+
+    @Mock
+    protected View shapeView;
+
+    @Mock
+    protected RequiresCommandManager.CommandManagerProvider<AbstractCanvasHandler> commandManagerProvider;
+
+    protected Bounds shapeViewBounds = BoundsImpl.build();
+
+    @Captor
+    protected ArgumentCaptor<KeyboardControl.KeyShortcutCallback> keyShortcutCallbackCaptor;
+
+    @Captor
+    protected ArgumentCaptor<Command> commandCaptor;
+
+    @Captor
+    protected ArgumentCaptor<CanvasSelectionEvent> canvasSelectionEventCaptor;
+
+    @Captor
+    protected ArgumentCaptor<TextDoubleClickHandler> textDoubleClickHandlerCaptor;
+
+    @Captor
+    protected ArgumentCaptor<TextEnterHandler> textEnterHandlerCaptor;
+
+    @Captor
+    protected ArgumentCaptor<TextExitHandler> textExitHandlerCaptor;
+
+    protected C control;
+
+    interface TestShapeView extends ShapeView,
+                                    HasTitle,
+                                    HasEventHandlers {
+
+    }
+
+    @Before
+    public void setup() {
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+        when(floatingView.hide()).thenReturn(floatingView);
+        when(floatingView.setHideCallback(any(Command.class))).thenReturn(floatingView);
+        when(floatingView.setTimeOut(anyInt())).thenReturn(floatingView);
+        when(floatingView.setX(anyDouble())).thenReturn(floatingView);
+        when(floatingView.setY(anyDouble())).thenReturn(floatingView);
+        when(textEditorBox.getElement()).thenReturn(textEditBoxElement);
+        when(element.getUUID()).thenReturn(UUID);
+        when(element.getContent()).thenReturn(shapeView);
+        when(shapeView.getBounds()).thenReturn(shapeViewBounds);
+        when(canvasHandler.getCanvas()).thenReturn(canvas);
+        when(canvasHandler.getAbstractCanvas()).thenReturn(abstractCanvas);
+        when(abstractCanvas.getView()).thenReturn(abstractCanvasView);
+        when(canvas.getShape(eq(UUID))).thenReturn(shape);
+        when(shape.getUUID()).thenReturn(UUID);
+        when(shape.getShapeView()).thenReturn(testShapeView);
+
+        this.control = spy(getControl());
+
+        doReturn(textEditBoxWidget).when(control).wrapTextEditorBoxElement(eq(textEditBoxElement));
+    }
+
+    protected abstract C getControl();
+
+    @Test
+    public void testBind() {
+        control.bind(session);
+
+        verify(keyboardControl).addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class));
+    }
+
+    @Test
+    public void testBindKeyControlHandledKey() {
+        control.bind(session);
+
+        verify(keyboardControl).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyboardControl.KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.ESC);
+
+        verify(control).onKeyDownEvent(eq(KeyboardEvent.Key.ESC));
+
+        verify(control).hide();
+    }
+
+    @Test
+    public void testBindKeyControlUnhandledKey() {
+        control.bind(session);
+
+        verify(keyboardControl).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
+
+        final KeyboardControl.KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
+        keyShortcutCallback.onKeyShortcut(KeyboardEvent.Key.ARROW_DOWN);
+
+        verify(control).onKeyDownEvent(eq(KeyboardEvent.Key.ARROW_DOWN));
+
+        verify(control, never()).hide();
+    }
+
+    @Test
+    public void testEnable() {
+        control.enable(canvasHandler);
+
+        verify(textEditorBox).initialize(eq(canvasHandler),
+                                         any(Command.class));
+        verify(floatingView).hide();
+        verify(floatingView).setHideCallback(any(Command.class));
+        verify(floatingView).setTimeOut(AbstractCanvasInPlaceTextEditorControl.FLOATING_VIEW_TIMEOUT);
+        verify(floatingView).add(textEditBoxWidget);
+    }
+
+    @Test
+    public void testEnableCloseCallback() {
+        control.enable(canvasHandler);
+
+        verify(textEditorBox).initialize(eq(canvasHandler),
+                                         commandCaptor.capture());
+
+        final Command command = commandCaptor.getValue();
+        command.execute();
+
+        verify(control).hide();
+        verify(canvasSelectionEvent).fire(canvasSelectionEventCaptor.capture());
+
+        final CanvasSelectionEvent cse = canvasSelectionEventCaptor.getValue();
+        assertEquals(canvasHandler,
+                     cse.getCanvasHandler());
+    }
+
+    @Test
+    public void testEnableTimeoutCallback() {
+        control.enable(canvasHandler);
+
+        verify(floatingView).setHideCallback(commandCaptor.capture());
+
+        final Command command = commandCaptor.getValue();
+        command.execute();
+
+        verify(textEditorBox).flush();
+    }
+
+    @Test
+    public void testRegisterDoubleClickHandler() {
+        control.enable(canvasHandler);
+
+        when(testShapeView.supports(ViewEventType.TEXT_DBL_CLICK)).thenReturn(true);
+
+        control.register(element);
+
+        //We cannot check AbstractCanvasHandlerRegistrationControl.registerHandler(..) is called; so this is the next best thing
+        assertTrue(control.isRegistered(element));
+
+        verify(testShapeView).addHandler(eq(ViewEventType.TEXT_DBL_CLICK),
+                                         textDoubleClickHandlerCaptor.capture());
+        final TextDoubleClickHandler textDoubleClickHandler = textDoubleClickHandlerCaptor.getValue();
+        textDoubleClickHandler.handle(new TextDoubleClickEvent(0, 1, X, Y));
+
+        verify(control).show(eq(element),
+                             eq(X),
+                             eq(Y));
+    }
+
+    @Test
+    public void testRegisterTextEnter() {
+        control.enable(canvasHandler);
+
+        when(testShapeView.supports(ViewEventType.TEXT_ENTER)).thenReturn(true);
+
+        control.register(element);
+
+        //We cannot check AbstractCanvasHandlerRegistrationControl.registerHandler(..) is called; so this is the next best thing
+        assertTrue(control.isRegistered(element));
+
+        verify(testShapeView).addHandler(eq(ViewEventType.TEXT_ENTER),
+                                         textEnterHandlerCaptor.capture());
+        final TextEnterHandler textEnterHandler = textEnterHandlerCaptor.getValue();
+        textEnterHandler.handle(new TextEnterEvent(0, 1, X, Y));
+        verify(abstractCanvasView).setCursor(eq(AbstractCanvas.Cursors.TEXT));
+    }
+
+    @Test
+    public void testRegisterTextExit() {
+        control.enable(canvasHandler);
+
+        when(testShapeView.supports(ViewEventType.TEXT_EXIT)).thenReturn(true);
+
+        control.register(element);
+
+        //We cannot check AbstractCanvasHandlerRegistrationControl.registerHandler(..) is called; so this is the next best thing
+        assertTrue(control.isRegistered(element));
+
+        verify(testShapeView).addHandler(eq(ViewEventType.TEXT_EXIT),
+                                         textExitHandlerCaptor.capture());
+        final TextExitHandler textExitHandler = textExitHandlerCaptor.getValue();
+        textExitHandler.handle(new TextExitEvent(0, 1, X, Y));
+        verify(abstractCanvasView).setCursor(eq(AbstractCanvas.Cursors.AUTO));
+    }
+
+    @Test
+    public void testShowWhenAlreadyShown() {
+        control.enable(canvasHandler);
+
+        when(textEditorBox.isVisible()).thenReturn(true);
+
+        control.show(element, X, Y);
+
+        verify(textEditorBox).flush();
+        assertShow();
+    }
+
+    @Test
+    public void testShowWhenNotAlreadyShown() {
+        control.enable(canvasHandler);
+
+        when(textEditorBox.isVisible()).thenReturn(false);
+
+        control.show(element, X, Y);
+
+        assertShow();
+    }
+
+    @Test
+    public void testHideWhenIsVisible() {
+        control.enable(canvasHandler);
+
+        control.show(element, X, Y);
+
+        reset(textEditorBox, floatingView);
+
+        when(textEditorBox.isVisible()).thenReturn(true);
+
+        control.hide();
+
+        assertHide(1);
+    }
+
+    @Test
+    public void testHideWhenIsNotVisible() {
+        control.enable(canvasHandler);
+
+        reset(textEditorBox, floatingView);
+
+        when(textEditorBox.isVisible()).thenReturn(false);
+
+        control.hide();
+
+        assertHide(0);
+    }
+
+    @Test
+    public void testSetCommandManagerProvider() {
+        control.setCommandManagerProvider(commandManagerProvider);
+
+        verify(textEditorBox).setCommandManagerProvider(eq(commandManagerProvider));
+    }
+
+    @Test
+    public void testDoDisableWhenShown() {
+        control.enable(canvasHandler);
+        control.show(element, X, Y);
+
+        reset(textEditorBox, floatingView);
+
+        control.doDisable();
+
+        verify(testShapeView).setFillAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_NOT_EDIT_ALPHA));
+        verify(testShapeView).setTitleAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_NOT_EDIT_ALPHA));
+        verify(textEditorBox).hide();
+    }
+
+    @Test
+    public void testDoDisableWhenNotShown() {
+        control.doDisable();
+
+        verify(textEditorBox).hide();
+    }
+
+    @Test
+    public void testFinal() {
+        try {
+            control.finalize();
+
+            verify(floatingView).destroy();
+        } catch (Throwable t) {
+            fail(t.getMessage());
+        }
+    }
+
+    @Test
+    public void testOnCanvasClearSelectionEvent() {
+        control.onCanvasClearSelectionEvent(new CanvasClearSelectionEvent(canvasHandler));
+
+        verify(control).flush();
+    }
+
+    @Test
+    public void testOnCanvasShapeRemovedEvent() {
+        control.onCanvasShapeRemovedEvent(new CanvasShapeRemovedEvent(canvas, shape));
+
+        verify(control).flush();
+    }
+
+    @Test
+    public void testOnCanvasFocusedEvent() {
+        control.onCanvasFocusedEvent(new CanvasFocusedEvent(canvas));
+
+        verify(control).flush();
+    }
+
+    private void assertShow() {
+        verify(testShapeView).setFillAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_EDIT_ALPHA));
+        verify(testShapeView).setTitleAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_EDIT_ALPHA));
+        verify(canvas).draw();
+
+        verify(textEditorBox).show(eq(element));
+
+        verify(floatingView).setX(eq(X));
+        verify(floatingView).setY(eq(Y));
+        verify(floatingView).show();
+    }
+
+    private void assertHide(final int t) {
+        verify(testShapeView, times(t)).setFillAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_NOT_EDIT_ALPHA));
+        verify(testShapeView, times(t)).setTitleAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_NOT_EDIT_ALPHA));
+
+        verify(textEditorBox, times(t)).hide();
+        verify(floatingView, times(t)).hide();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlMultiLineTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlMultiLineTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
+
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CanvasInPlaceTextEditorControlMultiLineTest extends AbstractCanvasInPlaceTextEditorControlTest<CanvasInPlaceTextEditorControlMultiLine> {
+
+    @Override
+    protected CanvasInPlaceTextEditorControlMultiLine getControl() {
+        return new CanvasInPlaceTextEditorControlMultiLine(floatingView,
+                                                           textEditorBox,
+                                                           canvasSelectionEvent);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlSingleLineTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/CanvasInPlaceTextEditorControlSingleLineTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
+
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CanvasInPlaceTextEditorControlSingleLineTest extends AbstractCanvasInPlaceTextEditorControlTest<CanvasInPlaceTextEditorControlSingleLine> {
+
+    @Override
+    protected CanvasInPlaceTextEditorControlSingleLine getControl() {
+        return new CanvasInPlaceTextEditorControlSingleLine(floatingView,
+                                                            textEditorBox,
+                                                            canvasSelectionEvent);
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-7181

I fixed the reported issues and also added support for writing back updated text when ```tab``` is pressed.