### PR TITLE
JBPM-6829 : Stunner - Morphing issues for BPMN activities

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/MorphAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/MorphAdapter.java
@@ -30,6 +30,11 @@ public interface MorphAdapter<S> extends Adapter {
     <T> Iterable<MorphDefinition> getMorphDefinitions(final T definition);
 
     /**
+     * Returns the morphing definitions for the given DefinitionId and BaseId
+     */
+    Iterable<MorphDefinition> getMorphDefinitions(final String id, final String baseId);
+
+    /**
      * Returns the morphing properties for the given Definition instance, if any.
      */
     <T> Iterable<MorphProperty> getMorphProperties(final T definition);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
@@ -16,12 +16,14 @@
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.shape.EdgeShape;
 import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.util.ShapeUtils;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
@@ -30,6 +32,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Dock;
+import org.kie.workbench.common.stunner.core.graph.content.relationship.Relationship;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 
@@ -69,39 +72,38 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
         context.applyElementMutation(candidate,
                                      MutationContext.STATIC);
 
-        // Update incoming connections for new shape ( so magnets, connectors, etc on view side ).
-        final List<Edge> inEdges = candidate.getInEdges();
-        if (null != inEdges && !inEdges.isEmpty()) {
-            for (final Edge inEdge : inEdges) {
-                if (isViewEdge(inEdge)) {
-                    final Node inNode = inEdge.getSourceNode();
-                    updateConnections(context,
-                                      inEdge,
-                                      inNode,
-                                      candidate);
-                }
-            }
-        }
-
-        // Update outgoing connections as well for new shape.
-        final List<Edge> outEdges = candidate.getOutEdges();
-        if (null != outEdges && !outEdges.isEmpty()) {
-            for (final Edge outEdge : outEdges) {
-                if (isViewEdge(outEdge)) {
-                    final Node targetNode = outEdge.getTargetNode();
-                    updateConnections(context,
-                                      outEdge,
-                                      candidate,
-                                      targetNode);
-                }
-            }
-        }
+        updateEdges(context, candidate);
 
         GraphUtils.getDockParent(candidate).ifPresent(dockParent-> {
             builder.addCommand(new CanvasDockNodeCommand(dockParent , candidate));
         });
 
         return builder.build().execute(context);
+    }
+
+    private void updateEdges(AbstractCanvasHandler context, Node<? extends Definition<?>, Edge> candidate) {
+        // Update incoming edges for the new shape
+        Optional.ofNullable(candidate.getInEdges())
+                .ifPresent(edges -> edges.stream()
+                        .filter(this::isViewEdge)
+                        .forEach(edge -> updateConnections(context, edge, edge.getSourceNode(), candidate)));
+
+        // Update outgoing edges for the new shape.
+        Optional.ofNullable(candidate.getOutEdges())
+                .ifPresent(edges -> edges.stream()
+                        .forEach(edge -> {
+                            if (isViewEdge(edge)) {
+                                updateConnections(context, edge, candidate, edge.getTargetNode());
+                            } else if (edge.getContent() instanceof Relationship) {
+                                updateChild(context, edge.getSourceNode(), edge.getTargetNode());
+                            }
+                        })
+                );
+    }
+
+    private void updateChild(AbstractCanvasHandler context, Node parent, Node child) {
+        context.addChild(parent, child);
+        ShapeUtils.moveViewConnectorsToTop(context, child);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/AbstractMorphAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/AbstractMorphAdapter.java
@@ -57,8 +57,7 @@ public abstract class AbstractMorphAdapter<S> implements MorphAdapter<S> {
         return null;
     }
 
-    protected Iterable<MorphDefinition> getMorphDefinitions(final String id,
-                                                            final String baseId) {
+    public Iterable<MorphDefinition> getMorphDefinitions(final String id, final String baseId) {
         if (null != id) {
             final List<MorphDefinition> result = new LinkedList<>();
             for (MorphDefinition morphDefinition : morphDefinitions) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseNonContainerSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseNonContainerSubprocess.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition;
+
+import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.SimulationSet;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.morph.MorphBase;
+
+@MorphBase(defaultType = ReusableSubprocess.class, targets = {BaseTask.class})
+public abstract class BaseNonContainerSubprocess extends BaseSubprocess {
+
+    @Category
+    public static final transient String category = BPMNCategories.SUB_PROCESSES;
+
+    public BaseNonContainerSubprocess(BPMNGeneralSet general, BackgroundSet backgroundSet, FontSet fontSet, RectangleDimensionsSet dimensionsSet, SimulationSet simulationSet) {
+        super(general, backgroundSet, fontSet, dimensionsSet, simulationSet);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseSubprocess.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.definition.La
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.MorphBase;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@MorphBase(defaultType = ReusableSubprocess.class, targets = {BaseTask.class})
+@MorphBase(defaultType = EmbeddedSubprocess.class)
 public abstract class BaseSubprocess implements BPMNViewDefinition {
 
     @Category

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseTask.java
@@ -41,7 +41,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.morph.MorphPr
 import org.kie.workbench.common.stunner.core.definition.annotation.morph.MorphPropertyValueBinding;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@MorphBase(defaultType = NoneTask.class, targets = {ReusableSubprocess.class})
+@MorphBase(defaultType = NoneTask.class, targets = {BaseNonContainerSubprocess.class})
 public abstract class BaseTask implements BPMNViewDefinition {
 
     public static final Set<String> TASK_LABELS = new HashSet<String>() {{

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ReusableSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/ReusableSubprocess.java
@@ -46,14 +46,14 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Portable
 @Bindable
 @Definition(graphFactory = NodeFactory.class)
-@Morph(base = BaseSubprocess.class)
+@Morph(base = BaseNonContainerSubprocess.class)
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
 @FormDefinition(
         startElement = "general",
         policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)}
 )
-public class ReusableSubprocess extends BaseSubprocess implements DataIOModel {
+public class ReusableSubprocess extends BaseNonContainerSubprocess implements DataIOModel {
 
     @PropertySet
     @FormField(

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/workitem/BaseServiceTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/workitem/BaseServiceTask.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.workitem;
+
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNCategories;
+import org.kie.workbench.common.stunner.bpmn.definition.BaseTask;
+import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.general.TaskGeneralSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.simulation.SimulationSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.TaskType;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+
+public abstract class BaseServiceTask extends BaseTask {
+
+    @Category
+    public static final transient String category = BPMNCategories.SERVICE_TASKS;
+
+    public BaseServiceTask(TaskGeneralSet general, BackgroundSet backgroundSet, FontSet fontSet, RectangleDimensionsSet dimensionsSet, SimulationSet simulationSet, TaskType taskType) {
+        super(general, backgroundSet, fontSet, dimensionsSet, simulationSet, taskType);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/workitem/ServiceTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/workitem/ServiceTask.java
@@ -26,7 +26,6 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNCategories;
-import org.kie.workbench.common.stunner.bpmn.definition.BaseTask;
 import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOModel;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOSet;
@@ -61,7 +60,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
         startElement = "general",
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)}
 )
-public class ServiceTask extends BaseTask implements DataIOModel {
+public class ServiceTask extends BaseServiceTask implements DataIOModel {
 
     @PropertySet
     @FormField(

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilderTest.java
@@ -136,7 +136,8 @@ public class BPMNPaletteDefinitionBuilderTest {
                                                   paletteDefinitionBuilder,
                                                   translationService,
                                                   () -> workItemDefinitionRegistry,
-                                                  serviceTaskBuilder);
+                                                  serviceTaskBuilder,
+                                                  definitionUtils);
         tested.init();
     }
 


### PR DESCRIPTION
Changes related to this PR:
- Morph from tasks to reusable sub-processes
- Morph from reusable sub-processes to tasks
- Service tasks **not**  allowed to be morphed
- Morph between sub-processes (containers) except reusable (that is not a container)
- Fix morph sub-process with children or docked nodes

PS:  I need to update the `MorphCanvasNodeCommandTest.java`  but depending on this https://github.com/kiegroup/kie-wb-common/pull/1893 to be merged before that includes the test class.

@romartin 
@LuboTerifaj 