### PR TITLE
[7.7.x] Settings fixes

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectScreen.java
@@ -271,8 +271,11 @@ public class ProjectScreen {
 
     public void showSettings() {
         if (userCanUpdateProject()) {
-            SettingsPresenter.View settingsView = this.settingsPresenter.getView();
-            this.view.setContent(settingsView.getElement());
+            settingsPresenter.setupUsingCurrentSection().then(i -> {
+                SettingsPresenter.View settingsView = this.settingsPresenter.getView();
+                this.view.setContent(settingsView.getElement());
+                return promises.resolve();
+            });
         }
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/SettingsPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/SettingsPresenter.java
@@ -130,11 +130,11 @@ public class SettingsPresenter {
         setupUsingCurrentSection();
     }
 
-    void setupUsingCurrentSection() {
+    public Promise<Void> setupUsingCurrentSection() {
         view.init(this);
 
         if (!projectContext.getActiveModule().isPresent()) {
-            return;
+            return promises.resolve();
         }
 
         view.showBusyIndicator();
@@ -150,7 +150,7 @@ public class SettingsPresenter {
 
         pathToPom.onConcurrentUpdate(info -> concurrentPomUpdateInfo = info);
 
-        promises.promisify(projectScreenService, s -> {
+        return promises.promisify(projectScreenService, s -> {
             return s.load(pathToPom);
         }).then(model -> {
             this.model = model;

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/ProjectScreenTest.java
@@ -244,14 +244,17 @@ public class ProjectScreenTest extends ProjectScreenTestBase {
         SettingsPresenter.View settingsView = mock(SettingsPresenter.View.class);
         when(settingsView.getElement()).thenReturn(new HTMLElement());
         when(this.settingsPresenter.getView()).thenReturn(settingsView);
+        doReturn(promises.resolve()).when(settingsPresenter).setupUsingCurrentSection();
 
         {
             doReturn(false).when(this.presenter).userCanUpdateProject();
             this.presenter.showSettings();
+            verify(view, never()).setContent(any());
         }
         {
             doReturn(true).when(this.presenter).userCanUpdateProject();
             this.presenter.showSettings();
+            verify(view).setContent(any());
         }
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/SettingsPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/SettingsPresenterTest.java
@@ -119,7 +119,7 @@ public class SettingsPresenterTest {
         final List<Section<ProjectScreenModel>> sections = Arrays.asList(section1, section2);
 
         doReturn(sections).when(settingsSections).getList();
-        doNothing().when(presenter).setupUsingCurrentSection();
+        doReturn(promises.resolve()).when(presenter).setupUsingCurrentSection();
 
         presenter.setup();
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/test/java/org/kie/workbench/common/screens/projecteditor/backend/server/ProjectScreenServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/src/test/java/org/kie/workbench/common/screens/projecteditor/backend/server/ProjectScreenServiceImplTest.java
@@ -832,7 +832,7 @@ public class ProjectScreenServiceImplTest {
                                 eq(true));
 
         final POM updatedPom = pomArgumentCaptor.getValue();
-        assertEquals("newName [1]", updatedPom.getName());
+        assertEquals("newName-1", updatedPom.getName());
         assertEquals("newName", updatedPom.getGav().getArtifactId());
     }
 


### PR DESCRIPTION
AF-1233: Manually added dependencies do not show up in Dependencies
AF-1236: Newly created persistable data objects are not automatically added to the list of Project Persistable Data Objects
AF-1237: Project duplication should use the suffix "-2" instead of " [2]"

Part of an ensemble:
* https://github.com/kiegroup/appformer/pull/393
* https://github.com/kiegroup/kie-wb-common/pull/1862