### PR TITLE
DROOLS-2721: [DMN Designer] InputData node can not be connected to BKM node

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationRequirement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationRequirement.java
@@ -42,6 +42,8 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 @CanConnect(startRole = "decision", endRole = "decision")
 @CanConnect(startRole = "input-data", endRole = "decision")
+@CanConnect(startRole = "business-knowledge-model", endRole = "business-knowledge-model")
+@CanConnect(startRole = "input-data", endRole = "business-knowledge-model")
 @RuleExtension(handler = AcyclicDirectedGraphRule.class, typeArguments = {InformationRequirement.class})
 @RuleExtension(handler = SingleConnectorPerTypeGraphRule.class, typeArguments = {InformationRequirement.class})
 @NoValidation


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2721

@jomarko I also tested this fix with https://github.com/kiegroup/kie-wb-common/pull/1955 and it worked OK.