### PR TITLE
JBPM-6491 Fix connections positions inside sub-process

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/Bpmn2JsonUnmarshaller.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/Bpmn2JsonUnmarshaller.java
@@ -542,7 +542,7 @@ public class Bpmn2JsonUnmarshaller {
                         if (sourceBounds != null) {
                             Point first = edgePoints.get(0);
                             first.setX(first.getX() + getBoundsForElement(container,
-                                                                          plane).getX() + (sourceBounds.getWidth() / 2));
+                                                                          plane).getX());
                             first.setY(first.getY() + getBoundsForElement(container,
                                                                           plane).getY());
                         }
@@ -555,7 +555,7 @@ public class Bpmn2JsonUnmarshaller {
                         if (targetBounds != null) {
                             Point last = edgePoints.get(edgePoints.size() - 1);
                             last.setX(last.getX() + getBoundsForElement(container,
-                                                                        plane).getX() - (targetBounds.getWidth() / 2));
+                                                                        plane).getX());
                             last.setY(last.getY() + getBoundsForElement(container,
                                                                         plane).getY());
                         }


### PR DESCRIPTION
Fix to the issue regarding connections inside sub-processes that were not being persisted on the right position.
See the comment reported on https://issues.jboss.org/browse/RHPAM-468?focusedCommentId=13576673&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13576673

This will be ported to the **7.7.x** after merging.

@romartin 
@LuboTerifaj 
Can you please give priority on this review since this is a blocker, thanks.

@evacchi this change is on the old marshaller, can you please check this behavior on the new marshaller to make sure the same issue is not happening, thanks!