### PR TITLE
JBPM-6702 Issues once resizing a shape: fix connections positions

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
@@ -317,6 +317,23 @@ public class GraphUtils {
                 .collect(Collectors.toList());
     }
 
+    public static List<Edge<? extends ViewConnector<?>, Node>> getSourceConnections(final Node<?, ? extends Edge> element) {
+        Objects.requireNonNull(element.getOutEdges());
+        return getConnections(element.getOutEdges());
+    }
+
+    public static List<Edge<? extends ViewConnector<?>, Node>> getTargetConnections(final Node<?, ? extends Edge> element) {
+        Objects.requireNonNull(element.getInEdges());
+        return getConnections(element.getInEdges());
+    }
+
+    private static List<Edge<? extends ViewConnector<?>, Node>> getConnections(List<? extends Edge> edges) {
+        return edges.stream()
+                .filter(edge -> (edge.getContent() instanceof ViewConnector))
+                .map(edge -> (Edge<? extends ViewConnector<?>, Node>) edge)
+                .collect(Collectors.toList());
+    }
+
     public static boolean isDockedNode(final Node<?, ? extends Edge> element) {
         return Objects.nonNull(element.getInEdges()) ?
                 element.getInEdges()


### PR DESCRIPTION
The `MagnetConnection` locations in the edge are now updated to the current shape magnet position after resize. You can resize a shape with connections, save the diagram and open again to check the new positions.

@romartin 
@LuboTerifaj 
