### PR TITLE
DROOLS-2644: [DMN Designer] Deletion of the column causes last column width increase

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommand.java
@@ -54,6 +54,7 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
     private final InputClause oldInputClause;
     private final List<UnaryTests> oldColumnData;
     private final GridColumn<?> oldUiModelColumn;
+    private final List<Double> oldColumnWidths;
 
     public DeleteInputClauseCommand(final DecisionTable dtable,
                                     final GridData uiModel,
@@ -69,6 +70,7 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
         this.oldInputClause = dtable.getInput().get(uiColumnIndex - DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
         this.oldColumnData = extractColumnData();
         this.oldUiModelColumn = uiModel.getColumns().get(uiColumnIndex);
+        this.oldColumnWidths = CommandUtils.extractColumnWidths(uiModel);
     }
 
     private List<UnaryTests> extractColumnData() {
@@ -143,6 +145,7 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
                 }
 
                 updateParentInformation();
+                restoreColumnWidths();
 
                 canvasOperation.execute();
 
@@ -153,5 +156,9 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
 
     public void updateParentInformation() {
         CommandUtils.updateParentInformation(uiModel);
+    }
+
+    public void restoreColumnWidths() {
+        CommandUtils.restoreColumnWidths(uiModel, oldColumnWidths);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommand.java
@@ -54,6 +54,7 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
     private final OutputClause oldOutputClause;
     private final List<LiteralExpression> oldColumnData;
     private final GridColumn<?> oldUiModelColumn;
+    private final List<Double> oldColumnWidths;
 
     public DeleteOutputClauseCommand(final DecisionTable dtable,
                                      final GridData uiModel,
@@ -69,6 +70,7 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
         this.oldOutputClause = dtable.getOutput().get(getOutputClauseIndex());
         this.oldColumnData = extractColumnData();
         this.oldUiModelColumn = uiModel.getColumns().get(uiColumnIndex);
+        this.oldColumnWidths = CommandUtils.extractColumnWidths(uiModel);
     }
 
     private List<LiteralExpression> extractColumnData() {
@@ -143,6 +145,7 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
                 }
 
                 updateParentInformation();
+                restoreColumnWidths();
 
                 canvasOperation.execute();
 
@@ -153,5 +156,9 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
 
     public void updateParentInformation() {
         CommandUtils.updateParentInformation(uiModel);
+    }
+
+    public void restoreColumnWidths() {
+        CommandUtils.restoreColumnWidths(uiModel, oldColumnWidths);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommand.java
@@ -54,6 +54,7 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
     private final InformationItem oldInformationItem;
     private final List<Expression> oldColumnData;
     private final GridColumn<?> oldUiModelColumn;
+    private final List<Double> oldColumnWidths;
 
     public DeleteRelationColumnCommand(final Relation relation,
                                        final GridData uiModel,
@@ -69,6 +70,7 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
         this.oldInformationItem = relation.getColumn().get(uiColumnIndex - RelationUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
         this.oldColumnData = extractColumnData(uiColumnIndex);
         this.oldUiModelColumn = uiModel.getColumns().get(uiColumnIndex);
+        this.oldColumnWidths = CommandUtils.extractColumnWidths(uiModel);
     }
 
     private List<Expression> extractColumnData(final int uiColumnIndex) {
@@ -139,6 +141,7 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
                 }
 
                 updateParentInformation();
+                restoreColumnWidths();
 
                 canvasOperation.execute();
 
@@ -149,5 +152,9 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
 
     public void updateParentInformation() {
         CommandUtils.updateParentInformation(uiModel);
+    }
+
+    public void restoreColumnWidths() {
+        CommandUtils.restoreColumnWidths(uiModel, oldColumnWidths);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.commands.util;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
@@ -99,5 +100,21 @@ public class CommandUtils {
         final GridCell<?> cell = cellTuple.getGridWidget().getModel().getCell(cellTuple.getRowIndex(),
                                                                               cellTuple.getColumnIndex());
         return Optional.ofNullable(cell == null ? null : cell.getValue());
+    }
+
+    public static List<Double> extractColumnWidths(final GridData uiModel) {
+        return uiModel.getColumns()
+                .stream()
+                .map(GridColumn::getWidth)
+                .collect(Collectors.toList());
+    }
+
+    public static void restoreColumnWidths(final GridData uiModel,
+                                           final List<Double> oldColumnWidths) {
+        IntStream.range(0, oldColumnWidths.size())
+                .forEach(index -> uiModel
+                        .getColumns()
+                        .get(index)
+                        .setWidth(oldColumnWidths.get(index)));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
@@ -16,8 +16,16 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
+import java.util.Optional;
+
 import com.google.gwt.user.client.ui.RequiresResize;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 public class GridCellTuple implements RequiresResize {
@@ -56,8 +64,28 @@ public class GridCellTuple implements RequiresResize {
 
     public void proposeContainingColumnWidth(final double proposedWidth) {
         final GridColumn<?> parentColumn = gridWidget.getModel().getColumns().get(columnIndex);
-        final double requiredWidth = Math.max(proposedWidth, parentColumn.getWidth());
+        final double requiredWidth = Math.max(proposedWidth, getMinimumParentColumnWidth(proposedWidth));
         parentColumn.setWidth(requiredWidth);
+    }
+
+    private double getMinimumParentColumnWidth(final double proposedWidth) {
+        double minimumWidth = proposedWidth;
+        final GridData uiModel = gridWidget.getModel();
+        for (GridRow row : uiModel.getRows()) {
+            final GridCell<?> cell = row.getCells().get(columnIndex);
+            if (cell != null) {
+                final GridCellValue<?> value = cell.getValue();
+                if (value instanceof ExpressionCellValue) {
+                    final ExpressionCellValue ecv = (ExpressionCellValue) value;
+                    final Optional<BaseExpressionGrid> editor = ecv.getValue();
+                    if (editor.isPresent()) {
+                        final BaseExpressionGrid beg = editor.get();
+                        minimumWidth = Math.max(minimumWidth, beg.getMinimumWidth());
+                    }
+                }
+            }
+        }
+        return minimumWidth;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
@@ -236,5 +236,6 @@ public class DeleteInputClauseCommandTest {
 
         verify(canvasOperation).execute();
         verify(command).updateParentInformation();
+        verify(command).restoreColumnWidths();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
@@ -236,5 +236,6 @@ public class DeleteOutputClauseCommandTest {
 
         verify(canvasOperation).execute();
         verify(command).updateParentInformation();
+        verify(command).restoreColumnWidths();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
@@ -328,6 +328,7 @@ public class DeleteRelationColumnCommandTest {
                      uiModel.getCell(0, 1).getValue().getValue());
 
         verify(command).updateParentInformation();
+        verify(command).restoreColumnWidths();
 
         verify(canvasOperation).execute();
     }
@@ -356,6 +357,7 @@ public class DeleteRelationColumnCommandTest {
                      uiModel.getRowCount());
 
         verify(command).updateParentInformation();
+        verify(command).restoreColumnWidths();
 
         verify(canvasOperation).execute();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
@@ -259,6 +259,39 @@ public class CommandUtilsTest {
         Assertions.assertThat(CommandUtils.extractGridCellValue(cellTuple)).hasValue(gridCellValue);
     }
 
+    @Test
+    public void testExtractColumnWidths() {
+        final GridColumn uiColumn1 = new RowNumberColumn();
+        final GridColumn uiColumn2 = new RowNumberColumn();
+        uiColumn1.setWidth(100.0);
+        uiColumn2.setWidth(200.0);
+        uiModel.appendColumn(uiColumn1);
+        uiModel.appendColumn(uiColumn2);
+
+        final List<Double> columnWidths = CommandUtils.extractColumnWidths(uiModel);
+
+        Assertions.assertThat(columnWidths).containsExactly(100.0, 200.0);
+    }
+
+    @Test
+    public void testRestoreColumnWidths() {
+        final GridColumn uiColumn1 = new RowNumberColumn();
+        final GridColumn uiColumn2 = new RowNumberColumn();
+        uiColumn1.setWidth(100.0);
+        uiColumn2.setWidth(200.0);
+        uiModel.appendColumn(uiColumn1);
+        uiModel.appendColumn(uiColumn2);
+
+        final List<Double> columnWidths = CommandUtils.extractColumnWidths(uiModel);
+
+        uiColumn1.setWidth(300.0);
+        uiColumn2.setWidth(500.0);
+
+        CommandUtils.restoreColumnWidths(uiModel, columnWidths);
+
+        Assertions.assertThat(columnWidths).containsExactly(100.0, 200.0);
+    }
+
     private void assertParentInformationValues(final int expressionColumnIndex) {
         IntStream.range(0, ROW_COUNT)
                 .forEach(rowIndex -> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTupleTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTupleTest.java
@@ -90,6 +90,18 @@ public class GridCellTupleTest {
     }
 
     @Test
+    public void testProposeContainingColumnWidthWhenLargerThanExistingEditor() {
+        gridData.setCell(0, 0, () -> new DMNGridCell<>(new ExpressionCellValue(Optional.of(existingEditor))));
+        when(existingEditor.getPadding()).thenReturn(BaseExpressionGrid.DEFAULT_PADDING);
+        when(existingEditor.getMinimumWidth()).thenReturn(200.0);
+        when(gridColumn.getWidth()).thenReturn(100.0);
+
+        tuple.proposeContainingColumnWidth(300.0);
+
+        verify(gridColumn).setWidth(300.0);
+    }
+
+    @Test
     public void testOnResizeSetsColumnWidth() {
         when(gridColumn.getWidth()).thenReturn(100.0);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTupleTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTupleTest.java
@@ -16,9 +16,13 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
+import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -38,6 +42,9 @@ public class GridCellTupleTest {
     @Mock
     private GridColumn gridColumn;
 
+    @Mock
+    private BaseExpressionGrid existingEditor;
+
     private GridData gridData;
 
     private GridCellTuple tuple;
@@ -47,6 +54,7 @@ public class GridCellTupleTest {
         tuple = new GridCellTuple(0, 0, gridWidget);
         gridData = new BaseGridData(false);
         gridData.appendColumn(gridColumn);
+        gridData.appendRow(new DMNGridRow());
 
         when(gridWidget.getModel()).thenReturn(gridData);
     }
@@ -66,7 +74,19 @@ public class GridCellTupleTest {
 
         tuple.proposeContainingColumnWidth(50.0);
 
-        verify(gridColumn).setWidth(100.0);
+        verify(gridColumn).setWidth(50.0);
+    }
+
+    @Test
+    public void testProposeContainingColumnWidthWhenSmallerThanExistingEditor() {
+        gridData.setCell(0, 0, () -> new DMNGridCell<>(new ExpressionCellValue(Optional.of(existingEditor))));
+        when(existingEditor.getPadding()).thenReturn(BaseExpressionGrid.DEFAULT_PADDING);
+        when(existingEditor.getMinimumWidth()).thenReturn(200.0);
+        when(gridColumn.getWidth()).thenReturn(100.0);
+
+        tuple.proposeContainingColumnWidth(50.0);
+
+        verify(gridColumn).setWidth(200.0);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2644

The issue was that when a column was resized it considered the maximum of the "proposed" width (could be narrower than it was, when deleting a column) and the current column width. I've changed this to consider the "proposed" width and the minimum required for any editors in the column.