### PR TITLE
DROOLS-2579: [DMN Designer] Add support for setting 'DMNModelInstrumentedBase.setParent(..)' to the UI model as and when Users create new elements

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasExpression.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.dmn.api.definition;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 
 public interface HasExpression {
@@ -22,4 +23,6 @@ public interface HasExpression {
     Expression getExpression();
 
     void setExpression(final Expression expression);
+
+    DMNModelInstrumentedBase asDMNModelInstrumentedBase();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Binding.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Binding.java
@@ -41,4 +41,9 @@ public class Binding extends DMNModelInstrumentedBase implements HasExpression {
     public void setExpression(final Expression value) {
         this.expression = value;
     }
+
+    @Override
+    public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+        return this;
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextEntry.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextEntry.java
@@ -41,4 +41,9 @@ public class ContextEntry extends DMNModelInstrumentedBase implements HasExpress
     public void setExpression(final Expression value) {
         this.expression = value;
     }
+
+    @Override
+    public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+        return this;
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
@@ -201,4 +201,9 @@ public class Decision extends DRGElement implements HasExpression,
     public void setExpression(final Expression expression) {
         this.expression = expression;
     }
+
+    @Override
+    public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+        return this;
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
@@ -70,6 +70,11 @@ public class FunctionDefinition extends Expression implements HasExpression {
         this.expression = expression;
     }
 
+    @Override
+    public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+        return this;
+    }
+
     public List<InformationItem> getFormalParameter() {
         if (formalParameter == null) {
             formalParameter = new ArrayList<>();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Invocation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Invocation.java
@@ -61,6 +61,11 @@ public class Invocation extends Expression implements HasExpression {
         this.expression = value;
     }
 
+    @Override
+    public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+        return this;
+    }
+
     public List<Binding> getBinding() {
         if (binding == null) {
             binding = new ArrayList<>();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -297,6 +297,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.workbench.stunner</groupId>
+      <artifactId>kie-wb-common-stunner-core-common</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/builder/ObserverBuilderControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/builder/ObserverBuilderControl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.canvas.controls.builder;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.core.client.api.ClientDefinitionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.impl.Observer;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationMessages;
+import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
+import org.kie.workbench.common.stunner.core.graph.processing.index.bounds.GraphBoundsIndexer;
+import org.kie.workbench.common.stunner.core.rule.RuleManager;
+
+@DMNEditor
+@Dependent
+@Observer
+public class ObserverBuilderControl extends org.kie.workbench.common.stunner.core.client.canvas.controls.builder.impl.ObserverBuilderControl {
+
+    @Inject
+    public ObserverBuilderControl(final ClientDefinitionManager clientDefinitionManager,
+                                  final ClientFactoryService clientFactoryServices,
+                                  final RuleManager ruleManager,
+                                  final @DMNEditor CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                  final ClientTranslationMessages translationMessages,
+                                  final GraphBoundsIndexer graphBoundsIndexer,
+                                  final Event<CanvasSelectionEvent> canvasSelectionEvent) {
+        super(clientDefinitionManager,
+              clientFactoryServices,
+              ruleManager,
+              canvasCommandFactory,
+              translationMessages,
+              graphBoundsIndexer,
+              canvasSelectionEvent);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/CreateNodeAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/CreateNodeAction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.canvas.controls.toolbox;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.core.client.api.ClientFactoryManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.session.Session;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+
+@Dependent
+@DMNFlowActionsToolbox
+public class CreateNodeAction extends org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeAction {
+
+    @Inject
+    public CreateNodeAction(final DefinitionUtils definitionUtils,
+                            final ClientFactoryManager clientFactoryManager,
+                            final CanvasLayoutUtils canvasLayoutUtils,
+                            final Event<CanvasSelectionEvent> selectionEvent,
+                            final ClientTranslationService translationService,
+                            final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                            final @DMNEditor CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory) {
+        super(definitionUtils,
+              clientFactoryManager,
+              canvasLayoutUtils,
+              selectionEvent,
+              translationService,
+              sessionCommandManager,
+              canvasCommandFactory);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactory.java
@@ -57,7 +57,7 @@ public class DMNFlowActionsToolboxFactory
     public DMNFlowActionsToolboxFactory(final DefinitionUtils definitionUtils,
                                         final CommonLookups commonLookups,
                                         final @Any ManagedInstance<CreateConnectorAction> createConnectorActions,
-                                        final @Any ManagedInstance<CreateNodeAction> createNodeActions,
+                                        final @Any @DMNFlowActionsToolbox ManagedInstance<CreateNodeAction> createNodeActions,
                                         final @Any @FlowActionsToolbox ManagedInstance<ActionsToolboxView> views) {
         this.definitionUtils = definitionUtils;
         this.commonLookups = commonLookups;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommand.java
@@ -77,6 +77,8 @@ public class AddContextEntryCommand extends AbstractCanvasGraphCommand implement
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext gce) {
                 context.getContextEntry().add(uiRowIndex,
                                               contextEntry);
+                contextEntry.setParent(context);
+                contextEntry.getVariable().setParent(contextEntry);
 
                 return GraphCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommand.java
@@ -87,15 +87,19 @@ public class AddDecisionRuleCommand extends AbstractCanvasGraphCommand implement
                     final UnaryTests ut = new UnaryTests();
                     ut.setText(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE);
                     rule.getInputEntry().add(ut);
+                    ut.setParent(rule);
                 }
                 for (int oe = 0; oe < dtable.getOutput().size(); oe++) {
                     final LiteralExpression le = new LiteralExpression();
                     le.setText(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE);
                     rule.getOutputEntry().add(le);
+                    le.setParent(rule);
                 }
                 final Description d = new Description();
                 d.setValue(DESCRIPTION_DEFAULT_VALUE);
                 rule.setDescription(d);
+
+                rule.setParent(dtable);
 
                 return GraphCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommand.java
@@ -83,7 +83,10 @@ public class AddInputClauseCommand extends AbstractCanvasGraphCommand implements
                     final UnaryTests ut = new UnaryTests();
                     ut.setText(INPUT_CLAUSE_DEFAULT_VALUE);
                     rule.getInputEntry().add(clauseIndex, ut);
+                    ut.setParent(rule);
                 });
+
+                inputClause.setParent(dtable);
 
                 return GraphCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommand.java
@@ -84,7 +84,10 @@ public class AddOutputClauseCommand extends AbstractCanvasGraphCommand implement
                     final LiteralExpression le = new LiteralExpression();
                     le.setText(OUTPUT_CLAUSE_DEFAULT_VALUE);
                     rule.getOutputEntry().add(clauseIndex, le);
+                    le.setParent(rule);
                 });
+
+                outputClause.setParent(dtable);
 
                 return GraphCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/AddParameterCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/AddParameterCommand.java
@@ -59,6 +59,8 @@ public class AddParameterCommand extends AbstractCanvasGraphCommand implements V
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext gce) {
                 function.getFormalParameter().add(parameter);
 
+                parameter.setParent(function);
+
                 return GraphCommandResultBuilder.SUCCESS;
             }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/AddParameterBindingCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/AddParameterBindingCommand.java
@@ -78,6 +78,9 @@ public class AddParameterBindingCommand extends AbstractCanvasGraphCommand imple
                 invocation.getBinding().add(uiRowIndex,
                                             binding);
 
+                binding.setParent(invocation);
+                binding.getParameter().setParent(binding);
+
                 return GraphCommandResultBuilder.SUCCESS;
             }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommand.java
@@ -80,9 +80,11 @@ public class AddRelationColumnCommand extends AbstractCanvasGraphCommand impleme
                                          informationItem);
                 relation.getRow().forEach(row -> {
                     final LiteralExpression le = new LiteralExpression();
-                    row.getExpression().add(iiIndex,
-                                            le);
+                    row.getExpression().add(iiIndex, le);
+                    le.setParent(row);
                 });
+
+                informationItem.setParent(relation);
 
                 return GraphCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommand.java
@@ -81,7 +81,10 @@ public class AddRelationRowCommand extends AbstractCanvasGraphCommand implements
                 relation.getColumn().forEach(ii -> {
                     final LiteralExpression le = new LiteralExpression();
                     row.getExpression().add(le);
+                    le.setParent(row);
                 });
+
+                row.setParent(relation);
 
                 return GraphCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/undefined/SetCellValueCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/undefined/SetCellValueCommand.java
@@ -75,10 +75,16 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
             }
 
             @Override
+            @SuppressWarnings("unchecked")
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
                 uiModelMapper.get().toDMNModel(cellTuple.getRowIndex(),
                                                cellTuple.getColumnIndex(),
                                                () -> Optional.of(cellTuple.getValue()));
+
+                // The parent of the Expression represented by the ExpressionCellValue
+                // is set by UndefinedExpressionUIModelMapper instead of this Command
+                // for simplicity.
+
                 return GraphCommandResultBuilder.SUCCESS;
             }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/DefaultCanvasCommandFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.canvas.AddChildNodeCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessor;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ViewTraverseProcessor;
