### PR TITLE
[RHBA-685-7.7.x]: Redirected to Spaces when Organizational Unit is not active

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-client/src/test/java/org/guvnor/ala/ui/client/provider/status/runtime/RuntimePresenterActionsTest.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-client/src/test/java/org/guvnor/ala/ui/client/provider/status/runtime/RuntimePresenterActionsTest.java
@@ -216,7 +216,7 @@ public class RuntimePresenterActionsTest
                times(1)).error(any(Message.class),
                                exceptionCaptor.capture());
         assertEquals(ERROR_MESSAGE,
-                     exceptionCaptor.getValue().getCause().getMessage());
+                     exceptionCaptor.getValue().getMessage());
     }
 
     @Test
@@ -265,7 +265,7 @@ public class RuntimePresenterActionsTest
                times(1)).error(any(Message.class),
                                exceptionCaptor.capture());
         assertEquals(ERROR_MESSAGE,
-                     exceptionCaptor.getValue().getCause().getMessage());
+                     exceptionCaptor.getValue().getMessage());
         verify(popupHelper,
                times(1)).showBusyIndicator(BUSY_POPUP_MESSAGE);
         verify(popupHelper,
@@ -321,9 +321,9 @@ public class RuntimePresenterActionsTest
         RuntimeKey currentKey = runtime.getKey();
 
         RuntimeException deleteException = new RuntimeException(ERROR_MESSAGE);
-        //needs to use null instead of ERROR_MESSAGE because of the CallerMock
+
         when(translationService.format(RuntimePresenter_RuntimeDeleteFailedMessage,
-                                       null)).thenReturn(CONFIRM_MESSAGE_2);
+                                       ERROR_MESSAGE)).thenReturn(CONFIRM_MESSAGE_2);
         when(translationService.getTranslation(RuntimePresenter_RuntimeDeleteFailedTitle)).thenReturn(TITLE_2);
         when(translationService.getTranslation(RuntimePresenter_RuntimeDeletingMessage)).thenReturn(BUSY_POPUP_MESSAGE);
 
@@ -361,9 +361,9 @@ public class RuntimePresenterActionsTest
         RuntimeKey currentKey = runtime.getKey();
 
         RuntimeException deleteException = new RuntimeException(ERROR_MESSAGE);
-        //needs to use null instead of ERROR_MESSAGE because of the CallerMock
+
         when(translationService.format(RuntimePresenter_RuntimeDeleteFailedMessage,
-                                       null)).thenReturn(CONFIRM_MESSAGE_2);
+                                       ERROR_MESSAGE)).thenReturn(CONFIRM_MESSAGE_2);
         when(translationService.getTranslation(RuntimePresenter_RuntimeDeleteFailedTitle)).thenReturn(TITLE_2);
 
         when(translationService.getTranslation(RuntimePresenter_RuntimeConfirmForcedDeleteTitle)).thenReturn(TITLE_3);
@@ -463,7 +463,7 @@ public class RuntimePresenterActionsTest
                times(1)).error(any(Message.class),
                                exceptionCaptor.capture());
         assertEquals(ERROR_MESSAGE,
-                     exceptionCaptor.getValue().getCause().getMessage());
+                     exceptionCaptor.getValue().getMessage());
         verify(popupHelper,
                times(1)).showBusyIndicator(BUSY_POPUP_MESSAGE);
         verify(popupHelper,
@@ -536,7 +536,7 @@ public class RuntimePresenterActionsTest
                times(1)).error(any(Message.class),
                                exceptionCaptor.capture());
         assertEquals(ERROR_MESSAGE,
-                     exceptionCaptor.getValue().getCause().getMessage());
+                     exceptionCaptor.getValue().getMessage());
     }
 
     @Test
