### PR TITLE
[7.7.x] AF-1212: [Project Settings] After adding project's persistable data objects, the project cannot be saved ("A project with the same name already exists in this space.")

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/generalsettings/GeneralSettingsPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/generalsettings/GeneralSettingsPresenter.java
@@ -168,7 +168,8 @@ public class GeneralSettingsPresenter extends Section<ProjectScreenModel> {
                         .then(o -> executeValidation(s -> s.isProjectNameValid(pom.getName()), view.getInvalidNameMessage()))
                         .then(o -> executeValidation(projectService,
                                                      s -> s.spaceHasNoProjectsWithName(libraryPlaces.getActiveWorkspaceContext().getOrganizationalUnit(),
-                                                                                       pom.getName()),
+                                                                                       pom.getName(),
+                                                                                       libraryPlaces.getActiveWorkspaceContext()),
                                                      view.getDuplicatedProjectNameMessage()))
                         .catch_(this::showErrorAndReject),
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/generalsettings/GeneralSettingsPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/generalsettings/GeneralSettingsPresenterTest.java
@@ -225,7 +225,9 @@ public class GeneralSettingsPresenterTest {
         doReturn(true).when(validationService).validateGroupId(eq("GroupId"));
         doReturn(true).when(validationService).validateArtifactId(eq("ArtifactId"));
         doReturn(true).when(validationService).validateGAVVersion(eq("Version"));
-        doReturn(true).when(projectService).spaceHasNoProjectsWithName(any(), eq("Name"));
+        doReturn(true).when(projectService).spaceHasNoProjectsWithName(any(),
+                                                                       eq("Name"),
+                                                                       eq(project));
 
         generalSettingsPresenter.validate().catch_(i -> {
             Assert.fail("Promise should've been resolved!");
@@ -243,7 +245,8 @@ public class GeneralSettingsPresenterTest {
                                                            any(),
                                                            eq("DuplicatedProjectNameMessage"));
         verify(projectService).spaceHasNoProjectsWithName(any(),
-                                                          eq("Name"));
+                                                          eq("Name"),
+                                                          eq(project));
 
         verify(generalSettingsPresenter).validateStringIsNotEmpty(eq("GroupId"),
                                                                   eq("EmptyGroupIdMessage"));


### PR DESCRIPTION
Cherry-picked from https://github.com/kiegroup/kie-wb-common/pull/1830.

Part of an ensemble:
* https://github.com/kiegroup/appformer/pull/391
* https://github.com/kiegroup/kie-wb-common/pull/1857