### PR TITLE
RHPAM-470 (Stunner) - Validate and generate the right BPMN process id name and data properties

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
@@ -207,7 +207,7 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
                                 true,
                                 CONSTANT_PROMPT,
                                 ENTER_CONSTANT_PROMPT);
-        name.setRegExp("^[a-zA-Z0-9\\-\\.\\_]*$",
+        name.setRegExp("^[a-zA-Z0-9\\-\\_]*$",
                        StunnerFormsClientFieldsConstants.INSTANCE.Removed_invalid_characters_from_name(),
                        StunnerFormsClientFieldsConstants.INSTANCE.Invalid_character_in_name());
         customDataType.addKeyDownHandler(new KeyDownHandler() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -154,7 +154,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                               true,
                               CUSTOM_PROMPT,
                               ENTER_TYPE_PROMPT);
-        name.setRegExp("^[a-zA-Z0-9\\-\\.\\_]*$",
+        name.setRegExp("^[a-zA-Z0-9\\-\\_]*$",
                        "Removed invalid characters from name",
                        "Invalid character in name");
         customDataType.addKeyDownHandler(new KeyDownHandler() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBoxTest.java
@@ -198,6 +198,8 @@ public class VariableNameTextBoxTest {
                      isValidResult);
         isValidResult = textBox.isValidValue("-",
                                              false);
+        assertEquals(null,
+                     isValidResult);
         isValidResult = textBox.isValidValue("_",
                                              true);
         assertEquals(null,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBoxTest.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.KeyPressEvent;
@@ -50,7 +49,7 @@ import static org.mockito.Mockito.when;
 @RunWith(Parameterized.class)
 public class VariableNameTextBoxTest {
 
-    private static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\.\\_]*$";
+    private static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\_]*$";
     private static final String ERROR_MESSAGE = "some error";
     private static final String ERROR_REMOVED = "some error reg exp";
     private static final String ERROR_TYPED = "some error reg exp2";
@@ -67,9 +66,6 @@ public class VariableNameTextBoxTest {
 
     @Mock
     private KeyPressEvent keyPressEvent;
-
-    @Mock
-    private NativeEvent nativeEvent;
 
     private boolean caseSensitive;
 
@@ -111,6 +107,7 @@ public class VariableNameTextBoxTest {
         INVALID_VALUES.add("abc");
         INVALID_VALUES.add("CdE");
         INVALID_VALUES.add("a#$%1");
+        INVALID_VALUES.add("a.");
         textBox.setInvalidValues(INVALID_VALUES,
                                  caseSensitive,
                                  ERROR_MESSAGE);
@@ -179,6 +176,9 @@ public class VariableNameTextBoxTest {
         makeValidResult = textBox.makeValidValue("a#b$2%1");
         assertEquals("ab21",
                      makeValidResult);
+        makeValidResult = textBox.makeValidValue("a#b$2%1.3-4_5");
+        assertEquals("ab213-4_5",
+                     makeValidResult);
     }
 
     @Test
@@ -189,6 +189,20 @@ public class VariableNameTextBoxTest {
         assertEquals(null,
                      isValidResult);
         isValidResult = textBox.isValidValue("a",
+                                             false);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("-",
+                                             true);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("-",
+                                             false);
+        isValidResult = textBox.isValidValue("_",
+                                             true);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("_",
                                              false);
         assertEquals(null,
                      isValidResult);
@@ -220,6 +234,16 @@ public class VariableNameTextBoxTest {
         isValidResult = textBox.isValidValue("a#$%1",
                                              false);
         assertEquals(ERROR_TYPED + ": #$%",
+                     isValidResult);
+
+        isValidResult = textBox.isValidValue("a.",
+                                             true);
+        assertEquals(ERROR_MESSAGE,
+                     isValidResult);
+
+        isValidResult = textBox.isValidValue("a.",
+                                             false);
+        assertEquals(ERROR_TYPED + ": .",
                      isValidResult);
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/RHPAM-470

Process name value and id were fixed in other changes.
Process data variables now won't accept dots. The dots seemed to be the
only invalid character that was still allowed.