### PR TITLE
DROOLS-2156: DMN decision table names should be presented as titles in editor screen

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
@@ -169,7 +169,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
         return spy;
     }
 
-    Optional<HasName> spyHasName(Optional<HasName> hasName) {
+    Optional<HasName> spyHasName(final Optional<HasName> hasName) {
         final Name name = new Name() {
             @Override
             public String getValue() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
@@ -27,6 +27,8 @@ import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.client.commands.ClearExpressionTypeCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
@@ -65,8 +67,11 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
     private final GridColumn expressionColumn;
 
     private String nodeUUID;
-    private HasExpression hasExpression;
     private Optional<HasName> hasName = Optional.empty();
+    private HasExpression hasExpression;
+
+    private final ParameterizedCommand<Optional<Expression>> onHasExpressionChanged;
+    private final ParameterizedCommand<Optional<HasName>> onHasNameChanged;
 
     private ExpressionContainerUIModelMapper uiModelMapper;
 
@@ -78,6 +83,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
                                    final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                    final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitions,
                                    final Supplier<ExpressionGridCache> expressionGridCache,
+                                   final ParameterizedCommand<Optional<Expression>> onHasExpressionChanged,
                                    final ParameterizedCommand<Optional<HasName>> onHasNameChanged) {
         super(new DMNGridData(),
               gridLayer,
@@ -89,12 +95,15 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
         this.sessionCommandManager = sessionCommandManager;
         this.expressionGridCache = expressionGridCache;
 
+        this.onHasExpressionChanged = onHasExpressionChanged;
+        this.onHasNameChanged = onHasNameChanged;
+
         this.uiModelMapper = new ExpressionContainerUIModelMapper(parent,
                                                                   this::getModel,
                                                                   () -> Optional.ofNullable(hasExpression.getExpression()),
                                                                   () -> nodeUUID,
                                                                   () -> hasExpression,
-                                                                  () -> spyHasName(onHasNameChanged),
+                                                                  () -> hasName,
                                                                   expressionEditorDefinitions,
                                                                   expressionGridCache,
                                                                   listSelector);
@@ -113,38 +122,6 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
         getRenderer().setColumnRenderConstraint((isSelectionLayer, gridColumn) -> !isSelectionLayer || gridColumn.equals(expressionColumn));
     }
 
-    Optional<HasName> spyHasName(final ParameterizedCommand<Optional<HasName>> onHasNameChanged) {
-        final Name name = new Name() {
-            @Override
-            public String getValue() {
-                return hasName.orElse(HasName.NOP).getName().getValue();
-            }
-
-            @Override
-            public void setValue(final String value) {
-                hasName.ifPresent(hn -> {
-                    hn.getName().setValue(value);
-                    onHasNameChanged.execute(hasName);
-                });
-            }
-        };
-
-        return Optional.of(new HasName() {
-            @Override
-            public Name getName() {
-                return name;
-            }
-
-            @Override
-            public void setName(final Name name) {
-                hasName.ifPresent(hn -> {
-                    hn.setName(name);
-                    onHasNameChanged.execute(hasName);
-                });
-            }
-        });
-    }
-
     @Override
     public boolean onDragHandle(final INodeXYEvent event) {
         return false;
@@ -160,14 +137,70 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
                               final HasExpression hasExpression,
                               final Optional<HasName> hasName) {
         this.nodeUUID = nodeUUID;
-        this.hasExpression = hasExpression;
-        this.hasName = hasName;
+        this.hasExpression = spyHasExpression(hasExpression);
+        this.hasName = spyHasName(hasName);
 
         uiModelMapper.fromDMNModel(0, 0);
 
         final double width = expressionColumn.getWidth();
         final double minWidth = expressionColumn.getMinimumWidth();
         resizeBasedOnCellExpressionEditor(Math.max(width, minWidth));
+    }
+
+    HasExpression spyHasExpression(final HasExpression hasExpression) {
+        final HasExpression spy = new HasExpression() {
+            @Override
+            public Expression getExpression() {
+                return hasExpression.getExpression();
+            }
+
+            @Override
+            public void setExpression(final Expression expression) {
+                hasExpression.setExpression(expression);
+                onHasExpressionChanged.execute(Optional.ofNullable(expression));
+            }
+
+            @Override
+            public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+                return hasExpression.getExpression();
+            }
+        };
+
+        return spy;
+    }
+
+    Optional<HasName> spyHasName(Optional<HasName> hasName) {
+        final Name name = new Name() {
+            @Override
+            public String getValue() {
+                return hasName.orElse(HasName.NOP).getName().getValue();
+            }
+
+            @Override
+            public void setValue(final String value) {
+                hasName.ifPresent(hn -> {
+                    hn.getName().setValue(value);
+                    onHasNameChanged.execute(hasName);
+                });
+            }
+        };
+
+        final HasName spy = new HasName() {
+            @Override
+            public Name getName() {
+                return name;
+            }
+
+            @Override
+            public void setName(final Name name) {
+                hasName.ifPresent(hn -> {
+                    hn.setName(name);
+                    onHasNameChanged.execute(hasName);
+                });
+            }
+        };
+
+        return Optional.of(spy);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.html
@@ -18,6 +18,9 @@
     <div class="kie-dmn-return-to-DRG">
         <i class="fa fa-angle-double-left" aria-hidden="true"></i><a href="#" data-field="returnToDRG"></a>
     </div>
+    <div class="kie-dmn-expression-type">
+        <h3 data-field="expressionType"></h3>
+    </div>
     <div class="kie-dmn-expression-editor">
         <div data-field="dmn-table"></div>
     </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -20,16 +20,19 @@ import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import com.ait.lienzo.client.core.types.Transform;
 import com.google.gwt.event.dom.client.ClickEvent;
 import org.jboss.errai.common.client.dom.Anchor;
+import org.jboss.errai.common.client.dom.Heading;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
@@ -59,6 +62,9 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     @DataField("returnToDRG")
     private Anchor returnToDRG;
 
+    @DataField("expressionType")
+    private Heading expressionType;
+
     private ExpressionContainerGrid expressionContainerGrid;
 
     private DMNGridPanel gridPanel;
@@ -79,6 +85,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
     @Inject
     public ExpressionEditorViewImpl(final Anchor returnToDRG,
+                                    final @Named("h2") Heading expressionType,
                                     final @DMNEditor DMNGridPanel gridPanel,
                                     final @DMNEditor DMNGridLayer gridLayer,
                                     final @DMNEditor RestrictedMousePanMediator mousePanMediator,
@@ -89,6 +96,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                     final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
         this.returnToDRG = returnToDRG;
+        this.expressionType = expressionType;
 
         this.gridPanel = gridPanel;
         this.gridLayer = gridLayer;
@@ -135,6 +143,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                                               sessionCommandManager,
                                                               expressionEditorDefinitionsSupplier,
                                                               getExpressionGridCacheSupplier(),
+                                                              this::setExpressionTypeText,
                                                               this::setReturnToDRGText);
         gridLayer.removeAll();
         gridLayer.add(expressionContainerGrid);
@@ -167,11 +176,18 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                               hasName);
 
         setReturnToDRGText(hasName);
+        setExpressionTypeText(Optional.ofNullable(hasExpression.getExpression()));
     }
 
     private void setReturnToDRGText(final Optional<HasName> hasName) {
         hasName.ifPresent(name -> returnToDRG.setTextContent(translationService.format(DMNEditorConstants.ExpressionEditor_ReturnToDRG,
                                                                                        name.getName().getValue())));
+    }
+
+    private void setExpressionTypeText(final Optional<Expression> expression) {
+        expressionType.setTextContent(expression.isPresent() ?
+                                              expression.get().getClass().getSimpleName() :
+                                              "<" + translationService.getTranslation(DMNEditorConstants.ExpressionEditor_UndefinedExpressionType) + ">");
     }
 
     @SuppressWarnings("unused")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.less
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+@blockHeight_returnToDRGHeight: 32;
+@blockHeight_expressionType: 32;
+@blockHeight_total: @blockHeight_returnToDRGHeight + @blockHeight_expressionType;
+
 .kie-dmn-container {
   display: flex;
   flex-direction: column;
@@ -23,7 +27,7 @@
 }
 
 .kie-dmn-return-to-DRG {
-  height: 32px;
+  height: @blockHeight_returnToDRGHeight px;
   display: block;
 }
 
@@ -32,10 +36,15 @@
   padding: 0 9px 0 7px;
 }
 
