### PR TITLE
AF-1248: Add profile to enable skipping of gwt compilation of showcases

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
@@ -1034,7 +1034,21 @@
         </pluginManagement>
       </build>
     </profile>
-
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -1449,12 +1449,7 @@
   <profiles>
     <!-- Fast compiled build including Source maps for easier debugging. -->
     <profile>
-      <id>sourcemaps</id>
-      <activation>
-        <property>
-          <name>sourcemaps</name>
-        </property>
-      </activation>
+      <id>sources</id>
       <build>
         <plugins>
           <plugin>
@@ -1492,6 +1487,21 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -1075,12 +1075,7 @@
 
     <!-- Fast compiled build including Source maps for easier debugging. -->
     <profile>
-      <id>sourcemaps</id>
-      <activation>
-        <property>
-          <name>sourcemaps</name>
-        </property>
-      </activation>
+      <id>sources</id>
       <build>
         <plugins>
           <plugin>
@@ -1118,6 +1113,21 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Hello @romartin,

I'm introducing a new profile that will enable to skip gwt compilation of showcases in `downstream-pullrequests` jobs. In normal build, nothing is skipped. Only when you add `-Pno-showcase` to mvn command line, the showcases won't be gwt-compiled.

Part of an ensemble:
https://github.com/kiegroup/jbpm-wb/pull/1160
https://github.com/kiegroup/kie-wb-common/pull/1917
https://github.com/kiegroup/drools-wb/pull/877
https://github.com/kiegroup/appformer/pull/401