### PR TITLE
DROOLS-2743: [DMN Designer] Download as toolbar button

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -44,7 +44,6 @@ import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
-import org.kie.workbench.common.stunner.project.client.editor.ProjectEditorMenuSessionItems;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramFocusEvent;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramLoseFocusEvent;
 import org.kie.workbench.common.stunner.project.client.screens.ProjectMessagesListener;
@@ -93,7 +92,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final ClientProjectDiagramService projectDiagramServices,
                             final ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances,
                             final ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances,
-                            final ProjectEditorMenuSessionItems menuSessionItems,
+                            final DMNProjectEditorMenuSessionItems menuSessionItems,
                             final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                             final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
                             final ProjectMessagesListener projectMessagesListener,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectDiagramEditorMenuItemsBuilder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectDiagramEditorMenuItemsBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.editor;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.project.client.resources.i18n.DMNProjectClientConstants;
+import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorMenuItemsBuilder;
+
+@Dependent
+@Typed(DMNProjectDiagramEditorMenuItemsBuilder.class)
+public class DMNProjectDiagramEditorMenuItemsBuilder extends AbstractProjectDiagramEditorMenuItemsBuilder {
+
+    @SuppressWarnings("unused")
+    protected DMNProjectDiagramEditorMenuItemsBuilder() {
+        //CDI proxy
+        super();
+    }
+
+    @Inject
+    public DMNProjectDiagramEditorMenuItemsBuilder(final ClientTranslationService translationService,
+                                                   final PopupUtil popupUtil) {
+        super(translationService,
+              popupUtil);
+    }
+
+    @Override
+    protected String getExportAsRawLabel() {
+        return translationService.getValue(DMNProjectClientConstants.DMNDiagramResourceTypeDownload);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectEditorMenuSessionItems.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectEditorMenuSessionItems.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.editor;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
+import org.kie.workbench.common.stunner.project.client.session.EditorSessionCommands;
+
+@Dependent
+@Typed(DMNProjectEditorMenuSessionItems.class)
+public class DMNProjectEditorMenuSessionItems extends AbstractProjectEditorMenuSessionItems<DMNProjectDiagramEditorMenuItemsBuilder> {
+
+    @Inject
+    public DMNProjectEditorMenuSessionItems(final DMNProjectDiagramEditorMenuItemsBuilder itemsBuilder,
+                                            final EditorSessionCommands sessionCommands) {
+        super(itemsBuilder,
+              sessionCommands);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/ProjectToolbarStateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/ProjectToolbarStateHandler.java
@@ -29,7 +29,7 @@ import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteS
 import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
-import org.kie.workbench.common.stunner.project.client.editor.ProjectEditorMenuSessionItems;
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
 
 public class ProjectToolbarStateHandler implements ToolbarStateHandler {
 
@@ -45,10 +45,10 @@ public class ProjectToolbarStateHandler implements ToolbarStateHandler {
 
     private final Map<Class<? extends ClientSessionCommand>, Boolean> commandStates = new HashMap<>();
 
-    private final ProjectEditorMenuSessionItems projectEditorMenuSessionItems;
+    private final AbstractProjectEditorMenuSessionItems projectEditorMenuSessionItems;
 
     @SuppressWarnings("unchecked")
-    public ProjectToolbarStateHandler(final ProjectEditorMenuSessionItems projectEditorMenuSessionItems) {
+    public ProjectToolbarStateHandler(final AbstractProjectEditorMenuSessionItems projectEditorMenuSessionItems) {
         this.projectEditorMenuSessionItems = projectEditorMenuSessionItems;
 
         Arrays.asList(COMMAND_CLASSES).forEach(clazz -> commandStates.put(clazz, false));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/resources/i18n/DMNProjectClientConstants.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/resources/i18n/DMNProjectClientConstants.java
@@ -25,4 +25,7 @@ public interface DMNProjectClientConstants {
 
     @TranslationKey(defaultValue = "")
     String DMNDiagramResourceTypeDescription = "DMNDiagramResourceType.description";
+
+    @TranslationKey(defaultValue = "")
+    String DMNDiagramResourceTypeDownload = "DMNDiagramResourceType.download";
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/resources/org/kie/workbench/common/dmn/project/client/resources/i18n/DMNProjectClientConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/resources/org/kie/workbench/common/dmn/project/client/resources/i18n/DMNProjectClientConstants.properties
@@ -1,2 +1,3 @@
 DMNDiagramResourceType.shortName=DMN (Preview)
 DMNDiagramResourceType.description=DMN (Preview)
+DMNDiagramResourceType.download=Download as DMN

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorTest;
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
 import org.kie.workbench.common.workbench.client.PerspectiveIds;
 import org.mockito.Mock;
 import org.uberfire.mvp.PlaceRequest;
@@ -69,6 +70,9 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     @Mock
     private EditExpressionEvent editExpressionEvent;
 
+    @Mock
+    private DMNProjectEditorMenuSessionItems dmnProjectMenuSessionItems;
+
     private DMNDiagramEditor diagramEditor;
 
     @Override
@@ -97,7 +101,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                  clientProjectDiagramService,
                                                  sessionEditorPresenters,
                                                  sessionViewerPresenters,
-                                                 getMenuSessionItems(),
+                                                 (DMNProjectEditorMenuSessionItems) getMenuSessionItems(),
                                                  onDiagramFocusEvent,
                                                  onDiagramLostFocusEvent,
                                                  projectMessagesListener,
@@ -123,6 +127,11 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         });
 
         return diagramEditor;
+    }
+
+    @Override
+    protected AbstractProjectEditorMenuSessionItems getMenuSessionItems() {
+        return dmnProjectMenuSessionItems;
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectDiagramEditorMenuItemsBuilderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectDiagramEditorMenuItemsBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.project.client.editor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.project.client.resources.i18n.DMNProjectClientConstants;
+import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNProjectDiagramEditorMenuItemsBuilderTest {
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private PopupUtil popupUtil;
+
+    private DMNProjectDiagramEditorMenuItemsBuilder builder;
+
+    @Before
+    public void setup() {
+        this.builder = new DMNProjectDiagramEditorMenuItemsBuilder(translationService, popupUtil);
+
+        when(translationService.getValue(anyString())).thenAnswer(i -> i.getArguments()[0].toString());
+    }
+
+    @Test
+    public void testExportAsRawLabel() {
+        assertEquals(DMNProjectClientConstants.DMNDiagramResourceTypeDownload,
+                     builder.getExportAsRawLabel());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/ProjectToolbarStateHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/ProjectToolbarStateHandlerTest.java
@@ -26,7 +26,6 @@ import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteS
 import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
-import org.kie.workbench.common.stunner.project.client.editor.ProjectEditorMenuSessionItems;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -37,7 +36,7 @@ import static org.mockito.Mockito.when;
 public class ProjectToolbarStateHandlerTest {
 
     @Mock
-    private ProjectEditorMenuSessionItems editorMenuSessionItems;
+    private DMNProjectEditorMenuSessionItems editorMenuSessionItems;
 
     private ProjectToolbarStateHandler toolbarStateHandler;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -117,7 +117,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
     protected ClientProjectDiagramService projectDiagramServices;
     private final ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances;
     private final ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances;
-    private ProjectEditorMenuSessionItems menuSessionItems;
+    private AbstractProjectEditorMenuSessionItems<?> menuSessionItems;
     private ProjectMessagesListener projectMessagesListener;
 
     private Event<OnDiagramFocusEvent> onDiagramFocusEvent;
@@ -145,7 +145,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
                                         final ClientProjectDiagramService projectDiagramServices,
                                         final ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances,
                                         final ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances,
-                                        final ProjectEditorMenuSessionItems menuSessionItems,
+                                        final AbstractProjectEditorMenuSessionItems<?> menuSessionItems,
                                         final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                                         final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
                                         final ProjectMessagesListener projectMessagesListener,
@@ -721,7 +721,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
             getView().setWidget(xmlEditorView.asWidget());
             editorProxy = makeXmlEditorProxy();
             hideLoadingViews();
-            notification.fire(new NotificationEvent(translationService.getValue(DIAGRAM_PARSING_ERROR, Objects.toString(e.getMessage(),"")),
+            notification.fire(new NotificationEvent(translationService.getValue(DIAGRAM_PARSING_ERROR, Objects.toString(e.getMessage(), "")),
                                                     NotificationEvent.NotificationType.ERROR));
 
             Scheduler.get().scheduleDeferred(xmlEditorView::onResize);
@@ -780,7 +780,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
         return null;
     }
 
-    public ProjectEditorMenuSessionItems getMenuSessionItems() {
+    public AbstractProjectEditorMenuSessionItems getMenuSessionItems() {
         return menuSessionItems;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorMenuItemsBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorMenuItemsBuilder.java
@@ -15,9 +15,6 @@
  */
 package org.kie.workbench.common.stunner.project.client.editor;
 
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-
 import com.google.gwt.user.client.ui.IsWidget;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
@@ -36,21 +33,19 @@ import org.kie.workbench.common.stunner.project.client.resources.i18n.StunnerPro
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuItem;
 
-@Dependent
-public class ProjectDiagramEditorMenuItemsBuilder {
+public abstract class AbstractProjectDiagramEditorMenuItemsBuilder {
 
-    private final ClientTranslationService translationService;
+    protected final ClientTranslationService translationService;
 
-    private final PopupUtil popupUtil;
+    protected final PopupUtil popupUtil;
 
-    protected ProjectDiagramEditorMenuItemsBuilder() {
+    protected AbstractProjectDiagramEditorMenuItemsBuilder() {
         this(null,
              null);
     }
 
-    @Inject
-    public ProjectDiagramEditorMenuItemsBuilder(final ClientTranslationService translationService,
-                                                final PopupUtil popupUtil) {
+    public AbstractProjectDiagramEditorMenuItemsBuilder(final ClientTranslationService translationService,
+                                                        final PopupUtil popupUtil) {
         this.translationService = translationService;
         this.popupUtil = popupUtil;
     }
@@ -99,10 +94,10 @@ public class ProjectDiagramEditorMenuItemsBuilder {
                     setIcon(IconType.ERASER);
                     setTitle(translationService.getValue(CoreTranslationMessages.CLEAR_DIAGRAM));
                     addClickHandler(clickEvent ->
-                                            ProjectDiagramEditorMenuItemsBuilder.this.executeWithConfirm(command,
-                                                                                                         translationService.getValue(CoreTranslationMessages.CLEAR_DIAGRAM),
-                                                                                                         translationService.getValue(CoreTranslationMessages.CLEAR_DIAGRAM),
-                                                                                                         translationService.getValue(CoreTranslationMessages.CONFIRM_CLEAR_DIAGRAM)));
+                                            AbstractProjectDiagramEditorMenuItemsBuilder.this.executeWithConfirm(command,
+                                                                                                                 translationService.getValue(CoreTranslationMessages.CLEAR_DIAGRAM),
+                                                                                                                 translationService.getValue(CoreTranslationMessages.CLEAR_DIAGRAM),
+                                                                                                                 translationService.getValue(CoreTranslationMessages.CONFIRM_CLEAR_DIAGRAM)));
                 }});
     }
 
@@ -198,7 +193,7 @@ public class ProjectDiagramEditorMenuItemsBuilder {
                                    final Command exportJPGCommand,
                                    final Command exportSVGCommand,
                                    final Command exportPDFCommand,
-                                   final Command exportBPMNCommand) {
+                                   final Command exportAsRawCommand) {
         final DropDownMenu menu = new DropDownMenu() {{
             setPull(Pull.RIGHT);
         }};
@@ -226,11 +221,12 @@ public class ProjectDiagramEditorMenuItemsBuilder {
             setTitle(translationService.getValue(CoreTranslationMessages.EXPORT_PDF));
             addClickHandler(event -> exportPDFCommand.execute());
         }});
-        menu.add(new AnchorListItem(translationService.getValue(CoreTranslationMessages.EXPORT_BPMN)) {{
+        final String exportAsRawLabel = getExportAsRawLabel();
+        menu.add(new AnchorListItem(exportAsRawLabel) {{
             setIcon(IconType.FILE_TEXT_O);
             setIconPosition(IconPosition.LEFT);
-            setTitle(translationService.getValue(CoreTranslationMessages.EXPORT_BPMN));
-            addClickHandler(event -> exportBPMNCommand.execute());
+            setTitle(exportAsRawLabel);
+            addClickHandler(event -> exportAsRawCommand.execute());
         }});
 
         final Button button = new Button() {{
@@ -247,6 +243,8 @@ public class ProjectDiagramEditorMenuItemsBuilder {
                                                                button);
         return buildItem(group);
     }
+
+    protected abstract String getExportAsRawLabel();
 
     public MenuItem newValidateItem(final Command command) {
         return buildItem(buildValidateItem(command));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorMenuItemsBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorMenuItemsBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.stunner.project.client.editor;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
@@ -194,54 +195,44 @@ public abstract class AbstractProjectDiagramEditorMenuItemsBuilder {
                                    final Command exportSVGCommand,
                                    final Command exportPDFCommand,
                                    final Command exportAsRawCommand) {
-        final DropDownMenu menu = new DropDownMenu() {{
-            setPull(Pull.RIGHT);
-        }};
-        menu.add(new AnchorListItem(translationService.getValue(CoreTranslationMessages.EXPORT_PNG)) {{
-            setIcon(IconType.FILE_IMAGE_O);
-            setIconPosition(IconPosition.LEFT);
-            setTitle(translationService.getValue(CoreTranslationMessages.EXPORT_PNG));
-            addClickHandler(event -> exportPNGCommand.execute());
-        }});
-        menu.add(new AnchorListItem(translationService.getValue(CoreTranslationMessages.EXPORT_JPG)) {{
-            setIcon(IconType.FILE_IMAGE_O);
-            setIconPosition(IconPosition.LEFT);
-            setTitle(translationService.getValue(CoreTranslationMessages.EXPORT_JPG));
-            addClickHandler(event -> exportJPGCommand.execute());
-        }});
-        menu.add(new AnchorListItem(translationService.getValue(CoreTranslationMessages.EXPORT_SVG)) {{
-            setIcon(IconType.FILE_IMAGE_O);
-            setIconPosition(IconPosition.LEFT);
-            setTitle(translationService.getValue(CoreTranslationMessages.EXPORT_SVG));
-            addClickHandler(event -> exportSVGCommand.execute());
-        }});
-        menu.add(new AnchorListItem(translationService.getValue(CoreTranslationMessages.EXPORT_PDF)) {{
-            setIcon(IconType.FILE_PDF_O);
-            setIconPosition(IconPosition.LEFT);
-            setTitle(translationService.getValue(CoreTranslationMessages.EXPORT_PDF));
-            addClickHandler(event -> exportPDFCommand.execute());
-        }});
-        final String exportAsRawLabel = getExportAsRawLabel();
-        menu.add(new AnchorListItem(exportAsRawLabel) {{
-            setIcon(IconType.FILE_TEXT_O);
-            setIconPosition(IconPosition.LEFT);
-            setTitle(exportAsRawLabel);
-            addClickHandler(event -> exportAsRawCommand.execute());
-        }});
+        final DropDownMenu menu = GWT.create(DropDownMenu.class);
+        menu.setPull(Pull.RIGHT);
 
-        final Button button = new Button() {{
-            setToggleCaret(true);
-            setDataToggle(Toggle.DROPDOWN);
-            setIcon(IconType.DOWNLOAD);
-            setSize(ButtonSize.SMALL);
-            setTitle(translationService.getValue(StunnerProjectClientConstants.DOWNLOAD_DIAGRAM));
-        }};
-        final IsWidget group = MenuUtils.buildHasEnabledWidget(new ButtonGroup() {{
-                                                                   add(button);
-                                                                   add(menu);
-                                                               }},
+        menu.add(makeExportMenuItemWidget(translationService.getValue(CoreTranslationMessages.EXPORT_PNG),
+                                          exportPNGCommand));
+        menu.add(makeExportMenuItemWidget(translationService.getValue(CoreTranslationMessages.EXPORT_JPG),
+                                          exportJPGCommand));
+        menu.add(makeExportMenuItemWidget(translationService.getValue(CoreTranslationMessages.EXPORT_SVG),
+                                          exportSVGCommand));
+        menu.add(makeExportMenuItemWidget(translationService.getValue(CoreTranslationMessages.EXPORT_PDF),
+                                          exportPDFCommand));
+        menu.add(makeExportMenuItemWidget(getExportAsRawLabel(),
+                                          exportAsRawCommand));
+
+        final Button button = GWT.create(Button.class);
+        final ButtonGroup buttonGroup = GWT.create(ButtonGroup.class);
+        buttonGroup.add(button);
+        buttonGroup.add(menu);
+        button.setToggleCaret(true);
+        button.setDataToggle(Toggle.DROPDOWN);
+        button.setIcon(IconType.DOWNLOAD);
+        button.setSize(ButtonSize.SMALL);
+        button.setTitle(translationService.getValue(StunnerProjectClientConstants.DOWNLOAD_DIAGRAM));
+
+        final IsWidget group = MenuUtils.buildHasEnabledWidget(buttonGroup,
                                                                button);
         return buildItem(group);
+    }
+
+    private AnchorListItem makeExportMenuItemWidget(final String caption,
+                                                    final Command onClickCommand) {
+        final AnchorListItem exportMenuItemWidget = GWT.create(AnchorListItem.class);
+        exportMenuItemWidget.setIcon(IconType.FILE_IMAGE_O);
+        exportMenuItemWidget.setIconPosition(IconPosition.LEFT);
+        exportMenuItemWidget.setText(caption);
+        exportMenuItemWidget.setTitle(caption);
+        exportMenuItemWidget.addClickHandler(event -> onClickCommand.execute());
+        return exportMenuItemWidget;
     }
 
     protected abstract String getExportAsRawLabel();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectEditorMenuSessionItems.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectEditorMenuSessionItems.java
@@ -23,8 +23,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.annotation.PreDestroy;
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
@@ -52,10 +50,9 @@ import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuItem;
 
-@Dependent
-public class ProjectEditorMenuSessionItems {
+public abstract class AbstractProjectEditorMenuSessionItems<BUILDER extends AbstractProjectDiagramEditorMenuItemsBuilder> {
 
-    private final ProjectDiagramEditorMenuItemsBuilder itemsBuilder;
+    private final BUILDER itemsBuilder;
     private final Map<Class<? extends ClientSessionCommand>, MenuItem> menuItems;
     private final EditorSessionCommands sessionCommands;
 
@@ -63,9 +60,8 @@ public class ProjectEditorMenuSessionItems {
     private Command loadingCompleted;
     private Consumer<String> errorConsumer;
 
-    @Inject
-    public ProjectEditorMenuSessionItems(final ProjectDiagramEditorMenuItemsBuilder itemsBuilder,
-                                         final EditorSessionCommands sessionCommands) {
+    public AbstractProjectEditorMenuSessionItems(final BUILDER itemsBuilder,
+                                                 final EditorSessionCommands sessionCommands) {
         this.itemsBuilder = itemsBuilder;
         this.sessionCommands = sessionCommands;
         this.menuItems = new HashMap<>(20);
@@ -77,17 +73,17 @@ public class ProjectEditorMenuSessionItems {
         };
     }
 
-    public ProjectEditorMenuSessionItems setLoadingStarts(final Command loadingStarts) {
+    public AbstractProjectEditorMenuSessionItems<BUILDER> setLoadingStarts(final Command loadingStarts) {
         this.loadingStarts = loadingStarts;
         return this;
     }
 
-    public ProjectEditorMenuSessionItems setLoadingCompleted(final Command loadingCompleted) {
+    public AbstractProjectEditorMenuSessionItems<BUILDER> setLoadingCompleted(final Command loadingCompleted) {
         this.loadingCompleted = loadingCompleted;
         return this;
     }
 
-    public ProjectEditorMenuSessionItems setErrorConsumer(final Consumer<String> errorConsumer) {
+    public AbstractProjectEditorMenuSessionItems<BUILDER> setErrorConsumer(final Consumer<String> errorConsumer) {
         this.errorConsumer = errorConsumer;
         return this;
     }
@@ -202,7 +198,7 @@ public class ProjectEditorMenuSessionItems {
 
             @Override
             public void onError(final Collection<DiagramElementViolation<RuleViolation>> violations) {
-                ProjectEditorMenuSessionItems.this.onError(violations.toString());
+                AbstractProjectEditorMenuSessionItems.this.onError(violations.toString());
             }
         });
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorMenuItemsBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorMenuItemsBuilderTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.project.client.editor;
+
+import java.util.List;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwtmockito.GwtMockito;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.AnchorListItem;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class AbstractProjectDiagramEditorMenuItemsBuilderTest {
+
+    private static final String EXPORT_RAW = "export";
+
+    @Mock
+    private Command exportPNGCommand;
+
+    @Mock
+    private Command exportJPGCommand;
+
+    @Mock
+    private Command exportSVGCommand;
+
+    @Mock
+    private Command exportPDFCommand;
+
+    @Mock
+    private Command exportAsRawCommand;
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private PopupUtil popupUtil;
+
+    @Mock
+    private AnchorListItem listItem;
+
+    @Mock
+    private ClickEvent clickEvent;
+
+    @Captor
+    private ArgumentCaptor<String> listItemTextCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> listItemTitleCaptor;
+
+    @Captor
+    private ArgumentCaptor<ClickHandler> listItemClickHandlerCaptor;
+
+    private AbstractProjectDiagramEditorMenuItemsBuilder menuItemsBuilder;
+
+    @Before
+    public void setup() {
+        GwtMockito.useProviderForType(AnchorListItem.class, aClass -> listItem);
+
+        this.menuItemsBuilder = new AbstractProjectDiagramEditorMenuItemsBuilder(translationService, popupUtil) {
+            @Override
+            protected String getExportAsRawLabel() {
+                return EXPORT_RAW;
+            }
+        };
+
+        when(translationService.getValue(anyString())).thenAnswer(i -> i.getArguments()[0].toString());
+    }
+
+    @Test
+    public void testExportsItem() {
+        menuItemsBuilder.newExportsItem(exportPNGCommand,
+                                        exportJPGCommand,
+                                        exportSVGCommand,
+                                        exportPDFCommand,
+                                        exportAsRawCommand);
+
+        verify(listItem,
+               times(5)).setText(listItemTextCaptor.capture());
+        final List<String> listItemText = listItemTextCaptor.getAllValues();
+        assertEquals(5,
+                     listItemText.size());
+        assertEquals(CoreTranslationMessages.EXPORT_PNG,
+                     listItemText.get(0));
+        assertEquals(CoreTranslationMessages.EXPORT_JPG,
+                     listItemText.get(1));
+        assertEquals(CoreTranslationMessages.EXPORT_SVG,
+                     listItemText.get(2));
+        assertEquals(CoreTranslationMessages.EXPORT_PDF,
+                     listItemText.get(3));
+        assertEquals(EXPORT_RAW,
+                     listItemText.get(4));
+
+        verify(listItem,
+               times(5)).setTitle(listItemTitleCaptor.capture());
+        final List<String> listItemTitle = listItemTitleCaptor.getAllValues();
+        assertEquals(5,
+                     listItemTitle.size());
+        assertEquals(CoreTranslationMessages.EXPORT_PNG,
+                     listItemTitle.get(0));
+        assertEquals(CoreTranslationMessages.EXPORT_JPG,
+                     listItemTitle.get(1));
+        assertEquals(CoreTranslationMessages.EXPORT_SVG,
+                     listItemTitle.get(2));
+        assertEquals(CoreTranslationMessages.EXPORT_PDF,
+                     listItemTitle.get(3));
+        assertEquals(EXPORT_RAW,
+                     listItemTitle.get(4));
+
+        verify(listItem,
+               times(5)).addClickHandler(listItemClickHandlerCaptor.capture());
+        final List<ClickHandler> listItemClickHandler = listItemClickHandlerCaptor.getAllValues();
+        assertEquals(5,
+                     listItemClickHandler.size());
+        listItemClickHandler.get(0).onClick(clickEvent);
+        verify(exportPNGCommand).execute();
+        listItemClickHandler.get(1).onClick(clickEvent);
+        verify(exportJPGCommand).execute();
+        listItemClickHandler.get(2).onClick(clickEvent);
+        verify(exportSVGCommand).execute();
+        listItemClickHandler.get(3).onClick(clickEvent);
+        verify(exportPDFCommand).execute();
+        listItemClickHandler.get(4).onClick(clickEvent);
+        verify(exportAsRawCommand).execute();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -157,7 +157,7 @@ public class AbstractProjectDiagramEditorTest {
     protected ManagedInstance<SessionViewerPresenter<ViewerSession>> sessionViewerPresenters;
 
     @Mock
-    protected ProjectEditorMenuSessionItems projectMenuSessionItems;
+    protected AbstractProjectEditorMenuSessionItems projectMenuSessionItems;
 
     @Mock
     protected EventSourceMock<OnDiagramFocusEvent> onDiagramFocusEvent;
@@ -292,7 +292,7 @@ public class AbstractProjectDiagramEditorTest {
         return resourceType;
     }
 
-    protected ProjectEditorMenuSessionItems getMenuSessionItems() {
+    protected AbstractProjectEditorMenuSessionItems getMenuSessionItems() {
         return projectMenuSessionItems;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorStub.java
@@ -51,7 +51,7 @@ class ProjectDiagramEditorStub extends AbstractProjectDiagramEditor<ClientResour
                                     final ClientProjectDiagramService projectDiagramServices,
                                     final ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances,
                                     final ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances,
-                                    final ProjectEditorMenuSessionItems menuSessionItems,
+                                    final AbstractProjectEditorMenuSessionItems menuSessionItems,
                                     final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                                     final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
                                     final ProjectMessagesListener projectMessagesListener,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
@@ -146,7 +146,7 @@ public class ProjectDiagramEditorTest {
     private SessionPresenter.View presenterView;
 
     @Mock
-    private ProjectEditorMenuSessionItems sessionItems;
+    private AbstractProjectEditorMenuSessionItems sessionItems;
 
     @Mock
     private EditorSessionCommands editorSessionCommands;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectEditorMenuSessionItemsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectEditorMenuSessionItemsTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 public class ProjectEditorMenuSessionItemsTest {
 
     @Mock
-    private ProjectDiagramEditorMenuItemsBuilder itemsBuilder;
+    private AbstractProjectDiagramEditorMenuItemsBuilder itemsBuilder;
 
     @Mock
     private EditorSessionCommands sessionCommands;
@@ -49,12 +49,21 @@ public class ProjectEditorMenuSessionItemsTest {
     @Mock
     private FileMenuBuilder fileMenuBuilder;
 
-    private ProjectEditorMenuSessionItems editorMenuSessionItems;
+    private AbstractProjectEditorMenuSessionItems editorMenuSessionItems;
+
+    private static class TestAbstractProjectEditorMenuSessionItems extends AbstractProjectEditorMenuSessionItems<AbstractProjectDiagramEditorMenuItemsBuilder> {
+
+        public TestAbstractProjectEditorMenuSessionItems(final AbstractProjectDiagramEditorMenuItemsBuilder itemsBuilder,
+                                                         final EditorSessionCommands sessionCommands) {
+            super(itemsBuilder,
+                  sessionCommands);
+        }
+    }
 
     @Before
     public void setup() {
-        editorMenuSessionItems = new ProjectEditorMenuSessionItems(itemsBuilder,
-                                                                   sessionCommands);
+        editorMenuSessionItems = new TestAbstractProjectEditorMenuSessionItems(itemsBuilder,
+                                                                               sessionCommands);
         when(fileMenuBuilder.addNewTopLevelMenu(any(MenuItem.class))).thenReturn(fileMenuBuilder);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNProjectDiagramEditorMenuItemsBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNProjectDiagramEditorMenuItemsBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.bpmn.project.client.editor;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorMenuItemsBuilder;
+
+@Dependent
+@Typed(BPMNProjectDiagramEditorMenuItemsBuilder.class)
+public class BPMNProjectDiagramEditorMenuItemsBuilder extends AbstractProjectDiagramEditorMenuItemsBuilder {
+
+    @SuppressWarnings("unused")
+    public BPMNProjectDiagramEditorMenuItemsBuilder() {
+        //CDI proxy
+    }
+
+    @Inject
+    public BPMNProjectDiagramEditorMenuItemsBuilder(final ClientTranslationService translationService,
+                                                    final PopupUtil popupUtil) {
+        super(translationService,
+              popupUtil);
+    }
+
+    @Override
+    protected String getExportAsRawLabel() {
+        return translationService.getValue(CoreTranslationMessages.EXPORT_BPMN);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNProjectEditorMenuSessionItems.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNProjectEditorMenuSessionItems.java
@@ -35,22 +35,21 @@ import org.kie.workbench.common.stunner.client.widgets.menu.MenuUtils;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
-import org.kie.workbench.common.stunner.project.client.editor.ProjectDiagramEditorMenuItemsBuilder;
-import org.kie.workbench.common.stunner.project.client.editor.ProjectEditorMenuSessionItems;
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuItem;
 
 @Dependent
 @Typed(BPMNProjectEditorMenuSessionItems.class)
-public class BPMNProjectEditorMenuSessionItems extends ProjectEditorMenuSessionItems {
+public class BPMNProjectEditorMenuSessionItems extends AbstractProjectEditorMenuSessionItems<BPMNProjectDiagramEditorMenuItemsBuilder> {
 
     private Command onMigrate;
     private MenuItem migrateMenuItem;
     private MenuItem formsItem;
 
     @Inject
-    public BPMNProjectEditorMenuSessionItems(final ProjectDiagramEditorMenuItemsBuilder itemsBuilder,
+    public BPMNProjectEditorMenuSessionItems(final BPMNProjectDiagramEditorMenuItemsBuilder itemsBuilder,
                                              final BPMNEditorSessionCommands sessionCommands) {
         super(itemsBuilder,
               sessionCommands);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorTest.java
@@ -30,7 +30,7 @@ import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorTest;
-import org.kie.workbench.common.stunner.project.client.editor.ProjectEditorMenuSessionItems;
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
@@ -107,7 +107,7 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     }
 
     @Override
-    protected ProjectEditorMenuSessionItems getMenuSessionItems() {
+    protected AbstractProjectEditorMenuSessionItems getMenuSessionItems() {
         return bpmnMenuSessionItems;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNProjectDiagramEditorMenuItemsBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNProjectDiagramEditorMenuItemsBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.bpmn.project.client.editor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BPMNProjectDiagramEditorMenuItemsBuilderTest {
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private PopupUtil popupUtil;
+
+    private BPMNProjectDiagramEditorMenuItemsBuilder builder;
+
+    @Before
+    public void setup() {
+        this.builder = new BPMNProjectDiagramEditorMenuItemsBuilder(translationService, popupUtil);
+
+        when(translationService.getValue(anyString())).thenAnswer(i -> i.getArguments()[0].toString());
+    }
+
+    @Test
+    public void testExportAsRawLabel() {
+        assertEquals(CoreTranslationMessages.EXPORT_BPMN,
+                     builder.getExportAsRawLabel());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
@@ -33,7 +33,6 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
-import org.kie.workbench.common.stunner.project.client.editor.ProjectEditorMenuSessionItems;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramFocusEvent;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramLoseFocusEvent;
 import org.kie.workbench.common.stunner.project.client.screens.ProjectMessagesListener;
@@ -76,7 +75,7 @@ public class CaseManagementDiagramEditor extends AbstractProjectDiagramEditor<Ca
                                        final ClientProjectDiagramService projectDiagramServices,
                                        final ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances,
                                        final ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances,
-                                       final ProjectEditorMenuSessionItems menuSessionItems,
+                                       final CaseManagementProjectEditorMenuSessionItems menuSessionItems,
                                        final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                                        final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
                                        final ProjectMessagesListener projectMessagesListener,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementProjectDiagramEditorMenuItemsBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementProjectDiagramEditorMenuItemsBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.cm.project.client.editor;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
+import org.kie.workbench.common.stunner.cm.project.client.resources.i18n.CaseManagementProjectClientConstants;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorMenuItemsBuilder;
+
+@Dependent
+@Typed(CaseManagementProjectDiagramEditorMenuItemsBuilder.class)
+public class CaseManagementProjectDiagramEditorMenuItemsBuilder extends AbstractProjectDiagramEditorMenuItemsBuilder {
+
+    @SuppressWarnings("unused")
+    public CaseManagementProjectDiagramEditorMenuItemsBuilder() {
+        //CDI proxy
+    }
+
+    @Inject
+    public CaseManagementProjectDiagramEditorMenuItemsBuilder(final ClientTranslationService translationService,
+                                                              final PopupUtil popupUtil) {
+        super(translationService,
+              popupUtil);
+    }
+
+    @Override
+    protected String getExportAsRawLabel() {
+        return translationService.getValue(CaseManagementProjectClientConstants.CaseManagementDiagramResourceTypeDownload);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementProjectEditorMenuSessionItems.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementProjectEditorMenuSessionItems.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.cm.project.client.editor;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
+import org.kie.workbench.common.stunner.project.client.session.EditorSessionCommands;
+
+@Dependent
+@Typed(CaseManagementProjectEditorMenuSessionItems.class)
+public class CaseManagementProjectEditorMenuSessionItems extends AbstractProjectEditorMenuSessionItems<CaseManagementProjectDiagramEditorMenuItemsBuilder> {
+
+    @Inject
+    public CaseManagementProjectEditorMenuSessionItems(final CaseManagementProjectDiagramEditorMenuItemsBuilder itemsBuilder,
+                                                       final EditorSessionCommands sessionCommands) {
+        super(itemsBuilder,
+              sessionCommands);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/resources/i18n/CaseManagementProjectClientConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/resources/i18n/CaseManagementProjectClientConstants.java
@@ -25,4 +25,7 @@ public interface CaseManagementProjectClientConstants {
 
     @TranslationKey(defaultValue = "")
     String CaseManagementDiagramResourceTypeDescription = "CaseManagementDiagramResourceType.description";
+
+    @TranslationKey(defaultValue = "")
+    String CaseManagementDiagramResourceTypeDownload = "CaseManagementDiagramResourceType.download";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/resources/org/kie/workbench/common/stunner/cm/project/client/resources/i18n/CaseManagementProjectClientConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/resources/org/kie/workbench/common/stunner/cm/project/client/resources/i18n/CaseManagementProjectClientConstants.properties
@@ -1,2 +1,3 @@
 CaseManagementDiagramResourceType=Case Management (Preview)
 CaseManagementDiagramResourceType.description=Case Management (Preview)
+CaseManagementDiagramResourceType.download=Download as Case Management file

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/test/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementProjectDiagramEditorMenuItemsBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/test/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementProjectDiagramEditorMenuItemsBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.cm.project.client.editor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
+import org.kie.workbench.common.stunner.cm.project.client.resources.i18n.CaseManagementProjectClientConstants;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseManagementProjectDiagramEditorMenuItemsBuilderTest {
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private PopupUtil popupUtil;
+
+    private CaseManagementProjectDiagramEditorMenuItemsBuilder builder;
+
+    @Before
+    public void setup() {
+        this.builder = new CaseManagementProjectDiagramEditorMenuItemsBuilder(translationService, popupUtil);
+
+        when(translationService.getValue(anyString())).thenAnswer(i -> i.getArguments()[0].toString());
+    }
+
+    @Test
+    public void testExportAsRawLabel() {
+        assertEquals(CaseManagementProjectClientConstants.CaseManagementDiagramResourceTypeDownload,
+                     builder.getExportAsRawLabel());
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2743

Depends on both the following preceding PRs being merged first:

- https://github.com/kiegroup/kie-wb-common/pull/1975
- https://github.com/kiegroup/kie-wb-common/pull/1981

@romartin Further to the discussion on DROOLS-2743 this PR moves the "export" menu caption out of the class causing the pain to the different sub-classes of ```AbstractProjectDiagramEditor``` (and their related menu/toolbar setup).

Just 4th commit for this PR.. this will be rebased as the other PRs are merged...