### PR TITLE
JBPM-7180: Stunner - Name change widget appear in wrong position for containers

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorMultiLineBox.java
@@ -25,6 +25,10 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.Mult
 @MultiLineTextEditorBox
 public class TextEditorMultiLineBox extends AbstractTextEditorBox {
 
+    private static final double OFFSET_X = 90.0;
+
+    private static final double OFFSET_Y = 40.0;
+
     private final TextEditorBoxView view;
 
     @Inject
@@ -35,5 +39,15 @@ public class TextEditorMultiLineBox extends AbstractTextEditorBox {
     @Override
     protected TextEditorBoxView getView() {
         return view;
+    }
+
+    @Override
+    public double getDisplayOffsetX() {
+        return OFFSET_X;
+    }
+
+    @Override
+    public double getDisplayOffsetY() {
+        return OFFSET_Y;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/TextEditorSingleLineBox.java
@@ -25,6 +25,10 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.Sing
 @SingleLineTextEditorBox
 public class TextEditorSingleLineBox extends AbstractTextEditorBox {
 
+    private static final double OFFSET_X = 70.0;
+
+    private static final double OFFSET_Y = 20.0;
+
     private final TextEditorBoxView view;
 
     @Inject
@@ -35,5 +39,15 @@ public class TextEditorSingleLineBox extends AbstractTextEditorBox {
     @Override
     protected TextEditorBoxView getView() {
         return view;
+    }
+
+    @Override
+    public double getDisplayOffsetX() {
+        return OFFSET_X;
+    }
+
+    @Override
+    public double getDisplayOffsetY() {
+        return OFFSET_Y;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControl.java
@@ -46,8 +46,6 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitEve
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.content.view.View;
-import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 import org.uberfire.mvp.Command;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
@@ -165,16 +163,13 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
         this.uuid = item.getUUID();
         enableShapeEdit();
         getTextEditorBox().show(item);
-        double[] size;
-        try {
-            size = GraphUtils.getNodeSize((View) item.getContent());
-        } catch (final ClassCastException e) {
-            size = null;
-        }
-        final double rx = null != size ? size[0] / 2 : 0d;
+        final double offsetX = getTextEditorBox().getDisplayOffsetX();
+        final double offsetY = getTextEditorBox().getDisplayOffsetY();
         getFloatingView()
-                .setX(x - rx)
+                .setX(x)
                 .setY(y)
+                .setOffsetX(-offsetX)
+                .setOffsetY(-offsetY)
                 .show();
         return this;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextEditorBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextEditorBox.java
@@ -36,6 +36,14 @@ public interface TextEditorBox<C extends CanvasHandler, E extends Element>
     void hide();
 
     void flush();
+
+    default double getDisplayOffsetX() {
+        return 0.0;
+    }
+
+    default double getDisplayOffsetY() {
+        return 0.0;
+    }
 }
 
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
@@ -163,6 +163,8 @@ public abstract class AbstractCanvasInPlaceTextEditorControlTest<C extends Abstr
         when(floatingView.setTimeOut(anyInt())).thenReturn(floatingView);
         when(floatingView.setX(anyDouble())).thenReturn(floatingView);
         when(floatingView.setY(anyDouble())).thenReturn(floatingView);
+        when(floatingView.setOffsetX(anyDouble())).thenReturn(floatingView);
+        when(floatingView.setOffsetY(anyDouble())).thenReturn(floatingView);
         when(textEditorBox.getElement()).thenReturn(textEditBoxElement);
         when(element.getUUID()).thenReturn(UUID);
         when(element.getContent()).thenReturn(shapeView);
@@ -442,6 +444,8 @@ public abstract class AbstractCanvasInPlaceTextEditorControlTest<C extends Abstr
 
         verify(floatingView).setX(eq(X));
         verify(floatingView).setY(eq(Y));
+        verify(floatingView).setOffsetX(eq(-textEditorBox.getDisplayOffsetX()));
+        verify(floatingView).setOffsetY(eq(-textEditorBox.getDisplayOffsetY()));
         verify(floatingView).show();
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-7180

@tiagodolphine Would you mind taking a look please?

The issue was that the in-place popup was being positioned at the mouse co-ordinate less half the width/height of the containers bounds - which is a really strange thing to do. Ideally the popup should be positioned at the mouse co-ordinate less half the popups height/width; however unfortunately (I tried) the popup height/width is not available until after it is shown and re-positioning it then would lead to flickering.... so I did what was most simple and just positioned at 50% of the CSS min-height/min-width settings. Works much better.  