### PR TITLE
RHPAM-1065 (Stunner) - Stunner - Catching Error event on canvas

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateErrorEventCatching.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateErrorEventCatching.java
@@ -98,6 +98,10 @@ public class IntermediateErrorEventCatching extends BaseCatchingIntermediateEven
     @Override
     protected void initLabels() {
         super.initLabels();
+
+        labels.remove("all");
+        labels.remove("lane_child");
+        labels.remove("IntermediateEventsMorph");
         labels.remove("sequence_end");
         labels.remove("FromEventbasedGateway");
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/RHPAM-1065

Removed a few labels to so the actual rules could match BPMN 2.0 specification.