### PR TITLE
JBPM-7297 (Stunner) - Stunner - doesn't allow to create processes with

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
@@ -54,8 +54,6 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 // **** Cardinality rules for connectors ****
 // No incoming sequence flows for start events.
 @EdgeOccurrences(role = "Startevents_all", type = EdgeOccurrences.EdgeType.INCOMING, max = 0)
-// Only single outgoing sequence flow for start events.
-@EdgeOccurrences(role = "Startevents_outgoing_all", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
 // No outgoing sequence flows for end events.
 @EdgeOccurrences(role = "Endevents_all", type = EdgeOccurrences.EdgeType.OUTGOING, max = 0)
 // A single outgoing sequence flows for message flow_start roles, such as Tasks or Subprocess.


### PR DESCRIPTION
JBPM-7297 (Stunner) - Stunner - doesn't allow to create processes with multiple outgoing connections from Start Event
https://issues.jboss.org/browse/JBPM-7297

Adjusted rules to match BPMN 2.0 specification.