+
+@DMNEditor
+@ApplicationScoped
+public class DefaultCanvasCommandFactory extends org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory {
+
+    protected DefaultCanvasCommandFactory() {
+        super();
+    }
+
+    @Inject
+    public DefaultCanvasCommandFactory(final ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors,
+                                       final ManagedInstance<ViewTraverseProcessor> viewTraverseProcessors) {
+        super(childrenTraverseProcessors,
+              viewTraverseProcessors);
+    }
+
+    @Override
+    public CanvasCommand<AbstractCanvasHandler> addChildNode(final Node parent,
+                                                             final Node candidate,
+                                                             final String shapeSetId) {
+        return new AddChildNodeCommand(parent,
+                                       candidate,
+                                       shapeSetId);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/AddChildNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/AddChildNodeCommand.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+public class AddChildNodeCommand extends org.kie.workbench.common.stunner.core.client.canvas.command.AddChildNodeCommand {
+
+    public AddChildNodeCommand(final Node parent,
+                               final Node candidate,
+                               final String shapeSetId) {
+        super(parent,
+              candidate,
+              shapeSetId);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
+        return new org.kie.workbench.common.dmn.client.commands.factory.graph.AddChildNodeCommand(parent,
+                                                                                                  candidate);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/AddChildNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/AddChildNodeCommand.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+
+@Portable
+public class AddChildNodeCommand extends org.kie.workbench.common.stunner.core.graph.command.impl.AddChildNodeCommand {
+
+    public AddChildNodeCommand(final @MapsTo("parentUUID") String parentUUID,
+                               final @MapsTo("candidate") Node candidate,
+                               final @MapsTo("location") Point2D location) {
+        super(parentUUID,
+              candidate,
+              location);
+    }
+
+    public AddChildNodeCommand(final Node<?, Edge> parent,
+                               final Node candidate) {
+        super(parent,
+              candidate);
+    }
+
+    @Override
+    protected SetChildNodeCommand getSetChildNodeCommand(final Node<?, Edge> parent,
+                                                         final Node candidate) {
+        return new SetChildNodeCommand(parent,
+                                       candidate);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/SetChildNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/SetChildNodeCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+@Portable
+public class SetChildNodeCommand extends org.kie.workbench.common.stunner.core.graph.command.impl.SetChildNodeCommand {
+
+    public SetChildNodeCommand(final @MapsTo("parentUUID") String parentUUID,
+                               final @MapsTo("candidateUUID") String candidateUUID) {
+        super(parentUUID,
+              candidateUUID);
+    }
+
+    public SetChildNodeCommand(final Node<?, Edge> parent,
+                               final Node<?, Edge> candidate) {
+        super(parent,
+              candidate);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
+        final CommandResult<RuleViolation> results = super.execute(context);
+        if (!results.getType().equals(CommandResult.Type.ERROR)) {
+            final Node<?, Edge> parent = getParent(context);
+            final Node<?, Edge> candidate = getCandidate(context);
+            if (parent.getContent() instanceof View) {
+                final DMNModelInstrumentedBase parentDMNModel = (DMNModelInstrumentedBase) ((View) parent.getContent()).getDefinition();
+                if (candidate.getContent() instanceof View) {
+                    final DMNModelInstrumentedBase childDMNModel = (DMNModelInstrumentedBase) ((View) candidate.getContent()).getDefinition();
+                    childDMNModel.setParent(parentDMNModel);
+                }
+            }
+        }
+        return results;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
@@ -99,13 +99,22 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
         //Add one ContextEntry for the User to start with
         final Context context = new Context();
         final ContextEntry contextEntry = new ContextEntry();
-        contextEntry.setVariable(new InformationItem());
+        final InformationItem informationItem = new InformationItem();
+        contextEntry.setVariable(informationItem);
         context.getContextEntry().add(contextEntry);
 
         //Add (default) "result" entry
         final ContextEntry resultEntry = new ContextEntry();
-        resultEntry.setExpression(new LiteralExpression());
+        final LiteralExpression literalExpression = new LiteralExpression();
+        resultEntry.setExpression(literalExpression);
         context.getContextEntry().add(resultEntry);
+
+        //Setup parent relationships
+        contextEntry.setParent(context);
+        informationItem.setParent(contextEntry);
+        resultEntry.setParent(context);
+        literalExpression.setParent(resultEntry);
+
         return Optional.of(context);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
@@ -139,6 +139,14 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
 
         dtable.getRule().add(dr);
 
+        //Setup parent relationships
+        ic.setParent(dtable);
+        oc.setParent(dtable);
+        dr.setParent(dtable);
+        le.setParent(ic);
+        drut.setParent(dr);
+        drle.setParent(dr);
+
         return Optional.of(dtable);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
@@ -98,12 +98,20 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
     @Override
     public Optional<Invocation> getModelClass() {
         final Invocation invocation = new Invocation();
-        invocation.setExpression(new LiteralExpression());
+        final LiteralExpression literalExpression = new LiteralExpression();
+        invocation.setExpression(literalExpression);
+
         final InformationItem parameter = new InformationItem();
         parameter.setName(new Name("p0"));
         final Binding binding = new Binding();
         binding.setParameter(parameter);
         invocation.getBinding().add(binding);
+
+        //Setup parent relationships
+        literalExpression.setParent(invocation);
+        binding.setParent(invocation);
+        parameter.setParent(binding);
+
         return Optional.of(invocation);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
@@ -92,9 +92,16 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
         final Relation relation = new Relation();
         final InformationItem column = new InformationItem();
         final org.kie.workbench.common.dmn.api.definition.v1_1.List row = new org.kie.workbench.common.dmn.api.definition.v1_1.List();
-        row.getExpression().add(new LiteralExpression());
+        final LiteralExpression literalExpression = new LiteralExpression();
+        row.getExpression().add(literalExpression);
         relation.getColumn().add(column);
         relation.getRow().add(row);
+
+        //Setup parent relationships
+        column.setParent(relation);
+        row.setParent(relation);
+        literalExpression.setParent(row);
+
         return Optional.of(relation);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
@@ -75,7 +75,10 @@ public class UndefinedExpressionUIModelMapper extends BaseUIModelMapper<Expressi
                            final Supplier<Optional<GridCellValue<?>>> cell) {
         cell.get().ifPresent(v -> {
             final ExpressionCellValue ecv = (ExpressionCellValue) v;
-            ecv.getValue().ifPresent(beg -> hasExpression.setExpression((Expression) beg.getExpression().orElse(null)));
+            ecv.getValue().ifPresent(beg -> {
+                hasExpression.setExpression((Expression) beg.getExpression().orElse(null));
+                beg.getExpression().ifPresent(e -> ((Expression) e).setParent(hasExpression.asDMNModelInstrumentedBase()));
+            });
         });
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommandTest.java
@@ -203,6 +203,11 @@ public class AddContextEntryCommandTest {
                      context.getContextEntry().get(0));
         assertEquals(defaultResultContextEntry,
                      context.getContextEntry().get(1));
+
+        assertEquals(context,
+                     contextEntry.getParent());
+        assertEquals(contextEntry,
+                     contextEntry.getVariable().getParent());
     }
 
     @Test
@@ -228,6 +233,11 @@ public class AddContextEntryCommandTest {
                      context.getContextEntry().get(1));
         assertEquals(defaultResultContextEntry,
                      context.getContextEntry().get(2));
+
+        assertEquals(context,
+                     contextEntry.getParent());
+        assertEquals(contextEntry,
+                     contextEntry.getVariable().getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
@@ -154,6 +154,9 @@ public class AddDecisionRuleCommandTest {
         assertTrue(rule.getDescription() != null);
         assertTrue(rule.getDescription().getValue() != null);
         assertFalse(rule.getDescription().getValue().isEmpty());
+
+        assertEquals(dtable,
+                     rule.getParent());
     }
 
     @Test
@@ -180,7 +183,11 @@ public class AddDecisionRuleCommandTest {
         for (int inputIndex = 0; inputIndex < inputsCount; inputIndex++) {
             assertTrue(rule.getInputEntry().get(inputIndex).getText() != null);
             assertFalse(rule.getInputEntry().get(inputIndex).getText().isEmpty());
+            assertEquals(rule, rule.getInputEntry().get(inputIndex).getParent());
         }
+
+        assertEquals(dtable,
+                     rule.getParent());
     }
 
     @Test
@@ -207,7 +214,11 @@ public class AddDecisionRuleCommandTest {
         for (int outputIndex = 0; outputIndex < outputsCount; outputIndex++) {
             assertTrue(rule.getOutputEntry().get(outputIndex).getText() != null);
             assertFalse(rule.getOutputEntry().get(outputIndex).getText().isEmpty());
+            assertEquals(rule, rule.getOutputEntry().get(outputIndex).getParent());
         }
+
+        assertEquals(dtable,
+                     rule.getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
@@ -133,12 +133,19 @@ public class AddInputClauseCommandTest {
         assertEquals(1, dtable.getInput().size());
 
         // first rule
-        assertEquals(1, dtable.getRule().get(0).getInputEntry().size());
-        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(0).getInputEntry().get(0).getText());
+        final List<UnaryTests> inputEntriesRuleOne = dtable.getRule().get(0).getInputEntry();
+        assertEquals(1, inputEntriesRuleOne.size());
+        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, inputEntriesRuleOne.get(0).getText());
+        assertEquals(dtable.getRule().get(0), inputEntriesRuleOne.get(0).getParent());
 
         // second rule
-        assertEquals(1, dtable.getRule().get(1).getInputEntry().size());
-        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(1).getInputEntry().get(0).getText());
+        final List<UnaryTests> inputEntriesRuleTwo = dtable.getRule().get(1).getInputEntry();
+        assertEquals(1, inputEntriesRuleTwo.size());
+        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, inputEntriesRuleTwo.get(0).getText());
+        assertEquals(dtable.getRule().get(1), inputEntriesRuleTwo.get(0).getParent());
+
+        assertEquals(dtable,
+                     inputClause.getParent());
     }
 
     @Test
@@ -163,14 +170,21 @@ public class AddInputClauseCommandTest {
         assertEquals(2, dtable.getInput().size());
 
         // first rule
-        assertEquals(2, dtable.getRule().get(0).getInputEntry().size());
-        assertEquals(ruleOneOldInput, dtable.getRule().get(0).getInputEntry().get(1).getText());
-        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(0).getInputEntry().get(0).getText());
+        final List<UnaryTests> inputEntriesRuleOne = dtable.getRule().get(0).getInputEntry();
+        assertEquals(2, inputEntriesRuleOne.size());
+        assertEquals(ruleOneOldInput, inputEntriesRuleOne.get(1).getText());
+        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, inputEntriesRuleOne.get(0).getText());
+        assertEquals(dtable.getRule().get(0), inputEntriesRuleOne.get(0).getParent());
 
         // second rule
-        assertEquals(2, dtable.getRule().get(1).getInputEntry().size());
-        assertEquals(ruleTwoOldInput, dtable.getRule().get(1).getInputEntry().get(1).getText());
-        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(1).getInputEntry().get(0).getText());
+        final List<UnaryTests> inputEntriesRuleTwo = dtable.getRule().get(1).getInputEntry();
+        assertEquals(2, inputEntriesRuleTwo.size());
+        assertEquals(ruleTwoOldInput, inputEntriesRuleTwo.get(1).getText());
+        assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, inputEntriesRuleTwo.get(0).getText());
+        assertEquals(dtable.getRule().get(1), inputEntriesRuleTwo.get(0).getParent());
+
+        assertEquals(dtable,
+                     inputClause.getParent());
     }
 
     @Test
@@ -197,10 +211,14 @@ public class AddInputClauseCommandTest {
         final List<UnaryTests> ruleInputs = dtable.getRule().get(0).getInputEntry();
 
         // first rule
-        assertEquals(3, dtable.getRule().get(0).getInputEntry().size());
+        assertEquals(3, ruleInputs.size());
         assertEquals(ruleInputOne, ruleInputs.get(0).getText());
         assertEquals(AddInputClauseCommand.INPUT_CLAUSE_DEFAULT_VALUE, ruleInputs.get(1).getText());
+        assertEquals(dtable.getRule().get(0), ruleInputs.get(1).getParent());
         assertEquals(ruleInputTwo, ruleInputs.get(2).getText());
+
+        assertEquals(dtable,
+                     inputClause.getParent());
     }
 
     @Test(expected = ArrayIndexOutOfBoundsException.class)

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -149,12 +149,58 @@ public class AddOutputClauseCommandTest {
         assertEquals(1, dtable.getOutput().size());
 
         // first rule
-        assertEquals(1, dtable.getRule().get(0).getOutputEntry().size());
-        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(0).getOutputEntry().get(0).getText());
+        final List<LiteralExpression> outputEntriesRuleOne = dtable.getRule().get(0).getOutputEntry();
+        assertEquals(1, outputEntriesRuleOne.size());
+        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, outputEntriesRuleOne.get(0).getText());
+        assertEquals(dtable.getRule().get(0), outputEntriesRuleOne.get(0).getParent());
 
         // second rule
-        assertEquals(1, dtable.getRule().get(1).getOutputEntry().size());
-        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(1).getOutputEntry().get(0).getText());
+        final List<LiteralExpression> outputEntriesRuleTwo = dtable.getRule().get(1).getOutputEntry();
+        assertEquals(1, outputEntriesRuleTwo.size());
+        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, outputEntriesRuleTwo.get(0).getText());
+        assertEquals(dtable.getRule().get(1), outputEntriesRuleTwo.get(0).getParent());
+
+        assertEquals(dtable,
+                     outputClause.getParent());
+    }
+
+    @Test
+    public void testGraphCommandExecuteExistingNotAffected() throws Exception {
+        makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
+
+        final String ruleOneOldOutput = "old rule 1";
+        final String ruleTwoOldOutput = "old rule 2";
+
+        dtable.getOutput().add(new OutputClause());
+        addRuleWithOutputClauseValues(ruleOneOldOutput);
+        addRuleWithOutputClauseValues(ruleTwoOldOutput);
+
+        assertEquals(1, dtable.getOutput().size());
+
+        //Graph command will insert new OutputClause at index 0 of the OutputEntries
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(canvasHandler);
+
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(graphCommandExecutionContext));
+
+        assertEquals(2, dtable.getOutput().size());
+
+        // first rule
+        final List<LiteralExpression> outputEntriesRuleOne = dtable.getRule().get(0).getOutputEntry();
+        assertEquals(2, outputEntriesRuleOne.size());
+        assertEquals(ruleOneOldOutput, outputEntriesRuleOne.get(1).getText());
+        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, outputEntriesRuleOne.get(0).getText());
+        assertEquals(dtable.getRule().get(0), outputEntriesRuleOne.get(0).getParent());
+
+        // second rule
+        final List<LiteralExpression> outputEntriesRuleTwo = dtable.getRule().get(1).getOutputEntry();
+        assertEquals(2, outputEntriesRuleTwo.size());
+        assertEquals(ruleTwoOldOutput, outputEntriesRuleTwo.get(1).getText());
+        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, outputEntriesRuleTwo.get(0).getText());
+        assertEquals(dtable.getRule().get(1), outputEntriesRuleTwo.get(0).getParent());
+
+        assertEquals(dtable,
+                     outputClause.getParent());
     }
 
     @Test
