### PR TITLE
[7.7.x] RHPAM-755 (Stunner) - Copy of timer is created when copying name to doc

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
@@ -48,6 +48,7 @@ public class LienzoPanel implements IsWidget {
     private final Event<CanvasMouseUpEvent> mouseUpEvent;
     private View view;
 
+    private boolean focused;
     private boolean listening;
 
     @Inject
@@ -61,6 +62,7 @@ public class LienzoPanel implements IsWidget {
         this.keyUpEvent = keyUpEvent;
         this.mouseDownEvent = mouseDownEvent;
         this.mouseUpEvent = mouseUpEvent;
+        this.focused = false;
         this.listening = false;
     }
 
@@ -84,9 +86,18 @@ public class LienzoPanel implements IsWidget {
     }
 
     public void destroy() {
+        this.focused = false;
         this.listening = false;
         view.destroy();
         view = null;
+    }
+
+    void onFocus() {
+        focused = true;
+    }
+
+    void onBlur() {
+        focused = false;
     }
 
     void onMouseDown() {
@@ -110,7 +121,7 @@ public class LienzoPanel implements IsWidget {
     }
 
     void onKeyPress(final int unicodeChar) {
-        if (listening) {
+        if (focused && listening) {
             final KeyboardEvent.Key key = getKey(unicodeChar);
             if (null != key) {
                 keyPressEvent.fire(new KeyPressEvent(key));
@@ -119,7 +130,7 @@ public class LienzoPanel implements IsWidget {
     }
 
     void onKeyDown(final int unicodeChar) {
-        if (listening) {
+        if (focused && listening) {
             final KeyboardEvent.Key key = getKey(unicodeChar);
             if (null != key) {
                 keyDownEvent.fire(new KeyDownEvent(key));
@@ -128,7 +139,7 @@ public class LienzoPanel implements IsWidget {
     }
 
     void onKeyUp(final int unicodeChar) {
-        if (listening) {
+        if (focused && listening) {
             final KeyboardEvent.Key key = getKey(unicodeChar);
             if (null != key) {
                 keyUpEvent.fire(new KeyUpEvent(key));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
@@ -32,6 +32,12 @@ public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoP
         super(width,
               height);
         handlerRegistrationManager.register(
+                addFocusHandler(focusEvent -> presenter.onFocus())
+        );
+        handlerRegistrationManager.register(
+                addBlurHandler(blurEvent -> presenter.onBlur())
+        );
+        handlerRegistrationManager.register(
                 addMouseOverHandler(mouseOverEvent -> presenter.onMouseOver())
         );
         handlerRegistrationManager.register(


### PR DESCRIPTION
https://issues.jboss.org/browse/RHPAM-755

For the Lienzo canvas panel to listen to key press, down and up events
the mouse has to be over it and the panel has to be focused as well.

The mouse part was already implemented and working soo it was not
changed.