### PR TITLE
JBPM-6702 - Stunner Fix NPE when resizing a shape

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImpl.java
@@ -70,7 +70,6 @@ import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
 import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
-import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 import org.kie.workbench.common.stunner.core.rule.violations.BoundsExceededViolation;
 
@@ -314,22 +313,22 @@ public class ResizeControlImpl extends AbstractCanvasHandlerRegistrationControl<
         GraphUtils.getSourceConnections(node)
                 .forEach(edge -> edge.getContent()
                         .getSourceConnection()
-                        .ifPresent(connection -> handleConnections(commandBuilder, node, edge, () -> connection, () -> canvasCommandFactory.setSourceNode(node, edge, connection)))
+                        .ifPresent(connection -> handleConnections(commandBuilder, node, () -> connection, () -> canvasCommandFactory.setSourceNode(node, edge, connection)))
                 );
 
         GraphUtils.getTargetConnections(node)
                 .forEach(edge -> edge.getContent()
                         .getTargetConnection()
-                        .ifPresent(connection -> handleConnections(commandBuilder, node, edge, () -> connection, () -> canvasCommandFactory.setTargetNode(node, edge, connection))
+                        .ifPresent(connection -> handleConnections(commandBuilder, node, () -> connection, () -> canvasCommandFactory.setTargetNode(node, edge, connection))
                         )
                 );
     }
 
     private void handleConnections(final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder,
-                                   final Node<View<?>, Edge> node, Edge<? extends ViewConnector<?>, Node> edge,
-                                   final Supplier<Connection> connecionSupplier,
+                                   final Node<View<?>, Edge> node,
+                                   final Supplier<Connection> connectionSupplier,
                                    final Supplier<CanvasCommand<AbstractCanvasHandler>> commandSupplier) {
-        final Connection connection = connecionSupplier.get();
+        final Connection connection = connectionSupplier.get();
         if (Objects.isNull(connection) || !(connection instanceof MagnetConnection)) {
             return;
         }
@@ -340,8 +339,13 @@ public class ResizeControlImpl extends AbstractCanvasHandlerRegistrationControl<
             Optional.ofNullable(WiresUtils.isWiresShape(shape.getShapeView()) ? (WiresShape) shape.getShapeView() : null)
                     .ifPresent(wiresShape -> {
                         final WiresMagnet magnet = wiresShape.getMagnets().getMagnet(index);
-                        connection.getLocation().setX(magnet.getX());
-                        connection.getLocation().setY(magnet.getY());
+                        if (Objects.nonNull(magnetConnection.getLocation())) {
+                            magnetConnection.getLocation().setX(magnet.getX());
+                            magnetConnection.getLocation().setY(magnet.getY());
+                        } else {
+                            magnetConnection.setLocation(new Point2D(magnet.getX(), magnet.getY()));
+                        }
+
                         commandBuilder.addCommand(commandSupplier.get());
                     });
         });

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImplTest.java
@@ -73,6 +73,7 @@ import org.mockito.Mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -280,7 +281,7 @@ public class ResizeControlImplTest {
         when(connectorEdgeTarget.getUUID()).thenReturn(CONNECTOR_EDGE_TARGET_UUID);
 
         magnetConnection = new MagnetConnection.Builder().atX(0).atY(0).magnet(MagnetConnection.MAGNET_CENTER).build();
-        magnetConnectionTarget = new MagnetConnection.Builder().atX(1).atY(1).magnet(1).build();
+        magnetConnectionTarget = new MagnetConnection.Builder().magnet(1).build();
         when(viewConnector.getSourceConnection()).thenReturn(Optional.of(magnetConnection));
         when(viewConnectorTarget.getTargetConnection()).thenReturn(Optional.of(magnetConnectionTarget));
         when(canvas.getShape(CONNECTOR_EDGE_UUID)).thenReturn(connectorShape);
@@ -340,8 +341,7 @@ public class ResizeControlImplTest {
         //assert initial connection position
         assertEquals(magnetConnection.getLocation().getX(), 0, 0);
         assertEquals(magnetConnection.getLocation().getY(), 0, 0);
-        assertEquals(magnetConnectionTarget.getLocation().getX(), 1, 0);
-        assertEquals(magnetConnectionTarget.getLocation().getY(), 1, 0);
+        assertNull(magnetConnectionTarget.getLocation());
 
         final ResizeHandler resizeHandler = resizeHandlerArgumentCaptor.getValue();
         final double x = 121.45d;


### PR DESCRIPTION
Fix to the reopened JBPM-6702, see [comment](https://issues.jboss.org/browse/JBPM-6702?focusedCommentId=13574574&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13574574), that was an issue when the `location` attribute from the `MangetConnection` was **null** and trying to resize the shape was throwing a **NPE**.

@romartin 
@LuboTerifaj 