@@ -181,42 +227,14 @@ public class AddOutputClauseCommandTest {
         final List<LiteralExpression> ruleOutputs = dtable.getRule().get(0).getOutputEntry();
 
         // first rule
-        assertEquals(3, dtable.getRule().get(0).getOutputEntry().size());
+        assertEquals(3, ruleOutputs.size());
         assertEquals(ruleOutputOne, ruleOutputs.get(0).getText());
         assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, ruleOutputs.get(1).getText());
+        assertEquals(dtable.getRule().get(0), ruleOutputs.get(1).getParent());
         assertEquals(ruleOutputTwo, ruleOutputs.get(2).getText());
-    }
 
-    @Test
-    public void testGraphCommandExecuteExistingNotAffected() throws Exception {
-        makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
-
-        final String ruleOneOldOutput = "old rule 1";
-        final String ruleTwoOldOutput = "old rule 2";
-
-        dtable.getOutput().add(new OutputClause());
-        addRuleWithOutputClauseValues(ruleOneOldOutput);
-        addRuleWithOutputClauseValues(ruleTwoOldOutput);
-
-        assertEquals(1, dtable.getOutput().size());
-
-        //Graph command will insert new OutputClause at index 0 of the OutputEntries
-        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(canvasHandler);
-
-        assertEquals(GraphCommandResultBuilder.SUCCESS,
-                     graphCommand.execute(graphCommandExecutionContext));
-
-        assertEquals(2, dtable.getOutput().size());
-
-        // first rule
-        assertEquals(2, dtable.getRule().get(0).getOutputEntry().size());
-        assertEquals(ruleOneOldOutput, dtable.getRule().get(0).getOutputEntry().get(1).getText());
-        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(0).getOutputEntry().get(0).getText());
-
-        // second rule
-        assertEquals(2, dtable.getRule().get(1).getOutputEntry().size());
-        assertEquals(ruleTwoOldOutput, dtable.getRule().get(1).getOutputEntry().get(1).getText());
-        assertEquals(AddOutputClauseCommand.OUTPUT_CLAUSE_DEFAULT_VALUE, dtable.getRule().get(1).getOutputEntry().get(0).getText());
+        assertEquals(dtable,
+                     outputClause.getParent());
     }
 
     @Test(expected = ArrayIndexOutOfBoundsException.class)

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/AddParameterCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/AddParameterCommandTest.java
@@ -87,6 +87,9 @@ public class AddParameterCommandTest {
 
         assertFormalParameters(2,
                                otherParameter, parameter);
+
+        assertEquals(function,
+                     parameter.getParent());
     }
 
     @Test
