### PR TITLE
JBPM-7132 (Stunner) - Copy of timer is created when copying name to doc

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
@@ -53,18 +53,6 @@ public class LienzoPanel implements IsWidget {
         return view;
     }
 
-    private boolean focused;
-
-    protected boolean isFocused() {
-        return focused;
-    }
-
-    private boolean listening;
-
-    protected boolean isListening() {
-        return listening;
-    }
-
     @Inject
     public LienzoPanel(final Event<KeyPressEvent> keyPressEvent,
                        final Event<KeyDownEvent> keyDownEvent,
@@ -76,8 +64,6 @@ public class LienzoPanel implements IsWidget {
         this.keyUpEvent = keyUpEvent;
         this.mouseDownEvent = mouseDownEvent;
         this.mouseUpEvent = mouseUpEvent;
-        this.focused = false;
-        this.listening = false;
     }
 
     @Override
@@ -100,64 +86,36 @@ public class LienzoPanel implements IsWidget {
     }
 
     public void destroy() {
-        this.focused = false;
-        this.listening = false;
         view.destroy();
         view = null;
     }
 
-    void onFocus() {
-        focused = true;
-    }
-
-    void onBlur() {
-        focused = false;
-    }
-
     void onMouseDown() {
-        if (listening) {
-            mouseDownEvent.fire(new CanvasMouseDownEvent());
-        }
+        mouseDownEvent.fire(new CanvasMouseDownEvent());
     }
 
     void onMouseUp() {
-        if (listening) {
-            mouseUpEvent.fire(new CanvasMouseUpEvent());
-        }
-    }
-
-    void onMouseOver() {
-        this.listening = true;
-    }
-
-    void onMouseOut() {
-        this.listening = false;
+        mouseUpEvent.fire(new CanvasMouseUpEvent());
     }
 
     void onKeyPress(final int unicodeChar) {
-        if (focused && listening) {
-            final KeyboardEvent.Key key = getKey(unicodeChar);
-            if (null != key) {
-                keyPressEvent.fire(new KeyPressEvent(key));
-            }
+        final KeyboardEvent.Key key = getKey(unicodeChar);
+        if (null != key) {
+            keyPressEvent.fire(new KeyPressEvent(key));
         }
     }
 
     void onKeyDown(final int unicodeChar) {
-        if (focused && listening) {
-            final KeyboardEvent.Key key = getKey(unicodeChar);
-            if (null != key) {
-                keyDownEvent.fire(new KeyDownEvent(key));
-            }
+        final KeyboardEvent.Key key = getKey(unicodeChar);
+        if (null != key) {
+            keyDownEvent.fire(new KeyDownEvent(key));
         }
     }
 
     void onKeyUp(final int unicodeChar) {
-        if (focused && listening) {
-            final KeyboardEvent.Key key = getKey(unicodeChar);
-            if (null != key) {
-                keyUpEvent.fire(new KeyUpEvent(key));
-            }
+        final KeyboardEvent.Key key = getKey(unicodeChar);
+        if (null != key) {
+            keyUpEvent.fire(new KeyUpEvent(key));
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
@@ -46,6 +46,7 @@ public class LienzoPanel implements IsWidget {
     private final Event<KeyUpEvent> keyUpEvent;
     private final Event<CanvasMouseDownEvent> mouseDownEvent;
     private final Event<CanvasMouseUpEvent> mouseUpEvent;
+
     private View view;
 
     protected View getView() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanel.java
@@ -46,7 +46,6 @@ public class LienzoPanel implements IsWidget {
     private final Event<KeyUpEvent> keyUpEvent;
     private final Event<CanvasMouseDownEvent> mouseDownEvent;
     private final Event<CanvasMouseUpEvent> mouseUpEvent;
-
     private View view;
 
     protected View getView() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
@@ -55,43 +55,37 @@ public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoP
                 addBlurHandler(blurEvent -> presenter.onBlur())
         );
         handlerRegistrationManager.register(
-                addFocusHandler(focusEvent -> presenter.onFocus())
-        );
-        handlerRegistrationManager.register(
-                addBlurHandler(blurEvent -> presenter.onBlur())
-        );
-        handlerRegistrationManager.register(
                 addMouseOverHandler(mouseOverEvent -> presenter.onMouseOver())
         );
         handlerRegistrationManager.register(
                 addMouseOutHandler(mouseOutEvent -> presenter.onMouseOut())
         );
         handlerRegistrationManager.register(
-                addMouseDownHandler(mouseDownEvent -> presenter.onMouseDown())
+                addMouseDownHandler(event -> presenter.onMouseDown())
         );
         handlerRegistrationManager.register(
-                addMouseUpHandler(mouseUpEvent -> presenter.onMouseUp())
+                addMouseUpHandler(event -> presenter.onMouseUp())
         );
         handlerRegistrationManager.register(
-                getRootPanel().addDomHandler(keyPressEvent -> {
-                                                 final int unicodeChar = keyPressEvent.getUnicodeCharCode();
-                                                 this.presenter.onKeyPress(unicodeChar);
-                                             },
-                                             KeyPressEvent.getType())
+                RootPanel.get().addDomHandler(keyPressEvent -> {
+                                                  final int unicodeChar = keyPressEvent.getUnicodeCharCode();
+                                                  presenter.onKeyPress(unicodeChar);
+                                              },
+                                              KeyPressEvent.getType())
         );
         handlerRegistrationManager.register(
-                getRootPanel().addDomHandler(keyDownEvent -> {
-                                                 final int unicodeChar = keyDownEvent.getNativeKeyCode();
-                                                 this.presenter.onKeyDown(unicodeChar);
-                                             },
-                                             KeyDownEvent.getType())
+                RootPanel.get().addDomHandler(keyDownEvent -> {
+                                                  final int unicodeChar = keyDownEvent.getNativeKeyCode();
+                                                  presenter.onKeyDown(unicodeChar);
+                                              },
+                                              KeyDownEvent.getType())
         );
         handlerRegistrationManager.register(
-                getRootPanel().addDomHandler(keyUpEvent -> {
-                                                 final int unicodeChar = keyUpEvent.getNativeKeyCode();
-                                                 this.presenter.onKeyUp(unicodeChar);
-                                             },
-                                             KeyUpEvent.getType())
+                RootPanel.get().addDomHandler(keyUpEvent -> {
+                                                  final int unicodeChar = keyUpEvent.getNativeKeyCode();
+                                                  presenter.onKeyUp(unicodeChar);
+                                              },
+                                              KeyUpEvent.getType())
         );
 
         this.presenter = presenter;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
@@ -55,6 +55,12 @@ public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoP
                 addBlurHandler(blurEvent -> presenter.onBlur())
         );
         handlerRegistrationManager.register(
+                addFocusHandler(focusEvent -> presenter.onFocus())
+        );
+        handlerRegistrationManager.register(
+                addBlurHandler(blurEvent -> presenter.onBlur())
+        );
+        handlerRegistrationManager.register(
                 addMouseOverHandler(mouseOverEvent -> presenter.onMouseOver())
         );
         handlerRegistrationManager.register(

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelView.java
@@ -16,10 +16,6 @@
 
 package org.kie.workbench.common.stunner.client.widgets.canvas.view;
 
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyPressEvent;
-import com.google.gwt.event.dom.client.KeyUpEvent;
-import com.google.gwt.user.client.ui.RootPanel;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.HandlerRegistrationImpl;
 
 public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoPanel.View {
@@ -29,65 +25,20 @@ public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoP
 
     public LienzoPanelView(final int width,
                            final int height) {
+
         this(width, height, new HandlerRegistrationImpl());
+        initHandlers();
     }
 
     protected LienzoPanelView(final int width,
                               final int height,
                               HandlerRegistrationImpl handlerRegistrationImpl) {
-        super(width,
-              height);
-
+        super(width, height);
         handlerRegistrationManager = handlerRegistrationImpl;
-    }
-
-    protected RootPanel getRootPanel() {
-        return RootPanel.get();
     }
 
     @Override
     public void init(final LienzoPanel presenter) {
-
-        handlerRegistrationManager.register(
-                addFocusHandler(focusEvent -> presenter.onFocus())
-        );
-        handlerRegistrationManager.register(
-                addBlurHandler(blurEvent -> presenter.onBlur())
-        );
-        handlerRegistrationManager.register(
-                addMouseOverHandler(mouseOverEvent -> presenter.onMouseOver())
-        );
-        handlerRegistrationManager.register(
-                addMouseOutHandler(mouseOutEvent -> presenter.onMouseOut())
-        );
-        handlerRegistrationManager.register(
-                addMouseDownHandler(event -> presenter.onMouseDown())
-        );
-        handlerRegistrationManager.register(
-                addMouseUpHandler(event -> presenter.onMouseUp())
-        );
-        handlerRegistrationManager.register(
-                RootPanel.get().addDomHandler(keyPressEvent -> {
-                                                  final int unicodeChar = keyPressEvent.getUnicodeCharCode();
-                                                  presenter.onKeyPress(unicodeChar);
-                                              },
-                                              KeyPressEvent.getType())
-        );
-        handlerRegistrationManager.register(
-                RootPanel.get().addDomHandler(keyDownEvent -> {
-                                                  final int unicodeChar = keyDownEvent.getNativeKeyCode();
-                                                  presenter.onKeyDown(unicodeChar);
-                                              },
-                                              KeyDownEvent.getType())
-        );
-        handlerRegistrationManager.register(
-                RootPanel.get().addDomHandler(keyUpEvent -> {
-                                                  final int unicodeChar = keyUpEvent.getNativeKeyCode();
-                                                  presenter.onKeyUp(unicodeChar);
-                                              },
-                                              KeyUpEvent.getType())
-        );
-
         this.presenter = presenter;
     }
 
@@ -96,5 +47,33 @@ public class LienzoPanelView extends FocusableLienzoPanelView implements LienzoP
         handlerRegistrationManager.removeHandler();
         presenter = null;
         super.destroy();
+    }
+
+    protected void initHandlers() {
+
+        handlerRegistrationManager.register(
+                addMouseDownHandler(mouseDownEvent -> presenter.onMouseDown())
+        );
+        handlerRegistrationManager.register(
+                addMouseUpHandler(mouseUpEvent -> presenter.onMouseUp())
+        );
+        handlerRegistrationManager.register(
+                addKeyPressHandler(keyPressEvent -> {
+                    final int unicodeChar = keyPressEvent.getUnicodeCharCode();
+                    presenter.onKeyPress(unicodeChar);
+                })
+        );
+        handlerRegistrationManager.register(
+                addKeyDownHandler(keyDownEvent -> {
+                    final int unicodeChar = keyDownEvent.getNativeKeyCode();
+                    presenter.onKeyDown(unicodeChar);
+                })
+        );
+        handlerRegistrationManager.register(
+                addKeyUpHandler(keyUpEvent -> {
+                    final int unicodeChar = keyUpEvent.getNativeKeyCode();
+                    presenter.onKeyUp(unicodeChar);
+                })
+        );
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelTest.java
@@ -27,9 +27,7 @@ import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -64,105 +62,31 @@ public class LienzoPanelTest {
     }
 
     @Test
-    public void testOnFocus() {
-        lienzoPanel.onFocus();
-        assertEquals(lienzoPanel.isFocused(), true);
-    }
-
-    @Test
-    public void testOnBlur() {
-        lienzoPanel.onBlur();
-        assertEquals(lienzoPanel.isFocused(), false);
-    }
-
-    @Test
-    public void testOnMouseOver() {
-        lienzoPanel.onMouseOver();
-        assertEquals(lienzoPanel.isListening(), true);
-    }
-
-    @Test
-    public void testOnMouseOut() {
-        lienzoPanel.onMouseOut();
-        assertEquals(lienzoPanel.isListening(), false);
-    }
-
-    @Test
     public void testOnMouseDown() {
-        lienzoPanel.onMouseOut();
-        lienzoPanel.onMouseDown();
-        verify(mouseDownEvent, never()).fire(any(CanvasMouseDownEvent.class));
-
-        lienzoPanel.onMouseOver();
         lienzoPanel.onMouseDown();
         verify(mouseDownEvent, times(1)).fire(any(CanvasMouseDownEvent.class));
     }
 
     @Test
+    public void testOnMouseUp() {
+        lienzoPanel.onMouseUp();
+        verify(mouseUpEvent, times(1)).fire(any(CanvasMouseUpEvent.class));
+    }
+
+    @Test
     public void testOnKeyPress() {
-        lienzoPanel.onMouseOut();
-        lienzoPanel.onBlur();
-        lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyPressEvent, never()).fire(any(KeyPressEvent.class));
-
-        lienzoPanel.onMouseOut();
-        lienzoPanel.onFocus();
-        lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyPressEvent, never()).fire(any(KeyPressEvent.class));
-
-        lienzoPanel.onMouseOver();
-        lienzoPanel.onBlur();
-        lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyPressEvent, never()).fire(any(KeyPressEvent.class));
-
-        lienzoPanel.onMouseOver();
-        lienzoPanel.onFocus();
         lienzoPanel.onKeyPress(KeyboardEvent.Key.DELETE.getUnicharCode());
         verify(keyPressEvent, times(1)).fire(any(KeyPressEvent.class));
     }
 
     @Test
     public void testOnKeyDown() {
-        lienzoPanel.onMouseOut();
-        lienzoPanel.onBlur();
-        lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyDownEvent, never()).fire(any(KeyDownEvent.class));
-
-        lienzoPanel.onMouseOut();
-        lienzoPanel.onFocus();
-        lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyDownEvent, never()).fire(any(KeyDownEvent.class));
-
-        lienzoPanel.onMouseOver();
-        lienzoPanel.onBlur();
-        lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyDownEvent, never()).fire(any(KeyDownEvent.class));
-
-        lienzoPanel.onMouseOver();
-        lienzoPanel.onFocus();
         lienzoPanel.onKeyDown(KeyboardEvent.Key.DELETE.getUnicharCode());
         verify(keyDownEvent, times(1)).fire(any(KeyDownEvent.class));
     }
 
     @Test
     public void testOnKeyUp() {
-        lienzoPanel.onMouseOut();
-        lienzoPanel.onBlur();
-        lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyUpEvent, never()).fire(any(KeyUpEvent.class));
-
-        lienzoPanel.onMouseOut();
-        lienzoPanel.onFocus();
-        lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyUpEvent, never()).fire(any(KeyUpEvent.class));
-
-        lienzoPanel.onMouseOver();
-        lienzoPanel.onBlur();
-        lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
-        verify(keyUpEvent, never()).fire(any(KeyUpEvent.class));
-
-        lienzoPanel.onMouseOver();
-        lienzoPanel.onFocus();
         lienzoPanel.onKeyUp(KeyboardEvent.Key.DELETE.getUnicharCode());
         verify(keyUpEvent, times(1)).fire(any(KeyUpEvent.class));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/view/LienzoPanelViewTest.java
@@ -17,20 +17,12 @@
 package org.kie.workbench.common.stunner.client.widgets.canvas.view;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import com.google.gwt.event.dom.client.BlurHandler;
-import com.google.gwt.event.dom.client.FocusHandler;
-import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
-import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.event.dom.client.KeyPressHandler;
-import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.dom.client.MouseDownHandler;
-import com.google.gwt.event.dom.client.MouseOutHandler;
-import com.google.gwt.event.dom.client.MouseOverHandler;
 import com.google.gwt.event.dom.client.MouseUpHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.ui.RootPanel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,10 +31,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class LienzoPanelViewTest {
@@ -50,37 +40,24 @@ public class LienzoPanelViewTest {
     @Mock
     private HandlerRegistrationImpl handlerRegistrationManager;
 
-    @Mock
-    private RootPanel rootPanel;
-
-    @Mock
-    private LienzoPanel lienzoPanel;
-
     private LienzoPanelView spyTested;
 
     @Before
     public void setup() {
         spyTested = Mockito.spy(new LienzoPanelView(200, 200, handlerRegistrationManager));
-        when(spyTested.getRootPanel()).thenReturn(rootPanel);
     }
 
     @Test
-    public void testInit() {
-        spyTested.init(lienzoPanel);
+    public void testInitHandlers() {
+        spyTested.initHandlers();
 
-        verify(spyTested).addFocusHandler(any(FocusHandler.class));
-        verify(spyTested).addBlurHandler(any(BlurHandler.class));
-
-        verify(spyTested).addMouseOverHandler(any(MouseOverHandler.class));
-        verify(spyTested).addMouseOutHandler(any(MouseOutHandler.class));
         verify(spyTested).addMouseDownHandler(any(MouseDownHandler.class));
         verify(spyTested).addMouseUpHandler(any(MouseUpHandler.class));
-        verify(spyTested).addMouseUpHandler(any(MouseUpHandler.class));
 
-        verify(rootPanel).addDomHandler(any(KeyPressHandler.class), eq(KeyPressEvent.getType()));
-        verify(rootPanel).addDomHandler(any(KeyUpHandler.class), eq(KeyUpEvent.getType()));
-        verify(rootPanel).addDomHandler(any(KeyDownHandler.class), eq(KeyDownEvent.getType()));
+        verify(spyTested).addKeyPressHandler(any(KeyPressHandler.class));
+        verify(spyTested).addKeyDownHandler(any(KeyDownHandler.class));
+        verify(spyTested).addKeyUpHandler(any(KeyUpHandler.class));
 
-        verify(handlerRegistrationManager, times(9)).register(any(HandlerRegistration.class));
+        verify(handlerRegistrationManager, times(5)).register(any(HandlerRegistration.class));
     }
 }


### PR DESCRIPTION
JBPM-7132 (Stunner) - Copy of timer is created when copying name to doc
https://issues.jboss.org/browse/JBPM-7132

Fix because IE Issues. Using panel key events now. For key presses to
be listened the panel(Canvas) must have focus. Mouse position is not taken 
into account anymore.