### PR TITLE
DROOLS-2425: [DMN Designer] Undo of relation column deletion is not proper

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
@@ -60,7 +60,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final ExpressionGridCache expressionGridCache;
+    private final Supplier<ExpressionGridCache> expressionGridCache;
     private final GridCellTuple parent = new GridCellTuple(0, 0, this);
     private final GridColumn expressionColumn;
 
@@ -77,7 +77,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
                                    final SessionManager sessionManager,
                                    final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                    final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitions,
-                                   final ExpressionGridCache expressionGridCache,
+                                   final Supplier<ExpressionGridCache> expressionGridCache,
                                    final ParameterizedCommand<Optional<HasName>> onHasNameChanged) {
         super(new DMNGridData(),
               gridLayer,
@@ -193,7 +193,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
                                                                      nodeUUID,
                                                                      hasExpression,
                                                                      uiModelMapper,
-                                                                     expressionGridCache,
+                                                                     expressionGridCache.get(),
                                                                      () -> {
                                                                          final double minWidth = expressionColumn.getMinimumWidth();
                                                                          resizeBasedOnCellExpressionEditor(minWidth);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapper.java
@@ -41,7 +41,7 @@ public class ExpressionContainerUIModelMapper extends BaseUIModelMapper<Expressi
     private final Supplier<HasExpression> hasExpression;
     private final Supplier<Optional<HasName>> hasName;
     private final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitions;
-    private final ExpressionGridCache expressionGridCache;
+    private final Supplier<ExpressionGridCache> expressionGridCache;
     private final ListSelectorView.Presenter listSelector;
 
     public ExpressionContainerUIModelMapper(final GridCellTuple parent,
@@ -51,7 +51,7 @@ public class ExpressionContainerUIModelMapper extends BaseUIModelMapper<Expressi
                                             final Supplier<HasExpression> hasExpression,
                                             final Supplier<Optional<HasName>> hasName,
                                             final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitions,
-                                            final ExpressionGridCache expressionGridCache,
+                                            final Supplier<ExpressionGridCache> expressionGridCache,
                                             final ListSelectorView.Presenter listSelector) {
         super(uiModel,
               dmnModel);
@@ -75,7 +75,7 @@ public class ExpressionContainerUIModelMapper extends BaseUIModelMapper<Expressi
 
         final Optional<ExpressionEditorDefinition<Expression>> expressionEditorDefinition = expressionEditorDefinitions.get().getExpressionEditorDefinition(expression);
         expressionEditorDefinition.ifPresent(definition -> {
-            Optional<BaseExpressionGrid> editor = expressionGridCache.getExpressionGrid(uuid);
+            Optional<BaseExpressionGrid> editor = expressionGridCache.get().getExpressionGrid(uuid);
             if (!editor.isPresent()) {
                 final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
                                                                                   Optional.of(uuid),
@@ -83,7 +83,7 @@ public class ExpressionContainerUIModelMapper extends BaseUIModelMapper<Expressi
                                                                                   expression,
                                                                                   hasName,
                                                                                   0);
-                expressionGridCache.putExpressionGrid(uuid, oEditor);
+                expressionGridCache.get().putExpressionGrid(uuid, oEditor);
                 editor = oEditor;
             }
             final Optional<BaseExpressionGrid> _editor = editor;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
@@ -32,8 +32,8 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorD
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
+import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
-import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
@@ -52,7 +52,6 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Expression, DMNGridData> {
 
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
-    private ExpressionGridCache expressionGridCache;
 
     public UndefinedExpressionEditorDefinition() {
         //CDI proxy
@@ -69,8 +68,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                final CellEditorControlsView.Presenter cellEditorControls,
                                                final ListSelectorView.Presenter listSelector,
                                                final TranslationService translationService,
-                                               final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
-                                               final ExpressionGridCache expressionGridCache) {
+                                               final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
         super(gridPanel,
               gridLayer,
               definitionUtils,
@@ -82,7 +80,6 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
               listSelector,
               translationService);
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
-        this.expressionGridCache = expressionGridCache;
     }
 
     @Override
@@ -125,7 +122,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                        translationService,
                                                        nesting,
                                                        expressionEditorDefinitionsSupplier,
-                                                       expressionGridCache));
+                                                       ((DMNSession) sessionManager.getCurrentSession()).getExpressionGridCache()));
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRenderer.java
@@ -49,7 +49,7 @@ public class QNameFieldRenderer extends FieldRenderer<QNameFieldDefinition, Defa
 
     //Required for Unit Testing
     void setFormGroup(final ManagedInstance<DefaultFormGroup> formGroupInstance) {
-        this.formGroupsInstance=formGroupInstance;
+        this.formGroupsInstance = formGroupInstance;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNEditorSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNEditorSession.java
@@ -20,6 +20,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.SingleLineTextEditorBox;
@@ -53,8 +54,7 @@ import org.uberfire.mvp.Command;
 
 @Dependent
 @DMNEditor
-public class DMNEditorSession
-        extends DefaultEditorSession {
+public class DMNEditorSession extends DefaultEditorSession implements DMNSession {
 
     @Inject
     public DMNEditorSession(final ManagedSession session,
@@ -74,27 +74,32 @@ public class DMNEditorSession
     @Override
     public void init(final Metadata metadata,
                      final Command callback) {
-        super.init(s ->
-                           s.registerCanvasControl(ZoomControl.class)
-                                   .registerCanvasControl(PanControl.class)
-                                   .registerCanvasHandlerControl(SelectionControl.class,
-                                                                 MultipleSelection.class)
-                                   .registerCanvasHandlerControl(ResizeControl.class)
-                                   .registerCanvasHandlerControl(ConnectionAcceptorControl.class)
-                                   .registerCanvasHandlerControl(ContainmentAcceptorControl.class)
-                                   .registerCanvasHandlerControl(DockingAcceptorControl.class)
-                                   .registerCanvasHandlerControl(CanvasInPlaceTextEditorControl.class,
-                                                                 SingleLineTextEditorBox.class)
-                                   .registerCanvasHandlerControl(LocationControl.class)
-                                   .registerCanvasHandlerControl(ToolboxControl.class)
-                                   .registerCanvasHandlerControl(ElementBuilderControl.class,
-                                                                 Observer.class)
-                                   .registerCanvasHandlerControl(NodeBuilderControl.class)
-                                   .registerCanvasHandlerControl(EdgeBuilderControl.class)
-                                   .registerCanvasControl(KeyboardControl.class)
-                                   .registerCanvasControl(ClipboardControl.class)
-                                   .registerCanvasHandlerControl(ControlPointControl.class),
+        super.init(s -> s.registerCanvasControl(ZoomControl.class)
+                           .registerCanvasControl(PanControl.class)
+                           .registerCanvasHandlerControl(SelectionControl.class,
+                                                         MultipleSelection.class)
+                           .registerCanvasHandlerControl(ResizeControl.class)
+                           .registerCanvasHandlerControl(ConnectionAcceptorControl.class)
+                           .registerCanvasHandlerControl(ContainmentAcceptorControl.class)
+                           .registerCanvasHandlerControl(DockingAcceptorControl.class)
+                           .registerCanvasHandlerControl(CanvasInPlaceTextEditorControl.class,
+                                                         SingleLineTextEditorBox.class)
+                           .registerCanvasHandlerControl(LocationControl.class)
+                           .registerCanvasHandlerControl(ToolboxControl.class)
+                           .registerCanvasHandlerControl(ElementBuilderControl.class,
+                                                         Observer.class)
+                           .registerCanvasHandlerControl(NodeBuilderControl.class)
+                           .registerCanvasHandlerControl(EdgeBuilderControl.class)
+                           .registerCanvasControl(KeyboardControl.class)
+                           .registerCanvasControl(ClipboardControl.class)
+                           .registerCanvasHandlerControl(ControlPointControl.class)
+                           .registerCanvasControl(ExpressionGridCache.class),
                    metadata,
                    callback);
+    }
+
+    @Override
+    public ExpressionGridCache getExpressionGridCache() {
+        return (ExpressionGridCache) getSession().getCanvasControl(ExpressionGridCache.class);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNSession.java
@@ -14,24 +14,14 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.client.widgets.grid;
+package org.kie.workbench.common.dmn.client.session;
 
-import java.util.Optional;
-
+import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 
-public interface ExpressionGridCache extends CanvasControl<AbstractCanvas> {
+public interface DMNSession extends ClientSession<AbstractCanvas, AbstractCanvasHandler> {
 
-    Optional<BaseExpressionGrid> getExpressionGrid(final String nodeUUID);
-
-    void putExpressionGrid(final String nodeUUID,
-                           final Optional<BaseExpressionGrid> gridWidget);
-
-    void removeExpressionGrid(final String nodeUUID);
-
-    interface IsCacheable {
-
-        boolean isCacheable();
-    }
+    ExpressionGridCache getExpressionGridCache();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNViewerSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNViewerSession.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.MultipleSelection;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.impl.DefaultViewerSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.uberfire.mvp.Command;
+
+@Dependent
+@DMNEditor
+public class DMNViewerSession extends DefaultViewerSession implements DMNSession {
+
+    @Inject
+    public DMNViewerSession(final ManagedSession session,
+                            final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager) {
+        super(session,
+              canvasCommandManager);
+    }
+
+    @Override
+    public void init(final Metadata metadata,
+                     final Command callback) {
+        init(s -> s.registerCanvasControl(ZoomControl.class)
+                     .registerCanvasControl(PanControl.class)
+                     .registerCanvasHandlerControl(SelectionControl.class,
+                                                   MultipleSelection.class)
+                     .registerCanvasControl(ExpressionGridCache.class),
+             metadata,
+             callback);
+    }
+
+    @Override
+    public ExpressionGridCache getExpressionGridCache() {
+        return (ExpressionGridCache) getSession().getCanvasControl(ExpressionGridCache.class);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImpl.java
@@ -42,7 +42,7 @@ public class ExpressionGridCacheImpl extends AbstractCanvasControl<AbstractCanva
 
     @Override
     public Optional<BaseExpressionGrid> getExpressionGrid(final String nodeUUID) {
-        return cache.containsKey(nodeUUID) ? cache.get(nodeUUID) : Optional.empty();
+        return cache.getOrDefault(nodeUUID, Optional.empty());
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImpl.java
@@ -20,12 +20,25 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 
-@ApplicationScoped
-public class ExpressionGridCacheImpl implements ExpressionGridCache {
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasControl;
+
+@Dependent
+public class ExpressionGridCacheImpl extends AbstractCanvasControl<AbstractCanvas> implements ExpressionGridCache {
 
     private Map<String, Optional<BaseExpressionGrid>> cache = new HashMap<>();
+
+    @Override
+    protected void doInit() {
+        cache = new HashMap<>();
+    }
+
+    @Override
+    protected void doDestroy() {
+        cache.clear();
+    }
 
     @Override
     public Optional<BaseExpressionGrid> getExpressionGrid(final String nodeUUID) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNEditorToolbar.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNEditorToolbar.java
@@ -122,6 +122,7 @@ public class DMNEditorToolbar
     public PasteToolbarCommand getPasteToolbarCommand() {
         return (PasteToolbarCommand) toolbar.getCommand(12);
     }
+
     public SaveToolbarCommand getSaveToolbarCommand() {
         return (SaveToolbarCommand) toolbar.getCommand(13);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/images/shapes/dmn-shapes.css
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/images/shapes/dmn-shapes.css
@@ -20,35 +20,34 @@
     *******************************
  */
 .businessKnowledgeModel {
-    fill:#ffffff;
-    stroke:#000000;
-    stroke-width:0.5px;
+    fill: #ffffff;
+    stroke: #000000;
+    stroke-width: 0.5px;
 }
 
 .decision {
-    fill:#ffffff;
-    stroke:#000000;
-    stroke-width:0.5px;
+    fill: #ffffff;
+    stroke: #000000;
+    stroke-width: 0.5px;
 }
 
 .inputData {
-    fill:#ffffff;
-    stroke:#000000;
-    stroke-width:0.5px;
+    fill: #ffffff;
+    stroke: #000000;
+    stroke-width: 0.5px;
 }
 
 .knowledgeSource {
-    fill:#ffffff;
-    stroke:#000000;
-    stroke-width:0.5px;
+    fill: #ffffff;
+    stroke: #000000;
+    stroke-width: 0.5px;
 }
 
 .textAnnotation {
-    fill:#ffffff;
-    stroke:#000000;
-    stroke-width:0.5px;
+    fill: #ffffff;
+    stroke: #000000;
+    stroke-width: 0.5px;
 }
-
 
 /*
     *******************************
@@ -71,9 +70,11 @@
 .shape-state-selected {
     stroke: blue;
 }
-.shape-state-highlight{
+
+.shape-state-highlight {
     stroke: blue;
 }
+
 .shape-state-invalid {
     stroke: red;
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
@@ -177,7 +177,7 @@ public class ExpressionContainerGridTest {
                                                 sessionManager,
                                                 sessionCommandManager,
                                                 expressionEditorDefinitionsSupplier,
-                                                expressionGridCache,
+                                                () -> expressionGridCache,
                                                 onHasNameChanged);
 
         this.gridLayer.add(grid);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapperTest.java
@@ -50,8 +50,10 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -140,7 +142,7 @@ public class ExpressionContainerUIModelMapperTest {
                                                                                                              any(Optional.class),
                                                                                                              anyInt());
 
-        expressionGridCache = new ExpressionGridCacheImpl();
+        expressionGridCache = spy(new ExpressionGridCacheImpl());
         mapper = new ExpressionContainerUIModelMapper(parent,
                                                       () -> uiModel,
                                                       () -> Optional.ofNullable(expression),
@@ -207,6 +209,9 @@ public class ExpressionContainerUIModelMapperTest {
                                                             eq(Optional.of(hasName)),
                                                             eq(0));
 
+        verify(expressionGridCache).putExpressionGrid(nodeUUIDCaptor.getValue().get(),
+                                                      Optional.of(literalExpressionEditor));
+
         mapper.fromDMNModel(0, 0);
 
         //There should only be one interaction with LiteralExpressionEditorDefinition
@@ -216,6 +221,8 @@ public class ExpressionContainerUIModelMapperTest {
                                                             any(Optional.class),
                                                             any(Optional.class),
                                                             anyInt());
+        verify(expressionGridCache).putExpressionGrid(anyString(),
+                                                      any(Optional.class));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapperTest.java
@@ -148,7 +148,7 @@ public class ExpressionContainerUIModelMapperTest {
                                                       () -> hasExpression,
                                                       () -> Optional.of(hasName),
                                                       expressionEditorDefinitionsSupplier,
-                                                      expressionGridCache,
+                                                      () -> expressionGridCache,
                                                       listSelector);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorTest.java
@@ -25,11 +25,14 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.client.decision.DecisionNavigatorPresenter;
+import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
+import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCacheImpl;
 import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNEditorToolbar;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.ToolbarCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
@@ -68,14 +71,23 @@ public class ExpressionEditorTest {
     @Mock
     private Command command;
 
+    @Mock
+    private ManagedSession session;
+
     private ExpressionEditor testedEditor;
+
+    private ExpressionGridCache expressionGridCache;
 
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
-        testedEditor = spy(new ExpressionEditor(view, decisionNavigator));
+        this.expressionGridCache = new ExpressionGridCacheImpl();
+
+        testedEditor = spy(new ExpressionEditor(view,
+                                                decisionNavigator));
         when(sessionPresenter.getToolbar()).thenReturn(editorToolbar);
         when(editorToolbar.isEnabled(any(ToolbarCommand.class))).thenReturn(true);
+        when(session.getCanvasControl(eq(ExpressionGridCache.class))).thenReturn(expressionGridCache);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionEditorDefinition;
+import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCacheImpl;
@@ -68,6 +69,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class ExpressionEditorViewImplTest {
@@ -90,6 +92,9 @@ public class ExpressionEditorViewImplTest {
     private CellEditorControlsView.Presenter cellEditorControls;
 
     @Mock
+    private ExpressionEditorView.Presenter presenter;
+
+    @Mock
     private TranslationService translationService;
 
     @Mock
@@ -97,6 +102,9 @@ public class ExpressionEditorViewImplTest {
 
     @Mock
     private SessionManager sessionManager;
+
+    @Mock
+    private DMNEditorSession session;
 
     @Mock
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
@@ -156,6 +164,9 @@ public class ExpressionEditorViewImplTest {
         doReturn(new BaseGridData()).when(editor).getModel();
 
         this.expressionGridCache = new ExpressionGridCacheImpl();
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        when(session.getExpressionGridCache()).thenReturn(expressionGridCache);
+
         this.view = spy(new ExpressionEditorViewImpl(returnToDRG,
                                                      gridPanel,
                                                      gridLayer,
@@ -165,8 +176,8 @@ public class ExpressionEditorViewImplTest {
                                                      listSelector,
                                                      sessionManager,
                                                      sessionCommandManager,
-                                                     expressionEditorDefinitionsSupplier,
-                                                     expressionGridCache));
+                                                     expressionEditorDefinitionsSupplier));
+        view.init(presenter);
 
         final ExpressionEditorDefinitions expressionEditorDefinitions = new ExpressionEditorDefinitions();
         expressionEditorDefinitions.add(undefinedExpressionEditorDefinition);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -196,6 +196,13 @@ public class ExpressionEditorViewImplTest {
     }
 
     @Test
+    public void testInit() {
+        verify(view).setupGridPanel();
+        verify(view).setupGridWidget();
+        verify(view).setupGridWidgetPanControl();
+    }
+
+    @Test
     public void testSetupGridPanel() {
         verify(viewport).setTransform(transformArgumentCaptor.capture());
         final Transform transform = transformArgumentCaptor.getValue();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionT
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ContextGrid;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionCell;
+import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCacheImpl;
@@ -56,7 +57,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -103,7 +104,7 @@ public class UndefinedExpressionGridTest {
     private SessionManager sessionManager;
 
     @Mock
-    private ClientSession session;
+    private DMNEditorSession session;
 
     @Mock
     private AbstractCanvasHandler handler;
@@ -153,6 +154,9 @@ public class UndefinedExpressionGridTest {
     @Mock
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
+    @Mock
+    private ManagedSession managedSession;
+
     @Captor
     private ArgumentCaptor<SetCellValueCommand> setCellValueCommandArgumentCaptor;
 
@@ -175,6 +179,9 @@ public class UndefinedExpressionGridTest {
     @SuppressWarnings("unchecked")
     public void setup() {
         expressionGridCache = spy(new ExpressionGridCacheImpl());
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        when(session.getExpressionGridCache()).thenReturn(expressionGridCache);
+
         definition = new UndefinedExpressionEditorDefinition(gridPanel,
                                                              gridLayer,
                                                              definitionUtils,
@@ -185,8 +192,7 @@ public class UndefinedExpressionGridTest {
                                                              cellEditorControls,
                                                              listSelector,
                                                              translationService,
-                                                             expressionEditorDefinitionsSupplier,
-                                                             expressionGridCache);
+                                                             expressionEditorDefinitionsSupplier);
 
         expression = definition.getModelClass();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/BaseDMNSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/BaseDMNSessionTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
+import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.pan.PanControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.MultipleSelection;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistryLoader;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.preferences.StunnerPreferences;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class BaseDMNSessionTest<S extends AbstractSession<AbstractCanvas, AbstractCanvasHandler>> {
+
+    @Mock
+    protected CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
+
+    @Mock
+    protected Metadata metadata;
+
+    @Mock
+    protected Command callback;
+
+    @Mock
+    protected DefinitionUtils definitionUtils;
+
+    @Mock
+    protected StunnerPreferencesRegistryLoader stunnerPreferencesLoader;
+
+    @Mock
+    protected StunnerPreferences stunnerPreferences;
+
+    @Mock
+    protected AbstractCanvas canvas;
+
+    @Mock
+    protected AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    protected ZoomControl zoomControl;
+
+    @Mock
+    protected PanControl panControl;
+
+    @Mock
+    protected SelectionControl selectionControl;
+
+    @Mock
+    protected ExpressionGridCache expressionGridCacheControl;
+
+    protected ManagedSession managedSession;
+
+    protected ManagedInstance<AbstractCanvas> canvasInstances;
+
+    protected ManagedInstance<AbstractCanvasHandler> canvasHandlerInstances;
+
+    protected ManagedInstance<CanvasControl<AbstractCanvas>> canvasControlInstances;
+
+    protected ManagedInstance<CanvasControl<AbstractCanvasHandler>> canvasHandlerControlInstances;
+
+    protected S session;
+
+    protected Map<CanvasControl, Class> canvasControlRegistrations;
+
+    protected Map<CanvasControl, Class> canvasHandlerControlRegistrations;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.canvasInstances = new ManagedInstanceStub<>(canvas);
+        this.canvasHandlerInstances = new ManagedInstanceStub<>(canvasHandler);
+
+        this.canvasControlRegistrations = new HashMap<>();
+        this.canvasControlRegistrations.putAll(getCanvasControlRegistrations());
+        this.canvasControlRegistrations.put(zoomControl, ZoomControl.class);
+        this.canvasControlRegistrations.put(panControl, PanControl.class);
+        this.canvasControlRegistrations.put(expressionGridCacheControl, ExpressionGridCache.class);
+
+        final CanvasControl[] canvasControls = new CanvasControl[0];
+        this.canvasControlInstances = spy(new ManagedInstanceStub<>(canvasControlRegistrations.keySet().toArray(canvasControls)));
+        this.canvasControlRegistrations.entrySet().forEach(e -> when(canvasControlInstances.select(eq(e.getValue()), Mockito.<Annotation>anyVararg())).thenReturn(new ManagedInstanceStub<>(e.getKey())));
+
+        this.canvasHandlerControlRegistrations = new HashMap<>();
+        this.canvasHandlerControlRegistrations.putAll(getCanvasHandlerControlRegistrations());
+        this.canvasHandlerControlRegistrations.put(selectionControl, SelectionControl.class);
+
+        final CanvasControl[] canvasHandlerControls = new CanvasControl[0];
+        this.canvasHandlerControlInstances = spy(new ManagedInstanceStub<>(canvasHandlerControlRegistrations.keySet().toArray(canvasHandlerControls)));
+        this.canvasHandlerControlRegistrations.entrySet().forEach(e -> when(canvasHandlerControlInstances.select(eq(e.getValue()), Mockito.<Annotation>anyVararg())).thenReturn(new ManagedInstanceStub<>(e.getKey())));
+
+        this.managedSession = spy(new ManagedSession(definitionUtils,
+                                                     canvasInstances,
+                                                     canvasHandlerInstances,
+                                                     canvasControlInstances,
+                                                     canvasHandlerControlInstances,
+                                                     stunnerPreferencesLoader));
+
+        this.session = getSession();
+
+        doAnswer(i -> {
+            final ParameterizedCommand<StunnerPreferences> callback = (ParameterizedCommand) i.getArguments()[1];
+            callback.execute(stunnerPreferences);
+            return null;
+        }).when(stunnerPreferencesLoader).load(anyString(), any(ParameterizedCommand.class), any(ParameterizedCommand.class));
+    }
+
+    protected abstract S getSession();
+
+    protected abstract Map<CanvasControl, Class> getCanvasControlRegistrations();
+
+    protected abstract Map<CanvasControl, Class> getCanvasHandlerControlRegistrations();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testInit() {
+        session.init(metadata, callback);
+
+        canvasControlRegistrations.values().forEach(c -> verify(managedSession).registerCanvasControl(eq(c)));
+        canvasHandlerControlRegistrations.values().forEach(c -> verify(managedSession).registerCanvasHandlerControl(eq(c), any(Class.class)));
+        assertInitQualifiers();
+
+        verify(managedSession).init(eq(metadata), eq(callback));
+    }
+
+    protected void assertInitQualifiers() {
+        verify(managedSession).registerCanvasHandlerControl(eq(SelectionControl.class), eq(MultipleSelection.class));
+    }
+
+    @Test
+    public void testDestroy() {
+        //Session must first have been initialised
+        session.init(metadata, callback);
+
+        session.destroy();
+
+        canvasControlRegistrations.keySet().forEach(r -> verify(r).destroy());
+        canvasHandlerControlRegistrations.keySet().forEach(r -> verify(r).destroy());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNEditorSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNEditorSessionTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.CanvasInPlaceTextEditorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.SingleLineTextEditorBox;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.EdgeBuilderControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.ElementBuilderControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.NodeBuilderControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.impl.Observer;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.clipboard.ClipboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.ConnectionAcceptorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.connection.ControlPointControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.containment.ContainmentAcceptorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.docking.DockingAcceptorControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.drag.LocationControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.ToolboxControl;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistry;
+import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
+import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNEditorSessionTest extends BaseDMNSessionTest<DMNEditorSession> {
+
+    @Mock
+    private RegistryFactory registryFactory;
+
+    @Mock
+    private CommandRegistry commandRegistry;
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> requestCommandManager;
+
+    @Mock
+    private StunnerPreferencesRegistry stunnerPreferencesRegistry;
+
+    @Mock
+    private ResizeControl resizeControl;
+
+    @Mock
+    private ConnectionAcceptorControl connectionAcceptorControl;
+
+    @Mock
+    private ContainmentAcceptorControl containmentAcceptorControl;
+
+    @Mock
+    private DockingAcceptorControl dockingAcceptorControl;
+
+    @Mock
+    private CanvasInPlaceTextEditorControl canvasInPlaceTextEditorControl;
+
+    @Mock
+    private LocationControl locationControl;
+
+    @Mock
+    private ToolboxControl toolboxControl;
+
+    @Mock
+    private ElementBuilderControl elementBuilderControl;
+
+    @Mock
+    private NodeBuilderControl nodeBuilderControl;
+
+    @Mock
+    private EdgeBuilderControl edgeBuilderControl;
+
+    @Mock
+    private ControlPointControl controlPointControl;
+
+    @Mock
+    private KeyboardControl keyboardControl;
+
+    @Mock
+    private ClipboardControl clipboardControl;
+
+    @Before
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        when(registryFactory.newCommandRegistry()).thenReturn(commandRegistry);
+        super.setup();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected DMNEditorSession getSession() {
+        final DMNEditorSession session = new DMNEditorSession(managedSession,
+                                                              registryFactory,
+                                                              canvasCommandManager,
+                                                              sessionCommandManager,
+                                                              requestCommandManager,
+                                                              stunnerPreferencesRegistry);
+        session.constructInstance();
+        return session;
+    }
+
+    @Override
+    protected Map<CanvasControl, Class> getCanvasControlRegistrations() {
+        final HashMap<CanvasControl, Class> canvasControls = new HashMap<>();
+        canvasControls.put(keyboardControl, KeyboardControl.class);
+        canvasControls.put(clipboardControl, ClipboardControl.class);
+        return canvasControls;
+    }
+
+    @Override
+    protected Map<CanvasControl, Class> getCanvasHandlerControlRegistrations() {
+        final HashMap<CanvasControl, Class> canvasHandlerControls = new HashMap<>();
+        canvasHandlerControls.put(resizeControl, ResizeControl.class);
+        canvasHandlerControls.put(connectionAcceptorControl, ConnectionAcceptorControl.class);
+        canvasHandlerControls.put(containmentAcceptorControl, ContainmentAcceptorControl.class);
+        canvasHandlerControls.put(dockingAcceptorControl, DockingAcceptorControl.class);
+        canvasHandlerControls.put(canvasInPlaceTextEditorControl, CanvasInPlaceTextEditorControl.class);
+        canvasHandlerControls.put(locationControl, LocationControl.class);
+        canvasHandlerControls.put(toolboxControl, ToolboxControl.class);
+        canvasHandlerControls.put(elementBuilderControl, ElementBuilderControl.class);
+        canvasHandlerControls.put(nodeBuilderControl, NodeBuilderControl.class);
+        canvasHandlerControls.put(edgeBuilderControl, EdgeBuilderControl.class);
+        canvasHandlerControls.put(controlPointControl, ControlPointControl.class);
+        return canvasHandlerControls;
+    }
+
+    @Override
+    protected void assertInitQualifiers() {
+        super.assertInitQualifiers();
+        verify(managedSession).registerCanvasHandlerControl(eq(CanvasInPlaceTextEditorControl.class), eq(SingleLineTextEditorBox.class));
+        verify(managedSession).registerCanvasHandlerControl(eq(ElementBuilderControl.class), eq(Observer.class));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNViewerSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNViewerSessionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.session;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNViewerSessionTest extends BaseDMNSessionTest<DMNViewerSession> {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected DMNViewerSession getSession() {
+        final DMNViewerSession session = new DMNViewerSession(managedSession,
+                                                              canvasCommandManager);
+        session.constructInstance();
+        return session;
+    }
+
+    @Override
+    protected Map<CanvasControl, Class> getCanvasControlRegistrations() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    protected Map<CanvasControl, Class> getCanvasHandlerControlRegistrations() {
+        return Collections.emptyMap();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlersTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlersTest.java
@@ -72,6 +72,5 @@ public class DMNViewHandlersTest {
         verify(shape).setMaxWidth(eq(Width.MAX));
         verify(shape).setMinHeight(eq(Height.MIN));
         verify(shape).setMaxHeight(eq(Height.MAX));
-
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImplTest.java
@@ -108,4 +108,30 @@ public class ExpressionGridCacheImplTest {
 
         assertThat(content).isEmpty();
     }
+
+    @Test
+    public void testDoInit() {
+        when(editor.isCacheable()).thenReturn(true);
+
+        cache.putExpressionGrid(UUID, Optional.of(editor));
+
+        assertThat(cache.getContent()).isNotEmpty();
+
+        cache.doInit();
+
+        assertThat(cache.getContent()).isEmpty();
+    }
+
+    @Test
+    public void testDoDestroy() {
+        when(editor.isCacheable()).thenReturn(true);
+
+        cache.putExpressionGrid(UUID, Optional.of(editor));
+
+        assertThat(cache.getContent()).isNotEmpty();
+
+        cache.doDestroy();
+
+        assertThat(cache.getContent()).isEmpty();
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -333,13 +333,13 @@ public class SessionDiagramEditorScreen {
         decisionNavigatorDock.resetContent();
     }
 
+    void destroySession() {
+        presenter.destroy();
+    }
+
     @WorkbenchMenu
     public Menus getMenu() {
         return menu;
-    }
-
-    void destroySession() {
-        presenter.destroy();
     }
 
     @WorkbenchPartTitle

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
@@ -138,6 +138,10 @@ public class DefaultEditorSession
         session.destroy();
     }
 
+    protected ManagedSession getSession() {
+        return session;
+    }
+
     @Override
     public AbstractCanvas getCanvas() {
         return session.getCanvas();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSession.java
@@ -40,7 +40,6 @@ public class DefaultViewerSession
     private final ManagedSession session;
     private final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
 
-
     @Inject
     public DefaultViewerSession(final ManagedSession session,
                                 final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager) {
@@ -84,6 +83,10 @@ public class DefaultViewerSession
     @Override
     public void destroy() {
         session.destroy();
+    }
+
+    protected ManagedSession getSession() {
+        return session;
     }
 
     @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2425

@romartin I added the cache's life-cycle to ```ManagedSession``` (remember our discussions?!)

The issue was that after saving, closing and re-opening the (Context etc) grid was retrieved from the cache however associated to a new "parent" that lead to sizing/re-sizing issues that updated the size of the "old" (disconnected) parent and not the "current" parent. 

The cache's life-cycle is now tied to that of the ```Session``` and hence destroyed when the editor is closed. I also added a ```DMNViewerSession``` (although it is not accessible at the moment, as it is not possible to open read-only versions until I integrate the editor into a "project showcase" - as opposed to "standalone showcase"). This is because I have to cast the ```Session``` to get access to the new Canvas Control for the cache.