### PR TITLE
JBPM-6882 Fix control points inside sub-process

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
@@ -249,9 +249,10 @@ public class LocationControlImpl
         final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> builder =
                 new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
                         .forward();
-        int i = 0;
-        for (final Element element : elements) {
-            builder.addCommand(createMoveCommand(element, locations[i++]));
+
+        for (int i = 0; i < elements.length; i++) {
+            final Element element = elements[i];
+            builder.addCommand(createMoveCommand(element, locations[i]));
 
             //check connectors
             ShapeView shapeView = canvasHandler.getCanvas().getShape(element.getUUID()).getShapeView();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,8 +37,12 @@ import com.ait.lienzo.client.core.shape.wires.ILocationAcceptor;
 import com.ait.lienzo.client.core.shape.wires.SelectionManager;
 import com.ait.lienzo.client.core.shape.wires.WiresContainer;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.ShapeControlUtils;
 import com.ait.lienzo.client.core.types.BoundingBox;
+import com.ait.lienzo.client.core.types.Point2DArray;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
+import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresUtils;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
@@ -75,6 +80,7 @@ import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
@@ -239,24 +245,30 @@ public class LocationControlImpl
             throw new IllegalArgumentException("The length for the elements to move " +
                                                        "does not match the locations provided.");
         }
-        Command<AbstractCanvasHandler, CanvasViolation> command;
-        if (elements.length == 1) {
-            command = createMoveCommand(elements[0],
-                                        locations[0]);
-        } else {
-            final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> builder =
-                    new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
-                            .forward();
-            int i = 0;
-            for (final Element element : elements) {
-                final CanvasCommand<AbstractCanvasHandler> c =
-                        createMoveCommand(element,
-                                          locations[i]);
-                builder.addCommand(c);
-                i++;
+
+        final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> builder =
+                new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
+                        .forward();
+        int i = 0;
+        for (final Element element : elements) {
+            builder.addCommand(createMoveCommand(element, locations[i++]));
+
+            //check connectors
+            ShapeView shapeView = canvasHandler.getCanvas().getShape(element.getUUID()).getShapeView();
+            if (shapeView instanceof WiresShape) {
+                ShapeControlUtils.getConnectors((WiresShape) shapeView).values()
+                        .stream()
+                        .forEach(wiresConnector -> {
+                            Optional.ofNullable(canvasHandler.getGraphIndex().getEdge(WiresUtils.getShapeUUID(wiresConnector.getGroup())))
+                                    .ifPresent(edge -> {
+                                        final Point2DArray controlPoints = wiresConnector.getControlPoints();
+                                        builder.addCommands(moveControlPointsCommands(edge, controlPoints));
+                                    });
+                        });
             }
-            command = builder.build();
         }
+
+        final Command<AbstractCanvasHandler, CanvasViolation> command = builder.build();
 
         CommandResult<CanvasViolation> result = getCommandManager().allow(canvasHandler, command);
         if (!CommandUtils.isError(result)) {
@@ -269,6 +281,15 @@ public class LocationControlImpl
         }
 
         return result;
+    }
+
+    private List<Command<AbstractCanvasHandler, CanvasViolation>> moveControlPointsCommands(Edge edge, Point2DArray controlPoints) {
+        return ((ViewConnector) edge.getContent()).getControlPoints()
+                .stream()
+                .map(cp -> {
+                    com.ait.lienzo.client.core.types.Point2D lienzoCP = controlPoints.get(cp.getIndex());
+                    return canvasCommandFactory.updateControlPointPosition(edge, cp, new Point2D(lienzoCP.getX(), lienzoCP.getY()));
+                }).collect(Collectors.toList());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
@@ -256,7 +256,7 @@ public class LocationControlImpl
             //check connectors
             ShapeView shapeView = canvasHandler.getCanvas().getShape(element.getUUID()).getShapeView();
             if (shapeView instanceof WiresShape) {
-                ShapeControlUtils.getConnectors((WiresShape) shapeView).values()
+                ShapeControlUtils.getChildConnectorWithinShape((WiresShape) shapeView).values()
                         .stream()
                         .forEach(wiresConnector -> {
                             Optional.ofNullable(canvasHandler.getGraphIndex().getEdge(WiresUtils.getShapeUUID(wiresConnector.getGroup())))

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/wires/WiresUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/wires/WiresUtils.java
@@ -35,6 +35,14 @@ public final class WiresUtils {
         private String uuid;
         private String group;
 
+        public UserData() {
+        }
+
+        public UserData(String uuid, String group) {
+            this.uuid = uuid;
+            this.group = group;
+        }
+
         public String getUuid() {
             return uuid;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.wires.ILocationAcceptor;
 import com.ait.lienzo.client.core.shape.wires.MagnetManager;
 import com.ait.lienzo.client.core.shape.wires.SelectionManager;
@@ -243,7 +244,7 @@ public class LocationControlImplTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testMove() {
+    public void testMove() throws Exception {
         final WiresShapeView wiresShape = mock(WiresShapeView.class);
         final WiresShapeView childWiresShape = mock(WiresShapeView.class);
         final MagnetManager.Magnets magnets = mock(MagnetManager.Magnets.class);
@@ -260,8 +261,17 @@ public class LocationControlImplTest {
         final ControlPoint controlPoint = new ControlPointImpl(new Point2D(0, 0), 0);
         final List<ControlPoint> controlPoints = Arrays.asList(controlPoint);
         final ViewConnector viewConnector = mock(ViewConnector.class);
+        Group parentGroup = mock(Group.class);
+        BoundingBox parentBB = new BoundingBox(0, 0, 200, 200);
+        MultiPath head = mock(MultiPath.class);
+        MultiPath tail = mock(MultiPath.class);
 
         when(childWiresShape.getMagnets()).thenReturn(magnets);
+        when(childWiresShape.getParent()).thenReturn(wiresShape);
+        when(wiresShape.getGroup()).thenReturn(parentGroup);
+        when(parentGroup.getBoundingBox()).thenReturn(parentBB);
+        when(wiresShape.getX()).thenReturn(0d);
+        when(wiresShape.getY()).thenReturn(0d);
         when(magnets.size()).thenReturn(1);
         when(magnets.getMagnet(0)).thenReturn(magnet);
         when(magnet.getConnectionsSize()).thenReturn(connections.size());
@@ -270,6 +280,10 @@ public class LocationControlImplTest {
         when(connector.getGroup()).thenReturn(connectorGroup);
         when(connectorGroup.uuid()).thenReturn(connectorUUID);
         when(connector.getControlPoints()).thenReturn(controlPointsLienzo);
+        when(connector.getHead()).thenReturn(head);
+        when(connector.getTail()).thenReturn(tail);
+        when(head.getLocation()).thenReturn(new com.ait.lienzo.client.core.types.Point2D(1, 1));
+        when(tail.getLocation()).thenReturn(new com.ait.lienzo.client.core.types.Point2D(2, 2));
         when(wiresShape.getChildShapes()).thenReturn(children);
         when(shape.getShapeView()).thenReturn(wiresShape);
         when(graphIndex.getEdge(connectorUUID)).thenReturn(connectorEdge);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
@@ -16,23 +16,35 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.canvas.controls;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.wires.ILocationAcceptor;
+import com.ait.lienzo.client.core.shape.wires.MagnetManager;
 import com.ait.lienzo.client.core.shape.wires.SelectionManager;
+import com.ait.lienzo.client.core.shape.wires.WiresConnection;
+import com.ait.lienzo.client.core.shape.wires.WiresConnector;
 import com.ait.lienzo.client.core.shape.wires.WiresContainer;
+import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresCompositeControl;
 import com.ait.lienzo.client.core.types.BoundingBox;
+import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
+import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresUtils;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresShapeView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Layer;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateControlPointPositionCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPositionCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.event.ShapeLocationsChangedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
@@ -46,17 +58,23 @@ import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseEnterHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewHandler;
+import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPointImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
@@ -226,6 +244,39 @@ public class LocationControlImplTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testMove() {
+        final WiresShapeView wiresShape = mock(WiresShapeView.class);
+        final WiresShapeView childWiresShape = mock(WiresShapeView.class);
+        final MagnetManager.Magnets magnets = mock(MagnetManager.Magnets.class);
+        final WiresMagnet magnet = mock(WiresMagnet.class);
+        final WiresConnection connection = mock(WiresConnection.class);
+        final NFastArrayList<WiresConnection> connections = new NFastArrayList<>(connection);
+        final WiresConnector connector = mock(WiresConnector.class);
+        final String connectorUUID = UUID.uuid();
+        final NFastArrayList<WiresShape> children = new NFastArrayList<>(childWiresShape);
+        final Group connectorGroup = mock(Group.class);
+        final Edge connectorEdge = mock(Edge.class);
+        final com.ait.lienzo.client.core.types.Point2D controlPointLienzo = new com.ait.lienzo.client.core.types.Point2D(100, 100);
+        final Point2DArray controlPointsLienzo = new Point2DArray(controlPointLienzo);
+        final ControlPoint controlPoint = new ControlPointImpl(new Point2D(0, 0), 0);
+        final List<ControlPoint> controlPoints = Arrays.asList(controlPoint);
+        final ViewConnector viewConnector = mock(ViewConnector.class);
+
+        when(childWiresShape.getMagnets()).thenReturn(magnets);
+        when(magnets.size()).thenReturn(1);
+        when(magnets.getMagnet(0)).thenReturn(magnet);
+        when(magnet.getConnectionsSize()).thenReturn(connections.size());
+        when(magnet.getConnections()).thenReturn(connections);
+        when(connection.getConnector()).thenReturn(connector);
+        when(connector.getGroup()).thenReturn(connectorGroup);
+        when(connectorGroup.uuid()).thenReturn(connectorUUID);
+        when(connector.getControlPoints()).thenReturn(controlPointsLienzo);
+        when(wiresShape.getChildShapes()).thenReturn(children);
+        when(shape.getShapeView()).thenReturn(wiresShape);
+        when(graphIndex.getEdge(connectorUUID)).thenReturn(connectorEdge);
+        when(connectorEdge.getContent()).thenReturn(viewConnector);
+        when(viewConnector.getControlPoints()).thenReturn(controlPoints);
+        when(connectorGroup.getUserData()).thenReturn(new WiresUtils.UserData(connectorUUID, ""));
+
         tested.init(canvasHandler);
         tested.register(element);
         Point2D location = new Point2D(45d, 65.5d);
@@ -238,9 +289,17 @@ public class LocationControlImplTest {
         verify(shapeLocationsChangedEvent, times(1)).fire(shapeLocationsChangedEventCaptor.capture());
         assertTrue(shapeLocationsChangedEventCaptor.getValue() instanceof ShapeLocationsChangedEvent);
 
-        final UpdateElementPositionCommand command = (UpdateElementPositionCommand) commandArgumentCaptor.getValue();
-        assertEquals(element, command.getElement());
-        assertEquals(location, command.getLocation());
+        //assert parent node move
+        final CompositeCommand command = (CompositeCommand) commandArgumentCaptor.getValue();
+        UpdateElementPositionCommand updateElementPositionCommand = (UpdateElementPositionCommand) command.getCommands().get(0);
+        assertEquals(element, updateElementPositionCommand.getElement());
+        assertEquals(location, updateElementPositionCommand.getLocation());
+
+        //assert child connector control point move
+        final UpdateControlPointPositionCommand controlPointCommand = (UpdateControlPointPositionCommand) command.getCommands().get(1);
+        assertEquals(controlPoint, controlPointCommand.getControlPoint());
+        assertEquals(new Point2D(controlPointLienzo.getX(), controlPointLienzo.getY()), controlPointCommand.getPosition());
+        assertEquals(connectorEdge, controlPointCommand.getCandidate());
     }
 
     @Test
@@ -259,9 +318,11 @@ public class LocationControlImplTest {
         ArgumentCaptor<CanvasCommand> commandArgumentCaptor = ArgumentCaptor.forClass(CanvasCommand.class);
         verify(commandManager, times(1)).execute(eq(canvasHandler),
                                                  commandArgumentCaptor.capture());
-        final UpdateElementPositionCommand command = (UpdateElementPositionCommand) commandArgumentCaptor.getValue();
-        assertEquals(element, command.getElement());
-        assertEquals(new Point2D(40d, 50d), command.getLocation());
+
+        final CompositeCommand command = (CompositeCommand) commandArgumentCaptor.getValue();
+        UpdateElementPositionCommand updateElementPositionCommand = (UpdateElementPositionCommand) command.getCommands().get(0);
+        assertEquals(element, updateElementPositionCommand.getElement());
+        assertEquals(new Point2D(40d, 50d), updateElementPositionCommand.getLocation());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateControlPointPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateControlPointPositionCommand.java
@@ -50,4 +50,16 @@ public class UpdateControlPointPositionCommand extends AbstractCanvasGraphComman
     protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
         return new UpdateCanvasControlPointPositionCommand(candidate, controlPoint, position);
     }
+
+    public Edge getCandidate() {
+        return candidate;
+    }
+
+    public ControlPoint getControlPoint() {
+        return controlPoint;
+    }
+
+    public Point2D getPosition() {
+        return position;
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -106,6 +106,21 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-cdi-shared</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-navigation</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-jaxrs-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Now the connector control points position are updated when the parent changes its position.

Related PRs:
https://github.com/kiegroup/lienzo-core/pull/44
https://github.com/kiegroup/lienzo-tests/pull/28

@romartin 
@LuboTerifaj 
@hasys 