@@ -98,6 +101,9 @@ public class AddParameterCommandTest {
 
         assertFormalParameters(1,
                                parameter);
+
+        assertEquals(function,
+                     parameter.getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/AddParameterBindingCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/AddParameterBindingCommandTest.java
@@ -197,6 +197,11 @@ public class AddParameterBindingCommandTest {
                      c.execute(gce));
 
         assertBindingDefinitions(otherBinding, binding);
+
+        assertEquals(invocation,
+                     binding.getParent());
+        assertEquals(binding,
+                     binding.getParameter().getParent());
     }
 
     @Test
@@ -214,6 +219,11 @@ public class AddParameterBindingCommandTest {
                      c.execute(gce));
 
         assertBindingDefinitions(binding, firstBinding, secondBinding);
+
+        assertEquals(invocation,
+                     binding.getParent());
+        assertEquals(binding,
+                     binding.getParameter().getParent());
     }
 
     @Test
@@ -231,6 +241,11 @@ public class AddParameterBindingCommandTest {
                      c.execute(gce));
 
         assertBindingDefinitions(firstBinding, binding, secondBinding);
+
+        assertEquals(invocation,
+                     binding.getParent());
+        assertEquals(binding,
+                     binding.getParameter().getParent());
     }
 
     @Test
@@ -243,6 +258,11 @@ public class AddParameterBindingCommandTest {
                      c.execute(gce));
 
         assertBindingDefinitions(binding);
