### PR TITLE
JBPM-7132 (Stunner) - Copy of timer is created when copying name to doc

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
@@ -46,10 +46,24 @@ public class LienzoPanel implements IsWidget {
     private final Event<KeyUpEvent> keyUpEvent;
     private final Event<CanvasMouseDownEvent> mouseDownEvent;
     private final Event<CanvasMouseUpEvent> mouseUpEvent;
+
     private View view;
 
+    protected View getView() {
+        return view;
+    }
+
     private boolean focused;
+
+    protected boolean isFocused() {
+        return focused;
+    }
+
     private boolean listening;
+
+    protected boolean isListening() {
+        return listening;
+    }
 
     @Inject
     public LienzoPanel(final Event<KeyPressEvent> keyPressEvent,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
@@ -48,6 +48,7 @@ public class LienzoPanel implements IsWidget {
     private final Event<CanvasMouseUpEvent> mouseUpEvent;
     private View view;
 
+    private boolean focused;
     private boolean listening;
 
     @Inject
@@ -61,6 +62,7 @@ public class LienzoPanel implements IsWidget {
         this.keyUpEvent = keyUpEvent;
         this.mouseDownEvent = mouseDownEvent;
         this.mouseUpEvent = mouseUpEvent;
+        this.focused = false;
         this.listening = false;
     }
 
@@ -84,9 +86,18 @@ public class LienzoPanel implements IsWidget {
     }
 
     public void destroy() {
+        this.focused = false;
         this.listening = false;
         view.destroy();
         view = null;
+    }
+
+    void onFocus() {
+        focused = true;
+    }
+
+    void onBlur() {
+        focused = false;
     }
 
     void onMouseDown() {
@@ -110,7 +121,7 @@ public class LienzoPanel implements IsWidget {
     }
 
     void onKeyPress(final int unicodeChar) {
-        if (listening) {
+        if (focused && listening) {
             final KeyboardEvent.Key key = getKey(unicodeChar);
             if (null != key) {
                 keyPressEvent.fire(new KeyPressEvent(key));
@@ -119,7 +130,7 @@ public class LienzoPanel implements IsWidget {
     }
 
     void onKeyDown(final int unicodeChar) {
-        if (listening) {
+        if (focused && listening) {
             final KeyboardEvent.Key key = getKey(unicodeChar);
             if (null != key) {
                 keyDownEvent.fire(new KeyDownEvent(key));
@@ -128,7 +139,7 @@ public class LienzoPanel implements IsWidget {
     }
 
     void onKeyUp(final int unicodeChar) {
-        if (listening) {
+        if (focused && listening) {
             final KeyboardEvent.Key key = getKey(unicodeChar);
             if (null != key) {
                 keyUpEvent.fire(new KeyUpEvent(key));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
@@ -24,13 +24,30 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.HandlerRegi
 
 public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoPanel.View {
 
-    private final HandlerRegistrationImpl handlerRegistrationManager = new HandlerRegistrationImpl();
+    private final HandlerRegistrationImpl handlerRegistrationManager;
     private LienzoPanel presenter;
 
     public LienzoPanelView(final int width,
                            final int height) {
+        this(width, height, new HandlerRegistrationImpl());
+    }
+
+    protected LienzoPanelView(final int width,
+                              final int height,
+                              HandlerRegistrationImpl handlerRegistrationImpl) {
         super(width,
               height);
+
+        handlerRegistrationManager = handlerRegistrationImpl;
+    }
+
+    protected RootPanel getRootPanel() {
+        return RootPanel.get();
+    }
+
+    @Override
+    public void init(final LienzoPanel presenter) {
+
         handlerRegistrationManager.register(
                 addFocusHandler(focusEvent -> presenter.onFocus())
         );
@@ -44,36 +61,33 @@ public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoP
                 addMouseOutHandler(mouseOutEvent -> presenter.onMouseOut())
         );
         handlerRegistrationManager.register(
-                addMouseDownHandler(event -> presenter.onMouseDown())
+                addMouseDownHandler(mouseDownEvent -> presenter.onMouseDown())
         );
         handlerRegistrationManager.register(
-                addMouseUpHandler(event -> presenter.onMouseUp())
+                addMouseUpHandler(mouseUpEvent -> presenter.onMouseUp())
         );
         handlerRegistrationManager.register(
-                RootPanel.get().addDomHandler(keyPressEvent -> {
-                                                  final int unicodeChar = keyPressEvent.getUnicodeCharCode();
-                                                  presenter.onKeyPress(unicodeChar);
-                                              },
-                                              KeyPressEvent.getType())
+                getRootPanel().addDomHandler(keyPressEvent -> {
+                                                 final int unicodeChar = keyPressEvent.getUnicodeCharCode();
+                                                 this.presenter.onKeyPress(unicodeChar);
+                                             },
+                                             KeyPressEvent.getType())
         );
         handlerRegistrationManager.register(
-                RootPanel.get().addDomHandler(keyDownEvent -> {
-                                                  final int unicodeChar = keyDownEvent.getNativeKeyCode();
-                                                  presenter.onKeyDown(unicodeChar);
-                                              },
-                                              KeyDownEvent.getType())
+                getRootPanel().addDomHandler(keyDownEvent -> {
+                                                 final int unicodeChar = keyDownEvent.getNativeKeyCode();
+                                                 this.presenter.onKeyDown(unicodeChar);
+                                             },
+                                             KeyDownEvent.getType())
         );
         handlerRegistrationManager.register(
-                RootPanel.get().addDomHandler(keyUpEvent -> {
-                                                  final int unicodeChar = keyUpEvent.getNativeKeyCode();
-                                                  presenter.onKeyUp(unicodeChar);
-                                              },
-                                              KeyUpEvent.getType())
+                getRootPanel().addDomHandler(keyUpEvent -> {
+                                                 final int unicodeChar = keyUpEvent.getNativeKeyCode();
+                                                 this.presenter.onKeyUp(unicodeChar);
+                                             },
+                                             KeyUpEvent.getType())
         );
-    }
 
-    @Override
-    public void init(final LienzoPanel presenter) {
         this.presenter = presenter;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
@@ -32,6 +32,12 @@ public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoP
         super(width,
               height);
         handlerRegistrationManager.register(
+                addFocusHandler(focusEvent -> presenter.onFocus())
+        );
+        handlerRegistrationManager.register(
+                addBlurHandler(blurEvent -> presenter.onBlur())
+        );
+        handlerRegistrationManager.register(
                 addMouseOverHandler(mouseOverEvent -> presenter.onMouseOver())
         );
         handlerRegistrationManager.register(

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.view;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseDownEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseUpEvent;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyDownEvent;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyPressEvent;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyUpEvent;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
+import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class LienzoPanelTest {
+
+    @Mock
+    private EventSourceMock<KeyPressEvent> keyPressEvent;
+
+    @Mock
+    private EventSourceMock<KeyDownEvent> keyDownEvent;
+
+    @Mock
+    private EventSourceMock<KeyUpEvent> keyUpEvent;
+
+    @Mock
+    private EventSourceMock<CanvasMouseDownEvent> mouseDownEvent;
+
+    @Mock
+    private EventSourceMock<CanvasMouseUpEvent> mouseUpEvent;
+
+    private LienzoPanel lienzoPanel;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        lienzoPanel = new LienzoPanel(keyPressEvent,
+                                      keyDownEvent,
+                                      keyUpEvent,
+                                      mouseDownEvent,
+                                      mouseUpEvent);
+    }
+
+    @Test
+    public void testOnFocus() {
+        lienzoPanel.onFocus();
+        assertEquals(lienzoPanel.isFocused(), true);
+    }
+
+    @Test
+    public void testOnBlur() {
+        lienzoPanel.onBlur();
+        assertEquals(lienzoPanel.isFocused(), false);
+    }
+
+    @Test
+    public void testOnMouseOver() {
+        lienzoPanel.onMouseOver();
+        assertEquals(lienzoPanel.isListening(), true);
+    }
+
+    @Test
+    public void testOnMouseOut() {
+        lienzoPanel.onMouseOut();
+        assertEquals(lienzoPanel.isListening(), false);
+    }
+
+    @Test
+    public void testOnMouseDown() {
+        lienzoPanel.onMouseOut();
+        lienzoPanel.onMouseDown();
+        verify(mouseDownEvent, never()).fire(any(CanvasMouseDownEvent.class));
+
+        lienzoPanel.onMouseOver();
+        lienzoPanel.onMouseDown();
+        verify(mouseDownEvent, times(1)).fire(any(CanvasMouseDownEvent.class));
+    }
+
+    @Test
+    public void testOnKeyPress() {
+        lienzoPanel.onMouseOut();
+        lienzoPanel.onBlur();
+        lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyPressEvent, never()).fire(any(KeyPressEvent.class));
+
+        lienzoPanel.onMouseOut();
+        lienzoPanel.onFocus();
+        lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyPressEvent, never()).fire(any(KeyPressEvent.class));
+
+        lienzoPanel.onMouseOver();
+        lienzoPanel.onBlur();
+        lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyPressEvent, never()).fire(any(KeyPressEvent.class));
+
+        lienzoPanel.onMouseOver();
+        lienzoPanel.onFocus();
+        lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyPressEvent, times(1)).fire(any(KeyPressEvent.class));
+    }
+
+    @Test
+    public void testOnKeyDown() {
+        lienzoPanel.onMouseOut();
+        lienzoPanel.onBlur();
+        lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyDownEvent, never()).fire(any(KeyDownEvent.class));
+
+        lienzoPanel.onMouseOut();
+        lienzoPanel.onFocus();
+        lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyDownEvent, never()).fire(any(KeyDownEvent.class));
+
+        lienzoPanel.onMouseOver();
+        lienzoPanel.onBlur();
+        lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyDownEvent, never()).fire(any(KeyDownEvent.class));
+
+        lienzoPanel.onMouseOver();
+        lienzoPanel.onFocus();
+        lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyDownEvent, times(1)).fire(any(KeyDownEvent.class));
+    }
+
+    @Test
+    public void testOnKeyUp() {
+        lienzoPanel.onMouseOut();
+        lienzoPanel.onBlur();
+        lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyUpEvent, never()).fire(any(KeyUpEvent.class));
+
+        lienzoPanel.onMouseOut();
+        lienzoPanel.onFocus();
+        lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyUpEvent, never()).fire(any(KeyUpEvent.class));
+
+        lienzoPanel.onMouseOver();
+        lienzoPanel.onBlur();
+        lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyUpEvent, never()).fire(any(KeyUpEvent.class));
+
+        lienzoPanel.onMouseOver();
+        lienzoPanel.onFocus();
+        lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
+        verify(keyUpEvent, times(1)).fire(any(KeyUpEvent.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelViewTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.view;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.FocusHandler;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.KeyPressEvent;
+import com.google.gwt.event.dom.client.KeyPressHandler;
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.dom.client.MouseDownHandler;
+import com.google.gwt.event.dom.client.MouseOutHandler;
+import com.google.gwt.event.dom.client.MouseOverHandler;
+import com.google.gwt.event.dom.client.MouseUpHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.RootPanel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.HandlerRegistrationImpl;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class LienzoPanelViewTest {
+
+    @Mock
+    private HandlerRegistrationImpl handlerRegistrationManager;
+
+    @Mock
+    private RootPanel rootPanel;
+
+    @Mock
+    private LienzoPanel lienzoPanel;
+
+    private LienzoPanelView spyTested;
+
+    @Before
+    public void setup() {
+        spyTested = Mockito.spy(new LienzoPanelView(200, 200, handlerRegistrationManager));
+        when(spyTested.getRootPanel()).thenReturn(rootPanel);
+    }
+
+    @Test
+    public void testInit() {
+        spyTested.init(lienzoPanel);
+
+        verify(spyTested).addFocusHandler(any(FocusHandler.class));
+        verify(spyTested).addBlurHandler(any(BlurHandler.class));
+
+        verify(spyTested).addMouseOverHandler(any(MouseOverHandler.class));
+        verify(spyTested).addMouseOutHandler(any(MouseOutHandler.class));
+        verify(spyTested).addMouseDownHandler(any(MouseDownHandler.class));
+        verify(spyTested).addMouseUpHandler(any(MouseUpHandler.class));
+        verify(spyTested).addMouseUpHandler(any(MouseUpHandler.class));
+
+        verify(rootPanel).addDomHandler(any(KeyPressHandler.class), eq(KeyPressEvent.getType()));
+        verify(rootPanel).addDomHandler(any(KeyUpHandler.class), eq(KeyUpEvent.getType()));
+        verify(rootPanel).addDomHandler(any(KeyDownHandler.class), eq(KeyDownEvent.getType()));
+
+        verify(handlerRegistrationManager, times(9)).register(any(HandlerRegistration.class));
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-7132

For the Lienzo canvas panel to listen to key press, down and up events
the mouse has to be over it and the panel has to be focused as well.

The mouse part was already implemented and working soo it was not
changed.