### PR TITLE
[7.7.x] DROOLS-2526 : [Test Scenario][IE] Can't be run

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/generalsettings/GitUrlsPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/generalsettings/GitUrlsPresenter.java
@@ -26,9 +26,8 @@ import javax.inject.Inject;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
-import org.kie.workbench.common.screens.library.client.settings.util.select.KieSelectElement;
-import org.kie.workbench.common.screens.library.client.settings.util.select.KieSelectElement.Option;
 import org.kie.workbench.common.screens.projecteditor.model.GitUrl;
+import org.kie.workbench.common.widgets.client.widget.KieSelectElement;
 import org.uberfire.client.mvp.UberElemental;
 import org.uberfire.workbench.events.NotificationEvent;
 
@@ -78,7 +77,7 @@ public class GitUrlsPresenter {
                 : gitUrls.get(0).getProtocol();
 
         protocolSelect.setup(view.getProtocolSelectContainer(),
-                             gitUrls.stream().map(GitUrl::getProtocol).map(p -> new Option(p, p)).collect(toList()),
+                             gitUrls.stream().map(GitUrl::getProtocol).map(p -> new KieSelectElement.Option(p, p)).collect(toList()),
                              selectedProtocol,
                              this::setSelectedProtocol);
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenter.java
@@ -20,8 +20,8 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.soup.project.datamodel.imports.Import;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 public class ExternalDataObjectsItemPresenter extends ListItemPresenter<Import, ExternalDataObjectsPresenter, ExternalDataObjectsItemPresenter.View> {
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsPresenter.java
@@ -29,8 +29,8 @@ import org.kie.workbench.common.screens.library.client.settings.SettingsSectionC
 import org.kie.workbench.common.screens.library.client.settings.util.sections.MenuItem;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.Section;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.SectionView;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
 import org.kie.workbench.common.screens.projecteditor.model.ProjectScreenModel;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 import org.kie.workbench.common.widgets.configresource.client.widget.unbound.AddImportPopup;
 import org.uberfire.client.promise.Promises;
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/KnowledgeBasesPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/KnowledgeBasesPresenter.java
@@ -32,11 +32,11 @@ import org.kie.workbench.common.screens.library.client.settings.sections.knowled
 import org.kie.workbench.common.screens.library.client.settings.util.sections.MenuItem;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.Section;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.SectionView;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
 import org.kie.workbench.common.screens.library.client.settings.util.modal.single.AddSingleValueModal;
 import org.kie.workbench.common.screens.projecteditor.model.ProjectScreenModel;
 import org.kie.workbench.common.services.shared.kmodule.KBaseModel;
 import org.kie.workbench.common.services.shared.kmodule.KModuleModel;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 import org.uberfire.client.promise.Promises;
 
 import static java.util.Comparator.comparing;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/KnowledgeBaseItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/KnowledgeBaseItemPresenter.java
@@ -30,13 +30,13 @@ import org.kie.workbench.common.screens.library.client.settings.sections.knowled
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.knowledgesessions.KnowledgeSessionsModal;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.packages.PackageItemPresenter;
 import org.kie.workbench.common.screens.library.client.settings.util.select.KieEnumSelectElement;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
 import org.kie.workbench.common.screens.library.client.settings.util.modal.single.AddSingleValueModal;
 import org.kie.workbench.common.services.shared.kmodule.AssertBehaviorOption;
 import org.kie.workbench.common.services.shared.kmodule.EventProcessingOption;
 import org.kie.workbench.common.services.shared.kmodule.KBaseModel;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 
 @Dependent
 public class KnowledgeBaseItemPresenter extends ListItemPresenter<KBaseModel, KnowledgeBasesPresenter, KnowledgeBaseItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/includedknowledgebases/IncludedKnowledgeBaseItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/includedknowledgebases/IncludedKnowledgeBaseItemPresenter.java
@@ -21,8 +21,8 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.KnowledgeBaseItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class IncludedKnowledgeBaseItemPresenter extends ListItemPresenter<String, KnowledgeBaseItemPresenter, IncludedKnowledgeBaseItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/KnowledgeSessionListItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/KnowledgeSessionListItemPresenter.java
@@ -28,12 +28,12 @@ import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.knowledgesessions.listener.ListenerListItemPresenter;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.knowledgesessions.workitemhandler.WorkItemHandlerListItemPresenter;
 import org.kie.workbench.common.screens.library.client.settings.util.select.KieEnumSelectElement;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
 import org.kie.workbench.common.services.shared.kmodule.ClockTypeOption;
 import org.kie.workbench.common.services.shared.kmodule.KSessionModel;
 import org.kie.workbench.common.services.shared.kmodule.ListenerModel;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 
 public class KnowledgeSessionListItemPresenter extends ListItemPresenter<KSessionModel, KnowledgeSessionsModal, KnowledgeSessionListItemPresenter.View> {
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/KnowledgeSessionsModal.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/KnowledgeSessionsModal.java
@@ -22,10 +22,10 @@ import javax.inject.Inject;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.KnowledgeBaseItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
 import org.kie.workbench.common.screens.library.client.settings.util.modal.Elemental2Modal;
 import org.kie.workbench.common.services.shared.kmodule.KBaseModel;
 import org.kie.workbench.common.services.shared.kmodule.KSessionModel;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 
 @Dependent
 public class KnowledgeSessionsModal extends Elemental2Modal<KnowledgeSessionsModal.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/listener/ListenerListItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/listener/ListenerListItemPresenter.java
@@ -23,9 +23,9 @@ import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.knowledgesessions.KnowledgeSessionListItemPresenter;
 import org.kie.workbench.common.screens.library.client.settings.util.select.KieEnumSelectElement;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
 import org.kie.workbench.common.services.shared.kmodule.ListenerModel;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class ListenerListItemPresenter extends ListItemPresenter<ListenerModel, KnowledgeSessionListItemPresenter, ListenerListItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/workitemhandler/WorkItemHandlerListItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/knowledgesessions/workitemhandler/WorkItemHandlerListItemPresenter.java
@@ -22,8 +22,8 @@ import javax.inject.Inject;
 import org.guvnor.common.services.project.model.WorkItemHandlerModel;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.knowledgesessions.KnowledgeSessionListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class WorkItemHandlerListItemPresenter extends ListItemPresenter<WorkItemHandlerModel, KnowledgeSessionListItemPresenter, WorkItemHandlerListItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/packages/PackageItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/knowledgebases/item/packages/PackageItemPresenter.java
@@ -21,8 +21,8 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.screens.library.client.settings.sections.knowledgebases.item.KnowledgeBaseItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class PackageItemPresenter extends ListItemPresenter<String, KnowledgeBaseItemPresenter, PackageItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/PersistencePresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/PersistencePresenter.java
@@ -40,10 +40,10 @@ import org.kie.workbench.common.screens.library.client.settings.sections.persist
 import org.kie.workbench.common.screens.library.client.settings.util.sections.MenuItem;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.Section;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.SectionView;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
 import org.kie.workbench.common.screens.library.client.settings.util.modal.doublevalue.AddDoubleValueModal;
 import org.kie.workbench.common.screens.library.client.settings.util.modal.single.AddSingleValueModal;
 import org.kie.workbench.common.screens.projecteditor.model.ProjectScreenModel;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.PathFactory;
 import org.uberfire.client.promise.Promises;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/persistabledataobjects/PersistableDataObjectsItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/persistabledataobjects/PersistableDataObjectsItemPresenter.java
@@ -21,8 +21,8 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.screens.library.client.settings.sections.persistence.PersistencePresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class PersistableDataObjectsItemPresenter extends ListItemPresenter<String, PersistencePresenter, PersistableDataObjectsItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/properties/PropertiesItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/persistence/properties/PropertiesItemPresenter.java
@@ -21,8 +21,8 @@ import javax.inject.Inject;
 
 import org.kie.workbench.common.screens.datamodeller.model.persistence.Property;
 import org.kie.workbench.common.screens.library.client.settings.sections.persistence.PersistencePresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class PropertiesItemPresenter extends ListItemPresenter<Property, PersistencePresenter, PropertiesItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/validation/ValidationItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/validation/ValidationItemPresenter.java
@@ -21,8 +21,8 @@ import javax.inject.Inject;
 
 import org.guvnor.common.services.project.model.ModuleRepositories;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class ValidationItemPresenter extends ListItemPresenter<ModuleRepositories.ModuleRepository, ValidationPresenter, ValidationItemPresenter.View> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/validation/ValidationPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/validation/ValidationPresenter.java
@@ -28,8 +28,8 @@ import org.kie.workbench.common.screens.library.client.settings.SettingsSectionC
 import org.kie.workbench.common.screens.library.client.settings.util.sections.MenuItem;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.Section;
 import org.kie.workbench.common.screens.library.client.settings.util.sections.SectionView;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
 import org.kie.workbench.common.screens.projecteditor.model.ProjectScreenModel;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 import org.uberfire.client.promise.Promises;
 
 import static java.util.Comparator.comparing;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/util/sections/MenuItem.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/util/sections/MenuItem.java
@@ -20,8 +20,8 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
+import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListItemView;
 
 @Dependent
 public class MenuItem<T> extends ListItemPresenter<Section<T>, SectionManager<T>, MenuItem.View<T>> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/util/sections/MenuItemsListPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/util/sections/MenuItemsListPresenter.java
@@ -20,7 +20,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
+import org.kie.workbench.common.widgets.client.widget.ListPresenter;
 
 @Dependent
 public class MenuItemsListPresenter<T> extends ListPresenter<Section<T>, MenuItem<T>> {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/util/select/KieEnumSelectElement.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/util/select/KieEnumSelectElement.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import elemental2.dom.Element;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.widgets.client.widget.KieSelectElement;
 
 import static java.util.stream.Collectors.toList;
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/generalsettings/GitUrlsPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/generalsettings/GitUrlsPresenterTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.library.client.settings.generalsettings.GitUrlsPresenter.View;
-import org.kie.workbench.common.screens.library.client.settings.util.select.KieSelectElement;
+import org.kie.workbench.common.widgets.client.widget.KieSelectElement;
 import org.kie.workbench.common.screens.projecteditor.model.GitUrl;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -16,6 +16,8 @@ import org.uberfire.workbench.events.NotificationEvent;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+
+import org.kie.workbench.common.screens.projecteditor.model.GitUrl;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/util/select/KieEnumSelectElementTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/util/select/KieEnumSelectElementTest.java
@@ -24,7 +24,8 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.library.client.settings.util.select.KieSelectElement.Option;
+import org.kie.workbench.common.widgets.client.widget.KieSelectElement;
+import org.kie.workbench.common.widgets.client.widget.KieSelectElement.Option;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
@@ -20,6 +20,11 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+    
     <!-- dependencies added because of new illegal transitive dependency check -->
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KSessionSelector.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KSessionSelector.java
@@ -17,7 +17,10 @@
 package org.kie.workbench.common.widgets.client.widget;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
@@ -96,23 +99,28 @@ public class KSessionSelector
     }
 
     private void initKBases(final String currentKSession) {
-        view.clear();
+
+        final ArrayList<String> kbaseNames = new ArrayList<>();
 
         if (kmodule.getKBases().isEmpty()) {
             addMockKBaseModel(DEFAULT_KIE_BASE,
                               DEFAULT_KIE_SESSION);
-            view.addKBase(DEFAULT_KIE_BASE);
+            kbaseNames.add(DEFAULT_KIE_BASE);
         } else {
             for (KBaseModel kBase : kmodule.getKBases().values()) {
-                view.addKBase(kBase.getName());
+                kbaseNames.add(kBase.getName());
             }
         }
+
+        Collections.sort(kbaseNames, (first, other) -> first.compareToIgnoreCase(other));
+
         if (isNotNullOrEmpty(currentKSession) && !kmoduleContainsCurrentKSession(currentKSession)) {
             addMockKBaseModel(NON_EXISTING_KBASE,
                               currentKSession);
-            view.addKBase(NON_EXISTING_KBASE);
+            kbaseNames.add(NON_EXISTING_KBASE);
             view.showWarningSelectedKSessionDoesNotExist();
         }
+        view.addKBases(kbaseNames.toArray(new String[kbaseNames.size()]));
     }
 
     private void addMockKBaseModel(final String kbaseName,

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorView.java
@@ -28,7 +28,7 @@ public interface KSessionSelectorView
     void setSelected(final String kbase,
                      final String ksession);
 
-    void addKBase(final String name);
+    void addKBases(final String... names);
 
     void setKSessions(final List<String> ksessions);
 
@@ -36,5 +36,4 @@ public interface KSessionSelectorView
 
     String getSelectedKSessionName();
 
-    void clear();
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorViewImpl.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorViewImpl.html
@@ -17,15 +17,13 @@
 <div class="container-fluid">
     <form>
         <div class="form-group ksession-form-group row">
-            <label for="kbaseSelect" class="control-label col-md-3" data-i18n-key="KnowledgeBase"></label>
-            <div class="col-md-9">
-                <select id="kbaseSelect" class="form-control"></select>
+            <label for="kbaseSelectContainer" class="control-label col-md-3" data-i18n-key="KnowledgeBase"></label>
+            <div class="col-md-9" id="kbaseSelectContainer">
             </div>
         </div>
         <div class="form-group ksession-form-group row">
-            <label for="ksessionSelect" class="control-label col-md-3" data-i18n-key="KnowledgeSession"></label>
-            <div class="col-md-9">
-                <select id="ksessionSelect" class="form-control"></select>
+            <label for="ksessionSelectContainer" class="control-label col-md-3" data-i18n-key="KnowledgeSession"></label>
+            <div class="col-md-9" id="ksessionSelectContainer">
             </div>
         </div>
     </form>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KieSelectElement.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KieSelectElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.library.client.settings.util.select;
+package org.kie.workbench.common.widgets.client.widget;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -27,8 +27,6 @@ import elemental2.dom.Element;
 import elemental2.dom.HTMLSelectElement;
 import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListPresenter;
 import org.uberfire.client.mvp.UberElemental;
 
 @Dependent

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KieSelectElementView.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KieSelectElementView.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KieSelectElementView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/KieSelectElementView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.library.client.settings.util.select;
+package org.kie.workbench.common.widgets.client.widget;
 
 import javax.inject.Inject;
 
@@ -26,7 +26,6 @@ import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.kie.workbench.common.screens.library.client.settings.util.list.ListItemView;
 
 @Templated
 public class KieSelectElementView implements KieSelectElement.View,

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/ListItemPresenter.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/ListItemPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.library.client.settings.util.list;
+package org.kie.workbench.common.widgets.client.widget;
 
 public abstract class ListItemPresenter<T, ParentPresenter, View extends ListItemView<? extends ListItemPresenter<T, ParentPresenter, View>>> {
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/ListItemView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/ListItemView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.library.client.settings.util.list;
+package org.kie.workbench.common.widgets.client.widget;
 
 import org.uberfire.client.mvp.UberElemental;
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/ListPresenter.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/ListPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.library.client.settings.util.list;
+package org.kie.workbench.common.widgets.client.widget;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,16 +90,16 @@ public abstract class ListPresenter<T, P extends ListItemPresenter<T, ?, ?>> {
         handleTable();
     }
 
-    protected void addToListElement(final T o) {
+    public void addToListElement(final T o) {
         addPresenter(newPresenterFor(o));
     }
 
-    protected void addPresenter(final P presenter) {
+    public void addPresenter(final P presenter) {
         presenters.add(presenter);
         listElement.appendChild(presenter.getView().getElement());
     }
 
-    protected P newPresenterFor(final T o) {
+    public P newPresenterFor(final T o) {
         final P listItemPresenter = this.itemPresenters.get();
         listItemPresenter.setListPresenter(this);
         itemPresenterConfigurator.accept(o, listItemPresenter);

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorTest.java
@@ -34,8 +34,14 @@ import org.uberfire.backend.vfs.Path;
 import org.uberfire.mocks.CallerMock;
 import org.uberfire.mvp.Command;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KSessionSelectorTest {
@@ -95,19 +101,6 @@ public class KSessionSelectorTest {
     }
 
     @Test
-    public void clearPreviousSetUp() throws
-            Exception {
-        selector.init(path,
-                      "first");
-        verify(view).clear();
-
-        selector.init(path,
-                      "second");
-        verify(view,
-               times(2)).clear();
-    }
-
-    @Test
     public void testSetKBaseAndKSession() throws Exception {
 
         selector.init(path,
@@ -127,8 +120,9 @@ public class KSessionSelectorTest {
     public void testKBaseAndKSessionNotPreviouslySet() throws Exception {
         selector.init(path,
                       null);
-
-        verify(view).addKBase("kbase1");
+        verify(view).addKBases("kbase1",
+                               "kbase2",
+                               "kbase3");
 
         ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(view).setKSessions(listArgumentCaptor.capture());
@@ -148,7 +142,7 @@ public class KSessionSelectorTest {
         selector.init(path,
                       null);
 
-        verify(view).addKBase("defaultKieBase");
+        verify(view).addKBases("defaultKieBase");
 
         ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(view).setKSessions(listArgumentCaptor.capture());
@@ -170,10 +164,7 @@ public class KSessionSelectorTest {
         selector.init(path,
                       "ksessionThatHasBeenRemovedFromKModuleXML");
 
-        verify(view).addKBase("kbase1");
-        verify(view).addKBase("kbase2");
-        verify(view).addKBase("kbase3");
-        verify(view).addKBase("---");
+        verify(view).addKBases("kbase1", "kbase2", "kbase3", "---");
 
         ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(view).setKSessions(listArgumentCaptor.capture());
@@ -199,8 +190,7 @@ public class KSessionSelectorTest {
         selector.init(path,
                       "ksessionThatHasBeenRemovedFromKModuleXML");
 
-        verify(view).addKBase("defaultKieBase");
-        verify(view).addKBase("---");
+        verify(view).addKBases("defaultKieBase", "---");
 
         ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(view).setKSessions(listArgumentCaptor.capture());

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorViewImplTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/KSessionSelectorViewImplTest.java
@@ -17,30 +17,32 @@
 package org.kie.workbench.common.widgets.client.widget;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.jboss.errai.common.client.dom.Document;
-import org.jboss.errai.common.client.dom.Label;
-import org.jboss.errai.common.client.dom.Select;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLDocument;
+import elemental2.dom.HTMLLabelElement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class KSessionSelectorViewImplTest {
 
     @Mock
-    private Document document;
+    private HTMLDocument document;
 
     @Mock
-    private Select kBaseSelect;
+    private HTMLDivElement kBaseSelect;
 
     @Mock
-    private Select kSessionSelect;
+    private HTMLDivElement kSessionSelect;
 
     @Mock
-    private Label warningLabel;
+    private HTMLLabelElement warningLabel;
 
     @Mock
     private KSessionSelector presenter;
@@ -52,6 +54,8 @@ public class KSessionSelectorViewImplTest {
         kSessionSelectorView = spy(new KSessionSelectorViewImpl(document,
                                                                 kBaseSelect,
                                                                 kSessionSelect,
+                                                                mock(KieSelectElement.class),
+                                                                mock(KieSelectElement.class),
                                                                 warningLabel));
         kSessionSelectorView.setPresenter(presenter);
     }
@@ -60,13 +64,6 @@ public class KSessionSelectorViewImplTest {
     public void testSetSelected() throws Exception {
         kSessionSelectorView.setSelected("kbaseName",
                                          "ksessionName");
-
-        verify(kSessionSelectorView).onSelectionChange();
-    }
-
-    @Test
-    public void testName() throws Exception {
-        kSessionSelectorView.onKSessionSelected(null);
 
         verify(kSessionSelectorView).onSelectionChange();
     }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/KieSelectElementTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/KieSelectElementTest.java
@@ -1,4 +1,19 @@
-package org.kie.workbench.common.screens.library.client.settings.util.select;
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.widgets.client.widget;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -11,7 +26,7 @@ import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.library.client.settings.util.select.KieSelectElement.Option;
+import org.kie.workbench.common.widgets.client.widget.KieSelectElement.Option;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 


### PR DESCRIPTION
(cherry picked from commit 026ac591201d4b573a860c2acd2e141bebde4ec9)

https://issues.jboss.org/browse/DROOLS-2526

Same as the one in master. This just had one import conflict that I had to fix.

IE did not select a value by default, other browsers did. I changed the KSessionSelector to use the latest dropdown codes we have. The real changes are in KSessionSelector, everything else is just there since I had to move the dropdown base to the commons project.

@manstis @jomarko You two might be the best ones to review this, thank you.

ping @barboras7

Bundle:
https://github.com/kiegroup/kie-wb-common/pull/1745
https://github.com/kiegroup/jbpm-wb/pull/1115