### PR TITLE
RHPAM-1048: Stunner - Intermediate Throwing Event can have more than one outgoing flow

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseThrowingIntermediateEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseThrowingIntermediateEvent.java
@@ -77,6 +77,7 @@ public abstract class BaseThrowingIntermediateEvent
         labels.add("FromEventbasedGateway");
         labels.add("IntermediateEventsMorph");
         labels.add("cmnop");
+        labels.add("IntermediateEventThrowing");
     }
 
     public BaseThrowingIntermediateEvent() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
@@ -63,11 +63,9 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @EdgeOccurrences(role = "messageflow_start", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
 // A single outgoing sequence flows for event types that can be docked (boundary) such as Intermediate Timer Event
 @EdgeOccurrences(role = "IntermediateEventOnActivityBoundary", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
-// Sequence flows cannot exceed bounds when any of the nodes are in an embedded subprocess context.
-
 @EdgeOccurrences(role = "IntermediateEventThrowing", type = EdgeOccurrences.EdgeType.OUTGOING, min = 1)
 @EdgeOccurrences(role = "IntermediateEventThrowing", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
-
+// Sequence flows cannot exceed bounds when any of the nodes are in an embedded subprocess context.
 @RuleExtension(handler = ConnectorParentsMatchHandler.class,
         typeArguments = {EmbeddedSubprocess.class},
         arguments = {"Sequence flow connectors cannot exceed the embbedded subprocess' bounds. " +

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
@@ -64,6 +64,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 // A single outgoing sequence flows for event types that can be docked (boundary) such as Intermediate Timer Event
 @EdgeOccurrences(role = "IntermediateEventOnActivityBoundary", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
 // Sequence flows cannot exceed bounds when any of the nodes are in an embedded subprocess context.
+
+@EdgeOccurrences(role = "IntermediateEventThrowing", type = EdgeOccurrences.EdgeType.OUTGOING, min = 1)
+@EdgeOccurrences(role = "IntermediateEventThrowing", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
+
 @RuleExtension(handler = ConnectorParentsMatchHandler.class,
         typeArguments = {EmbeddedSubprocess.class},
         arguments = {"Sequence flow connectors cannot exceed the embbedded subprocess' bounds. " +


### PR DESCRIPTION
https://issues.jboss.org/browse/RHPAM-1048

New SequenceFlow Rules added for max and min outgoing flows.