### PR TITLE
RHPAM-1065 [JBPM-7294] (Stunner) - Catching Error event on canvas

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
@@ -49,7 +49,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Portable
 @Bindable
 @Definition(graphFactory = NodeFactory.class, builder = BPMNDiagramImpl.BPMNDiagramBuilder.class)
-@CanContain(roles = {"all"})
+@CanContain(roles = {"base_element"})
 @FormDefinition(
         startElement = "diagramSet",
         policy = FieldPolicy.ONLY_MARKED,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseCatchingIntermediateEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseCatchingIntermediateEvent.java
@@ -77,6 +77,7 @@ public abstract class BaseCatchingIntermediateEvent
 
     protected void initLabels() {
         labels.add("all");
+        labels.add("base_element");
         labels.add("lane_child");
         labels.add("sequence_start");
         labels.add("sequence_end");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseEndEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseEndEvent.java
@@ -71,6 +71,7 @@ public abstract class BaseEndEvent implements BPMNViewDefinition,
 
     protected void initLabels() {
         labels.add("all");
+        labels.add("base_element");
         labels.add("lane_child");
         labels.add("sequence_end");
         labels.add("to_task_event");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseStartEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseStartEvent.java
@@ -82,6 +82,7 @@ public abstract class BaseStartEvent implements BPMNViewDefinition,
 
     protected void initLabels() {
         labels.add("all");
+        labels.add("base_element");
         labels.add("lane_child");
         labels.add("Startevents_all");
         labels.add("Startevents_outgoing_all");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseSubprocess.java
@@ -80,6 +80,7 @@ public abstract class BaseSubprocess implements BPMNViewDefinition {
 
     protected void initLabels() {
         labels.add("all");
+        labels.add("base_element");
         labels.add("lane_child");
         labels.add("sequence_start");
         labels.add("sequence_end");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseThrowingIntermediateEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BaseThrowingIntermediateEvent.java
@@ -68,6 +68,7 @@ public abstract class BaseThrowingIntermediateEvent
 
     protected void initLabels() {
         labels.add("all");
+        labels.add("base_element");
         labels.add("lane_child");
         labels.add("sequence_start");
         labels.add("sequence_end");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
@@ -52,7 +52,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Bindable
 @Definition(graphFactory = NodeFactory.class, builder = EmbeddedSubprocess.EmbeddedSubprocessBuilder.class)
 @Morph(base = BaseSubprocess.class)
-@CanContain(roles = {"all"})
+@CanContain(roles = {"base_element"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
 @FormDefinition(
         startElement = "general",

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EventSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EventSubprocess.java
@@ -51,7 +51,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Bindable
 @Definition(graphFactory = NodeFactory.class, builder = EventSubprocess.EventSubprocessBuilder.class)
 @Morph(base = BaseSubprocess.class)
-@CanContain(roles = {"all"})
+@CanContain(roles = {"base_element"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
 @FormDefinition(
         startElement = "general",

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateErrorEventCatching.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/IntermediateErrorEventCatching.java
@@ -98,6 +98,8 @@ public class IntermediateErrorEventCatching extends BaseCatchingIntermediateEven
     @Override
     protected void initLabels() {
         super.initLabels();
+        labels.remove("lane_child");
+        labels.remove("IntermediateEventsMorph");
         labels.remove("sequence_end");
         labels.remove("FromEventbasedGateway");
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/MultipleInstanceSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/MultipleInstanceSubprocess.java
@@ -49,7 +49,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@CanContain(roles = {"all"})
+@CanContain(roles = {"base_element"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
 @Definition(graphFactory = NodeFactory.class, builder = MultipleInstanceSubprocess.MultipleInstanceSubprocessBuilder.class)
 @Morph(base = BaseSubprocess.class)


### PR DESCRIPTION
Created a new role to identify all base elements.
And removed this role from the element that can't be contained.
This way all rules and decorations using the role "all" aren't affected.

Issue:
[RHPAM-1065](https://issues.jboss.org/browse/RHPAM-1065)
[JBPM-7294](https://issues.jboss.org/browse/JBPM-7294)

7.7.x Branch PR's:
kiegroup/kie-wb-common
[this one](https://github.com/kiegroup/kie-wb-common/pull/1998)

Master PR's:
kiegroup/kie-wb-common
#1979
