### PR TITLE
Stunner - Clean dependencies for lienzo-extensions module

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
@@ -45,38 +45,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Uberfire & Errai. -->
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-bus</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-ioc</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
     <!-- Lienzo. -->
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/GroupItem.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/GroupItem.java
@@ -20,13 +20,12 @@ import java.util.function.BiConsumer;
 
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPrimitive;
-import org.uberfire.mvp.Command;
 
 public class GroupItem extends AbstractItem<GroupItem, Group> implements Item<GroupItem> {
 
     private final Group group;
-    private BiConsumer<Group, Command> showExecutor;
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     public GroupItem() {
         this(new Group());
@@ -39,12 +38,12 @@ public class GroupItem extends AbstractItem<GroupItem, Group> implements Item<Gr
         group.setAlpha(0);
     }
 
-    public GroupItem useShowExecutor(final BiConsumer<Group, Command> executor) {
+    public GroupItem useShowExecutor(final BiConsumer<Group, Runnable> executor) {
         this.showExecutor = executor;
         return this;
     }
 
-    public GroupItem useHideExecutor(final BiConsumer<Group, Command> executor) {
+    public GroupItem useHideExecutor(final BiConsumer<Group, Runnable> executor) {
         this.hideExecutor = executor;
         return this;
     }
@@ -75,19 +74,19 @@ public class GroupItem extends AbstractItem<GroupItem, Group> implements Item<Gr
         return this;
     }
 
-    public GroupItem show(final Command before,
-                          final Command after) {
+    public GroupItem show(final Runnable before,
+                          final Runnable after) {
         if (!isVisible()) {
-            before.execute();
+            before.run();
             doShow(after);
         }
         return this;
     }
 
-    public GroupItem hide(final Command before,
-                          final Command after) {
+    public GroupItem hide(final Runnable before,
+                          final Runnable after) {
         if (isVisible()) {
-            before.execute();
+            before.run();
             doHide(after);
         }
         return this;
@@ -107,12 +106,12 @@ public class GroupItem extends AbstractItem<GroupItem, Group> implements Item<Gr
         return group;
     }
 
-    private void doShow(final Command callback) {
+    private void doShow(final Runnable callback) {
         showExecutor.accept(group,
                             callback);
     }
 
-    private void doHide(final Command callback) {
+    private void doHide(final Runnable callback) {
         hideExecutor.accept(group,
                             callback);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/ToolboxVisibilityExecutors.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/ToolboxVisibilityExecutors.java
@@ -26,7 +26,6 @@ import com.ait.lienzo.client.core.animation.IAnimation;
 import com.ait.lienzo.client.core.animation.IAnimationHandle;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.types.Point2D;
-import org.uberfire.mvp.Command;
 
 public class ToolboxVisibilityExecutors {
 
@@ -78,7 +77,7 @@ public class ToolboxVisibilityExecutors {
     }
 
     public abstract static class AnimatedGroupExecutor<T extends AnimatedGroupExecutor>
-            implements BiConsumer<Group, Command> {
+            implements BiConsumer<Group, Runnable> {
 
         private double animationDuration;
         private AnimationTweener animationTweener;
@@ -92,13 +91,13 @@ public class ToolboxVisibilityExecutors {
 
         @Override
         public void accept(final Group group,
-                           final Command callback) {
+                           final Runnable callback) {
             animate(group,
                     callback);
         }
 
         private void animate(final Group group,
-                             final Command callback) {
+                             final Runnable callback) {
             group.animate(animationTweener,
                           getProperties(),
                           animationDuration,
@@ -108,7 +107,7 @@ public class ToolboxVisibilityExecutors {
                                                   IAnimationHandle handle) {
                                   super.onClose(animation,
                                                 handle);
-                                  callback.execute();
+                                  callback.run();
                               }
                           });
         }
@@ -170,14 +169,14 @@ public class ToolboxVisibilityExecutors {
 
         @Override
         public void accept(final Group group,
-                           final Command callback) {
+                           final Runnable callback) {
             group
                     .setScale(getInitialScale())
                     .setAlpha(1);
             super.accept(group,
                          () -> {
                              group.setAlpha(alpha);
-                             callback.execute();
+                             callback.run();
                          });
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/AbstractDecoratedItem.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/AbstractDecoratedItem.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.types.BoundingBox;
-import org.uberfire.mvp.Command;
 
 public abstract class AbstractDecoratedItem<T extends DecoratedItem>
         extends AbstractPrimitiveItem<T>
@@ -42,11 +41,11 @@ public abstract class AbstractDecoratedItem<T extends DecoratedItem>
                     });
     }
 
-    public abstract T show(Command before,
-                           Command after);
+    public abstract T show(Runnable before,
+                           Runnable after);
 
-    public abstract T hide(Command before,
-                           Command after);
+    public abstract T hide(Runnable before,
+                           Runnable after);
 
     public abstract IPrimitive<?> getPrimitive();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/AbstractFocusableGroupItem.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/AbstractFocusableGroupItem.java
@@ -20,7 +20,6 @@ import com.ait.lienzo.client.core.animation.AnimationTweener;
 import com.google.gwt.user.client.Timer;
 import org.kie.workbench.common.stunner.lienzo.toolbox.GroupItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.ToolboxVisibilityExecutors;
-import org.uberfire.mvp.Command;
 
 public abstract class AbstractFocusableGroupItem<T extends AbstractFocusableGroupItem>
         extends AbstractGroupItem<T> {
@@ -86,20 +85,20 @@ public abstract class AbstractFocusableGroupItem<T extends AbstractFocusableGrou
     }
 
     @Override
-    public T show(final Command before,
-                  final Command after) {
+    public T show(final Runnable before,
+                  final Runnable after) {
         getGroupItem().show(before,
                             after);
         return cast();
     }
 
     @Override
-    public T hide(final Command before,
-                  final Command after) {
+    public T hide(final Runnable before,
+                  final Runnable after) {
         cancelTimers();
         getGroupItem().hide(() -> {
                                 unFocus();
-                                before.execute();
+                                before.run();
                             },
                             after);
         return cast();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/AbstractGroupItem.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/AbstractGroupItem.java
@@ -32,7 +32,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractDecoratedIt
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractPrimitiveItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratorItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.TooltipItem;
-import org.uberfire.mvp.Command;
 
 public abstract class AbstractGroupItem<T extends AbstractGroupItem>
         extends AbstractDecoratedItem<T> {
@@ -101,12 +100,12 @@ public abstract class AbstractGroupItem<T extends AbstractGroupItem>
         }
     }
 
-    public T useShowExecutor(final BiConsumer<Group, Command> executor) {
+    public T useShowExecutor(final BiConsumer<Group, Runnable> executor) {
         this.groupItem.useShowExecutor(executor);
         return cast();
     }
 
-    public T useHideExecutor(final BiConsumer<Group, Command> executor) {
+    public T useHideExecutor(final BiConsumer<Group, Runnable> executor) {
         this.groupItem.useHideExecutor(executor);
         return cast();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonGridItemImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonGridItemImpl.java
@@ -40,7 +40,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractPrimitiveIt
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.ButtonGridItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratorItem;
-import org.uberfire.mvp.Command;
 
 /**
  * A ButtonGridItem implementation.
@@ -123,8 +122,8 @@ public class ButtonGridItemImpl
             decoratorHandlers[0] = instance
                     .asPrimitive()
                     .setListening(true)
-                    .addNodeMouseEnterHandler(event -> itemFocusCallback.execute());
-            decoratorHandlers[1] = instance.asPrimitive().addNodeMouseExitHandler(event -> itemUnFocusCallback.execute());
+                    .addNodeMouseEnterHandler(event -> itemFocusCallback.run());
+            decoratorHandlers[1] = instance.asPrimitive().addNodeMouseExitHandler(event -> itemUnFocusCallback.run());
             registrations().register(decoratorHandlers[0]);
             registrations().register(decoratorHandlers[1]);
         }
@@ -132,20 +131,20 @@ public class ButtonGridItemImpl
     }
 
     @Override
-    public ButtonGridItemImpl show(final Command before,
-                                   final Command after) {
+    public ButtonGridItemImpl show(final Runnable before,
+                                   final Runnable after) {
         button.show(before,
                     after);
         return this;
     }
 
     @Override
-    public ButtonGridItemImpl hide(final Command before,
-                                   final Command after) {
+    public ButtonGridItemImpl hide(final Runnable before,
+                                   final Runnable after) {
         hideGrid(before,
                  () -> {
                      button.hide();
-                     after.execute();
+                     after.run();
                      batch();
                  });
         return this;
@@ -165,8 +164,8 @@ public class ButtonGridItemImpl
                         });
     }
 
-    private ButtonGridItemImpl hideGrid(final Command before,
-                                        final Command after) {
+    private ButtonGridItemImpl hideGrid(final Runnable before,
+                                        final Runnable after) {
         toolbox.hide(before,
                      after);
         return this;
@@ -233,12 +232,12 @@ public class ButtonGridItemImpl
         return button.getWrapped();
     }
 
-    public ButtonGridItemImpl useShowExecutor(final BiConsumer<Group, Command> executor) {
+    public ButtonGridItemImpl useShowExecutor(final BiConsumer<Group, Runnable> executor) {
         toolbox.getWrapped().useShowExecutor(executor);
         return this;
     }
 
-    public ButtonGridItemImpl useHideExecutor(final BiConsumer<Group, Command> executor) {
+    public ButtonGridItemImpl useHideExecutor(final BiConsumer<Group, Runnable> executor) {
         toolbox.getWrapped().useHideExecutor(executor);
         return this;
     }
@@ -264,18 +263,18 @@ public class ButtonGridItemImpl
     }
 
     private void registerItemFocusHandler(final AbstractDecoratedItem item,
-                                          final Command callback) {
+                                          final Runnable callback) {
         registrations()
                 .register(
-                        item.getPrimitive().addNodeMouseEnterHandler(event -> callback.execute())
+                        item.getPrimitive().addNodeMouseEnterHandler(event -> callback.run())
                 );
     }
 
     private void registerItemUnFocusHandler(final AbstractDecoratedItem item,
-                                            final Command callback) {
+                                            final Runnable callback) {
         registrations()
                 .register(
-                        item.getPrimitive().addNodeMouseExitHandler(event -> callback.execute())
+                        item.getPrimitive().addNodeMouseExitHandler(event -> callback.run())
                 );
     }
 
@@ -304,13 +303,13 @@ public class ButtonGridItemImpl
         return this;
     }
 
-    private final Command focusCallback = this::focus;
+    private final Runnable focusCallback = this::focus;
 
-    private final Command unFocusCallback = this::unFocus;
+    private final Runnable unFocusCallback = this::unFocus;
 
-    private final Command itemFocusCallback = this::focus;
+    private final Runnable itemFocusCallback = this::focus;
 
-    private final Command itemUnFocusCallback = this::unFocus;
+    private final Runnable itemUnFocusCallback = this::unFocus;
 
     private void scheduleTimer() {
         unFocusTimer.schedule(TIMER_DELAY_MILLIS);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonItemImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonItemImpl.java
@@ -26,7 +26,6 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.Shape;
 import com.google.gwt.event.shared.HandlerRegistration;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.ButtonItem;
-import org.uberfire.mvp.Command;
 
 public class ButtonItemImpl
         extends WrappedItem<ButtonItem>
@@ -50,12 +49,12 @@ public class ButtonItemImpl
         this.item = item;
     }
 
-    public ButtonItemImpl useShowExecutor(final BiConsumer<Group, Command> executor) {
+    public ButtonItemImpl useShowExecutor(final BiConsumer<Group, Runnable> executor) {
         this.getWrapped().useShowExecutor(executor);
         return this;
     }
 
-    public ButtonItemImpl useHideExecutor(final BiConsumer<Group, Command> executor) {
+    public ButtonItemImpl useHideExecutor(final BiConsumer<Group, Runnable> executor) {
         this.getWrapped().useHideExecutor(executor);
         return this;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/GroupImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/GroupImpl.java
@@ -22,7 +22,6 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.lienzo.toolbox.GroupItem;
-import org.uberfire.mvp.Command;
 
 class GroupImpl extends AbstractGroupItem<GroupImpl> {
 
@@ -40,23 +39,23 @@ class GroupImpl extends AbstractGroupItem<GroupImpl> {
     }
 
     @Override
-    public GroupImpl show(final Command before,
-                          final Command after) {
+    public GroupImpl show(final Runnable before,
+                          final Runnable after) {
         getGroupItem().show(() -> {
                                 showAddOns();
-                                before.execute();
+                                before.run();
                             },
                             after);
         return this;
     }
 
     @Override
-    public GroupImpl hide(final Command before,
-                          final Command after) {
+    public GroupImpl hide(final Runnable before,
+                          final Runnable after) {
         getGroupItem().hide(before,
                             () -> {
                                 hideAddOns();
-                                after.execute();
+                                after.run();
                             });
         return this;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ItemGridImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ItemGridImpl.java
@@ -31,7 +31,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.grid.Point2DGrid;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractDecoratedItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractPrimitiveItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
-import org.uberfire.mvp.Command;
 
 public class ItemGridImpl
         extends WrappedItem<ItemGridImpl>
@@ -40,7 +39,7 @@ public class ItemGridImpl
     private final AbstractGroupItem groupPrimitiveItem;
     private final List<AbstractDecoratedItem> items = new LinkedList<>();
     private Point2DGrid grid;
-    private Command refreshCallback;
+    private Runnable refreshCallback;
     private BoundingBox boundingBox;
 
     private Supplier<BoundingBox> boundingBoxSupplier = new Supplier<BoundingBox>() {
@@ -100,32 +99,32 @@ public class ItemGridImpl
     }
 
     @Override
-    public ItemGridImpl show(final Command before,
-                             final Command after) {
+    public ItemGridImpl show(final Runnable before,
+                             final Runnable after) {
         return super.show(() -> {
                               repositionItems();
                               for (final DecoratedItem button : items) {
                                   button.show();
                               }
-                              before.execute();
+                              before.run();
                           },
                           after);
     }
 
     @Override
-    public ItemGridImpl hide(final Command before,
-                             final Command after) {
+    public ItemGridImpl hide(final Runnable before,
+                             final Runnable after) {
         return super.hide(before,
                           () -> {
                               for (final DecoratedItem button : items) {
                                   button.hide();
                               }
-                              after.execute();
+                              after.run();
                               fireRefresh();
                           });
     }
 
-    public ItemGridImpl onRefresh(final Command refreshCallback) {
+    public ItemGridImpl onRefresh(final Runnable refreshCallback) {
         this.refreshCallback = refreshCallback;
         return this;
     }
@@ -138,12 +137,12 @@ public class ItemGridImpl
         return items.size();
     }
 
-    public ItemGridImpl useShowExecutor(final BiConsumer<Group, Command> executor) {
+    public ItemGridImpl useShowExecutor(final BiConsumer<Group, Runnable> executor) {
         this.getWrapped().useShowExecutor(executor);
         return this;
     }
 
-    public ItemGridImpl useHideExecutor(final BiConsumer<Group, Command> executor) {
+    public ItemGridImpl useHideExecutor(final BiConsumer<Group, Runnable> executor) {
         this.getWrapped().useHideExecutor(executor);
         return this;
     }
@@ -230,7 +229,7 @@ public class ItemGridImpl
 
     private void fireRefresh() {
         if (null != refreshCallback) {
-            refreshCallback.execute();
+            refreshCallback.run();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ToolboxImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ToolboxImpl.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.grid.Point2DGrid;
 import org.kie.workbench.common.stunner.lienzo.toolbox.grid.SizeConstrainedGrid;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.ItemsToolbox;
-import org.uberfire.mvp.Command;
 
 /**
  * An ItemsToolbox implementation.
@@ -45,9 +44,9 @@ public class ToolboxImpl
     private Direction at;
     private Point2D offset;
 
-    private final Command refreshExecutor = new Command() {
+    private final Runnable refreshExecutor = new Runnable() {
         @Override
-        public void execute() {
+        public void run() {
             if (null != items.getPrimitive().getLayer()) {
                 items.getPrimitive().getLayer().batch();
             }
@@ -110,34 +109,34 @@ public class ToolboxImpl
     }
 
     @Override
-    public ItemsToolbox show(final Command before,
-                             final Command after) {
+    public ItemsToolbox show(final Runnable before,
+                             final Runnable after) {
         return super.show(() -> {
                               reposition();
-                              before.execute();
+                              before.run();
                           },
                           () -> {
                               fireRefresh();
-                              after.execute();
+                              after.run();
                           });
     }
 
     @Override
-    public ItemsToolbox hide(final Command before,
-                             final Command after) {
+    public ItemsToolbox hide(final Runnable before,
+                             final Runnable after) {
         return super.hide(before,
                           () -> {
                               fireRefresh();
-                              after.execute();
+                              after.run();
                           });
     }
 
-    public ToolboxImpl useShowExecutor(final BiConsumer<Group, Command> executor) {
+    public ToolboxImpl useShowExecutor(final BiConsumer<Group, Runnable> executor) {
         this.getWrapped().useShowExecutor(executor);
         return this;
     }
 
-    public ToolboxImpl useHideExecutor(final BiConsumer<Group, Command> executor) {
+    public ToolboxImpl useHideExecutor(final BiConsumer<Group, Runnable> executor) {
         this.getWrapped().useHideExecutor(executor);
         return this;
     }
@@ -197,6 +196,6 @@ public class ToolboxImpl
     }
 
     private void fireRefresh() {
-        refreshExecutor.execute();
+        refreshExecutor.run();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/WiresShapeToolbox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/WiresShapeToolbox.java
@@ -37,7 +37,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratorItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.LayerToolbox;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.TooltipItem;
-import org.uberfire.mvp.Command;
 
 /**
  * A LayerToolbox implementation for WiresShape's.
@@ -127,12 +126,12 @@ public class WiresShapeToolbox
         return this;
     }
 
-    public WiresShapeToolbox useShowExecutor(final BiConsumer<Group, Command> executor) {
+    public WiresShapeToolbox useShowExecutor(final BiConsumer<Group, Runnable> executor) {
         toolbox.useShowExecutor(executor);
         return this;
     }
 
-    public WiresShapeToolbox useHideExecutor(final BiConsumer<Group, Command> executor) {
+    public WiresShapeToolbox useHideExecutor(final BiConsumer<Group, Runnable> executor) {
         toolbox.useHideExecutor(executor);
         return this;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/WrappedItem.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/WrappedItem.java
@@ -27,7 +27,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractDecoratedIt
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratorItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.TooltipItem;
-import org.uberfire.mvp.Command;
 
 public abstract class WrappedItem<T extends DecoratedItem>
         extends AbstractDecoratedItem<T> {
@@ -35,16 +34,16 @@ public abstract class WrappedItem<T extends DecoratedItem>
     protected abstract AbstractDecoratedItem<?> getWrapped();
 
     @Override
-    public T show(final Command before,
-                  final Command after) {
+    public T show(final Runnable before,
+                  final Runnable after) {
         getWrapped().show(before,
                           after);
         return cast();
     }
 
     @Override
-    public T hide(final Command before,
-                  final Command after) {
+    public T hide(final Runnable before,
+                  final Runnable after) {
         getWrapped().hide(before,
                           after);
         return cast();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/GroupItemTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/GroupItemTest.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -49,10 +48,10 @@ public class GroupItemTest {
     private IPrimitive<?> aPrimitive;
 
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     private GroupItem tested;
 
@@ -90,69 +89,69 @@ public class GroupItemTest {
     @Test
     public void testShow() {
         when(group.getAlpha()).thenReturn(0d);
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(showExecutor,
                times(1)).accept(eq(group),
                                 eq(after));
         verify(hideExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
     }
 
     @Test
     public void testNoNeedToShow() {
         when(group.getAlpha()).thenReturn(1d);
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(before,
-               never()).execute();
+               never()).run();
         verify(showExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
         verify(hideExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
     }
 
     @Test
     public void testHide() {
         when(group.getAlpha()).thenReturn(1d);
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(hideExecutor,
                times(1)).accept(eq(group),
                                 eq(after));
         verify(showExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
     }
 
     @Test
     public void testNoNeedToHide() {
         when(group.getAlpha()).thenReturn(0d);
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(before,
-               never()).execute();
+               never()).run();
         verify(showExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
         verify(hideExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonGridItemImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonGridItemImplTest.java
@@ -42,7 +42,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractDecoratedIt
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.decorator.BoxDecorator;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -70,10 +69,10 @@ public class ButtonGridItemImplTest {
                                                                    123d);
 
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private ButtonItemImpl button;
@@ -132,29 +131,29 @@ public class ButtonGridItemImplTest {
         when(toolboxWrap.getBoundingBox()).thenReturn(() -> toolboxBoundingBox);
         when(button1.getPrimitive()).thenReturn(button1Prim);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return button;
-        }).when(button).show(any(Command.class),
-                             any(Command.class));
+        }).when(button).show(any(Runnable.class),
+                             any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return button;
-        }).when(button).hide(any(Command.class),
-                             any(Command.class));
+        }).when(button).hide(any(Runnable.class),
+                             any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return toolbox;
-        }).when(toolbox).show(any(Command.class),
-                              any(Command.class));
+        }).when(toolbox).show(any(Runnable.class),
+                              any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return toolbox;
-        }).when(toolbox).hide(any(Command.class),
-                              any(Command.class));
+        }).when(toolbox).hide(any(Runnable.class),
+                              any(Runnable.class));
         tested = new ButtonGridItemImpl(button,
                                         toolbox)
                 .useHideExecutor(hideExecutor)
@@ -249,82 +248,82 @@ public class ButtonGridItemImplTest {
 
     @Test
     public void testShow() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(button,
                times(1)).show(eq(before),
                               eq(after));
         verify(button,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(toolbox,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(toolbox,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test
     public void testHide() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(toolbox,
-               times(1)).hide(any(Command.class),
-                              any(Command.class));
+               times(1)).hide(any(Runnable.class),
+                              any(Runnable.class));
         verify(toolbox,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(button,
                times(1)).hide();
         verify(button,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test
     public void testShowGrid() {
         tested.showGrid();
         verify(button,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(button,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(toolbox,
                times(1)).show();
         verify(toolbox,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
     }
 
     @Test
     public void testHideGrid() {
         tested.hideGrid();
         verify(button,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(button,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(toolbox,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(toolbox,
-               times(1)).hide(any(Command.class),
-                              any(Command.class));
+               times(1)).hide(any(Runnable.class),
+                              any(Runnable.class));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonItemImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ButtonItemImplTest.java
@@ -33,7 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -65,10 +64,10 @@ public class ButtonItemImplTest {
     private Group groupItemGroup;
 
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private BoundingPoints boundingPoints;
@@ -105,17 +104,17 @@ public class ButtonItemImplTest {
         when(boundingPoints.getBoundingBox()).thenReturn(boundingBox);
         when(groupItem.getBoundingBox()).thenReturn(() -> boundingBox);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).show(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).show(any(Runnable.class),
+                                any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).hide(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).hide(any(Runnable.class),
+                                any(Runnable.class));
         tested =
                 new ButtonItemImpl(groupItem)
                         .useHideExecutor(hideExecutor)
@@ -137,38 +136,38 @@ public class ButtonItemImplTest {
 
     @Test
     public void testShow() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(groupItem,
                times(1)).show(eq(before),
                               eq(after));
         verify(groupItem,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test
     public void testHide() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(groupItem,
-               times(1)).hide(any(Command.class),
+               times(1)).hide(any(Runnable.class),
                               eq(after));
         verify(groupItem,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/FocusableGroupTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/FocusableGroupTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.lienzo.toolbox.GroupItem;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -56,10 +55,10 @@ public class FocusableGroupTest {
     private GroupItem groupItem;
 
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private Group groupItemPrimitive;
@@ -81,17 +80,17 @@ public class FocusableGroupTest {
         when(groupItemPrimitive.getBoundingBox()).thenReturn(boundingBox);
         when(boundingPoints.getBoundingBox()).thenReturn(boundingBox);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).show(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).show(any(Runnable.class),
+                                any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).hide(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).hide(any(Runnable.class),
+                                any(Runnable.class));
         tested = spy(new FocusableGroup(groupItem,
                                         group)
                              .useHideExecutor(hideExecutor)
@@ -119,40 +118,40 @@ public class FocusableGroupTest {
 
     @Test
     public void testShow() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(groupItem,
-               times(1)).show(any(Command.class),
+               times(1)).show(any(Runnable.class),
                               eq(after));
         verify(groupItem,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test
     public void testHide() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(tested,
                times(1)).cancelTimers();
         verify(groupItem,
-               times(1)).hide(any(Command.class),
+               times(1)).hide(any(Runnable.class),
                               eq(after));
         verify(groupItem,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/GroupImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/GroupImplTest.java
@@ -30,7 +30,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.GroupItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratorItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.TooltipItem;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -56,10 +55,10 @@ public class GroupImplTest {
     private GroupItem groupItem;
 
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private Group group;
@@ -88,17 +87,17 @@ public class GroupImplTest {
         when(groupChildren.size()).thenReturn(1);
         when(boundingPoints.getBoundingBox()).thenReturn(boundingBox);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).show(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).show(any(Runnable.class),
+                                any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).hide(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).hide(any(Runnable.class),
+                                any(Runnable.class));
         tested = new GroupImpl(groupItem,
                                group)
                 .useHideExecutor(hideExecutor)
@@ -122,20 +121,20 @@ public class GroupImplTest {
 
     @Test
     public void testShow() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(groupItem,
-               times(1)).show(any(Command.class),
+               times(1)).show(any(Runnable.class),
                               eq(after));
         verify(groupItem,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
         verify(decorator,
                times(1)).show();
         verify(tooltip,
@@ -144,20 +143,20 @@ public class GroupImplTest {
 
     @Test
     public void testHide() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(groupItem,
                times(1)).hide(eq(before),
-                              any(Command.class));
+                              any(Runnable.class));
         verify(groupItem,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
         verify(decorator,
                times(3)).hide();
         verify(tooltip,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ItemGridImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ItemGridImplTest.java
@@ -35,7 +35,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.grid.FixedLayoutGrid;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractDecoratedItem;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -67,10 +66,10 @@ public class ItemGridImplTest {
     private Group group;
 
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private NFastArrayList groupChildren;
@@ -97,7 +96,7 @@ public class ItemGridImplTest {
     private BoundingBox button2BB;
 
     @Mock
-    private Command refreshCallback;
+    private Runnable refreshCallback;
 
     private ItemGridImpl tested;
     private FixedLayoutGrid grid = new FixedLayoutGrid(10,
@@ -132,21 +131,21 @@ public class ItemGridImplTest {
         when(groupChildren.size()).thenReturn(1);
         when(boundingPoints.getBoundingBox()).thenReturn(boundingBox);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             when(group.getAlpha()).thenReturn(1d);
             when(groupItem.isVisible()).thenReturn(true);
             return groupItem;
-        }).when(groupItem).show(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).show(any(Runnable.class),
+                                any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             when(group.getAlpha()).thenReturn(0d);
             when(groupItem.isVisible()).thenReturn(false);
             return groupItem;
-        }).when(groupItem).hide(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).hide(any(Runnable.class),
+                                any(Runnable.class));
 
         tested = new ItemGridImpl(groupItem)
                 .useHideExecutor(hideExecutor)
@@ -198,20 +197,20 @@ public class ItemGridImplTest {
 
     @Test
     public void testShow() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(groupItem,
-               times(1)).show(any(Command.class),
+               times(1)).show(any(Runnable.class),
                               eq(after));
         verify(groupItem,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
         // Button1
         ArgumentCaptor<Point2D> p1Captor = ArgumentCaptor.forClass(Point2D.class);
         verify(button1Prim,
@@ -239,25 +238,25 @@ public class ItemGridImplTest {
         verify(button2,
                times(1)).show();
         verify(refreshCallback,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test
     public void testHide() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(groupItem,
                times(1)).hide(eq(before),
-                              any(Command.class));
+                              any(Runnable.class));
         verify(groupItem,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
         verify(button1,
                times(2)).hide();
         verify(button1,
@@ -271,7 +270,7 @@ public class ItemGridImplTest {
         verify(button2,
                never()).destroy();
         verify(refreshCallback,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ItemImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ItemImplTest.java
@@ -33,7 +33,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.GroupItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.AbstractDecoratorItem;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.TooltipItem;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -63,7 +62,7 @@ public class ItemImplTest {
     private AbstractFocusableGroupItem.FocusGroupExecutor focusGroupExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private Shape shape;
@@ -89,17 +88,17 @@ public class ItemImplTest {
         when(shape.getBoundingBox()).thenReturn(boundingBox);
         when(boundingPoints.getBoundingBox()).thenReturn(boundingBox);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).show(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).show(any(Runnable.class),
+                                any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return groupItem;
-        }).when(groupItem).hide(any(Command.class),
-                                any(Command.class));
+        }).when(groupItem).hide(any(Runnable.class),
+                                any(Runnable.class));
         tested = new ItemImpl(groupItem,
                               shape)
                 .setFocusDelay(0)
@@ -131,45 +130,45 @@ public class ItemImplTest {
 
     @Test
     public void testShow() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(groupItem,
                times(1)).show(eq(before),
                               eq(after));
         verify(groupItem,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test
-    public void Command() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+    public void Runnable() {
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(groupItem,
-               times(1)).hide(any(Command.class),
+               times(1)).hide(any(Runnable.class),
                               eq(after));
         verify(groupItem,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
         verify(focusGroupExecutor,
                times(1)).unFocus();
         verify(focusGroupExecutor,
                never()).focus();
         verify(focusGroupExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
     }
 
     @Test
@@ -181,7 +180,7 @@ public class ItemImplTest {
                never()).unFocus();
         verify(focusGroupExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
     }
 
     @Test
@@ -193,7 +192,7 @@ public class ItemImplTest {
                never()).focus();
         verify(focusGroupExecutor,
                never()).accept(any(Group.class),
-                               any(Command.class));
+                               any(Runnable.class));
     }
 
     @Test
@@ -225,10 +224,10 @@ public class ItemImplTest {
         final AbstractFocusableGroupItem<ItemImpl>.FocusGroupExecutor focusExecutor =
                 spy(tested.getFocusGroupExecutor());
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return null;
         }).when(focusExecutor).accept(any(Group.class),
-                                      any(Command.class));
+                                      any(Runnable.class));
         focusExecutor.focus();
         verify(focusExecutor,
                times(1)).setAlpha(AbstractFocusableGroupItem.ALPHA_FOCUSED);
@@ -256,10 +255,10 @@ public class ItemImplTest {
         final AbstractFocusableGroupItem<ItemImpl>.FocusGroupExecutor focusExecutor =
                 spy(tested.getFocusGroupExecutor());
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return null;
         }).when(focusExecutor).accept(any(Group.class),
-                                      any(Command.class));
+                                      any(Runnable.class));
         focusExecutor.unFocus();
         verify(focusExecutor,
                times(1)).setAlpha(AbstractFocusableGroupItem.ALPHA_UNFOCUSED);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ToolboxImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ToolboxImplTest.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.grid.Point2DGrid;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -61,10 +60,10 @@ public class ToolboxImplTest {
                                                             100d,
                                                             200d);
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private ItemGridImpl wrapped;
@@ -84,7 +83,7 @@ public class ToolboxImplTest {
     @SuppressWarnings("unchecked")
     public void setUp() {
         when(wrapped.getBoundingBox()).thenReturn(() -> boundingBox);
-        when(wrapped.onRefresh(any(Command.class))).thenReturn(wrapped);
+        when(wrapped.onRefresh(any(Runnable.class))).thenReturn(wrapped);
         when(wrapped.asPrimitive()).thenReturn(group);
         when(wrapped.getPrimitive()).thenReturn(primitive);
         when(group.getAlpha()).thenReturn(0d);
@@ -92,17 +91,17 @@ public class ToolboxImplTest {
         when(group.getBoundingBox()).thenReturn(boundingBox);
         when(boundingPoints.getBoundingBox()).thenReturn(boundingBox);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return wrapped;
-        }).when(wrapped).show(any(Command.class),
-                              any(Command.class));
+        }).when(wrapped).show(any(Runnable.class),
+                              any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return wrapped;
-        }).when(wrapped).hide(any(Command.class),
-                              any(Command.class));
+        }).when(wrapped).hide(any(Runnable.class),
+                              any(Runnable.class));
         tested = new ToolboxImpl(() -> shapeBoundingBox,
                                  wrapped)
                 .useHideExecutor(hideExecutor)
@@ -191,20 +190,20 @@ public class ToolboxImplTest {
 
     @Test
     public void testShow() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.show(before,
                     after);
         verify(wrapped,
-               times(1)).show(any(Command.class),
-                              any(Command.class));
+               times(1)).show(any(Runnable.class),
+                              any(Runnable.class));
         verify(wrapped,
-               never()).hide(any(Command.class),
-                             any(Command.class));
+               never()).hide(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
         ArgumentCaptor<Point2D> pc = ArgumentCaptor.forClass(Point2D.class);
         verify(group,
                times(1)).setLocation(pc.capture());
@@ -219,20 +218,20 @@ public class ToolboxImplTest {
 
     @Test
     public void testHide() {
-        final Command before = mock(Command.class);
-        final Command after = mock(Command.class);
+        final Runnable before = mock(Runnable.class);
+        final Runnable after = mock(Runnable.class);
         tested.hide(before,
                     after);
         verify(wrapped,
                times(1)).hide(eq(before),
-                              any(Command.class));
+                              any(Runnable.class));
         verify(wrapped,
-               never()).show(any(Command.class),
-                             any(Command.class));
+               never()).show(any(Runnable.class),
+                             any(Runnable.class));
         verify(before,
-               times(1)).execute();
+               times(1)).run();
         verify(after,
-               times(1)).execute();
+               times(1)).run();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/WiresShapeToolboxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/WiresShapeToolboxTest.java
@@ -44,7 +44,6 @@ import org.kie.workbench.common.stunner.lienzo.toolbox.grid.Point2DGrid;
 import org.kie.workbench.common.stunner.lienzo.toolbox.items.DecoratedItem;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -65,10 +64,10 @@ public class WiresShapeToolboxTest {
                                                             100d,
                                                             200d);
     @Mock
-    private BiConsumer<Group, Command> showExecutor;
+    private BiConsumer<Group, Runnable> showExecutor;
 
     @Mock
-    private BiConsumer<Group, Command> hideExecutor;
+    private BiConsumer<Group, Runnable> hideExecutor;
 
     @Mock
     private WiresShape shape;
@@ -133,17 +132,17 @@ public class WiresShapeToolboxTest {
         when(shape.addWiresResizeStepHandler(any(WiresResizeStepHandler.class))).thenReturn(resizeStepRegistration);
         when(shape.addWiresResizeEndHandler(any(WiresResizeEndHandler.class))).thenReturn(resizeEndRegistration);
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return toolbox;
-        }).when(toolbox).show(any(Command.class),
-                              any(Command.class));
+        }).when(toolbox).show(any(Runnable.class),
+                              any(Runnable.class));
         doAnswer(invocationOnMock -> {
-            ((Command) invocationOnMock.getArguments()[0]).execute();
-            ((Command) invocationOnMock.getArguments()[1]).execute();
+            ((Runnable) invocationOnMock.getArguments()[0]).run();
+            ((Runnable) invocationOnMock.getArguments()[1]).run();
             return toolbox;
-        }).when(toolbox).hide(any(Command.class),
-                              any(Command.class));
+        }).when(toolbox).hide(any(Runnable.class),
+                              any(Runnable.class));
         tested = new WiresShapeToolbox(shape,
                                        toolbox,
                                        registrations)


### PR DESCRIPTION
Hey @manstis @hasys 

As @mdproctor noticed, the `stunner-lienzo-extensions` module, which was supposed to depend only on lienzo, was also including also a few dependencies from uf/errai, and should be not present.

It was only because the use of the class `org.uberfire.mvp.Command`, so I refactored this for `Runnable`. This way the dependency tree for this module is the excepted one. 

On the other hand I remember some talks with you @manstis about this - you was proposing not to use `Runnable` for client side stuff, is it? If so, which other functional interface can we use?

Thanks!!