### PR TITLE
[7.7.x] RHPAM-878 Stunner - SVG persisted on backend when saving a diagram

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditor.java
@@ -113,6 +113,7 @@ public class ExpressionEditor implements ExpressionEditorView.Presenter {
         boolean copyCommandEnabled = false;
         boolean cutCommandEnabled = false;
         boolean pasteCommandEnabled = false;
+        boolean saveCommandEnabled = false;
 
         private ToolbarCommandStateHandler(final DMNEditorToolbar toolbar) {
             this.toolbar = toolbar;
@@ -132,6 +133,7 @@ public class ExpressionEditor implements ExpressionEditorView.Presenter {
             this.copyCommandEnabled = toolbar.isEnabled((ToolbarCommand) toolbar.getCopyToolbarCommand());
             this.cutCommandEnabled = toolbar.isEnabled((ToolbarCommand) toolbar.getCutToolbarCommand());
             this.pasteCommandEnabled = toolbar.isEnabled((ToolbarCommand) toolbar.getPasteToolbarCommand());
+            this.saveCommandEnabled = toolbar.isEnabled((ToolbarCommand) toolbar.getSaveToolbarCommand());
 
             enableToolbarCommand(toolbar.getVisitGraphToolbarCommand(),
                                  false);
@@ -158,6 +160,8 @@ public class ExpressionEditor implements ExpressionEditorView.Presenter {
             enableToolbarCommand(toolbar.getCutToolbarCommand(),
                                  false);
             enableToolbarCommand(toolbar.getPasteToolbarCommand(),
+                                 false);
+            enableToolbarCommand(toolbar.getSaveToolbarCommand(),
                                  false);
         }
 
@@ -188,6 +192,8 @@ public class ExpressionEditor implements ExpressionEditorView.Presenter {
                                  cutCommandEnabled);
             enableToolbarCommand(toolbar.getPasteToolbarCommand(),
                                  pasteCommandEnabled);
+            enableToolbarCommand(toolbar.getSaveToolbarCommand(),
+                                 saveCommandEnabled);
         }
 
         private void enableToolbarCommand(final ToolbarCommand command,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNEditorToolbar.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNEditorToolbar.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ExportToP
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ExportToPngToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.PasteToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.RedoToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.SaveToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.SwitchGridToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.UndoToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ValidateToolbarCommand;
@@ -66,7 +67,8 @@ public class DMNEditorToolbar
                 .register(ExportToPdfToolbarCommand.class)
                 .register(CopyToolbarCommand.class)
                 .register(CutToolbarCommand.class)
-                .register(PasteToolbarCommand.class);
+                .register(PasteToolbarCommand.class)
+                .register(SaveToolbarCommand.class);
     }
 
     public VisitGraphToolbarCommand getVisitGraphToolbarCommand() {
@@ -119,6 +121,9 @@ public class DMNEditorToolbar
 
     public PasteToolbarCommand getPasteToolbarCommand() {
         return (PasteToolbarCommand) toolbar.getCommand(12);
+    }
+    public SaveToolbarCommand getSaveToolbarCommand() {
+        return (SaveToolbarCommand) toolbar.getCommand(13);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/ShowcaseDiagramService.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/ShowcaseDiagramService.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasExport;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Layer;
-import org.kie.workbench.common.stunner.core.client.service.ClientDiagramService;
+import org.kie.workbench.common.stunner.core.client.service.ClientDiagramServiceImpl;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
@@ -37,7 +37,7 @@ import org.uberfire.backend.vfs.Path;
 @ApplicationScoped
 public class ShowcaseDiagramService {
 
-    private final ClientDiagramService clientDiagramServices;
+    private final ClientDiagramServiceImpl clientDiagramServices;
     private final CanvasExport<AbstractCanvasHandler> canvasExport;
 
     protected ShowcaseDiagramService() {
@@ -46,7 +46,7 @@ public class ShowcaseDiagramService {
     }
 
     @Inject
-    public ShowcaseDiagramService(final ClientDiagramService clientDiagramServices,
+    public ShowcaseDiagramService(final ClientDiagramServiceImpl clientDiagramServices,
                                   final CanvasExport<AbstractCanvasHandler> canvasExport) {
         this.clientDiagramServices = clientDiagramServices;
         this.canvasExport = canvasExport;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/LienzoCanvasExport.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/LienzoCanvasExport.java
@@ -73,9 +73,12 @@ public class LienzoCanvasExport implements CanvasExport<AbstractCanvasHandler> {
         final com.ait.lienzo.client.core.shape.Layer layer = getLayer(canvasHandler).getLienzoLayer();
         final IContext2D svgContext2D = Context2DFactory.create(new SvgExportSettings(layer.getWidth(), layer.getHeight(), layer.getContext()));
         //draw on the context to be returned
-        layer.draw(new Context2D(new DelegateNativeContext2D(svgContext2D)));
+        layer.draw();
+
+        layer.draw(new Context2D(new DelegateNativeContext2D(svgContext2D, canvasHandler)));
         //redraw on canvas
         layer.draw();
+
         return svgContext2D;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/wires/WiresUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/wires/WiresUtils.java
@@ -121,6 +121,7 @@ public final class WiresUtils {
                                        final String uuid) {
         final UserData ud = assertUserData(shape);
         ud.setUuid(uuid);
+        shape.setID(uuid);
     }
 
     private static UserData assertUserData(final IDrawable<?> shape) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoCanvasExportTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoCanvasExportTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.canvas;
 
+import java.util.Optional;
+
 import com.ait.lienzo.client.core.Context2D;
 import com.ait.lienzo.client.core.INativeContext2D;
 import com.ait.lienzo.client.core.shape.Layer;
@@ -29,8 +31,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.export.DelegateNativeContext2D;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.export.LienzoCanvasExport;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionSetRegistry;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.uberfire.ext.editor.commons.client.file.exports.svg.IContext2D;
@@ -68,6 +76,29 @@ public class LienzoCanvasExportTest {
 
     private LienzoCanvasExport tested;
 
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    private final String DEF_SET_ID = "DEF_SET_ID";
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private TypeDefinitionSetRegistry definitionSets;
+
+    @Mock
+    private Object defSet;
+
+    @Mock
+    private AdapterManager adapters;
+
+    @Mock
+    private DefinitionSetAdapter<Object> definitionSetAdapter;
+
     @Before
     public void setup() {
         when(canvasHandler.getCanvas()).thenReturn(canvas);
@@ -77,6 +108,16 @@ public class LienzoCanvasExportTest {
         when(layer.getWidth()).thenReturn(100);
         when(layer.getHeight()).thenReturn(200);
         when(scratchPad.getContext()).thenReturn(context2D);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getDefinitionSetId()).thenReturn(DEF_SET_ID);
+        when(canvasHandler.getDefinitionManager()).thenReturn(definitionManager);
+        when(definitionManager.definitionSets()).thenReturn(definitionSets);
+        when(definitionSets.getDefinitionSetById(DEF_SET_ID)).thenReturn(defSet);
+        when(definitionManager.adapters()).thenReturn(adapters);
+        when(adapters.forDefinitionSet()).thenReturn(definitionSetAdapter);
+        when(definitionSetAdapter.getSvgNodeId(defSet)).thenReturn(Optional.of("id"));
+
         this.tested = new LienzoCanvasExport();
     }
 
@@ -126,11 +167,12 @@ public class LienzoCanvasExportTest {
 
     @Test
     public void testToContext2D() {
-        IContext2D context2D = spy(tested.toContext2D(canvasHandler));
+        IContext2D iContext2D = spy(tested.toContext2D(canvasHandler));
         verify(canvas).getLayer();
         ArgumentCaptor<Context2D> context2DArgumentCaptor = ArgumentCaptor.forClass(Context2D.class);
         verify(layer).draw(context2DArgumentCaptor.capture());
-        INativeContext2D nativeContext = spy(context2DArgumentCaptor.getValue().getNativeContext()) ;
+        INativeContext2D nativeContext = spy(context2DArgumentCaptor.getValue().getNativeContext());
         assertTrue(nativeContext instanceof DelegateNativeContext2D);
+        verify(definitionSetAdapter).getSvgNodeId(defSet);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/DelegateNativeContext2DTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/DelegateNativeContext2DTest.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.canvas.export;
 
+import java.util.HashMap;
+import java.util.Optional;
+
 import com.ait.lienzo.client.core.Path2D;
 import com.ait.lienzo.client.core.types.LinearGradient;
 import com.ait.lienzo.client.core.types.PathPartEntryJSO;
@@ -31,7 +34,15 @@ import elemental2.dom.HTMLCanvasElement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.client.lienzo.util.NativeClassConverter;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionSetRegistry;
+import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.uberfire.ext.editor.commons.client.file.exports.svg.IContext2D;
@@ -40,7 +51,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -49,6 +59,7 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class DelegateNativeContext2DTest {
 
+    public static final String NODE_UUID = UUID.uuid();
     private DelegateNativeContext2D delegateNativeContext2D;
 
     @Mock
@@ -67,12 +78,58 @@ public class DelegateNativeContext2DTest {
 
     private Element element;
 
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    private final String DEF_SET_ID = "DEF_SET_ID";
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private TypeDefinitionSetRegistry definitionSets;
+
+    @Mock
+    private Object defSet;
+
+    @Mock
+    private AdapterManager adapters;
+
+    @Mock
+    private DefinitionSetAdapter<Object> definitionSetAdapter;
+
+    @Mock
+    private Index graphIndex;
+
+    @Mock
+    private org.kie.workbench.common.stunner.core.graph.Element node;
+
+    private final String SVG_NODE_ID = "node_id";
+
     @Before
     public void setUp() throws Exception {
         htmlElement = new HTMLCanvasElement();
         element = GWT.create(Element.class);
         when(nativeClassConverter.convert(any(Element.class), eq(HTMLCanvasElement.class))).thenReturn(htmlElement);
-        delegateNativeContext2D = new DelegateNativeContext2D(context, nativeClassConverter);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getDefinitionSetId()).thenReturn(DEF_SET_ID);
+        when(canvasHandler.getDefinitionManager()).thenReturn(definitionManager);
+        when(definitionManager.definitionSets()).thenReturn(definitionSets);
+        when(definitionSets.getDefinitionSetById(DEF_SET_ID)).thenReturn(defSet);
+        when(definitionManager.adapters()).thenReturn(adapters);
+        when(adapters.forDefinitionSet()).thenReturn(definitionSetAdapter);
+        when(definitionSetAdapter.getSvgNodeId(defSet)).thenReturn(Optional.of(SVG_NODE_ID));
+        when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
+        when(graphIndex.get(NODE_UUID)).thenReturn(node);
+
+        delegateNativeContext2D = new DelegateNativeContext2D(context, canvasHandler, nativeClassConverter);
     }
 
     @Test
@@ -82,8 +139,10 @@ public class DelegateNativeContext2DTest {
 
     @Test
     public void saveContainer() {
-        delegateNativeContext2D.saveContainer();
-        verify(context, times(1)).saveGroup();
+        delegateNativeContext2D.saveContainer(NODE_UUID);
+        verify(context, times(1)).saveGroup(new HashMap<String, String>() {{
+            put(SVG_NODE_ID, NODE_UUID);
+        }});
     }
 
     @Test
@@ -389,7 +448,6 @@ public class DelegateNativeContext2DTest {
         verify(context).setShadowBlur(Mockito.anyInt());
 
         delegateNativeContext2D.setShadow(null);
-
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -507,12 +565,12 @@ public class DelegateNativeContext2DTest {
     @Test
     public void drawImage2() {
         delegateNativeContext2D.drawImage(element, 1, 1, 1, 1);
-        verify(context, times(1)).drawImage(htmlElement, 1, 1, 1 ,1);
+        verify(context, times(1)).drawImage(htmlElement, 1, 1, 1, 1);
     }
 
     @Test
     public void drawImage3() {
         delegateNativeContext2D.drawImage(element, 1, 1, 1, 1, 1, 1, 1, 1);
-        verify(context, times(1)).drawImage(htmlElement, 1, 1, 1 ,1, 1, 1, 1, 1);
+        verify(context, times(1)).drawImage(htmlElement, 1, 1, 1, 1, 1, 1, 1, 1);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToBpmnToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToBpmnToolbarCommand.java
@@ -20,13 +20,15 @@ import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToBpmnSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
-public class ExportToBpmnToolbarCommand extends AbstractToolbarCommand<ViewerSession, ExportToBpmnSessionCommand> {
+public class ExportToBpmnToolbarCommand extends AbstractToolbarCommand<AbstractSession<AbstractCanvas, AbstractCanvasHandler>, ExportToBpmnSessionCommand> {
 
     @Inject
     public ExportToBpmnToolbarCommand(final DefinitionUtils definitionUtils,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPdfToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPdfToolbarCommand.java
@@ -21,14 +21,16 @@ import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPdfSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
-public class ExportToPdfToolbarCommand extends AbstractToolbarCommand<ViewerSession, ExportToPdfSessionCommand> {
+public class ExportToPdfToolbarCommand extends AbstractToolbarCommand<AbstractSession<AbstractCanvas, AbstractCanvasHandler>, ExportToPdfSessionCommand> {
 
     @Inject
     public ExportToPdfToolbarCommand(final DefinitionUtils definitionUtils,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPngToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPngToolbarCommand.java
@@ -21,14 +21,16 @@ import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
-public class ExportToPngToolbarCommand extends AbstractToolbarCommand<ViewerSession, ExportToPngSessionCommand> {
+public class ExportToPngToolbarCommand extends AbstractToolbarCommand<AbstractSession<AbstractCanvas, AbstractCanvasHandler>, ExportToPngSessionCommand> {
 
     @Inject
     public ExportToPngToolbarCommand(final DefinitionUtils definitionUtils,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToSvgToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToSvgToolbarCommand.java
@@ -21,14 +21,16 @@ import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToSvgSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
-public class ExportToSvgToolbarCommand extends AbstractToolbarCommand<ViewerSession, ExportToSvgSessionCommand> {
+public class ExportToSvgToolbarCommand extends AbstractToolbarCommand<AbstractSession<AbstractCanvas, AbstractCanvasHandler>, ExportToSvgSessionCommand> {
 
     @Inject
     public ExportToSvgToolbarCommand(final DefinitionUtils definitionUtils,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SaveToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SaveToolbarCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
@@ -21,43 +20,39 @@ import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToJpgSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SaveDiagramSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
-public class ExportToJpgToolbarCommand extends AbstractToolbarCommand<AbstractSession<AbstractCanvas, AbstractCanvasHandler>, ExportToJpgSessionCommand> {
+public class SaveToolbarCommand extends AbstractToolbarCommand<EditorSession, SaveDiagramSessionCommand> {
 
     @Inject
-    public ExportToJpgToolbarCommand(final DefinitionUtils definitionUtils,
-                                     final ManagedInstance<ExportToJpgSessionCommand> command,
-                                     final ClientTranslationService translationService) {
-        super(definitionUtils,
-              command,
-              translationService);
+    public SaveToolbarCommand(final DefinitionUtils definitionUtils,
+                              final ManagedInstance<SaveDiagramSessionCommand> command,
+                              final ClientTranslationService translationService) {
+        super(definitionUtils, command, translationService);
+    }
+
+    @Override
+    public IconType getIcon() {
+        return IconType.SAVE;
+    }
+
+    @Override
+    public String getCaption() {
+        return translationService.getValue(CoreTranslationMessages.SAVE);
+    }
+
+    @Override
+    public String getTooltip() {
+        return translationService.getValue(CoreTranslationMessages.SAVE);
     }
 
     @Override
     protected boolean requiresConfirm() {
         return false;
-    }
-
-    @Override
-    public IconType getIcon() {
-        return IconType.FILE_IMAGE_O;
-    }
-
-    @Override
-    public String getCaption() {
-        return translationService.getValue(CoreTranslationMessages.EXPORT_JPG);
-    }
-
-    @Override
-    public String getTooltip() {
-        return translationService.getValue(CoreTranslationMessages.EXPORT_JPG);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/impl/ManagedEditorToolbar.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/impl/ManagedEditorToolbar.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ExportToP
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ExportToSvgToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.PasteToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.RedoToolbarCommand;
+import org.kie.workbench.common.stunner.client.widgets.toolbar.command.SaveToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.SwitchGridToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.UndoToolbarCommand;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.command.ValidateToolbarCommand;
@@ -63,7 +64,8 @@ public class ManagedEditorToolbar
                 .register(ExportToPdfToolbarCommand.class)
                 .register(CopyToolbarCommand.class)
                 .register(CutToolbarCommand.class)
-                .register(PasteToolbarCommand.class);
+                .register(PasteToolbarCommand.class)
+                .register(SaveToolbarCommand.class);
     }
 
     public VisitGraphToolbarCommand getVisitGraphToolbarCommand() {
@@ -120,6 +122,10 @@ public class ManagedEditorToolbar
 
     public PasteToolbarCommand getPasteToolbarCommand() {
         return (PasteToolbarCommand) toolbar.getCommand(13);
+    }
+
+    public SaveToolbarCommand getSaveToolbarCommand() {
+        return (SaveToolbarCommand) toolbar.getCommand(14);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/service/BaseDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/service/BaseDiagramService.java
@@ -58,6 +58,14 @@ public interface BaseDiagramService<M extends Metadata, D extends Diagram<Graph,
     M saveOrUpdate(final D diagram);
 
     /**
+     * Saves or updates the diagram.
+     * Save applies when diagram is not present on the VFS. A new path will be assigned and returned into
+     * the resulting metadata instance (eg: when diagrams are created and authored in client side).
+     * Update applies if the diagram is already present on the VFS.
+     */
+    Path saveOrUpdateSvg(final Path diagramPath, String rawDiagramSvg);
+
+    /**
      * Deletes the diagram.
      * Implementations can throw unchecked exceptions.
      * @return <code>true</code> if the operation result is success, <code>false</code> otherwise.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetAdapter.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.core.definition.adapter;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
@@ -57,4 +58,9 @@ public interface DefinitionSetAdapter<T> extends PriorityAdapter {
      * or <code>javax.enterprise.inject.Any</code>.
      */
     Annotation getQualifier(final T pojo);
+
+    /**
+     * Returns the definition set's node id for SVG generation.
+     */
+    Optional<String> getSvgNodeId(final T pojo);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetAdapterWrapper.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetAdapterWrapper.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.core.definition.adapter;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
@@ -76,5 +77,10 @@ public abstract class DefinitionSetAdapterWrapper<T, A extends DefinitionSetAdap
     @Override
     public boolean accepts(final Class<?> type) {
         return adapter.accepts(type);
+    }
+
+    @Override
+    public Optional<String> getSvgNodeId(T pojo) {
+        return adapter.getSvgNodeId(pojo);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/SvgNodeId.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/SvgNodeId.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.definition.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface SvgNodeId {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/property/PropertyMetaTypes.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/property/PropertyMetaTypes.java
@@ -46,5 +46,6 @@ public enum PropertyMetaTypes {
      * If the shape supports resize and it is resized on client side, these properties will be
      * updated with the radius value of an arc that produces the new bounding box size.
      */
-    RADIUS
+    RADIUS,
+    ID
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/i18n/StunnerTranslationService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/i18n/StunnerTranslationService.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.i18n;
 
+import java.util.Optional;
+
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 /**
@@ -67,4 +69,6 @@ public interface StunnerTranslationService {
      * Returns the localized message for the given rule violation.
      */
     String getViolationMessage(RuleViolation ruleViolation);
+
+    Optional<String> getDefinitionSetSvgNodeId(String defId);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/AbstractReflectDefinitionSetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/AbstractReflectDefinitionSetAdapter.java
@@ -16,14 +16,20 @@
 package org.kie.workbench.common.stunner.core.backend.definition.adapter;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.annotation.DefinitionSet;
+import org.kie.workbench.common.stunner.core.definition.annotation.SvgNodeId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractReflectDefinitionSetAdapter<T> extends AbstractReflectAdapter<T>
         implements DefinitionSetAdapter<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractReflectDefinitionSetAdapter.class);
 
     protected Set<String> getAnnotatedDefinitions(final T definitionSet) {
         Set<String> result = null;
@@ -56,5 +62,16 @@ public abstract class AbstractReflectDefinitionSetAdapter<T> extends AbstractRef
     @Override
     public String getDomain(final T definitionSet) {
         return BindableAdapterUtils.getDefinitionSetDomain(definitionSet.getClass());
+    }
+
+    @Override
+    public Optional<String> getSvgNodeId(T definitionSet) {
+        try {
+            return Optional.ofNullable(getAnnotatedFieldValue(definitionSet,
+                                                              SvgNodeId.class));
+        } catch (Exception e) {
+            LOG.error("Error obtaining annotated SvgNodeId for DefinitionSet with id " + getId(definitionSet));
+        }
+        return Optional.empty();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindableDefinitionAdapter.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.AbstractBindableDefinitionAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableDefinitionAdapter;
-import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,12 +131,5 @@ class BackendBindableDefinitionAdapter<T> extends AbstractBindableDefinitionAdap
             LOG.error("Error obtaining properties for Definition with id " + getId(definition));
         }
         return Collections.emptySet();
-    }
-
-    @Override
-    public Object getMetaProperty(final PropertyMetaTypes metaPropertyType,
-                                  final T pojo) {
-        // TODO
-        return null;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/AbstractCanvasHandlerControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/AbstractCanvasHandlerControl.java
@@ -35,6 +35,5 @@ public abstract class AbstractCanvasHandlerControl<H extends AbstractCanvasHandl
     @Override
     public void destroy() {
         doDestroy();
-        this.canvasHandler = null;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasFileExport.java
@@ -81,6 +81,10 @@ public class CanvasFileExport {
         svgFileExport.export(canvasExport.toContext2D(canvasHandler), fullFileName);
     }
 
+    public String exportToSvg(final AbstractCanvasHandler canvasHandler) {
+        return canvasExport.toContext2D(canvasHandler).getSerializedSvg();
+    }
+
     public void exportToJpg(final AbstractCanvasHandler canvasHandler,
                             final String fileName) {
         exportImage(canvasHandler,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindableDefinitionSetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindableDefinitionSetAdapter.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.core.client.definition.adapter.binding;
 
 import java.lang.annotation.Annotation;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
@@ -108,5 +109,10 @@ class ClientBindableDefinitionSetAdapter extends AbstractClientBindableAdapter<O
 
     private Set<String> getDefinitionIds() {
         return definitionIds;
+    }
+
+    @Override
+    public Optional<String> getSvgNodeId(Object pojo) {
+        return translationService.getDefinitionSetSvgNodeId(pojo.getClass().getName());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/service/ClientDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/service/ClientDiagramService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,35 +16,39 @@
 
 package org.kie.workbench.common.stunner.core.client.service;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
-import org.jboss.errai.common.client.api.Caller;
-import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Graph;
-import org.kie.workbench.common.stunner.core.service.DiagramLookupService;
-import org.kie.workbench.common.stunner.core.service.DiagramService;
+import org.kie.workbench.common.stunner.core.lookup.LookupManager;
+import org.kie.workbench.common.stunner.core.lookup.diagram.DiagramLookupRequest;
+import org.kie.workbench.common.stunner.core.lookup.diagram.DiagramRepresentation;
+import org.kie.workbench.common.stunner.core.service.BaseDiagramService;
+import org.uberfire.backend.vfs.Path;
 
-/**
- * A wrapper util class for handling different diagram services from client side.
- */
-@ApplicationScoped
-public class ClientDiagramService extends AbstractClientDiagramService<Metadata, Diagram<Graph, Metadata>, DiagramService> {
+public interface ClientDiagramService<M extends Metadata, D extends Diagram<Graph, M>, S extends BaseDiagramService<M, D>> {
 
-    protected ClientDiagramService() {
-        this(null,
-             null,
-             null);
-    }
+    void create(Path path,
+                String name,
+                String defSetId,
+                ServiceCallback<Path> callback);
 
-    @Inject
-    public ClientDiagramService(final ShapeManager shapeManager,
-                                final Caller<DiagramService> diagramServiceCaller,
-                                final Caller<DiagramLookupService> diagramLookupServiceCaller) {
-        super(shapeManager,
-              diagramServiceCaller,
-              diagramLookupServiceCaller);
-    }
+    @SuppressWarnings("unchecked")
+    void saveOrUpdate(D diagram,
+                      ServiceCallback<D> callback);
+
+    void saveOrUpdateSvg(Path diagramPath, String rawSvg, ServiceCallback<Path> callback);
+
+    void add(D diagram,
+             ServiceCallback<D> callback);
+
+    @SuppressWarnings("unchecked")
+    void getByPath(Path path,
+                   ServiceCallback<D> callback);
+
+    @SuppressWarnings("unchecked")
+    void lookup(DiagramLookupRequest request,
+                ServiceCallback<LookupManager.LookupResponse<DiagramRepresentation>> callback);
+
+    void getRawContent(D diagram,
+                       ServiceCallback<String> callback);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/service/ClientDiagramServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/service/ClientDiagramServiceImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.service;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.Caller;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.session.command.event.SaveDiagramSessionCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.service.BaseDiagramService;
+import org.kie.workbench.common.stunner.core.service.DiagramLookupService;
+import org.kie.workbench.common.stunner.core.service.DiagramService;
+
+/**
+ * A wrapper util class for handling different diagram services from client side.
+ */
+@Dependent
+public class ClientDiagramServiceImpl<M extends Metadata, D extends Diagram<Graph, M>, S extends BaseDiagramService<M, D>> extends AbstractClientDiagramService<M, D, S> {
+
+    protected ClientDiagramServiceImpl() {
+        super(null, null, null, null);
+    }
+
+
+    public ClientDiagramServiceImpl(final ShapeManager shapeManager,
+                                    final Caller<S> diagramServiceCaller,
+                                    final Caller<DiagramLookupService> diagramLookupServiceCaller,
+                                    final Event<SaveDiagramSessionCommandExecutedEvent> saveEvent) {
+        super(shapeManager,
+              diagramServiceCaller,
+              diagramLookupServiceCaller,
+              saveEvent);
+    }
+
+    @Inject
+    public ClientDiagramServiceImpl(final ShapeManager shapeManager,
+                                    final Caller<DiagramLookupService> diagramLookupServiceCaller,
+                                    final Event<SaveDiagramSessionCommandExecutedEvent> saveEvent,
+                                    final Caller<DiagramService> diagramServiceCaller) {
+        super(shapeManager,
+              (Caller<S>) diagramServiceCaller,
+              diagramLookupServiceCaller,
+              saveEvent);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/event/SaveDiagramSessionCommandExecutedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/event/SaveDiagramSessionCommandExecutedEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.event;
+
+public class SaveDiagramSessionCommandExecutedEvent {
+
+    private String diagramUUID;
+
+    public SaveDiagramSessionCommandExecutedEvent(final String diagramUUID) {
+        this.diagramUUID = diagramUUID;
+    }
+
+    public String getDiagramUUID() {
+        return diagramUUID;
+    }
+
+    @Override
+    public String toString() {
+        return "SaveDiagramSessionCommandExecutedEvent{" +
+                "diagramUUID='" + diagramUUID + '\'' +
+                '}';
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SaveDiagramSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SaveDiagramSessionCommand.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import java.util.Objects;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
+import org.kie.workbench.common.stunner.core.client.service.ClientDiagramService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.event.SaveDiagramSessionCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.kie.workbench.common.stunner.core.client.util.TimerUtils;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.uberfire.backend.vfs.Path;
+
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+
+/**
+ * This session commands saves the current Diagram on {@link CanvasHandler#getDiagram()}.
+ * This is responsible to generate the diagram SVG and save it as well.
+ * Does not support undo operation.
+ */
+@Dependent
+public class SaveDiagramSessionCommand extends AbstractClientSessionCommand<EditorSession> {
+
+    private static Logger LOGGER = Logger.getLogger(SaveDiagramSessionCommand.class.getName());
+
+    private final ClientDiagramService diagramService;
+    private final CanvasFileExport canvasExport;
+    private TimerUtils timer;
+
+    protected SaveDiagramSessionCommand() {
+        this(null, null);
+    }
+
+    @Inject
+    public SaveDiagramSessionCommand(final ClientDiagramService diagramService, final CanvasFileExport canvasExport) {
+        super(true);
+        this.diagramService = diagramService;
+        this.canvasExport = canvasExport;
+        this.timer = new TimerUtils();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V> void execute(final Callback<V> callback) {
+        //TODO: call the diagram client and remove the logic from Editor Screens
+    }
+
+    protected void onSaveDiagram(@Observes SaveDiagramSessionCommandExecutedEvent event) {
+        checkNotNull("event", event);
+
+        if (Objects.isNull(getSession())) {
+            LOGGER.severe("Session is null. Event: " + event);
+            return;
+        }
+
+        final Metadata diagramMetadata = getCanvasHandler().getDiagram().getMetadata();
+        if (Objects.equals(diagramMetadata.getCanvasRootUUID(), event.getDiagramUUID())) {
+
+            //prevents to render selection on canvas
+            getSession().getSelectionControl().clearSelection();
+
+            //This is a workaround to overcome the animations executed on canvas when clear selection
+            //FIXME: remove the delay, handle this on the proper way, i.e perform the action on a static way
+            timer.executeWithDelay(() -> {
+                final String rawSvg = canvasExport.exportToSvg(getCanvasHandler());
+                diagramService.saveOrUpdateSvg(diagramMetadata.getPath(), rawSvg, new ServiceCallback<Path>() {
+                    @Override
+                    public void onSuccess(Path path) {
+                        LOGGER.info("Diagram SVG saved on " + path);
+                    }
+
+                    @Override
+                    public void onError(ClientRuntimeError error) {
+                        LOGGER.severe("Error saving diagram SVG " + error.getMessage());
+                    }
+                });
+            }, 150);
+        }
+    }
+
+    protected void setTimer(TimerUtils timer) {
+        this.timer = timer;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/TimerUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/TimerUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.util;
+
+import com.google.gwt.user.client.Timer;
+
+public class TimerUtils {
+
+    public void executeWithDelay(Runnable executeFunction, int delayMillis) {
+        new Timer() {
+            public void run() {
+                executeFunction.run();
+            }
+        }.schedule(delayMillis);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/service/AbstractClientDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/service/AbstractClientDiagramServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.ShapeSet;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.session.command.event.SaveDiagramSessionCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Graph;
@@ -32,6 +33,7 @@ import org.kie.workbench.common.stunner.core.service.DiagramLookupService;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.mocks.EventSourceMock;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -44,6 +46,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public abstract class AbstractClientDiagramServiceTest<M extends Metadata, D extends Diagram<Graph, M>, S extends BaseDiagramService<M, D>, CS extends AbstractClientDiagramService<M, D, S>> {
 
+    private static final String RAW_DIAGRAM = "";
     @Mock
     protected ShapeManager shapeManager;
 
@@ -60,6 +63,9 @@ public abstract class AbstractClientDiagramServiceTest<M extends Metadata, D ext
     protected S diagramService;
 
     protected CS tested;
+
+    @Mock
+    protected EventSourceMock<SaveDiagramSessionCommandExecutedEvent> saveDiagramSessionCommandExecutedEventEvent;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -136,6 +142,14 @@ public abstract class AbstractClientDiagramServiceTest<M extends Metadata, D ext
                times(1)).onSuccess(eq(diagram));
         verify(callback,
                times(0)).onError(any(ClientRuntimeError.class));
+    }
+
+    @Test
+    public void testSaveOrUpdateSvg() {
+        final ServiceCallback<Path> callback = mock(ServiceCallback.class);
+
+        tested.saveOrUpdateSvg(path, RAW_DIAGRAM, callback);
+        verify(diagramService).saveOrUpdateSvg(path, RAW_DIAGRAM);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/service/ClientDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/service/ClientDiagramServiceTest.java
@@ -29,7 +29,7 @@ import org.uberfire.mocks.CallerMock;
 import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ClientDiagramServiceTest extends AbstractClientDiagramServiceTest<Metadata, Diagram<Graph, Metadata>, DiagramService, ClientDiagramService> {
+public class ClientDiagramServiceTest extends AbstractClientDiagramServiceTest<Metadata, Diagram<Graph, Metadata>, DiagramService, ClientDiagramServiceImpl<Metadata, Diagram<Graph, Metadata>, DiagramService>> {
 
     @Override
     protected Metadata makeTestMetadata() {
@@ -49,11 +49,12 @@ public class ClientDiagramServiceTest extends AbstractClientDiagramServiceTest<M
 
     @Override
     @SuppressWarnings("unchecked")
-    protected ClientDiagramService makeTestClientDiagramService() {
+    protected ClientDiagramServiceImpl makeTestClientDiagramService() {
         final Caller<DiagramService> diagramServiceCaller = new CallerMock<>(diagramService);
         final Caller<DiagramLookupService> diagramLookupServiceCaller = new CallerMock<>(diagramLookupService);
-        return new ClientDiagramService(shapeManager,
+        return new ClientDiagramServiceImpl(shapeManager,
                                         diagramServiceCaller,
-                                        diagramLookupServiceCaller);
+                                        diagramLookupServiceCaller,
+                                        saveDiagramSessionCommandExecutedEventEvent);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/AbstractExportSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/AbstractExportSessionCommandTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import org.junit.Before;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
+import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.client.util.TimerUtils;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.Path;
+
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractExportSessionCommandTest {
+
+    protected static final String FILE_NAME = "file-name1";
+
+    @Mock
+    protected CanvasFileExport canvasFileExport;
+
+    @Mock
+    protected ViewerSession session;
+
+    @Mock
+    protected AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    protected Diagram diagram;
+
+    @Mock
+    protected Metadata metadata;
+
+    @Mock
+    protected Path path;
+
+    @Mock
+    protected ClientSessionCommand.Callback callback;
+
+    @Before
+    public void setup() {
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getPath()).thenReturn(path);
+        when(path.getFileName()).thenReturn(FILE_NAME);
+    }
+
+    protected void setTimer(AbstractExportSessionCommand command) {
+        command.setTimer(new TimerUtils() {
+            @Override
+            public void executeWithDelay(Runnable executeFunction, int delayMillis) {
+                executeFunction.run();
+            }
+        });
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToBpmnSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToBpmnSessionCommandTest.java
@@ -16,21 +16,15 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.service.ClientDiagramService;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.editor.commons.client.file.exports.TextContent;
 import org.uberfire.ext.editor.commons.client.file.exports.TextFileExport;
@@ -41,31 +35,13 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ExportToBpmnSessionCommandTest {
-
-    private static final String FILE_NAME = "FILE_NAME";
+@RunWith(GwtMockitoTestRunner.class)
+public class ExportToBpmnSessionCommandTest extends AbstractExportSessionCommandTest {
 
     private static final String FILE_RAW_CONTENT = "FILE_RAW_CONTENT";
 
     private static final String ERROR = "ERROR";
-
-    @Mock
-    private ViewerSession session;
-
-    @Mock
-    private AbstractCanvasHandler canvasHandler;
-
-    @Mock
-    private Diagram diagram;
-
-    @Mock
-    private Metadata metadata;
-
-    @Mock
-    private Path path;
 
     @Mock
     private ClientDiagramService clientDiagramService;
@@ -78,32 +54,27 @@ public class ExportToBpmnSessionCommandTest {
 
     private ExportToBpmnSessionCommand command;
 
-    @Mock
-    private ClientSessionCommand.Callback callback;
-
     private ArgumentCaptor<ServiceCallback> callbackCaptor;
 
     private ArgumentCaptor<TextContent> textContentCaptor;
 
     @Before
     public void setUp() {
+        super.setup();
         callbackCaptor = ArgumentCaptor.forClass(ServiceCallback.class);
         textContentCaptor = ArgumentCaptor.forClass(TextContent.class);
-        when(session.getCanvasHandler()).thenReturn(canvasHandler);
-        when(canvasHandler.getDiagram()).thenReturn(diagram);
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getPath()).thenReturn(path);
-        when(path.getFileName()).thenReturn(FILE_NAME);
         command = new ExportToBpmnSessionCommand(clientDiagramService,
                                                  errorPopupPresenter,
                                                  textFileExport);
         command.bind(session);
+        setTimer(command);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testExportSuccessful() {
         command.execute(callback);
+
         verify(clientDiagramService,
                times(1)).getRawContent(eq(diagram),
                                        callbackCaptor.capture());
@@ -120,6 +91,7 @@ public class ExportToBpmnSessionCommandTest {
     @SuppressWarnings("unchecked")
     public void testExportUnSuccessful() {
         command.execute(callback);
+
         verify(clientDiagramService,
                times(1)).getRawContent(eq(diagram),
                                        callbackCaptor.capture());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToJpgSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToJpgSessionCommandTest.java
@@ -16,18 +16,11 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.backend.vfs.Path;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -35,45 +28,18 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ExportToJpgSessionCommandTest {
-
-    private static final String FILE_NAME = "file-name1";
-
-    @Mock
-    private CanvasFileExport canvasFileExport;
-
-    @Mock
-    private ViewerSession session;
-
-    @Mock
-    private AbstractCanvasHandler canvasHandler;
-
-    @Mock
-    private Diagram diagram;
-
-    @Mock
-    private Metadata metadata;
-
-    @Mock
-    private Path path;
-
-    @Mock
-    private ClientSessionCommand.Callback callback;
+@RunWith(GwtMockitoTestRunner.class)
+public class ExportToJpgSessionCommandTest extends AbstractExportSessionCommandTest {
 
     private ExportToJpgSessionCommand tested;
 
     @Before
-    public void setup() throws Exception {
-        when(session.getCanvasHandler()).thenReturn(canvasHandler);
-        when(canvasHandler.getDiagram()).thenReturn(diagram);
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getPath()).thenReturn(path);
-        when(path.getFileName()).thenReturn(FILE_NAME);
+    public void setup() {
+        super.setup();
         this.tested = new ExportToJpgSessionCommand(canvasFileExport);
         this.tested.bind(session);
+        setTimer(tested);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToPdfSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToPdfSessionCommandTest.java
@@ -16,18 +16,11 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.backend.vfs.Path;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -35,50 +28,26 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ExportToPdfSessionCommandTest {
+@RunWith(GwtMockitoTestRunner.class)
+public class ExportToPdfSessionCommandTest extends AbstractExportSessionCommandTest {
 
     private static final String FILE_NAME = "file-name1";
-
-    @Mock
-    private CanvasFileExport canvasFileExport;
-
-    @Mock
-    private ViewerSession session;
-
-    @Mock
-    private AbstractCanvasHandler canvasHandler;
-
-    @Mock
-    private Diagram diagram;
-
-    @Mock
-    private Metadata metadata;
-
-    @Mock
-    private Path path;
-
-    @Mock
-    private ClientSessionCommand.Callback callback;
 
     private ExportToPdfSessionCommand tested;
 
     @Before
-    public void setup() throws Exception {
-        when(session.getCanvasHandler()).thenReturn(canvasHandler);
-        when(canvasHandler.getDiagram()).thenReturn(diagram);
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getPath()).thenReturn(path);
-        when(path.getFileName()).thenReturn(FILE_NAME);
+    public void setup() {
+        super.setup();
         this.tested = new ExportToPdfSessionCommand(canvasFileExport);
         this.tested.bind(session);
+        setTimer(tested);
     }
 
     @Test
     public void testExport() {
         this.tested.execute(callback);
+
         verify(canvasFileExport,
                times(1)).exportToPdf(eq(canvasHandler),
                                      eq(FILE_NAME));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToPngSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToPngSessionCommandTest.java
@@ -16,18 +16,11 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.backend.vfs.Path;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -35,50 +28,24 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ExportToPngSessionCommandTest {
-
-    private static final String FILE_NAME = "file-name1";
-
-    @Mock
-    private CanvasFileExport canvasFileExport;
-
-    @Mock
-    private ViewerSession session;
-
-    @Mock
-    private AbstractCanvasHandler canvasHandler;
-
-    @Mock
-    private Diagram diagram;
-
-    @Mock
-    private Metadata metadata;
-
-    @Mock
-    private Path path;
-
-    @Mock
-    private ClientSessionCommand.Callback callback;
+@RunWith(GwtMockitoTestRunner.class)
+public class ExportToPngSessionCommandTest extends AbstractExportSessionCommandTest {
 
     private ExportToPngSessionCommand tested;
 
     @Before
-    public void setup() throws Exception {
-        when(session.getCanvasHandler()).thenReturn(canvasHandler);
-        when(canvasHandler.getDiagram()).thenReturn(diagram);
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getPath()).thenReturn(path);
-        when(path.getFileName()).thenReturn(FILE_NAME);
+    public void setup() {
+        super.setup();
         this.tested = new ExportToPngSessionCommand(canvasFileExport);
         this.tested.bind(session);
+        setTimer(this.tested);
     }
 
     @Test
     public void testExport() {
         this.tested.execute(callback);
+
         verify(canvasFileExport,
                times(1)).exportToPng(eq(canvasHandler),
                                      eq(FILE_NAME));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToSvgSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/ExportToSvgSessionCommandTest.java
@@ -16,18 +16,11 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
-import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.backend.vfs.Path;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -35,53 +28,27 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ExportToSvgSessionCommandTest {
-
-    private static final String FILE_NAME = "file-name1";
-
-    @Mock
-    private CanvasFileExport canvasFileExport;
-
-    @Mock
-    private ViewerSession session;
-
-    @Mock
-    private AbstractCanvasHandler canvasHandler;
-
-    @Mock
-    private Diagram diagram;
-
-    @Mock
-    private Metadata metadata;
-
-    @Mock
-    private Path path;
-
-    @Mock
-    private ClientSessionCommand.Callback callback;
+@RunWith(GwtMockitoTestRunner.class)
+public class ExportToSvgSessionCommandTest extends AbstractExportSessionCommandTest {
 
     private ExportToSvgSessionCommand tested;
 
     @Before
-    public void setup() throws Exception {
-        when(session.getCanvasHandler()).thenReturn(canvasHandler);
-        when(canvasHandler.getDiagram()).thenReturn(diagram);
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getPath()).thenReturn(path);
-        when(path.getFileName()).thenReturn(FILE_NAME);
-
+    public void setup() {
+        super.setup();
         this.tested = new ExportToSvgSessionCommand(canvasFileExport);
         this.tested.bind(session);
+        setTimer(this.tested);
     }
 
     @Test
     public void testExport() {
         tested.execute(callback);
+
         verify(canvasFileExport, times(1)).exportToSvg(eq(canvasHandler),
                                                        eq(FILE_NAME));
+
         verify(canvasFileExport, never()).exportToJpg(any(AbstractCanvasHandler.class),
                                                       anyString());
         verify(canvasFileExport, never()).exportToPdf(any(AbstractCanvasHandler.class),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SaveDiagramSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SaveDiagramSessionCommandTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
+import org.kie.workbench.common.stunner.core.client.service.ClientDiagramService;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.client.session.command.event.SaveDiagramSessionCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.kie.workbench.common.stunner.core.client.util.TimerUtils;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.util.UUID;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.Path;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class SaveDiagramSessionCommandTest {
+
+    private static final String DIAGRAM_UUID = UUID.uuid();
+    private static final String RAW_DIAGRAM = "";
+
+    private SaveDiagramSessionCommand command;
+
+    @Mock
+    private ClientDiagramService clientDiagramService;
+
+    @Mock
+    protected CanvasFileExport canvasFileExport;
+
+    @Mock
+    protected EditorSession session;
+
+    @Mock
+    protected AbstractCanvasHandler canvasHandler;
+
+    private SaveDiagramSessionCommandExecutedEvent saveDiagramSessionCommandExecutedEvent;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
+    private Path path;
+
+    @Mock
+    private SelectionControl selectionControl;
+
+    @Before
+    public void setUp() throws Exception {
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getPath()).thenReturn(path);
+        when(metadata.getCanvasRootUUID()).thenReturn(DIAGRAM_UUID);
+        when(session.getSelectionControl()).thenReturn(selectionControl);
+        when(canvasFileExport.exportToSvg(canvasHandler)).thenReturn(RAW_DIAGRAM);
+
+        saveDiagramSessionCommandExecutedEvent = new SaveDiagramSessionCommandExecutedEvent(DIAGRAM_UUID);
+        command = new SaveDiagramSessionCommand(clientDiagramService, canvasFileExport);
+        command.bind(session);
+
+        command.setTimer(new TimerUtils() {
+            @Override
+            public void executeWithDelay(Runnable executeFunction, int delayMillis) {
+                executeFunction.run();
+            }
+        });
+    }
+
+    @Test
+    public void onSaveDiagram() {
+        command.onSaveDiagram(saveDiagramSessionCommandExecutedEvent);
+        verify(selectionControl).clearSelection();
+        verify(clientDiagramService).saveOrUpdateSvg(eq(path), eq(RAW_DIAGRAM), any(ServiceCallback.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapDefinitionSetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapDefinitionSetAdapter.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.core.definition.adapter.bootstrap;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
@@ -82,5 +83,10 @@ class BootstrapDefinitionSetAdapter implements DefinitionSetAdapter<Object> {
 
     private DefinitionSetAdapter<Object> getWrapped(final Class<?> type) {
         return adapterRegistry.getDefinitionSetAdapter(type);
+    }
+
+    @Override
+    public Optional<String> getSvgNodeId(Object pojo) {
+        return getWrapped(pojo).getSvgNodeId(pojo);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/AbstractTranslationService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/AbstractTranslationService.java
@@ -27,6 +27,7 @@ public abstract class AbstractTranslationService implements StunnerTranslationSe
 
     public static final String TITLE_SUFFIX = "title";
     public static final String DESCRIPTION_SUFFIX = "description";
+    public static final String SVG_NODE_ID_SUFFIX = "svgNodeId";
     public static final String CAPTION_SUFFIX = "caption";
 
     @Override
@@ -53,6 +54,11 @@ public abstract class AbstractTranslationService implements StunnerTranslationSe
         PortablePreconditions.checkNotNull("defId",
                                            defId);
         return getValue(defId + I18N_SEPARATOR + DESCRIPTION_SUFFIX);
+    }
+
+    @Override
+    public Optional<String> getDefinitionSetSvgNodeId(String defId) {
+        return Optional.ofNullable(getValue(defId + I18N_SEPARATOR + SVG_NODE_ID_SUFFIX));
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessages.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessages.java
@@ -65,6 +65,8 @@ public class CoreTranslationMessages {
 
     public static final String REDO = "org.kie.workbench.common.stunner.core.client.toolbox.Redo";
 
+    public static final String SAVE = "org.kie.workbench.common.stunner.core.client.toolbox.Save";
+
     public static final String EXPORT_PNG = "org.kie.workbench.common.stunner.core.client.toolbox.ExportPNG";
 
     public static final String EXPORT_PDF = "org.kie.workbench.common.stunner.core.client.toolbox.ExportPDF";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/resources/i18n/StunnerCoreConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/resources/i18n/StunnerCoreConstants.properties
@@ -66,6 +66,7 @@ org.kie.workbench.common.stunner.core.client.toolbox.ExportPNG=Download as PNG
 org.kie.workbench.common.stunner.core.client.toolbox.ExportSVG=Download as SVG
 org.kie.workbench.common.stunner.core.client.toolbox.ExportBPMN=Download as BPMN
 org.kie.workbench.common.stunner.core.client.toolbox.Redo=Redo [Ctrl+Shift+z]
+org.kie.workbench.common.stunner.core.client.toolbox.Save=Save
 org.kie.workbench.common.stunner.core.client.toolbox.SwitchGrid=Switch grid
 org.kie.workbench.common.stunner.core.client.toolbox.Undo=Undo [Ctrl+z]
 org.kie.workbench.common.stunner.core.client.toolbox.Validate=Validate

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/DelegateDiagramService.java
@@ -84,4 +84,9 @@ public class DelegateDiagramService implements DiagramService {
     public String getRawContent(Diagram<Graph, Metadata> diagram) {
         return projectDiagramService.getRawContent(convert(diagram));
     }
+
+    @Override
+    public Path saveOrUpdateSvg(Path diagramPath, String rawDiagramSvg) {
+        return projectDiagramService.saveOrUpdateSvg(diagramPath, rawDiagramSvg);
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/ProjectDiagramServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/ProjectDiagramServiceImpl.java
@@ -176,6 +176,11 @@ public class ProjectDiagramServiceImpl extends KieService<ProjectDiagram>
     }
 
     @Override
+    public Path saveOrUpdateSvg(Path diagramPath, String rawDiagramSvg) {
+        return controller.saveOrUpdateSvg(diagramPath, rawDiagramSvg);
+    }
+
+    @Override
     public boolean delete(final ProjectDiagram diagram) {
         return controller.delete(diagram);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/ProjectDiagramServiceControllerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/ProjectDiagramServiceControllerTest.java
@@ -33,9 +33,6 @@ import org.kie.workbench.common.stunner.core.backend.service.AbstractVFSDiagramS
 import org.kie.workbench.common.stunner.core.backend.service.AbstractVFSDiagramServiceTest;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.factory.diagram.DiagramFactory;
-import org.kie.workbench.common.stunner.core.graph.Graph;
-import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
 import org.kie.workbench.common.stunner.project.diagram.ProjectDiagram;
 import org.kie.workbench.common.stunner.project.diagram.ProjectMetadata;
 import org.mockito.Mock;
@@ -123,17 +120,8 @@ public class ProjectDiagramServiceControllerTest
     public void testGetDiagramByPath() throws IOException {
         final Path path = mockGetDiagramByPathObjects();
 
-        Graph<DefinitionSet, ?> graph = mock(Graph.class);
-        DefinitionSet graphContent = mock(DefinitionSet.class);
-        when(graph.getContent()).thenReturn(graphContent);
-        when(graphContent.getDefinition()).thenReturn("DefinitionSet");
-
         when(diagramMarshaller.unmarshall(anyObject(),
                                           anyObject())).thenReturn(graph);
-
-        DiagramFactory diagramFactory = mock(DiagramFactory.class);
-        when(factoryRegistry.getDiagramFactory("DefinitionSet",
-                                               getMetadataType())).thenReturn(diagramFactory);
 
         when(diagramFactory.build(eq(FILE_NAME),
                                   any(Metadata.class),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/ProjectEditorMenuSessionItems.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/ProjectEditorMenuSessionItems.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.project.client.editor;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.annotation.PreDestroy;
@@ -145,7 +146,7 @@ public class ProjectEditorMenuSessionItems {
                 .bind(session)
                 .getCommands()
                 .visit((type, command) -> {
-                    command.listen(() -> menuItems.get(type).setEnabled(command.isEnabled()));
+                    command.listen(() -> Optional.ofNullable(menuItems.get(type)).ifPresent(item -> item.setEnabled(command.isEnabled())));
                 });
         // Default disabled items.
         setEnabled(session instanceof EditorSession);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/session/EditorSessionCommands.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/session/EditorSessionCommands.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportT
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToSvgSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SaveDiagramSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
@@ -65,7 +66,8 @@ public class EditorSessionCommands {
                 .register(ExportToBpmnSessionCommand.class)
                 .register(CopySelectionSessionCommand.class)
                 .register(PasteSelectionSessionCommand.class)
-                .register(CutSelectionSessionCommand.class);
+                .register(CutSelectionSessionCommand.class)
+                .register(SaveDiagramSessionCommand.class);
     }
 
     public EditorSessionCommands bind(final ClientSession session) {
@@ -135,6 +137,10 @@ public class EditorSessionCommands {
 
     public CutSelectionSessionCommand getCutSelectionSessionCommand() {
         return commands.get(14);
+    }
+
+    public SaveDiagramSessionCommand getSaveDiagramSessionCommand() {
+        return commands.get(15);
     }
 
     public <S extends ClientSessionCommand> S get(final int index) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/service/ClientProjectDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/service/ClientProjectDiagramServiceTest.java
@@ -63,7 +63,8 @@ public class ClientProjectDiagramServiceTest extends AbstractClientDiagramServic
         final Caller<DiagramLookupService> diagramLookupServiceCaller = new CallerMock<>(diagramLookupService);
         return new ClientProjectDiagramService(shapeManager,
                                                diagramServiceCaller,
-                                               diagramLookupServiceCaller);
+                                               diagramLookupServiceCaller,
+                                               saveDiagramSessionCommandExecutedEventEvent);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/BPMNDefinitionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/BPMNDefinitionSet.java
@@ -54,6 +54,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
 import org.kie.workbench.common.stunner.bpmn.factory.BPMNGraphFactory;
 import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
 import org.kie.workbench.common.stunner.core.definition.annotation.DefinitionSet;
+import org.kie.workbench.common.stunner.core.definition.annotation.SvgNodeId;
 import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.rule.annotation.CanContain;
 import org.kie.workbench.common.stunner.core.rule.annotation.Occurrences;
@@ -103,6 +104,9 @@ import org.kie.workbench.common.stunner.core.rule.annotation.Occurrences;
 @Occurrences(role = "Startevents_all", min = 1)
 @Occurrences(role = "Endevents_all", min = 1)
 public class BPMNDefinitionSet {
+
+    @SvgNodeId
+    public static final String SVG_BPMN_ID = "bpmn2nodeid";
 
     public BPMNDefinitionSet() {
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/Id.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/Id.java
@@ -27,10 +27,11 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.I18n
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNProperty;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.property.Value;
+import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 
 @Portable
 @Bindable
-@Property
+@Property(meta = PropertyMetaTypes.ID)
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class Id implements BPMNProperty {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -3,6 +3,7 @@
 # DefinitionSet
 #######################
 org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet.description=BPMN2
+org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet.svgNodeId=bpmn2nodeid
 
 #######################
 # Categories

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/validation/BPMNValidatorImpl.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import org.drools.core.xml.SemanticModules;
@@ -62,7 +63,7 @@ public class BPMNValidatorImpl implements BPMNValidator {
     }
 
     @Inject
-    public BPMNValidatorImpl(final DiagramService diagramService) {
+    public BPMNValidatorImpl(final @Default DiagramService diagramService) {
         this.diagramService = diagramService;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNEditorSessionCommands.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNEditorSessionCommands.java
@@ -55,14 +55,14 @@ public class BPMNEditorSessionCommands extends EditorSessionCommands {
     }
 
     public GenerateProcessFormsSessionCommand getGenerateProcessFormsSessionCommand() {
-        return get(15);
-    }
-
-    public GenerateDiagramFormsSessionCommand getGenerateDiagramFormsSessionCommand() {
         return get(16);
     }
 
-    public GenerateSelectedFormsSessionCommand getGenerateSelectedFormsSessionCommand() {
+    public GenerateDiagramFormsSessionCommand getGenerateDiagramFormsSessionCommand() {
         return get(17);
+    }
+
+    public GenerateSelectedFormsSessionCommand getGenerateSelectedFormsSessionCommand() {
+        return get(18);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/ShowcaseDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/ShowcaseDiagramService.java
@@ -23,7 +23,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasExport;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Layer;
-import org.kie.workbench.common.stunner.core.client.service.ClientDiagramService;
+import org.kie.workbench.common.stunner.core.client.service.ClientDiagramServiceImpl;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
@@ -38,7 +38,7 @@ import org.uberfire.backend.vfs.Path;
 @ApplicationScoped
 public class ShowcaseDiagramService {
 
-    private final ClientDiagramService clientDiagramServices;
+    private final ClientDiagramServiceImpl clientDiagramServices;
     private final CanvasExport<AbstractCanvasHandler> canvasExport;
 
     protected ShowcaseDiagramService() {
@@ -47,7 +47,7 @@ public class ShowcaseDiagramService {
     }
 
     @Inject
-    public ShowcaseDiagramService(final ClientDiagramService clientDiagramServices,
+    public ShowcaseDiagramService(final ClientDiagramServiceImpl clientDiagramServices,
                                   final CanvasExport<AbstractCanvasHandler> canvasExport) {
         this.clientDiagramServices = clientDiagramServices;
         this.canvasExport = canvasExport;


### PR DESCRIPTION
JBPM-7145 cherry pick https://github.com/kiegroup/kie-wb-common/commit/aaf9971e6fa4ee55907c661d1af0638a9d884e4f

++ AbstractCanvasHandlerControl fix to avoid NPE after Clear Canvas.

@romartin