### PR TITLE
JBPM-7317 Perfomance Improvements (getShape, applyState, remove CDI Event on draw)

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.AbstractSelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.MapSelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.MultipleSelection;
-import org.kie.workbench.common.stunner.core.client.canvas.event.CanvasDrawnEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.ShapeLocationsChangedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
@@ -189,11 +188,10 @@ public final class LienzoMultipleSelectionControl<H extends AbstractCanvasHandle
         return getWiresManager().getSelectionManager();
     }
 
-    void onCanvasDrawn(final @Observes CanvasDrawnEvent event) {
+    void onCanvasSelection(final @Observes CanvasSelectionEvent event) {
         checkNotNull("event",
                      event);
-        if (null != getCanvasHandler() &&
-                getCanvasHandler().getCanvas().equals(event.getCanvas())) {
+        if (Objects.equals(getCanvasHandler(), event.getCanvasHandler())) {
             selectionShapeProvider.moveShapeToTop();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControlTest.java
@@ -43,7 +43,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Layer;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.MapSelectionControl;
-import org.kie.workbench.common.stunner.core.client.canvas.event.CanvasDrawnEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.ShapeLocationsChangedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
@@ -346,7 +345,7 @@ public class LienzoMultipleSelectionControlTest {
                                                       clearSelectionEvent,
                                                       ssp);
         tested.init(canvasHandler);
-        tested.onCanvasDrawn(new CanvasDrawnEvent(canvas));
+        tested.onCanvasSelection(new CanvasSelectionEvent(canvasHandler, Collections.emptyList()));
         verify(ssp, times(1)).moveShapeToTop();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Canvas.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Canvas.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.core.client.canvas;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 import org.kie.workbench.common.stunner.core.client.shape.Shape;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Canvas.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Canvas.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,9 +44,9 @@ public interface Canvas<S extends Shape> {
     Canvas draw();
 
     /**
-     * Get a list of all Shapes on the Canvas
+     * Get all Shapes on the Canvas
      */
-    List<S> getShapes();
+    Collection<S> getShapes();
 
     /**
      * Returns the shape with the given identifier.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasTest.java
@@ -183,7 +183,7 @@ public class AbstractCanvasTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testDeleteShape() {
-        tested.shapes.add(parentShape);
+        tested.shapes.put(parentShape.getUUID(), parentShape);
         tested.deleteShape(parentShape);
         verify(canvasView,
                times(1)).removeShape(eq(parentShapeView));
@@ -201,8 +201,8 @@ public class AbstractCanvasTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testClear() {
-        tested.shapes.add(parentShape);
-        tested.shapes.add(childShape);
+        tested.shapes.put(parentShape.getUUID(), parentShape);
+        tested.shapes.put(childShape.getUUID(), childShape);
         tested.clear();
         verify(canvasView,
                times(1)).removeShape(eq(parentShapeView));
@@ -216,8 +216,8 @@ public class AbstractCanvasTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testDestroy() {
-        tested.shapes.add(parentShape);
-        tested.shapes.add(childShape);
+        tested.shapes.put(parentShape.getUUID(), parentShape);
+        tested.shapes.put(childShape.getUUID(), childShape);
         tested.destroy();
         verify(canvasView,
                times(1)).removeShape(eq(parentShapeView));


### PR DESCRIPTION
- Get shape using a Map instead of a List on AbstractCanvas
- Remove CDI event after canvas draw
- Selection only call applyState selected/unselected elements

Related to JBPM-7267: Improve computation performance 

@romartin 