### PR TITLE
JBPM-7332 Performance improvements: Remove Layer batch()/draw() and calls

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoLayer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoLayer.java
@@ -87,12 +87,6 @@ public class LienzoLayer extends AbstractLayer<LienzoLayer, ShapeView<?>, Shape<
     }
 
     @Override
-    public LienzoLayer draw() {
-        layer.batch();
-        return this;
-    }
-
-    @Override
     public void clear() {
         layer.clear();
     }
@@ -222,8 +216,6 @@ public class LienzoLayer extends AbstractLayer<LienzoLayer, ShapeView<?>, Shape<
         callback.apply(transform);
 
         getViewPort().setTransform(transform);
-
-        getViewPort().getScene().batch();
     }
 
     private void scale(final Transform transform,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/ConnectorDragProxyImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/ConnectorDragProxyImpl.java
@@ -141,7 +141,6 @@ public class ConnectorDragProxyImpl implements ConnectorDragProxy<AbstractCanvas
                                                callback.onComplete(x,
                                                                    y);
                                                deregisterTransientConnector();
-                                               getCanvas().draw();
                                            }
                                        });
         return this;
@@ -169,7 +168,6 @@ public class ConnectorDragProxyImpl implements ConnectorDragProxy<AbstractCanvas
     private void deregisterTransientConnector() {
         if (null != this.connectorShapeView) {
             getWiresManager().deregister(connectorShapeView);
-            getCanvas().draw();
             this.connectorShapeView = null;
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
@@ -72,7 +72,6 @@ public class ShapeGlyphDragHandlerImpl implements ShapeGlyphDragHandler<Abstract
         final Layer dragProxyLayer = new Layer();
         dragProxyLayer.add(dragShape);
         dragProxyPanel.add(dragProxyLayer);
-        dragProxyLayer.batch();
         setDragProxyPosition(dragProxyPanel, width, height, x, y);
         attachDragProxyHandlers(dragProxyPanel, dragProxyCallback);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Canvas.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Canvas.java
@@ -36,12 +36,6 @@ public interface Canvas<S extends Shape> {
      */
     Canvas initialize(final int width,
                       final int height);
-
-    /**
-     * Draws or batches the updates on the canvas.
-     */
-    Canvas draw();
-
     /**
      * Get all Shapes on the Canvas
      */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Layer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/Layer.java
@@ -27,8 +27,6 @@ public interface Layer<T, S, A> extends HasEventHandlers<T, A> {
 
     T removeShape(final S shape);
 
-    T draw();
-
     Transform getTransform();
 
     void clear();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvas.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvas.java
@@ -282,12 +282,6 @@ public abstract class AbstractCanvas<V extends AbstractCanvas.View>
         return this;
     }
 
-    @Override
-    public AbstractCanvas draw() {
-        view.getLayer().draw();
-        return this;
-    }
-
     public AbstractCanvas clear() {
         return clear(true);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
@@ -377,7 +377,6 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
         if (null != getCanvas()) {
             notifyCanvasClear();
             getCanvas().clear();
-            getCanvas().draw();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandler.java
@@ -156,7 +156,6 @@ public abstract class BaseCanvasHandler<D extends Diagram, C extends AbstractCan
                          final boolean fireEvents) {
         // Add the shapes on canvas and fire events.
         addShape(shape);
-        getCanvas().draw();
         if (fireEvents) {
             // Fire listeners.
             notifyCanvasElementAdded(candidate);
@@ -178,7 +177,6 @@ public abstract class BaseCanvasHandler<D extends Diagram, C extends AbstractCan
                                  shape);
         }
         removeShape(shape);
-        getCanvas().draw();
         if (fireEvents) {
             afterElementDeleted(element,
                                 shape);
@@ -234,7 +232,6 @@ public abstract class BaseCanvasHandler<D extends Diagram, C extends AbstractCan
                    graphShape);
         beforeElementUpdated(candidate,
                              graphShape);
-        getCanvas().draw();
         afterDraw(candidate,
                   graphShape);
         notifyCanvasElementUpdated(candidate);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControl.java
@@ -209,7 +209,6 @@ public abstract class AbstractCanvasInPlaceTextEditorControl
             final double alpha = editMode ? SHAPE_EDIT_ALPHA : SHAPE_NOT_EDIT_ALPHA;
             shape.getShapeView().setFillAlpha(alpha);
             hasTitle.setTitleAlpha(alpha);
-            getCanvas().draw();
             return true;
         }
         return false;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/ObserverBuilderControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/ObserverBuilderControl.java
@@ -89,7 +89,6 @@ public class ObserverBuilderControl extends AbstractElementBuilderControl
                                                   new BuildCallback() {
                                                       @Override
                                                       public void onSuccess(final String uuid) {
-                                                          canvasHandler.getCanvas().draw();
                                                           canvasSelectionEvent.fire(new CanvasSelectionEvent(canvasHandler,
                                                                                                              uuid));
                                                       }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
@@ -174,9 +174,6 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
 
     private SelectionControl<H, Element> clearSelection(final boolean fireEvent) {
         deselect(getSelectedItems());
-        if (null != getCanvas()) {
-            getCanvas().draw();
-        }
         if (fireEvent) {
             fireCanvasClear();
         }
@@ -197,9 +194,6 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
                         shape.applyState(ShapeState.NONE);
                     }
                 });
-
-        // Batch a show operation.
-        getCanvas().draw();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasHighlight.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasHighlight.java
@@ -59,7 +59,6 @@ public class CanvasHighlight {
             applyStateToShape(uuid,
                               ShapeState.INVALID);
         });
-        getCanvas().draw();
         return this;
     }
 
