### PR TITLE
JBPM-7180: Update test

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
@@ -78,6 +78,10 @@ public abstract class AbstractCanvasInPlaceTextEditorControlTest<C extends Abstr
 
     private static final double Y = 20.0;
 
+    private static final double OFFSET_X = 30.0;
+
+    private static final double OFFSET_Y = 40.0;
+
     @Mock
     protected FloatingView<IsWidget> floatingView;
 
@@ -165,6 +169,8 @@ public abstract class AbstractCanvasInPlaceTextEditorControlTest<C extends Abstr
         when(floatingView.setOffsetX(anyDouble())).thenReturn(floatingView);
         when(floatingView.setOffsetY(anyDouble())).thenReturn(floatingView);
         when(textEditorBox.getElement()).thenReturn(textEditBoxElement);
+        when(textEditorBox.getDisplayOffsetX()).thenReturn(OFFSET_X);
+        when(textEditorBox.getDisplayOffsetY()).thenReturn(OFFSET_Y);
         when(element.getUUID()).thenReturn(UUID);
         when(element.getContent()).thenReturn(shapeView);
         when(shapeView.getBounds()).thenReturn(shapeViewBounds);
@@ -411,8 +417,8 @@ public abstract class AbstractCanvasInPlaceTextEditorControlTest<C extends Abstr
 
         verify(floatingView).setX(eq(X));
         verify(floatingView).setY(eq(Y));
-        verify(floatingView).setOffsetX(eq(-textEditorBox.getDisplayOffsetX()));
-        verify(floatingView).setOffsetY(eq(-textEditorBox.getDisplayOffsetY()));
+        verify(floatingView).setOffsetX(eq(-OFFSET_X));
+        verify(floatingView).setOffsetY(eq(-OFFSET_Y));
         verify(floatingView).show();
     }
 


### PR DESCRIPTION
Using non default offset (non zero) should make the test more robust.

@manstis please, could you have a look?