### PR TITLE
JBPM-6831 [Stunner]: Do not allow connectors with empty target/source nodes

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommand.java
@@ -187,6 +187,16 @@ public final class SafeDeleteNodeCommand extends AbstractGraphCompositeCommand {
                         log("DeregisterNodeCommand [node=" + node.getUUID() + "]");
                         addCommand(new DeregisterNodeCommand(node));
                         safeDeleteCallback.ifPresent(c -> c.deleteNode(node));
+
+                        node.getInEdges()
+                                .stream()
+                                .filter(edge -> edge.getContent() instanceof ViewConnector)
+                                .forEach(edge -> RemoveTargetConnection(edge));
+
+                        node.getOutEdges()
+                                .stream()
+                                .filter(edge -> edge.getContent() instanceof ViewConnector)
+                                .forEach(edge -> RemoveSourceConnection(edge));
                     }
 
                     private void processCandidateConnectors() {
@@ -232,6 +242,20 @@ public final class SafeDeleteNodeCommand extends AbstractGraphCompositeCommand {
                 });
 
         return this;
+    }
+
+    private void RemoveTargetConnection(Edge edge) {
+        ViewConnector<?> connector = (ViewConnector<?>)edge.getContent();
+        addCommand(new SetConnectionTargetNodeCommand(null,
+                                                      edge,
+                                                      connector.getTargetConnection().orElse(null)));
+    }
+
+    private void RemoveSourceConnection(Edge edge) {
+        ViewConnector<?> connector = (ViewConnector<?>)edge.getContent();
+        addCommand(new SetConnectionSourceNodeCommand(null,
+                                                      edge,
+                                                      connector.getSourceConnection().orElse(null)));
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommandTest.java
@@ -58,7 +58,7 @@ public class SafeDeleteNodeCommandTest {
         final CommandResult<RuleViolation> result = tested.allow(graphTestHandler.graphCommandExecutionContext);
         final List<Command<GraphCommandExecutionContext, RuleViolation>> commands = tested.getCommands();
         assertNotNull(commands);
-        assertTrue(3 == commands.size());
+        assertTrue(4 == commands.size());
         final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(0);
         assertNotNull(removeChild);
         assertEquals(graphHolder.parentNode,
@@ -84,7 +84,7 @@ public class SafeDeleteNodeCommandTest {
         final CommandResult<RuleViolation> result = tested.allow(graphTestHandler.graphCommandExecutionContext);
         final List<Command<GraphCommandExecutionContext, RuleViolation>> commands = tested.getCommands();
         assertNotNull(commands);
-        assertTrue(3 == commands.size());
+        assertTrue(4 == commands.size());
         final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(0);
         assertNotNull(removeChild);
         assertEquals(graphHolder.parentNode,
@@ -112,7 +112,7 @@ public class SafeDeleteNodeCommandTest {
         final CommandResult<RuleViolation> result = tested.allow(graphTestHandler.graphCommandExecutionContext);
         final List<Command<GraphCommandExecutionContext, RuleViolation>> commands = tested.getCommands();
         assertNotNull(commands);
-        assertTrue(4 == commands.size());
+        assertTrue(6 == commands.size());
         final RemoveChildCommand removeChild = (RemoveChildCommand) commands.get(0);
         assertNotNull(removeChild);
         assertEquals(graphHolder.parentNode,


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-6831

Edge source and target values were not set to null and kept a reference
to the deleted node. This fixes this problem.

This does not fix the undo feature.