### PR TITLE
Stunner - Old Marshallers: Move sysout logging to LOG.debug

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/builder/BPMNGraphGenerator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/builder/BPMNGraphGenerator.java
@@ -59,11 +59,15 @@ import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegis
 import org.kie.workbench.common.stunner.core.rule.RuleManager;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.core.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Support for a basic single process hierarchy
  */
 public class BPMNGraphGenerator extends JsonGenerator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BPMNGraphGenerator.class);
 
     private final GraphObjectBuilderFactory bpmnGraphBuilderFactory;
     private final DefinitionManager definitionManager;
@@ -257,9 +261,9 @@ public class BPMNGraphGenerator extends JsonGenerator {
 
     // For local testing...
     private void logBuilders() {
-        log("Logging builders at creation time...");
+        LOG.debug("Logging builders at creation time...");
         for (GraphObjectBuilder<?, ?> builder : builders) {
-            log(builder.toString());
+            LOG.debug("{}", builder);
         }
     }
 
@@ -598,10 +602,6 @@ public class BPMNGraphGenerator extends JsonGenerator {
         @Override
         public void writeEndArray() {
         }
-    }
-
-    private void log(final String message) {
-        System.out.println(message);
     }
 
     /***********************************************************************************

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/parser/BPMN2JsonParser.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/parser/BPMN2JsonParser.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.base.ParserMinimalBase;
-import org.kie.workbench.common.stunner.bpmn.backend.marshall.json.builder.BPMNGraphGenerator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Edge;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/parser/BPMN2JsonParser.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/parser/BPMN2JsonParser.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.base.ParserMinimalBase;
+import org.kie.workbench.common.stunner.bpmn.backend.marshall.json.builder.BPMNGraphGenerator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -45,9 +46,13 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.AbstractChildrenTraverseCallback;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessorImpl;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.TreeWalkTraverseProcessorImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 // See org.codehaus.jackson.impl.ReaderBasedParser
 
 public class BPMN2JsonParser extends ParserMinimalBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BPMN2JsonParser.class);
 
     private Diagram<Graph, Metadata> diagram;
     private NodeParser rootParser;
@@ -142,7 +147,7 @@ public class BPMN2JsonParser extends ParserMinimalBase {
         }
         // Initialize all the element parsers added in the tree.
         BPMN2JsonParser.this.rootParser.initialize(parsingContext);
-        System.out.println("End of children and view traverse");
+        LOG.debug("End of children and view traverse");
     }
 
 


### PR DESCRIPTION
This PR changes places where sysout is used in old marshallers, so that they output to LOG.debug()
#1922 includes a fix for NEW marshallers related to logging
with these 2 PRs merged, console output should be zero

@romartin @hasys @LuboTerifaj 
