### PR TITLE
[AF-1209-7.7.x]: Revert "[RHBA-565-7.7.x]: [RHBA-565]: Copied asset is open after ResourceCopiedEvent is observed

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
@@ -87,7 +87,6 @@ import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.preferences.shared.impl.PreferenceScopeResolutionStrategyInfo;
 import org.uberfire.workbench.events.NotificationEvent;
-import org.uberfire.workbench.events.ResourceCopiedEvent;
 import org.uberfire.workbench.events.ResourceDeletedEvent;
 import org.uberfire.workbench.model.impl.PartDefinitionImpl;
 
@@ -867,11 +866,4 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
         this.placeManager.closePlace(new PathPlaceRequest(path));
     }
 
-    public void onResourceCopiedEvent(@Observes final ResourceCopiedEvent resourceCopiedEvent) {
-        if (this.isLibraryPerspectiveOpen()) {
-            Path path = resourceCopiedEvent.getDestinationPath();
-            this.goToAsset(path);
-            setupLibraryBreadCrumbsForAsset(path);
-        }
-    }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
@@ -79,7 +79,6 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
-import org.uberfire.workbench.events.ResourceCopiedEvent;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.impl.PartDefinitionImpl;
 
@@ -858,19 +857,5 @@ public class LibraryPlacesTest {
                              any(),
                              any(),
                              any());
-    }
-
-    @Test
-    public void testOnResourceCopiedEvent() {
-
-        doReturn(PlaceStatus.OPEN).when(placeManager).getStatus(LibraryPlaces.LIBRARY_PERSPECTIVE);
-
-        Path path = mock(Path.class);
-        ResourceCopiedEvent event = mock(ResourceCopiedEvent.class);
-        when(event.getDestinationPath()).thenReturn(path);
-
-        this.libraryPlaces.onResourceCopiedEvent(event);
-
-        verify(this.libraryPlaces).goToAsset(path);
     }
 }


### PR DESCRIPTION
From master: https://github.com/kiegroup/kie-wb-common/pull/1825

@manstis would you mind to review please?