+.kie-dmn-expression-type {
+  height: @blockHeight_expressionType px;
+  display: block;
+}
+
 .kie-dmn-expression-editor {
   display: flex;
   width: 100%;
-  height: ~"calc(100% - 32px)";
-  top: 32px;
+  height: ~"calc(100% - @{blockHeight_total}px)";
+  top: @blockHeight_total px;
 }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.client.commands.ClearExpressionTypeCommand;
@@ -136,6 +138,9 @@ public class ExpressionContainerGridTest {
     @Mock
     private ParameterizedCommand<Optional<HasName>> onHasNameChanged;
 
+    @Mock
+    private ParameterizedCommand<Optional<Expression>> onHasExpressionChanged;
+
     @Captor
     private ArgumentCaptor<Optional<HasName>> hasNameCaptor;
 
@@ -178,6 +183,7 @@ public class ExpressionContainerGridTest {
                                                 sessionCommandManager,
                                                 expressionEditorDefinitionsSupplier,
                                                 () -> expressionGridCache,
+                                                onHasExpressionChanged,
                                                 onHasNameChanged);
 
         this.gridLayer.add(grid);
@@ -366,7 +372,7 @@ public class ExpressionContainerGridTest {
                            hasExpression,
                            Optional.of(hasName));
 
-        final Optional<HasName> spy = grid.spyHasName(onHasNameChanged);
+        final Optional<HasName> spy = grid.spyHasName(Optional.of(hasName));
 
         assertThat(spy.isPresent()).isTrue();
         assertThat(spy.get().getName().getValue()).isEqualTo(NAME);
@@ -380,7 +386,7 @@ public class ExpressionContainerGridTest {
                            hasExpression,
                            Optional.of(hasName));
 
-        final Optional<HasName> spy = grid.spyHasName(onHasNameChanged);
+        final Optional<HasName> spy = grid.spyHasName(Optional.of(hasName));
 
         assertThat(spy.isPresent()).isTrue();
         spy.get().getName().setValue(NEW_NAME);
@@ -400,7 +406,7 @@ public class ExpressionContainerGridTest {
                            hasExpression,
                            Optional.of(hasName));
 
-        final Optional<HasName> spy = grid.spyHasName(onHasNameChanged);
+        final Optional<HasName> spy = grid.spyHasName(Optional.of(hasName));
 
         assertThat(spy.isPresent()).isTrue();
         spy.get().setName(newName);
@@ -416,7 +422,7 @@ public class ExpressionContainerGridTest {
                            hasExpression,
                            Optional.empty());
 
-        final Optional<HasName> spy = grid.spyHasName(onHasNameChanged);
+        final Optional<HasName> spy = grid.spyHasName(Optional.empty());
 
         assertThat(spy.isPresent()).isTrue();
         assertThat(spy.get().getName().getValue()).isEqualTo(HasName.NOP.getName().getValue());
@@ -431,7 +437,7 @@ public class ExpressionContainerGridTest {
                            hasExpression,
                            Optional.empty());
 
-        final Optional<HasName> spy = grid.spyHasName(onHasNameChanged);
+        final Optional<HasName> spy = grid.spyHasName(Optional.empty());
 
         assertThat(spy.isPresent()).isTrue();
         spy.get().getName().setValue(NEW_NAME);
@@ -451,12 +457,69 @@ public class ExpressionContainerGridTest {
                            hasExpression,
                            Optional.empty());
 
-        final Optional<HasName> spy = grid.spyHasName(onHasNameChanged);
+        final Optional<HasName> spy = grid.spyHasName(Optional.empty());
 
         assertThat(spy.isPresent()).isTrue();
         spy.get().setName(newName);
 
         assertThat(hasName.getName().getValue()).isEqualTo(NAME);
         verify(onHasNameChanged, never()).execute(any(Optional.class));
+    }
+
+    @Test
+    public void testSpyHasExpressionWithExpressionGet() {
+        when(hasExpression.getExpression()).thenReturn(literalExpression);
+
+        grid.setExpression(NODE_UUID,
+                           hasExpression,
+                           Optional.of(hasName));
+
+        final HasExpression spy = grid.spyHasExpression(hasExpression);
+
+        assertThat(spy.getExpression()).isEqualTo(literalExpression);
+    }
+
+    @Test
+    public void testSpyHasExpressionWithoutExpressionGet() {
+        grid.setExpression(NODE_UUID,
+                           hasExpression,
+                           Optional.of(hasName));
+
+        final HasExpression spy = grid.spyHasExpression(hasExpression);
+
+        assertThat(spy.getExpression()).isNull();
+    }
+
+    @Test
+    public void testSpyHasExpressionWithExpressionSet() {
+        final HasExpression hasExpression = new HasExpression() {
+
+            private Expression expression = new LiteralExpression();
+
+            @Override
+            public Expression getExpression() {
+                return expression;
+            }
+
+            @Override
+            public void setExpression(final Expression expression) {
+                this.expression = expression;
+            }
+
+            @Override
+            public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+                return null;
+            }
+        };
+
+        grid.setExpression(NODE_UUID,
+                           hasExpression,
+                           Optional.of(hasName));
+
+        final HasExpression spy = grid.spyHasExpression(hasExpression);
+
+        spy.setExpression(null);
+
+        assertThat(hasExpression.getExpression()).isNull();
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2156

The "Expression Editor" screen now contains the type of expression (identical to the Navigator).