### PR TITLE
[7.7.x] RHPAM-617: Stunner - it is not possible to open a process if you put incorrect symbol inside of Event trigger name

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
@@ -15,6 +15,8 @@
  */
 package org.kie.workbench.common.stunner.bpmn.definition.property.event.signal;
 
+import javax.validation.constraints.Pattern;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
@@ -32,6 +34,7 @@ public class SignalRef implements BPMNProperty {
 
     @Value
     @FieldValue
+    @Pattern(regexp = "^$|[a-zA-Z0-9_]+")
     private String value;
 
     public SignalRef() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -219,6 +219,7 @@ org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.Interrupt
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.ScopedSignalEventExecutionSet.label=Implementation/Execution
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.label=Signal
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.description=The Signal Reference
+org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.helpMessage=The allowed characters for the SignalRef are alphanumeric characters (a-z, A-Z, 0-9) and underscore '_'
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalScope.label=Signal Scope
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalScope.description=Defines the Signal Propagation Scope
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition.property.event.signal;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SignalRefTest {
+
+    private static final String WRONG_REF = "~`!@#$%^&*()_+=-{}|][:\"';?><,./";
+
+    private static final String VALID_REF = "validSIGNALREF0123456789_";
+
+    private Validator validator;
+
+    @Before
+    public void init() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    public void testSignalRefWithEmptySignal() {
+        SignalRef signalRef = new SignalRef();
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithValidSignal() {
+        SignalRef signalRef = new SignalRef(VALID_REF);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithWrongSignal() {
+        SignalRef signalRef = new SignalRef(WRONG_REF);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertFalse(validations.isEmpty());
+    }
+}


### PR DESCRIPTION
Copy of https://github.com/kiegroup/kie-wb-common/pull/1729

@romartin could you please review?