### PR TITLE
 JBPM-7373 Should URLDecode/URLEncode assigned values 

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomInput.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomInput.java
@@ -16,11 +16,14 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties;
 
+import java.util.List;
+
 import org.eclipse.bpmn2.Assignment;
 import org.eclipse.bpmn2.DataInput;
 import org.eclipse.bpmn2.DataInputAssociation;
 import org.eclipse.bpmn2.FormalExpression;
 import org.eclipse.bpmn2.InputOutputSpecification;
+import org.eclipse.bpmn2.InputSet;
 import org.eclipse.bpmn2.ItemDefinition;
 import org.eclipse.bpmn2.Task;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Ids;
@@ -65,7 +68,9 @@ public class CustomInput<T> {
             return;
         }
         DataInputAssociation input = input(value);
-        getIoSpecification(element).getDataInputs().add((DataInput) input.getTargetRef());
+        DataInput targetRef = (DataInput) input.getTargetRef();
+        getIoSpecification(element).getDataInputs().add(targetRef);
+        getIoSpecification(element).getInputSets().get(0).getDataInputRefs().add(targetRef);
         element.getDataInputAssociations().add(input);
     }
 
@@ -74,6 +79,10 @@ public class CustomInput<T> {
         if (ioSpecification == null) {
             ioSpecification = bpmn2.createInputOutputSpecification();
             element.setIoSpecification(ioSpecification);
+        }
+        List<InputSet> inputSets = ioSpecification.getInputSets();
+        if (inputSets.isEmpty()) {
+            inputSets.add(bpmn2.createInputSet());
         }
         return ioSpecification;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/CatchEventPropertyWriter.java
@@ -19,19 +19,25 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.pro
 import bpsim.ElementParameters;
 import org.eclipse.bpmn2.CatchEvent;
 import org.eclipse.bpmn2.EventDefinition;
+import org.eclipse.bpmn2.OutputSet;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.ParsedAssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.SimulationAttributeSets;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.SimulationAttributeSet;
 
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
+
 public class CatchEventPropertyWriter extends EventPropertyWriter {
 
     private final CatchEvent event;
+    private final OutputSet outputSet;
     private ElementParameters simulationParameters;
 
     public CatchEventPropertyWriter(CatchEvent event, VariableScope variableScope) {
         super(event, variableScope);
         this.event = event;
+        this.outputSet = bpmn2.createOutputSet();
+        event.setOutputSet(outputSet);
     }
 
     public void setAssignmentsInfo(AssignmentsInfo info) {
@@ -49,8 +55,8 @@ public class CatchEventPropertyWriter extends EventPropertyWriter {
                 .forEach(doa -> {
                     this.addItemDefinition(doa.getItemDefinition());
                     event.getDataOutputs().add(doa.getDataOutput());
-                    event.setOutputSet(doa.getOutputSet());
                     event.getDataOutputAssociation().add(doa.getAssociation());
+                    outputSet.getDataOutputRefs().add(doa.getDataOutput());
                 });
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/DeclarationWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/DeclarationWriter.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
 
 import org.eclipse.bpmn2.DataInput;
-import org.eclipse.bpmn2.InputSet;
 import org.eclipse.bpmn2.ItemDefinition;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.VariableDeclaration;
@@ -28,7 +27,6 @@ import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunn
 public class DeclarationWriter {
 
     private final String parentId;
-    private final InputSet inputSet;
     private final DataInput target;
     private final ItemDefinition typeDef;
     private final VariableDeclaration decl;
@@ -48,9 +46,6 @@ public class DeclarationWriter {
         // the value that we assign to `source`
         // e.g. myTarget
         this.target = readInputFrom(decl.getIdentifier(), typeDef);
-
-        this.inputSet = bpmn2.createInputSet();
-        this.inputSet.getDataInputRefs().add(target);
     }
 
     private ItemDefinition typedefInput(VariableDeclaration decl) {
@@ -76,10 +71,6 @@ public class DeclarationWriter {
 
     public ItemDefinition getItemDefinition() {
         return typeDef;
-    }
-
-    public InputSet getInputSet() {
-        return inputSet;
     }
 
     public String getVarId() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/InputAssignmentWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/InputAssignmentWriter.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
 import org.eclipse.bpmn2.Assignment;
 import org.eclipse.bpmn2.DataInput;
 import org.eclipse.bpmn2.DataInputAssociation;
@@ -26,6 +29,7 @@ import org.eclipse.bpmn2.Property;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration;
 
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.Scripts.asCData;
 
 public class InputAssignmentWriter {
 
@@ -93,7 +97,10 @@ public class InputAssignmentWriter {
         assignment.setTo(toExpr);
 
         FormalExpression fromExpr = bpmn2.createFormalExpression();
-        fromExpr.setBody(expression);
+        // this should be handled **outside** the marshallers!
+        String decodedExpression = decode(expression);
+        String cdataExpression = asCData(decodedExpression);
+        fromExpr.setBody(cdataExpression);
         assignment.setFrom(fromExpr);
 
         dataInputAssociation
@@ -118,5 +125,13 @@ public class InputAssignmentWriter {
 
     public DataInputAssociation getAssociation() {
         return association;
+    }
+
+    private String decode(String text) {
+        try {
+            return URLDecoder.decode(text,"UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(text, e);
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/InputAssignmentWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/InputAssignmentWriter.java
@@ -23,7 +23,6 @@ import org.eclipse.bpmn2.Assignment;
 import org.eclipse.bpmn2.DataInput;
 import org.eclipse.bpmn2.DataInputAssociation;
 import org.eclipse.bpmn2.FormalExpression;
-import org.eclipse.bpmn2.InputSet;
 import org.eclipse.bpmn2.ItemDefinition;
 import org.eclipse.bpmn2.Property;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration;
@@ -119,17 +118,13 @@ public class InputAssignmentWriter {
         return declarationWriter.getItemDefinition();
     }
 
-    public InputSet getInputSet() {
-        return declarationWriter.getInputSet();
-    }
-
     public DataInputAssociation getAssociation() {
         return association;
     }
 
     private String decode(String text) {
         try {
-            return URLDecoder.decode(text,"UTF-8");
+            return URLDecoder.decode(text, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new IllegalArgumentException(text, e);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/OutputAssignmentWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/OutputAssignmentWriter.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.pro
 import org.eclipse.bpmn2.DataOutput;
 import org.eclipse.bpmn2.DataOutputAssociation;
 import org.eclipse.bpmn2.ItemDefinition;
-import org.eclipse.bpmn2.OutputSet;
 import org.eclipse.bpmn2.Property;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.VariableDeclaration;
@@ -32,7 +31,6 @@ public class OutputAssignmentWriter {
     private final String parentId;
     private final DataOutputAssociation association;
     private final VariableDeclaration decl;
-    private final OutputSet outputSet;
     private final DataOutput source;
     private ItemDefinition typeDef;
 
@@ -54,9 +52,6 @@ public class OutputAssignmentWriter {
         // then we create the actual association between the two
         // e.g. mySource := myTarget (or, to put it differently, myTarget -> mySource)
         this.association = associationOf(variable.getTypedIdentifier(), source);
-
-        this.outputSet = bpmn2.createOutputSet();
-        this.outputSet.getDataOutputRefs().add(source);
     }
 
     private DataOutputAssociation associationOf(Property source, DataOutput dataOutput) {
@@ -90,10 +85,6 @@ public class OutputAssignmentWriter {
 
     public DataOutput getDataOutput() {
         return source;
-    }
-
-    public OutputSet getOutputSet() {
-        return outputSet;
     }
 
     public DataOutputAssociation getAssociation() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ThrowEventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ThrowEventPropertyWriter.java
@@ -20,19 +20,24 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.eclipse.bpmn2.EventDefinition;
+import org.eclipse.bpmn2.InputSet;
 import org.eclipse.bpmn2.ThrowEvent;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.ParsedAssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
 
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.AssignmentsInfos.isReservedIdentifier;
 
 public class ThrowEventPropertyWriter extends EventPropertyWriter {
 
     private final ThrowEvent throwEvent;
+    private final InputSet inputSet;
 
     public ThrowEventPropertyWriter(ThrowEvent flowElement, VariableScope variableScope) {
         super(flowElement, variableScope);
         this.throwEvent = flowElement;
+        this.inputSet = bpmn2.createInputSet();
+        throwEvent.setInputSet(inputSet);
     }
 
     @Override
@@ -45,8 +50,8 @@ public class ThrowEventPropertyWriter extends EventPropertyWriter {
                 .map(varDecl -> new DeclarationWriter(flowElement.getId(), varDecl))
                 .peek(dw -> {
                     this.addItemDefinition(dw.getItemDefinition());
-                    throwEvent.setInputSet(dw.getInputSet());
                     throwEvent.getDataInputs().add(dw.getDataInput());
+                    inputSet.getDataInputRefs().add(dw.getDataInput());
                 })
                 .flatMap(dw -> toInputAssignmentStream(assignmentsInfo, dw))
                 .forEach(dia -> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/sequenceflows/SequenceFlowConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/sequenceflows/SequenceFlowConverter.java
@@ -57,7 +57,7 @@ public class SequenceFlowConverter {
 
         if (pSrc == null || pTgt == null) {
             String msg = String.format("pSrc = %s, pTgt = %s", pSrc, pTgt);
-            LOG.warn(msg);
+            LOG.debug(msg);
             return Result.failure(msg);
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/AssignmentsInfos.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/AssignmentsInfos.java
@@ -16,19 +16,16 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.bpmn2.Assignment;
 import org.eclipse.bpmn2.DataInput;
 import org.eclipse.bpmn2.DataInputAssociation;
 import org.eclipse.bpmn2.DataOutput;
 import org.eclipse.bpmn2.DataOutputAssociation;
-import org.eclipse.bpmn2.FormalExpression;
-import org.eclipse.bpmn2.ItemAwareElement;
 import org.eclipse.bpmn2.Property;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Direction;
@@ -109,35 +106,12 @@ public class AssignmentsInfos {
     }
 
     private static List<AssociationDeclaration> inAssociationDeclarations(List<DataInputAssociation> inputAssociations) {
-        List<AssociationDeclaration> result = new ArrayList<>();
-        for (DataInputAssociation in : inputAssociations) {
-            List<ItemAwareElement> sourceList = in.getSourceRef();
-            List<Assignment> assignmentList = in.getAssignment();
-            String targetName = ((DataInput) in.getTargetRef()).getName();
-            if (isReservedIdentifier(targetName)) {
-                continue;
-            }
-
-            if (!sourceList.isEmpty()) {
-                String propertyName = getPropertyName((Property) sourceList.get(0));
-                result.add(new AssociationDeclaration(
-                        Direction.Input,
-                        Type.SourceTarget,
-                        propertyName,
-                        targetName));
-            } else if (!assignmentList.isEmpty()) {
-                Assignment assignment = assignmentList.get(0);
-                result.add(new AssociationDeclaration(
-                        Direction.Input,
-                        Type.FromTo,
-                        ((FormalExpression) assignment.getFrom()).getBody(),
-                        targetName));
-            } else {
-                throw new IllegalArgumentException("Cannot find SourceRef or Assignment for Target " + targetName);
-            }
-        }
-
-        return result;
+        return inputAssociations
+                .stream()
+                .map(InputAssignmentReader::fromAssociation)
+                .filter(Objects::nonNull)
+                .map(InputAssignmentReader::getAssociationDeclaration)
+                .collect(Collectors.toList());
     }
 
     private static List<AssociationDeclaration> outAssociationDeclarations(List<DataOutputAssociation> outputAssociations) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.List;
+
+import org.eclipse.bpmn2.Assignment;
+import org.eclipse.bpmn2.DataInput;
+import org.eclipse.bpmn2.DataInputAssociation;
+import org.eclipse.bpmn2.FormalExpression;
+import org.eclipse.bpmn2.ItemAwareElement;
+import org.eclipse.bpmn2.Property;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration;
+
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.AssignmentsInfos.isReservedIdentifier;
+
+public class InputAssignmentReader {
+
+    private final AssociationDeclaration associationDeclaration;
+
+    public static InputAssignmentReader fromAssociation(DataInputAssociation in) {
+        List<ItemAwareElement> sourceList = in.getSourceRef();
+        List<Assignment> assignmentList = in.getAssignment();
+        String targetName = ((DataInput) in.getTargetRef()).getName();
+        if (isReservedIdentifier(targetName)) {
+            return null;
+        }
+
+        if (!sourceList.isEmpty()) {
+            return new InputAssignmentReader(sourceList.get(0), targetName);
+        } else if (!assignmentList.isEmpty()) {
+            return new InputAssignmentReader(assignmentList.get(0), targetName);
+        } else {
+            throw new IllegalArgumentException("Cannot find SourceRef or Assignment for Target " + targetName);
+        }
+    }
+
+    InputAssignmentReader(Assignment assignment, String targetName) {
+        FormalExpression from = (FormalExpression) assignment.getFrom();
+        String body = from.getBody();
+        String encodedBody = encode(body);
+        this.associationDeclaration = new AssociationDeclaration(
+                AssociationDeclaration.Direction.Input,
+                AssociationDeclaration.Type.FromTo,
+                encodedBody,
+                targetName);
+    }
+
+    InputAssignmentReader(ItemAwareElement source, String targetName) {
+        String propertyName = getPropertyName((Property) source);
+        this.associationDeclaration = new AssociationDeclaration(
+                AssociationDeclaration.Direction.Input,
+                AssociationDeclaration.Type.SourceTarget,
+                propertyName,
+                targetName);
+    }
+
+    private String encode(String body) {
+        try {
+            return URLEncoder.encode(body, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(body, e);
+        }
+    }
+
+    public AssociationDeclaration getAssociationDeclaration() {
+        return associationDeclaration;
+    }
+
+    // fallback to ID for https://issues.jboss.org/browse/JBPM-6708
+    private static String getPropertyName(Property prop) {
+        return prop.getName() == null ? prop.getId() : prop.getName();
+    }
+
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomInputDefinitionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomInputDefinitionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties;
+
+import java.util.List;
+
+import org.eclipse.bpmn2.InputOutputSpecification;
+import org.eclipse.bpmn2.InputSet;
+import org.eclipse.bpmn2.Task;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
+
+public class CustomInputDefinitionTest {
+
+    @Test
+    public void shouldReuseInputSet() {
+        Task task = bpmn2.createTask();
+        StringInput stringInput = new StringInput("BLAH", "ATYPE", "DEFAULTVAL");
+        stringInput.of(task).set("VALUE");
+
+        StringInput stringInput2 = new StringInput("BLAH2", "ATYPE", "DEFAULTVAL");
+        stringInput.of(task).set("VALUE");
+
+
+        InputOutputSpecification ioSpecification = task.getIoSpecification();
+        List<InputSet> inputSets = ioSpecification.getInputSets();
+
+        assertEquals(1, inputSets.size());
+    }
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomInputDefinitionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomInputDefinitionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ import org.eclipse.bpmn2.InputSet;
 import org.eclipse.bpmn2.Task;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
 
 public class CustomInputDefinitionTest {
@@ -37,11 +37,9 @@ public class CustomInputDefinitionTest {
         StringInput stringInput2 = new StringInput("BLAH2", "ATYPE", "DEFAULTVAL");
         stringInput.of(task).set("VALUE");
 
-
         InputOutputSpecification ioSpecification = task.getIoSpecification();
         List<InputSet> inputSets = ioSpecification.getInputSets();
 
         assertEquals(1, inputSets.size());
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
+
+import java.util.List;
+
+import org.eclipse.bpmn2.InputSet;
+import org.eclipse.bpmn2.Task;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
+
+public class ActivityPropertyWriterTest {
+
+    @Test
+    public void shouldCreateOneInputSet() {
+        Task task = bpmn2.createTask();
+        ActivityPropertyWriter activityPropertyWriter =
+                new ActivityPropertyWriter(task, new FlatVariableScope());
+        activityPropertyWriter.setAssignmentsInfo(new AssignmentsInfo(
+                "|A:String|||"
+        ));
+        List<InputSet> inputSets = task.getIoSpecification().getInputSets();
+        assertEquals(1, inputSets.size());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/InputAssignmentWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/InputAssignmentWriterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import org.eclipse.bpmn2.Assignment;
+import org.eclipse.bpmn2.FormalExpression;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.VariableDeclaration;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Ids;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.Scripts.asCData;
+
+public class InputAssignmentWriterTest {
+
+    @Test
+    public void urlDecodeConstants() throws UnsupportedEncodingException {
+        String expected = "<<<#!!!#>>>";
+        String encoded = URLEncoder.encode(expected, "UTF-8");
+
+        VariableDeclaration variable = new VariableDeclaration("ID", "Object");
+        InputAssignmentWriter iaw = new InputAssignmentWriter(
+                new DeclarationWriter(
+                        "PARENT",
+                        variable),
+                encoded);
+
+        Assignment assignment = iaw.getAssociation().getAssignment().get(0);
+
+        FormalExpression to = (FormalExpression) assignment.getTo();
+        assertEquals(Ids.dataInput("PARENT", "ID"), to.getBody());
+
+        FormalExpression from = (FormalExpression) assignment.getFrom();
+        assertEquals(asCData(expected), from.getBody());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReaderTest.java
@@ -1,5 +1,54 @@
-import static org.junit.Assert.*;
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import org.eclipse.bpmn2.Assignment;
+import org.eclipse.bpmn2.FormalExpression;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
 
 public class InputAssignmentReaderTest {
 
+    @Test
+    public void urlEncodeConstants() throws UnsupportedEncodingException {
+        String decoded = "<<<#!!!#>>>";
+        String expected = URLEncoder.encode(decoded, "UTF-8");
+
+        Assignment assignment = bpmn2.createAssignment();
+        FormalExpression from = bpmn2.createFormalExpression();
+        from.setBody(decoded);
+
+        FormalExpression to = bpmn2.createFormalExpression();
+        to.setBody("ID");
+
+        assignment.setFrom(from);
+        assignment.setTo(to);
+
+        InputAssignmentReader iar = new InputAssignmentReader(assignment, "ID");
+
+        AssociationDeclaration associationDeclaration = iar.getAssociationDeclaration();
+
+        assertEquals(AssociationDeclaration.Type.FromTo, associationDeclaration.getType());
+        assertEquals(expected, associationDeclaration.getSource());
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReaderTest.java
@@ -1,0 +1,5 @@
+import static org.junit.Assert.*;
+
+public class InputAssignmentReaderTest {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/AssociationsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/AssociationsTest.java
@@ -75,7 +75,7 @@ public class AssociationsTest extends BPMNDiagramMarshallerBase {
                 p.getFlowElements().stream().filter(e -> e.getId().equals(TASK_ID)).findFirst().get();
         List<DataInputAssociation> associations = flowElement.getDataInputAssociations();
         assertEquals("myprocvar", findVar(associations, "From"));
-        assertEquals("HELLO", findAssignment(associations, "Body"));
+        assertEquals("<![CDATA[HELLO]]>", findAssignment(associations, "Body"));
     }
 
     public String findVar(List<DataInputAssociation> associations, String varName) {


### PR DESCRIPTION
I am "fixing" this in the marshallers, but it's actually a bug at a higher-level. URLEncoding/Decoding should not be handled in the marshallers, it's (I guess) a front-end concern.

In this PR we also
- fix handling of InputSet sections in XML
- disable an unrelated WARN logging which irked me

@romartin @hasys @LuboTerifaj  for review
