### PR TITLE
DROOLS-2628: [DMN Designer] DataInput toolbox actions

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/domain/DomainLookupFunctions.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/domain/DomainLookupFunctions.java
@@ -171,9 +171,9 @@ public class DomainLookupFunctions {
                     .getConnectionRules()
                     .stream()
                     .filter(rule -> rule.getRole().equals(edgeDefId))
-                    .filter(rule -> isSourceConnectionAllowed(rule, labels))
-                    .flatMap(rule -> rule.getPermittedConnections().stream()
-                            .map(CanConnect.PermittedConnection::getEndRole))
+                    .flatMap(rule -> rule.getPermittedConnections().stream())
+                    .filter(pc -> labels.contains(pc.getStartRole()))
+                    .map(CanConnect.PermittedConnection::getEndRole)
                     .collect(Collectors.toSet());
         }
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2628

@romartin The issue was that the ```anyMatch(..)``` in ```isSourceConnectionAllowed(..)``` results in ALL permitted connections matching and hence the target role for all source node types are collected. I've modified the code to get permitted connections whose ```startRole``` matches the source node's role(s) and then collect the ```endRole```. This fixes DMN and fixes all Unit Tests that broke as a result of adding the extra permitted connection in ```DomainLookupFunctionsTest```.