@@ -77,7 +76,6 @@ public class CanvasHighlight {
                     shape.applyState(ShapeState.NONE);
                 }
             });
-            getCanvas().draw();
             uuids.clear();
         }
         setValidCursor();
@@ -93,7 +91,6 @@ public class CanvasHighlight {
                             final ShapeState state) {
         applyStateToShape(node.getUUID(),
                           state);
-        getCanvas().draw();
     }
 
     private void applyStateToShape(final String uuid,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasHighlightVisitor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasHighlightVisitor.java
@@ -72,7 +72,6 @@ public class CanvasHighlightVisitor {
         if (index < shapes.size()) {
             final Shape shape = shapes.get(index);
             shape.applyState(ShapeState.HIGHLIGHT);
-            canvasHandler.getCanvas().draw();
             final Timer t = new Timer() {
 
                 @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandManagerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandManagerImpl.java
@@ -31,7 +31,6 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.DelegateCommandManager;
 import org.kie.workbench.common.stunner.core.command.HasCommandListener;
 import org.kie.workbench.common.stunner.core.command.impl.CommandManagerImpl;
-import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 
 /**
  * The default canvas command manager implementation.
@@ -101,9 +100,6 @@ public class CanvasCommandManagerImpl<H extends AbstractCanvasHandler>
         super.postExecute(context,
                           command,
                           result);
-        if (null != result && !CommandUtils.isError(result)) {
-            draw(context);
-        }
         if (null != this.listener) {
             listener.onExecute(context,
                                command,
@@ -124,9 +120,6 @@ public class CanvasCommandManagerImpl<H extends AbstractCanvasHandler>
         super.postUndo(context,
                        command,
                        result);
-        if (null != result && !CommandUtils.isError(result)) {
-            draw(context);
-        }
         if (null != this.listener) {
             listener.onUndo(context,
                             command,
@@ -142,10 +135,6 @@ public class CanvasCommandManagerImpl<H extends AbstractCanvasHandler>
     @Override
     public void setCommandListener(final CommandListener<H, CanvasViolation> listener) {
         this.listener = listener;
-    }
-
-    private void draw(final H context) {
-        context.getCanvas().draw();
     }
 }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/drag/NodeDragProxyImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/drag/NodeDragProxyImpl.java
@@ -106,7 +106,6 @@ public class NodeDragProxyImpl implements NodeDragProxy<AbstractCanvasHandler> {
                                                                connections[0],
                                                                connections[1]);
                                            deleteTransientEdgeShape();
-                                           canvas.draw();
                                        }
 
                                        private void drawEdge() {
@@ -120,7 +119,6 @@ public class NodeDragProxyImpl implements NodeDragProxy<AbstractCanvasHandler> {
                                                                                                       edgeSourceNodeShape.getShapeView(),
                                                                                                       nodeShape.getShapeView(),
                                                                                                       MutationContext.STATIC);
-                                           canvas.draw();
                                        }
 
                                        private MagnetConnection[] createShapeConnections() {
@@ -153,7 +151,6 @@ public class NodeDragProxyImpl implements NodeDragProxy<AbstractCanvasHandler> {
     private void deleteTransientEdgeShape() {
         if (null != this.transientEdgeShape) {
             getCanvas().deleteTransientShape(this.transientEdgeShape);
-            getCanvas().draw();
             this.transientEdgeShape = null;
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/validation/canvas/CanvasDiagramValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/validation/canvas/CanvasDiagramValidator.java
@@ -109,7 +109,6 @@ public class CanvasDiagramValidator<H extends AbstractCanvasHandler> {
                                          violation.getUUID());
             if (null != shape) {
                 shape.applyState(ShapeState.INVALID);
-                canvas.draw();
             }
             return true;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasTest.java
@@ -192,14 +192,6 @@ public class AbstractCanvasTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDraw() {
-        tested.draw();
-        verify(layer,
-               times(1)).draw();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
     public void testClear() {
         tested.shapes.put(parentShape.getUUID(), parentShape);
         tested.shapes.put(childShape.getUUID(), childShape);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
@@ -181,8 +181,6 @@ public class BaseCanvasHandlerTest {
                         false);
         verify(canvas,
                times(1)).addShape(eq(shape));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @Test
@@ -193,8 +191,6 @@ public class BaseCanvasHandlerTest {
                           false);
         verify(canvas,
                times(1)).deleteShape(eq(shape));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @Test
@@ -228,8 +224,6 @@ public class BaseCanvasHandlerTest {
         verify(shape,
                times(1)).applyProperties(eq(candidate),
                                          eq(mutationContext));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/AbstractCanvasInPlaceTextEditorControlTest.java
@@ -411,7 +411,6 @@ public abstract class AbstractCanvasInPlaceTextEditorControlTest<C extends Abstr
     private void assertShow() {
         verify(testShapeView).setFillAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_EDIT_ALPHA));
         verify(testShapeView).setTitleAlpha(eq(AbstractCanvasInPlaceTextEditorControl.SHAPE_EDIT_ALPHA));
-        verify(canvas).draw();
 
         verify(textEditorBox).show(eq(element));
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
@@ -51,7 +51,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -251,7 +250,6 @@ public class MapSelectionControlTest {
         tested.select(element);
         tested.clearSelection();
         assertTrue(tested.getSelectedItems().isEmpty());
-        verify(canvas, atLeastOnce()).draw();
         verify(shape, times(1)).applyState(eq(ShapeState.SELECTED));
         verify(shape, times(1)).applyState(eq(ShapeState.NONE));
         verify(shape, never()).applyState(eq(ShapeState.INVALID));
@@ -283,7 +281,6 @@ public class MapSelectionControlTest {
         CanvasClearSelectionEvent event = new CanvasClearSelectionEvent(canvasHandler);
         tested.onCanvasClearSelection(event);
         assertTrue(tested.getSelectedItems().isEmpty());
-        verify(canvas, atLeastOnce()).draw();
         verify(shape, times(1)).applyState(eq(ShapeState.SELECTED));
         verify(shape, times(1)).applyState(eq(ShapeState.NONE));
         verify(shape, never()).applyState(eq(ShapeState.INVALID));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasHighlightTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasHighlightTest.java
@@ -90,8 +90,6 @@ public class CanvasHighlightTest {
                times(0)).applyState(any(ShapeState.class));
         verify(canvasView,
                times(1)).setCursor(eq(AbstractCanvas.Cursors.AUTO));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @Test
@@ -107,8 +105,6 @@ public class CanvasHighlightTest {
                times(1)).setCursor(eq(AbstractCanvas.Cursors.AUTO));
         verify(canvasView,
                times(1)).setCursor(eq(AbstractCanvas.Cursors.NOT_ALLOWED));
-        verify(canvas,
-               times(2)).draw();
     }
 
     @Test
@@ -128,8 +124,6 @@ public class CanvasHighlightTest {
                times(1)).applyState(eq(ShapeState.INVALID));
         verify(canvasView,
                times(2)).setCursor(eq(AbstractCanvas.Cursors.NOT_ALLOWED));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @Test
@@ -148,8 +142,6 @@ public class CanvasHighlightTest {
                times(1)).applyState(eq(ShapeState.NONE));
         verify(canvasView,
                atLeastOnce()).setCursor(eq(AbstractCanvas.Cursors.AUTO));
-        verify(canvas,
-               times(3)).draw();
     }
 
     @Test
@@ -169,7 +161,5 @@ public class CanvasHighlightTest {
                times(0)).applyState(eq(ShapeState.NONE));
         verify(canvasView,
                atLeastOnce()).setCursor(eq(AbstractCanvas.Cursors.AUTO));
-        verify(canvas,
-               times(2)).draw();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/primitive/AbstractDragProxy.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/primitive/AbstractDragProxy.java
@@ -138,7 +138,6 @@ public abstract class AbstractDragProxy<T> {
 
                 setLocation(shapeProxy, x, y);
                 scheduleMove(callback, x, y, timeout);
-                layer.batch();
             }
         };
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/primitive/AbstractDragProxyTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/primitive/AbstractDragProxyTest.java
@@ -111,7 +111,7 @@ public class AbstractDragProxyTest {
 
         verify(abstractDragProxy).setLocation(shapeProxy, expectedX, expectedY);
         verify(abstractDragProxy).scheduleMove(callback, expectedX, expectedY, timeout);
-        verify(layer).batch();
+        verify(layer, never()).batch();
     }
 
     @Test
@@ -135,7 +135,7 @@ public class AbstractDragProxyTest {
 
         verify(abstractDragProxy).setLocation(shapeProxy, expectedX, expectedY);
         verify(abstractDragProxy).scheduleMove(callback, expectedX, expectedY, timeout);
-        verify(layer).batch();
+        verify(layer, never()).batch();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/command/CaseManagementDrawCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/command/CaseManagementDrawCommand.java
@@ -78,7 +78,6 @@ public class CaseManagementDrawCommand extends AbstractCanvasCommand {
                               @Override
                               public void endGraphTraversal() {
                                   super.endGraphTraversal();
-                                  context.getCanvas().draw();
                               }
                           });
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/canvas/CaseManagementCanvasHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/canvas/CaseManagementCanvasHandlerTest.java
@@ -174,8 +174,6 @@ public class CaseManagementCanvasHandlerTest {
 
         verify(canvas,
                times(1)).addShape(eq(shape));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @SuppressWarnings("unchecked")
@@ -220,8 +218,6 @@ public class CaseManagementCanvasHandlerTest {
 
         verify(canvas,
                times(1)).deleteShape(eq(shape));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @Test
@@ -356,8 +352,6 @@ public class CaseManagementCanvasHandlerTest {
         verify(shape,
                times(1)).applyProperties(eq(node),
                                          eq(mutationContext));
-        verify(canvas,
-               times(1)).draw();
     }
 
     @Test
@@ -378,9 +372,6 @@ public class CaseManagementCanvasHandlerTest {
         handler.register(shape,
                          node,
                          true);
-        verify(canvas,
-               times(1)).draw();
-
         handler.applyElementMutation(node,
                                      true,
                                      true,
@@ -392,7 +383,5 @@ public class CaseManagementCanvasHandlerTest {
         verify(shape,
                times(1)).applyProperties(eq(node),
                                          eq(mutationContext));
-        verify(canvas,
-               times(2)).draw();
     }
 }


### PR DESCRIPTION
Removing the Stunner `Layer.draw()` and all the calls referring to it. 
Removing some `batch()/draw()` that were being done directly to Lienzo Layer.

These calls were being duplicated / unnecessary since this is being handled on Lienzo, in this way all the Canvas interaction is expected to be faster. This PR is related to the https://github.com/kiegroup/lienzo-core/pull/42 so testing the full downstream here is a good way to validate all the changes.

@romartin @LuboTerifaj @hasys your detailed review will be very appreciated, since this is a core modification and we don't any regressions on this point.
@jomarko can you please help to review this mainly on DMN.

Thanks guys!

c/c @mdproctor 
