### PR TITLE
DROOLS-2473: [DMN Designer] Function language change inconsistency

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -134,7 +134,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                          expressionEditorDefinitionsSupplier,
                                          supplementaryEditorDefinitionsSupplier,
                                          listSelector,
-                                         nesting);
+                                         nesting + 1);
     }
 
     @Override
@@ -302,7 +302,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                                                                  hasExpression,
                                                                                  expression,
                                                                                  hasName,
-                                                                                 nesting);
+                                                                                 nesting + 1);
             doSetKind(kind,
                       function,
                       expression,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapper.java
@@ -101,7 +101,7 @@ public class FunctionUIModelMapper extends BaseUIModelMapper<FunctionDefinition>
                                                                  function,
                                                                  expression,
                                                                  Optional.empty(),
-                                                                 nesting + 1);
+                                                                 nesting);
         uiModel.get().setCell(rowIndex,
                               columnIndex,
                               () -> new FunctionGridCell<>(new ExpressionCellValue(editor),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapperTest.java
@@ -143,7 +143,7 @@ public class FunctionUIModelMapperTest {
                                                 expressionEditorDefinitionsSupplier,
                                                 supplementaryEditorDefinitionsSupplier,
                                                 listSelector,
-                                                0);
+                                                1);
         this.cellValueSupplier = Optional::empty;
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2473

The issue was that the nesting of **all** child grids (FEEL, Java or PMML) should be equal to ```FunctionGrid.nesting + 1```. It was not evident for Java or PMML as these use a "supplementary" grid that explicitly hides the header rather than depending on the nesting.