### PR TITLE
[7.7.x] DROOLS-2555 : Broken welcome page layout in IE11

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-client/src/main/java/org/kie/workbench/common/screens/home/client/widgets/home/HomeView.less
+++ b/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-client/src/main/java/org/kie/workbench/common/screens/home/client/widgets/home/HomeView.less
@@ -74,6 +74,7 @@
   }
 
   .kie-hero-card {
+    height: 210px;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -114,6 +115,7 @@
   .kie-hero-card__text {
     flex: 3 0;
     text-align: left;
+    width: 230px;
     @media (min-width: @screen-md-min) {
       flex: 1 1 ;
       text-align: center;

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/menu/ResetPerspectivesMenuBuilder.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/menu/ResetPerspectivesMenuBuilder.java
@@ -51,31 +51,34 @@ public class ResetPerspectivesMenuBuilder implements MenuFactory.CustomMenuBuild
     private AnchorListItem link = new AnchorListItem();
 
     public ResetPerspectivesMenuBuilder() {
-        link.setIcon( IconType.MEDKIT );
-        link.setTitle( CommonConstants.INSTANCE.ResetPerspectivesTooltip() );
-        link.addClickHandler( new ClickHandler() {
+        link.setIcon(IconType.MEDKIT);
+
+        link.getWidget(0).setStyleName("nav-item-iconic"); // Fix for IE11
+
+        link.setTitle(CommonConstants.INSTANCE.ResetPerspectivesTooltip());
+        link.addClickHandler(new ClickHandler() {
             @Override
-            public void onClick( ClickEvent event ) {
-                if ( Window.confirm( CommonConstants.INSTANCE.PromptResetPerspectives() ) ) {
+            public void onClick(ClickEvent event) {
+                if (Window.confirm(CommonConstants.INSTANCE.PromptResetPerspectives())) {
                     final PerspectiveActivity currentPerspective = perspectiveManager.getCurrentPerspective();
-                    perspectiveManager.removePerspectiveStates( new Command() {
+                    perspectiveManager.removePerspectiveStates(new Command() {
                         @Override
                         public void execute() {
-                            if ( currentPerspective != null ) {
+                            if (currentPerspective != null) {
                                 //Use ForcedPlaceRequest to force re-loading of the current Perspective
-                                final PlaceRequest pr = new ForcedPlaceRequest( currentPerspective.getIdentifier(),
-                                                                                currentPerspective.getPlace().getParameters() );
-                                placeManager.goTo( pr );
+                                final PlaceRequest pr = new ForcedPlaceRequest(currentPerspective.getIdentifier(),
+                                                                               currentPerspective.getPlace().getParameters());
+                                placeManager.goTo(pr);
                             }
                         }
-                    } );
+                    });
                 }
             }
-        } );
+        });
     }
 
     @Override
-    public void push( final MenuFactory.CustomMenuBuilder element ) {
+    public void push(final MenuFactory.CustomMenuBuilder element) {
         //Do nothing
     }
 


### PR DESCRIPTION
(cherry picked from commit e7a62add60788f1562eb64b60d8497ab046c2bb1)


https://issues.jboss.org/browse/DROOLS-2555

Bundle, but can be merged individually.
https://github.com/kiegroup/kie-wb-common/pull/1801
https://github.com/kiegroup/kie-wb-distributions/pull/762

@jomarko If you could also take a look at this.