### PR TITLE
Last change to Stunner Showcase README - Copyright adjustment per PR feedback & fix

### DIFF
--- a/kie-wb-common-stunner/README.md
+++ b/kie-wb-common-stunner/README.md
@@ -118,23 +118,18 @@ If you were able to use the IDE GUI to import the code style successfully above,
 2. In the search field, type '*file and code templates*'.
 3. Select the *Includes* tab.
 4. Select *File Header* in the left-hand list.
-5. Replace the content on the right-hand side with the following, then click *Apply* and/or *OK*:
+5. Remove any line in the template referencing @author, as KIE convention is to omit this in lieu of Git history information.
 
-         /*
-          * Copyright ${YEAR} Red Hat, Inc. and/or its affiliates.
-          *
-          * Licensed under the Apache License, Version 2.0 (the "License");
-          * you may not use this file except in compliance with the License.
-          * You may obtain a copy of the License at
-          *
-          *     http://www.apache.org/licenses/LICENSE-2.0
-          *
-          * Unless required by applicable law or agreed to in writing, software
-          * distributed under the License is distributed on an "AS IS" BASIS,
-          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-          * See the License for the specific language governing permissions and
-          * limitations under the License.
-         */
+***Configure Copyright Template***
+1. Open **Preferences** from the **File** (linux/Win) menu or **IntelliJ IDEA** app menu (mac).
+2. In the search field, type '*copyright*'.
+3. Select *Copyright Profiles*, located under *Copyright*.
+4. Click the plus (+) sign in the top-left corner, then enter "KIE Copyright" in the name field in the popup.
+5. Replace the contents of the *Copyright text* field with the contents of the [KIE licensing file](https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/master/ide-configuration/LICENSE-ASL-2.0-HEADER.txt).
+6. Within the newly pasted text, replace "*${year}*" with "*$today.year*", then click *Apply*.
+7. In the left-hand navigation tree, select *Copyright*, the parent node of the currently screen item.
+8. Use the *Default project copyright* dropdown to select the newly created "*KIE Copyright*" value.
+9. Click *Apply* and/or *OK*.
 
 ***Configure GWT Facets***
 1. If you don't already have a local copy of the GWT SDK, download the latest version [from here](http://www.gwtproject.org/download.html) and extract it somewhere safe where you keep other SDK's.

--- a/kie-wb-common-stunner/README.md
+++ b/kie-wb-common-stunner/README.md
@@ -102,7 +102,7 @@ If you have not run the step from **Before Working with the IDE** above, do so b
 5. Click *Import*.
 6. In the *Import From* popup, select "IntelliJ IDEA code style XML". If this option is not available, proceed to **Manually Importing the Code Style** below at this time.
 7. Navigate to the downloaded XML file and select it.
-8. Click *Apply* and/or *OK*.
+8. Click *Apply* and/or *OK*. 
 
 ***Manually Importing the Code Style***
 

--- a/kie-wb-common-stunner/README.md
+++ b/kie-wb-common-stunner/README.md
@@ -102,7 +102,7 @@ If you have not run the step from **Before Working with the IDE** above, do so b
 5. Click *Import*.
 6. In the *Import From* popup, select "IntelliJ IDEA code style XML". If this option is not available, proceed to **Manually Importing the Code Style** below at this time.
 7. Navigate to the downloaded XML file and select it.
-8. Click *Apply* and/or *OK*. 
+8. Click *Apply* and/or *OK*.
 
 ***Manually Importing the Code Style***
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/README.md
@@ -2,10 +2,14 @@ Stunner Showcase
 ================
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 Execution and demonstration of the various Stunner-based components can be achieved using the following provided Showcase modules. There are currently two showcases available, the [Stunner Project Showcase](./kie-wb-common-stunner-showcase-project) & the [Stunner Standalone Showcase](./kie-wb-common-stunner-showcase-standalone).
 =======
 Execution and demonstration of the various Stunner-based components can be achieved using the provided [Showcase modules](./kie-wb-common-stunner-showcase). There are currently two showcases available, the [Stunner Project Showcase](./kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project) & the [Stunner Standalone Showcase](./kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone).
 >>>>>>> fixing the standalone showcase README to refer back to the newly updated one so everything is in one place
+=======
+Execution and demonstration of the various Stunner-based components can be achieved using the following provided Showcase modules. There are currently two showcases available, the [Stunner Project Showcase](./kie-wb-common-stunner-showcase-project) & the [Stunner Standalone Showcase](./kie-wb-common-stunner-showcase-standalone).
+>>>>>>> fixing link pointers in the showcase parent directory README
 
   - **Stunner Standalone Showcase** focuses on presenting basic UberFire (Appformer)/Errai components, such as Process Designer, skipping over the more involved & resource-intensive integration of KIE Workbench/Library and Guvnor project components.
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/README.md
@@ -1,7 +1,11 @@
 Stunner Showcase
 ================
 
+<<<<<<< HEAD
 Execution and demonstration of the various Stunner-based components can be achieved using the following provided Showcase modules. There are currently two showcases available, the [Stunner Project Showcase](./kie-wb-common-stunner-showcase-project) & the [Stunner Standalone Showcase](./kie-wb-common-stunner-showcase-standalone).
+=======
+Execution and demonstration of the various Stunner-based components can be achieved using the provided [Showcase modules](./kie-wb-common-stunner-showcase). There are currently two showcases available, the [Stunner Project Showcase](./kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project) & the [Stunner Standalone Showcase](./kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone).
+>>>>>>> fixing the standalone showcase README to refer back to the newly updated one so everything is in one place
 
   - **Stunner Standalone Showcase** focuses on presenting basic UberFire (Appformer)/Errai components, such as Process Designer, skipping over the more involved & resource-intensive integration of KIE Workbench/Library and Guvnor project components.
 


### PR DESCRIPTION
Fixing copyright info to reference the official file and the correct IDEA Preferences config location in Stunner showcase README.