@@ -615,7 +615,7 @@ public class RuntimePresenterActionsTest
                times(1)).error(any(Message.class),
                                exceptionCaptor.capture());
         assertEquals(ERROR_MESSAGE,
-                     exceptionCaptor.getValue().getCause().getMessage());
+                     exceptionCaptor.getValue().getMessage());
     }
 
     private void preparePipelineDelete() {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -48,6 +47,7 @@ import org.guvnor.structure.repositories.RepositoryRemovedEvent;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.security.shared.exception.UnauthorizedException;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.screens.examples.model.ExampleProject;
@@ -109,17 +109,17 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
     public static final String ADD_ASSET_SCREEN = "AddAssetsScreen";
 
     public static final List<String> LIBRARY_PLACES = Arrays.asList(
-        LIBRARY_SCREEN,
-        ORG_UNITS_METRICS_SCREEN,
-        PROJECT_SCREEN,
-        PROJECT_METRICS_SCREEN,
-        PROJECT_DETAIL_SCREEN,
-        ORGANIZATIONAL_UNITS_SCREEN,
-        PROJECT_SETTINGS,
-        ADD_ASSET_SCREEN,
-        IMPORT_PROJECTS_SCREEN,
-        IMPORT_SAMPLE_PROJECTS_SCREEN,
-        PreferencesRootScreen.IDENTIFIER
+            LIBRARY_SCREEN,
+            ORG_UNITS_METRICS_SCREEN,
+            PROJECT_SCREEN,
+            PROJECT_METRICS_SCREEN,
+            PROJECT_DETAIL_SCREEN,
+            ORGANIZATIONAL_UNITS_SCREEN,
+            PROJECT_SETTINGS,
+            ADD_ASSET_SCREEN,
+            IMPORT_PROJECTS_SCREEN,
+            IMPORT_SAMPLE_PROJECTS_SCREEN,
+            PreferencesRootScreen.IDENTIFIER
     );
 
     private UberfireBreadcrumbs breadcrumbs;
@@ -570,14 +570,20 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
     public void goToLibrary() {
         if (!projectContext.getActiveOrganizationalUnit().isPresent()) {
             libraryService.call(
-                    new RemoteCallback<OrganizationalUnit>() {
-                        @Override
-                        public void callback(OrganizationalUnit organizationalUnit) {
-                            projectContextChangeEvent.fire(new WorkspaceProjectContextChangeEvent(organizationalUnit));
-                            setupLibraryPerspective();
+                    (RemoteCallback<OrganizationalUnit>) organizationalUnit -> {
+                        projectContextChangeEvent.fire(new WorkspaceProjectContextChangeEvent(organizationalUnit));
+                        setupLibraryPerspective();
+                    },
+                    (message, throwable) -> {
+                        try {
+                            throw throwable;
+                        } catch (UnauthorizedException ue) {
+                            this.goToOrganizationalUnits();
+                            return false;
+                        } catch (Throwable t) {
+                            return true; // Let default error handling happen.
                         }
-                    }
-            ).getDefaultOrganizationalUnit();
+                    }).getDefaultOrganizationalUnit();
         } else {
             setupLibraryPerspective();
         }
@@ -827,7 +833,7 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
         closingLibraryPlaces = false;
     }
 
-    public WorkspaceProject getActiveWorkspaceContext(){
+    public WorkspaceProject getActiveWorkspaceContext() {
         return this.projectContext.getActiveWorkspaceProject().orElseThrow(() -> new IllegalStateException("No active workspace project found"));
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/PersistencePresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/PersistencePresenterTest.java
@@ -161,7 +161,7 @@ public class PersistencePresenterTest {
                                                    return promises.resolve();
                                                },
                                                (final Promises.Error<?> e1) -> {
-                                                   Assert.assertEquals(e1.getThrowable().getCause(),
+                                                   Assert.assertEquals(e1.getThrowable(),
                                                                        testException);
                                                    return promises.resolve();
                                                }));

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
@@ -17,12 +17,9 @@
 package org.kie.workbench.common.screens.library.client.util;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Optional;
 import java.util.Set;
-
 import javax.enterprise.event.Event;
 
 import org.ext.uberfire.social.activities.model.ExtendedTypes;
@@ -41,6 +38,7 @@ import org.guvnor.structure.repositories.Branch;
 import org.guvnor.structure.repositories.Repository;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.security.shared.exception.UnauthorizedException;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -607,6 +605,14 @@ public class LibraryPlacesTest {
     }
 
     @Test
+    public void goToLibraryWhenUserIsNotAuthorizedToCreateProjectsTest() {
+        doReturn(Optional.ofNullable(null)).when(projectContext).getActiveOrganizationalUnit();
+        when(libraryService.getDefaultOrganizationalUnit()).thenThrow(new UnauthorizedException());
+        libraryPlaces.goToLibrary();
+        verify(libraryPlaces).goToOrganizationalUnits();
+    }
+
+    @Test
     public void goToProjectTest() {
         final PlaceRequest projectScreen = new DefaultPlaceRequest(LibraryPlaces.PROJECT_SCREEN);
         final PartDefinitionImpl part = new PartDefinitionImpl(projectScreen);
@@ -665,7 +671,8 @@ public class LibraryPlacesTest {
     @Test
     public void goToExternalImportProjectsTest() {
         doAnswer(inv -> {
-            final Command command = inv.getArgumentAt(0, Command.class);
+            final Command command = inv.getArgumentAt(0,
+                                                      Command.class);
             command.execute();
             return null;
         }).when(libraryPlaces).closeAllPlacesOrNothing(any());
@@ -847,7 +854,10 @@ public class LibraryPlacesTest {
         verify(placeManager).closeAllPlaces();
         verify(successCallback).execute();
         verify(closeUnsavedProjectAssetsPopUpPresenter,
-               never()).show(any(), any(), any(), any());
+               never()).show(any(),
+                             any(),
+                             any(),
+                             any());
     }
 
     @Test


### PR DESCRIPTION
If an user has no rights to create a Space, the default project could not be created. So the exception was catch and redirected to SpacesScreen to select another Space where the user has rights to see and edit.

Related to:
https://github.com/kiegroup/appformer/pull/328
https://github.com/kiegroup/kie-wb-common/pull/1715