### PR TITLE
AF-1202: User cannot see space allowed by permission settings

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/organizationalunit/OrganizationalUnitsScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/organizationalunit/OrganizationalUnitsScreen.java
@@ -129,19 +129,17 @@ public class OrganizationalUnitsScreen {
     }
 
     void setupOrganizationalUnits() {
-        if (organizationalUnitController.canReadOrgUnits()) {
-            view.showBusyIndicator();
-            libraryService.call((List<OrganizationalUnit> allOrganizationalUnits) -> {
-                organizationalUnits = allOrganizationalUnits;
-                if (allOrganizationalUnits.isEmpty()) {
-                    view.showNoOrganizationalUnits(emptyOrganizationalUnitsScreen.getView().getElement());
-                } else {
-                    refresh();
-                }
-                setupView();
-                view.hideBusyIndicator();
-            }).getOrganizationalUnits();
-        }
+        view.showBusyIndicator();
+        libraryService.call((List<OrganizationalUnit> allOrganizationalUnits) -> {
+            organizationalUnits = allOrganizationalUnits;
+            if (allOrganizationalUnits.isEmpty()) {
+                view.showNoOrganizationalUnits(emptyOrganizationalUnitsScreen.getView().getElement());
+            } else {
+                refresh();
+            }
+            setupView();
+            view.hideBusyIndicator();
+        }).getOrganizationalUnits();
     }
 
     public void refresh() {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/organizationalunit/OrganizationalUnitsScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/organizationalunit/OrganizationalUnitsScreenTest.java
@@ -137,15 +137,14 @@ public class OrganizationalUnitsScreenTest {
     }
 
     @Test
-    public void initWithoutReadOrgUnitsPermissionTest() {
+    public void initWithoutReadAllOrgUnitsPermissionTest() {
         doReturn(false).when(organizationalUnitController).canReadOrgUnits();
 
         presenter.init();
 
+        verify(view).clearOrganizationalUnits();
         verify(view,
-               never()).clearOrganizationalUnits();
-        verify(view,
-               never()).addOrganizationalUnit(any());
+               times(3)).addOrganizationalUnit(any());
     }
 
     @Test


### PR DESCRIPTION
It's ok to remove this check because the backend already returns only the spaces that the user has access to.