### PR TITLE
Stunner - Fix project showcase startup on SDM

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -107,7 +107,6 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-cdi-shared</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
@@ -1005,6 +1004,7 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-cdi-client</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -1400,6 +1400,7 @@
                 <include>src/main/webapp/WEB-INF/lib/</include>
                 <include>.errai/</include>
                 <include>.niogit/**</include>
+                <include>.index/</include>
               </includes>
             </fileset>
           </filesets>


### PR DESCRIPTION
Hey @hasys @tiagodolphine 

This is a fix for the project showcase, as @ederign pointed out there was an error on the pom, it was not starting up on SDM.

Thx