+
+        assertEquals(invocation,
+                     binding.getParent());
+        assertEquals(binding,
+                     binding.getParameter().getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
@@ -137,6 +137,11 @@ public class AddRelationColumnCommandTest {
         assertEquals(1,
                      relation.getRow().get(0).getExpression().size());
         assertTrue(relation.getRow().get(0).getExpression().get(0) instanceof LiteralExpression);
+
+        assertEquals(relation,
+                     informationItem.getParent());
+        assertEquals(relation.getRow().get(0),
+                     relation.getRow().get(0).getExpression().get(0).getParent());
     }
 
     @Test
@@ -167,6 +172,11 @@ public class AddRelationColumnCommandTest {
         assertTrue(relation.getRow().get(0).getExpression().get(0) instanceof LiteralExpression);
         assertEquals(existingLiteralExpression,
                      relation.getRow().get(0).getExpression().get(1));
+
+        assertEquals(relation,
+                     informationItem.getParent());
+        assertEquals(relation.getRow().get(0),
+                     relation.getRow().get(0).getExpression().get(0).getParent());
     }
 
     @Test
@@ -208,6 +218,11 @@ public class AddRelationColumnCommandTest {
         assertTrue(relation.getRow().get(0).getExpression().get(1) instanceof LiteralExpression);
         assertEquals(existingLiteralExpressionLast,
                      relation.getRow().get(0).getExpression().get(2));
+
+        assertEquals(relation,
+                     informationItem.getParent());
+        assertEquals(relation.getRow().get(0),
+                     relation.getRow().get(0).getExpression().get(1).getParent());
     }
 
     @Test
@@ -222,6 +237,9 @@ public class AddRelationColumnCommandTest {
                      relation.getColumn().get(0));
         assertEquals(0,
                      relation.getRow().size());
+
+        assertEquals(relation,
+                     informationItem.getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
@@ -139,6 +139,11 @@ public class AddRelationRowCommandTest {
         assertEquals(1,
                      relation.getRow().get(0).getExpression().size());
         assertTrue(relation.getRow().get(0).getExpression().get(0) instanceof LiteralExpression);
+
+        assertEquals(relation,
+                     row.getParent());
+        assertEquals(relation.getRow().get(0),
+                     relation.getRow().get(0).getExpression().get(0).getParent());
     }
 
     @Test
@@ -162,6 +167,11 @@ public class AddRelationRowCommandTest {
         assertEquals(1,
                      relation.getRow().get(1).getExpression().size());
         assertTrue(relation.getRow().get(1).getExpression().get(0) instanceof LiteralExpression);
+
+        assertEquals(relation,
+                     row.getParent());
+        assertEquals(relation.getRow().get(1),
+                     relation.getRow().get(1).getExpression().get(0).getParent());
     }
 
     @Test
@@ -174,6 +184,9 @@ public class AddRelationRowCommandTest {
                      relation.getRow().size());
         assertEquals(row,
                      relation.getRow().get(0));
+
+        assertEquals(relation,
+                     row.getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/SetChildNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/SetChildNodeCommandTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetChildNodeCommandTest extends org.kie.workbench.common.stunner.core.graph.command.impl.SetChildNodeCommandTest {
+
+    @Mock
+    private View parentContent;
+
+    @Mock
+    private View candidateContent;
+
+    @Mock
+    private DMNModelInstrumentedBase parentDefinition;
+
+    @Mock
+    private DMNModelInstrumentedBase candidateDefinition;
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+
+        when(parent.getContent()).thenReturn(parentContent);
+        when(candidate.getContent()).thenReturn(candidateContent);
+        when(parentContent.getDefinition()).thenReturn(parentDefinition);
+        when(candidateContent.getDefinition()).thenReturn(candidateDefinition);
+    }
+
+    @Override
+    protected SetChildNodeCommand makeSetChildNodeCommand() {
+        return new SetChildNodeCommand(PARENT_UUID, CANDIDATE_UUID);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testExecute() {
+        super.testExecute();
+
+        verify(candidateDefinition).setParent(eq(parentDefinition));
+    }
+
+    @Override
+    public void testExecuteCheckFailed() {
+        super.testExecuteCheckFailed();
+
+        verify(candidateDefinition, never()).setParent(any(DMNModelInstrumentedBase.class));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
@@ -148,6 +148,13 @@ public class ContextEditorDefinitionTest {
 
         assertNull(model.getContextEntry().get(1).getVariable());
         assertTrue(model.getContextEntry().get(1).getExpression() instanceof LiteralExpression);
+
+        model.getContextEntry().forEach(ce -> assertEquals(model, ce.getParent()));
+
+        assertEquals(model.getContextEntry().get(0),
+                     model.getContextEntry().get(0).getVariable().getParent());
+        assertEquals(model.getContextEntry().get(1),
+                     model.getContextEntry().get(1).getExpression().getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionTest.java
@@ -157,6 +157,14 @@ public class DecisionTableEditorDefinitionTest {
         assertThat(rule.getOutputEntry().get(0)).isInstanceOf(LiteralExpression.class);
 
         assertThat(rule.getDescription()).isNotNull();
+
+        assertThat(input.get(0).getParent()).isEqualTo(model);
+        assertThat(input.get(0).getInputExpression().getParent()).isEqualTo(input.get(0));
+        assertThat(output.get(0).getParent()).isEqualTo(model);
+
+        assertThat(rule.getParent()).isEqualTo(model);
+        assertThat(rule.getInputEntry().get(0).getParent()).isEqualTo(rule);
+        assertThat(rule.getOutputEntry().get(0).getParent()).isEqualTo(rule);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
@@ -154,6 +154,13 @@ public class InvocationEditorDefinitionTest {
         assertNull(model.getBinding().get(0).getExpression());
 
         assertNotNull(model.getId());
+
+        assertEquals(model,
+                     model.getExpression().getParent());
+        assertEquals(model,
+                     model.getBinding().get(0).getParent());
+        assertEquals(model.getBinding().get(0),
+                     model.getBinding().get(0).getParameter().getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
@@ -45,7 +46,9 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 
@@ -123,11 +126,21 @@ public class RelationEditorDefinitionTest {
         final Optional<Relation> oModel = definition.getModelClass();
         assertThat(oModel).isPresent();
 
-        assertNotNull(oModel.get().getRow());
-        assertNotNull(oModel.get().getRow().get(0).getExpression().get(0));
-        assertNotNull(oModel.get().getColumn());
+        final Relation model = oModel.get();
 
-        assertNotNull(oModel.get().getRow().get(0).getId());
+        assertNotNull(model.getRow());
+        assertNotNull(model.getRow().get(0).getExpression().get(0));
+        assertTrue(model.getRow().get(0).getExpression().get(0) instanceof LiteralExpression);
+        assertNotNull(model.getColumn());
+
+        assertNotNull(model.getRow().get(0).getId());
+
+        assertEquals(model,
+                     model.getRow().get(0).getParent());
+        assertEquals(model,
+                     model.getColumn().get(0).getParent());
+        assertEquals(model.getRow().get(0),
+                     model.getRow().get(0).getExpression().get(0).getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
@@ -56,6 +57,9 @@ public class UndefinedExpressionUIModelMapperTest {
 
     @Mock
     private HasExpression hasExpression;
+
+    @Mock
+    private DMNModelInstrumentedBase hasExpressionDMNModelInstrumentedBase;
 
     @Mock
     private LiteralExpressionGrid editor;
@@ -102,6 +106,7 @@ public class UndefinedExpressionUIModelMapperTest {
         when(parentGridWidget.getModel()).thenReturn(parentGridUiModel);
         when(parentGridUiModel.getCell(eq(PARENT_ROW_INDEX), eq(PARENT_COLUMN_INDEX))).thenReturn(parentGridUiCell);
         when(parentGridUiCell.getSelectionStrategy()).thenReturn(parentGridUiCellCellSelectionStrategy);
+        when(hasExpression.asDMNModelInstrumentedBase()).thenReturn(hasExpressionDMNModelInstrumentedBase);
     }
 
     @Test
@@ -142,5 +147,6 @@ public class UndefinedExpressionUIModelMapperTest {
         mapper.toDMNModel(0, 0, cellValueSupplier);
 
         verify(hasExpression).setExpression(eq(expression));
+        verify(expression).setParent(eq(hasExpressionDMNModelInstrumentedBase));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/AddChildNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/AddChildNodeCommand.java
@@ -77,14 +77,26 @@ public class AddChildNodeCommand extends AbstractGraphCompositeCommand {
     protected AddChildNodeCommand initialize(final GraphCommandExecutionContext context) {
         super.initialize(context);
         final Node<?, Edge> parent = getParent(context);
-        this.addCommand(new RegisterNodeCommand(candidate));
-        this.addCommand(new SetChildNodeCommand(parent,
-                                                candidate));
+        this.addCommand(getRegisterNodeCommand(candidate));
+        this.addCommand(getSetChildNodeCommand(parent, candidate));
         if (null != location) {
-            this.addCommand(new UpdateElementPositionCommand(candidate,
-                                                             location));
+            this.addCommand(getUpdateElementPositionCommand(candidate, location));
         }
         return this;
+    }
+
+    protected RegisterNodeCommand getRegisterNodeCommand(final Node candidate) {
+        return new RegisterNodeCommand(candidate);
+    }
+
+    protected SetChildNodeCommand getSetChildNodeCommand(final Node<?, Edge> parent,
+                                                         final Node candidate) {
+        return new SetChildNodeCommand(parent, candidate);
+    }
+
+    protected UpdateElementPositionCommand getUpdateElementPositionCommand(final Node candidate,
+                                                                           final Point2D location) {
+        return new UpdateElementPositionCommand(candidate, location);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetChildNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetChildNodeCommand.java
@@ -39,7 +39,7 @@ import org.kie.workbench.common.stunner.core.util.UUID;
  * Both nodes must already be crated and present on the graph storage.
  */
 @Portable
-public final class SetChildNodeCommand extends AbstractGraphCommand {
+public class SetChildNodeCommand extends AbstractGraphCommand {
 
     private final String parentUUID;
     private final String candidateUUID;
@@ -111,7 +111,7 @@ public final class SetChildNodeCommand extends AbstractGraphCommand {
     }
 
     @SuppressWarnings("unchecked")
-    private Node<?, Edge> getParent(final GraphCommandExecutionContext context) {
+    protected Node<?, Edge> getParent(final GraphCommandExecutionContext context) {
         if (null == parent) {
             parent = getNodeNotNull(context,
                                     parentUUID);
@@ -120,7 +120,7 @@ public final class SetChildNodeCommand extends AbstractGraphCommand {
     }
 
     @SuppressWarnings("unchecked")
-    private Node<?, Edge> getCandidate(final GraphCommandExecutionContext context) {
+    protected Node<?, Edge> getCandidate(final GraphCommandExecutionContext context) {
         if (null == candidate) {
             candidate = getNodeNotNull(context,
                                        candidateUUID);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetChildNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetChildNodeCommandTest.java
@@ -47,12 +47,12 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class SetChildNodeCommandTest extends AbstractGraphCommandTest {
 
-    private static final String PARENT_UUID = "parentUUID";
-    private static final String CANDIDATE_UUID = "candidateUUID";
+    protected static final String PARENT_UUID = "parentUUID";
+    protected static final String CANDIDATE_UUID = "candidateUUID";
 
-    private Node parent;
-    private Node candidate;
-    private SetChildNodeCommand tested;
+    protected Node parent;
+    protected Node candidate;
+    protected SetChildNodeCommand tested;
 
     @Before
     public void setup() throws Exception {
@@ -62,8 +62,11 @@ public class SetChildNodeCommandTest extends AbstractGraphCommandTest {
         this.candidate = mockNode(CANDIDATE_UUID);
         when(graphIndex.getNode(eq(PARENT_UUID))).thenReturn(parent);
         when(graphIndex.getNode(eq(CANDIDATE_UUID))).thenReturn(candidate);
-        this.tested = new SetChildNodeCommand(PARENT_UUID,
-                                              CANDIDATE_UUID);
+        this.tested = makeSetChildNodeCommand();
+    }
+
+    protected SetChildNodeCommand makeSetChildNodeCommand() {
+        return new SetChildNodeCommand(PARENT_UUID, CANDIDATE_UUID);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2579

The changes herein do nothing _visible_ in the editor; they simply set the "parent" ```DMNModelInstrumentedBase``` on a "child" ```DMNModelInstrumentedBase```.