### PR TITLE
[7.7.x] RHPAM-1107: Selected container gets changed

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
@@ -108,6 +108,10 @@ public class ContainerPresenter {
         return view;
     }
 
+    protected void setContainerSpec(ContainerSpec containerSpec){
+        this.containerSpec = containerSpec;
+    }
+
     public void onRefresh(@Observes final RefreshRemoteServers refresh) {
         if (refresh != null && refresh.getContainerSpecKey() != null) {
             load(refresh.getContainerSpecKey());
@@ -128,7 +132,10 @@ public class ContainerPresenter {
     public void loadContainers(@Observes final ContainerSpecData content) {
         if (content != null &&
                 content.getContainerSpec() != null &&
-                content.getContainers() != null) {
+                content.getContainers() != null &&
+                containerSpec!=null &&
+                containerSpec.getId()!=null &&
+                containerSpec.getId().equals(content.getContainerSpec().getId())) {
             setup(content.getContainerSpec(),
                   content.getContainers());
         } else {
@@ -153,6 +160,7 @@ public class ContainerPresenter {
         checkNotNull("containerSpecKey", containerSpecKey);
         runtimeManagementService.call((RemoteCallback<ContainerSpecData>) content -> {
             checkNotNull("content", content);
+            setContainerSpec(content.getContainerSpec());
             loadContainers(content);
         }).getContainersByContainerSpec(containerSpecKey.getServerTemplateKey().getId(),
                                         containerSpecKey.getId());

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenter.java
@@ -80,12 +80,13 @@ public class ContainerRemoteStatusPresenter {
                 final Map<String, ContainerCardPresenter> newIndexIndex = new HashMap<String, ContainerCardPresenter>( serverInstanceUpdated.getServerInstance().getContainers().size() );
                 index.put( updatedServerInstanceKey, newIndexIndex );
                 for ( final Container container : serverInstanceUpdated.getServerInstance().getContainers() ) {
-                    ContainerCardPresenter presenter = oldIndex.remove( container.getContainerName() );
+                    ContainerCardPresenter presenter = oldIndex.remove( container.getContainerSpecId() );
                     if ( !container.getStatus().equals( KieContainerStatus.STOPPED ) ) {
                         if ( presenter != null ) {
-                            presenter.updateContent( serverInstanceUpdated.getServerInstance(), container );
+                            presenter.updateContent(serverInstanceUpdated.getServerInstance(),
+                                                    container );
                         } else {
-                            presenter = buildContainer( container );
+                            presenter = buildContainer( container, false );
                         }
                         newIndexIndex.put( container.getContainerName(), presenter );
                     }
@@ -135,13 +136,15 @@ public class ContainerRemoteStatusPresenter {
     }
 
     private void buildAndIndexContainer( final Container container ) {
-        index( container, buildContainer( container ) );
+        index( container, buildContainer( container, true ) );
     }
 
-    private ContainerCardPresenter buildContainer( final Container container ) {
+    private ContainerCardPresenter buildContainer( final Container container, boolean addCard ) {
         final ContainerCardPresenter cardPresenter = cardPresenterProvider.get();
         cardPresenter.setup( container.getServerInstanceKey(), container );
-        view.addCard( cardPresenter.getView().asWidget() );
+        if(addCard) {
+            view.addCard( cardPresenter.getView().asWidget() );
+        }
         return cardPresenter;
     }
 
@@ -150,7 +153,7 @@ public class ContainerRemoteStatusPresenter {
         if ( !index.containsKey( container.getServerInstanceKey().getServerInstanceId() ) ) {
             index.put( container.getServerInstanceKey().getServerInstanceId(), new HashMap<String, ContainerCardPresenter>() );
         }
-        index.get( container.getServerInstanceKey().getServerInstanceId() ).put( container.getContainerName(), cardPresenter );
+        index.get( container.getServerInstanceKey().getServerInstanceId() ).put( container.getContainerSpecId(), cardPresenter );
     }
 
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/widget/card/body/BodyPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/widget/card/body/BodyPresenter.java
@@ -63,7 +63,7 @@ public class BodyPresenter {
     public void setup(final Collection<Message> messages) {
         checkNotNull("messages",
                      messages);
-
+        view.clear();
         if (messages.isEmpty()) {
             view.addNotification(setupNotification(null).getView());
         } else {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
@@ -171,6 +171,8 @@ public class ContainerPresenterTest {
         containers = new ArrayList<Container>();
         containerSpecData = new ContainerSpecData(containerSpec,
                                                   containers);
+
+        presenter.setContainerSpec(containerSpec);
     }
 
     @Test
@@ -242,6 +244,30 @@ public class ContainerPresenterTest {
         verifyLoad(true,
                    1);
     }
+
+    @Test
+    public void testLoadContainersOnlyOnSelectedContainerEvent() {
+
+        ContainerSpec containerSpec1 = new ContainerSpec("containerId1",
+                                                         "containerName",
+                                                         serverTemplateKey,
+                                                         releaseId,
+                                                         KieContainerStatus.STOPPED,
+                                                         new HashMap<Capability, ContainerConfig>());
+        presenter.setContainerSpec(containerSpec1);
+        presenter.loadContainers(containerSpecData);
+
+        verifyLoad(true,
+                   0);
+
+        presenter.setContainerSpec(containerSpec);
+        presenter.loadContainers(containerSpecData);
+
+        verifyLoad(true,
+                   1);
+
+    }
+
 
     @Test
     public void testRefresh() {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/widget/card/body/BodyPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/widget/card/body/BodyPresenterTest.java
@@ -66,6 +66,7 @@ public class BodyPresenterTest {
         final Message message = mock( Message.class );
         presenter.setup( Arrays.asList( message ) );
         verify( notificationPresenter ).setup( message );
+        verify(view).clear();
         verify( view ).addNotification( notificationPresenter.getView() );
     }
 
@@ -73,6 +74,7 @@ public class BodyPresenterTest {
     public void testSetupEmpty() {
         presenter.setup( Collections.<Message>emptyList() );
         verify( notificationPresenter ).setupOk();
+        verify(view).clear();
         verify( view ).addNotification( notificationPresenter.getView() );
     }
 


### PR DESCRIPTION
ContainerPresenter reacting only on ContainerSpecSelected event when it is the one that is being displayed
Use container.getContainerSpecId() instead container.getContainerName() to map containers
clear status notifications before add new one, added by update actions