### PR TITLE
[AF-1406] Asset cannot be created in default package

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/PackageListBoxViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/PackageListBoxViewImpl.java
@@ -68,7 +68,10 @@ public class PackageListBoxViewImpl
         return options;
     }
 
-    KieSelectElement.Option newOption(final String name, final String value) {
+    KieSelectElement.Option newOption(final String name, String value) {
+        if (value.isEmpty()) {
+            value = name;
+        }
         return new KieSelectElement.Option(name, value);
     }
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/PackageListBoxViewImplTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/PackageListBoxViewImplTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.widgets.client.handlers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.widget.KieSelectElement;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PackageListBoxViewImplTest {
+
+    @Mock
+    KieSelectElement kieSelectElement;
+
+    PackageListBoxViewImpl packageListBoxView = new PackageListBoxViewImpl(kieSelectElement);
+
+    @Test
+    public void whenEmptyValueShouldBeEqualsTheLabel() {
+
+        KieSelectElement.Option option = packageListBoxView.newOption("key", "value");
+        assertEquals(option.label, "key");
+        assertEquals(option.value, "value");
+
+        KieSelectElement.Option anotherOption = packageListBoxView.newOption("<default>", "");
+        assertEquals(anotherOption.label, "<default>");
+        assertEquals(anotherOption.value, "<default>");
+
+    }
+}


### PR DESCRIPTION
@Rikkola @tomasdavidorg 	

I'm not 100% sure if this is the right solution or I just 'shoot the messenger'.

But what happens is:

If the default package is select at first, all good because the value will be set to "default".

But if we change the package to another one, and then come back to default the select value will be "" and we cannot lookup the selected package.

@Rikkola this issue is for Friday EOD, could you please take a look if this is the best option or should I do something else? 

<img width="1676" alt="screenshot 2018-07-19 17 45 29" src="https://user-images.githubusercontent.com/531351/42972455-87906116-8b7d-11e8-86ed-65d3d1d66faa.png">

<img width="430" alt="screenshot 2018-07-19 17 45 44" src="https://user-images.githubusercontent.com/531351/42972465-8c3e5150-8b7d-11e8-9f1d-73c5ee80790f.png">
