### PR TITLE
Revert "AF-980: Indexing: Improve on false negatives during parallel Unit Test execution. NotThreadSafe is not inherited."

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/indexing/FormDefinitionIndexerTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/indexing/FormDefinitionIndexerTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import javax.enterprise.inject.Instance;
 
 import org.guvnor.common.services.project.categories.Form;
@@ -62,7 +61,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 @RunWith(MockitoJUnitRunner.class)
 public class FormDefinitionIndexerTest extends BaseIndexingTest<FormResourceTypeDefinition> {
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/indexing/ImpactAnalysisJavaFileTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/indexing/ImpactAnalysisJavaFileTest.java
@@ -26,8 +26,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.drools.core.beliefsystem.abductive.Abducible;
 import org.guvnor.common.services.project.categories.Model;
@@ -57,7 +55,6 @@ import static org.junit.Assert.*;
 /**
  * This annotation is used by the {{@link #testReferenceQueryInfrastructure()} method.
  */
-@NotThreadSafe
 @AnnotationValuesAnnotation
 public class ImpactAnalysisJavaFileTest extends BaseIndexingTest<JavaResourceTypeDefinition> {
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/indexing/query/FindResourcePartsQueryValidIndexTermsTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/indexing/query/FindResourcePartsQueryValidIndexTermsTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.guvnor.common.services.project.categories.Model;
@@ -56,7 +54,6 @@ import org.uberfire.paging.PageResponse;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourcePartsQueryValidIndexTermsTest extends BaseIndexingTest<JavaResourceTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/indexing/query/FindResourcesQueryValidIndexTermsTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/indexing/query/FindResourcesQueryValidIndexTermsTest.java
@@ -25,8 +25,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.guvnor.common.services.project.categories.Model;
 import org.junit.Test;
@@ -47,7 +45,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.paging.PageResponse;
 
-@NotThreadSafe
 public class FindResourcesQueryValidIndexTermsTest extends BaseIndexingTest<JavaResourceTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/BaseIndexingTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/BaseIndexingTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-
 import javax.enterprise.inject.Instance;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -43,9 +42,8 @@ import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.workbench.type.ResourceTypeDefinition;
 
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public abstract class BaseIndexingTest<T extends ResourceTypeDefinition> extends IndexingTest<T> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/IndexingTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/IndexingTest.java
@@ -59,11 +59,9 @@ import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.workbench.type.ResourceTypeDefinition;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public abstract class IndexingTest<T extends ResourceTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlInvalidDrl.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlInvalidDrl.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -49,7 +47,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class IndexDrlInvalidDrl extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField1Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField1Test.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeExpressionField1Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField2Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField2Test.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeExpressionField2Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField3Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField3Test.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeExpressionField3Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField4Test.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionField4Test.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeExpressionField4Test extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldCombinedTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldCombinedTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeExpressionFieldCombinedTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldTypeTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeExpressionFieldTypeTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeExpressionFieldTypeTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeFieldTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeFieldTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeFieldTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/drl/IndexDrlLHSTypeTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -36,7 +34,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDrlLHSTypeTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/impact/QueryOperationRequestTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/impact/QueryOperationRequestTest.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
@@ -47,7 +45,6 @@ import org.uberfire.java.nio.file.Path;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class QueryOperationRequestTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     // Setup fields, methods and other logic --------------------------------------------------------------------------------------

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/RefactoringQueryServiceImplGeneralTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/RefactoringQueryServiceImplGeneralTest.java
@@ -21,8 +21,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.backend.server.query.standa
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class RefactoringQueryServiceImplGeneralTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/assetUsages/AssetsUsageServiceImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/assetUsages/AssetsUsageServiceImplTest.java
@@ -21,8 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.guvnor.common.services.project.model.Package;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +45,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 @RunWith(MockitoJUnitRunner.class)
 public class AssetsUsageServiceImplTest extends BaseIndexingTest<TestJavaResourceTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryInvalidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourcePartReferencesQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryValidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcepartreferences/FindResourcePartReferencesQueryValidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -41,7 +39,6 @@ import org.uberfire.paging.PageResponse;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourcePartReferencesQueryValidIndexTermsTest
         extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourceparts/FindResourcePartsQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourceparts/FindResourcePartsQueryInvalidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourcePartsQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryInvalidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.model.query.RefactoringPage
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourceReferencesQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryValidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresourcereferences/FindResourceReferencesQueryValidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -42,7 +40,6 @@ import org.uberfire.paging.PageResponse;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourceReferencesQueryValidIndexTermsTest
         extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryInvalidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourcesQueryInvalidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryValidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findresources/FindResourcesQueryValidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -41,7 +39,6 @@ import org.uberfire.paging.PageResponse;
 
 import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindResourcesQueryValidIndexTermsTest extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 
     protected Set<NamedQuery> getQueries() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findrules/FindRulesByModuleQueryInvalidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findrules/FindRulesByModuleQueryInvalidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -34,10 +32,8 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValuePackageNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
-@NotThreadSafe
 public class FindRulesByModuleQueryInvalidIndexTermsTest
         extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findrules/FindRulesByModuleQueryValidIndexTermsTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/findrules/FindRulesByModuleQueryValidIndexTermsTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
@@ -41,13 +39,10 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.uberfire.paging.PageResponse;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class FindRulesByModuleQueryValidIndexTermsTest
         extends BaseIndexingTest<TestDrlFileTypeDefinition> {
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexAddedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexAddedResourcesTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
@@ -38,7 +36,6 @@ import org.uberfire.ext.metadata.io.KObjectUtil;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class IndexAddedResourcesTest extends BaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexCopiedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexCopiedResourcesTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -37,7 +35,6 @@ import org.uberfire.ext.metadata.io.KObjectUtil;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class IndexCopiedResourcesTest extends BaseIndexingTest {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexDeletedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexDeletedResourcesTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -37,7 +35,6 @@ import org.uberfire.ext.metadata.io.KObjectUtil;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class IndexDeletedResourcesTest extends BaseIndexingTest {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexFullTextTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexFullTextTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.WildcardQuery;
@@ -38,7 +36,6 @@ import org.uberfire.ext.metadata.io.KObjectUtil;
 import static org.mockito.Mockito.*;
 import static org.uberfire.ext.metadata.engine.MetaIndexEngine.FULL_TEXT_FIELD;
 
-@NotThreadSafe
 public class IndexFullTextTest extends BaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexUpdatedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/IndexUpdatedResourcesTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -38,7 +36,6 @@ import org.uberfire.ext.metadata.io.KObjectUtil;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class IndexUpdatedResourcesTest extends BaseIndexingTest {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryAddedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryAddedResourcesTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -36,7 +34,6 @@ import static org.mockito.Mockito.*;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class MultipleRepositoryAddedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryCopiedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryCopiedResourcesTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -36,7 +34,6 @@ import static org.mockito.Mockito.*;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class MultipleRepositoryCopiedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryDeletedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryDeletedResourcesTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -36,7 +34,6 @@ import static org.mockito.Mockito.*;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class MultipleRepositoryDeletedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryUpdatedResourcesTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/resources/MultipleRepositoryUpdatedResourcesTest.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -37,7 +35,6 @@ import static org.mockito.Mockito.*;
 
 import static org.mockito.Mockito.*;
 
-@NotThreadSafe
 public class MultipleRepositoryUpdatedResourcesTest extends MultipleRepositoryBaseIndexingTest<TestPropertiesFileTypeDefinition> {
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/indexing/BpmnFileIndexerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/indexing/BpmnFileIndexerTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.common.services.project.model.POM;
 import org.guvnor.common.services.project.model.Package;
@@ -58,7 +56,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 public class BpmnFileIndexerTest extends BaseIndexingTest<BPMNDefinitionSetResourceType> {
 
     private final static List<String> PROCESS_IDS = Arrays.asList(new String[]{"hiring", "ParentProcess", "SubProcess", "multiple-rule-tasks", "org.jbpm.signal", "org.jbpm.broken"});


### PR DESCRIPTION
See https://github.com/kiegroup/drools-wb/pull/801#issuecomment-399897253

This reverts commit ae6d40ec38585351c54c21c5df87c2c836f56c08.