### PR TITLE
JBPM-6883 Stunner - can't move with bend points

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ControlPointControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ControlPointControlImpl.java
@@ -31,6 +31,7 @@ import com.ait.lienzo.client.core.shape.wires.IControlPointsAcceptor;
 import com.ait.lienzo.client.core.shape.wires.WiresConnector;
 import com.ait.lienzo.client.core.types.Point2DArray;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
+import org.kie.workbench.common.stunner.client.lienzo.components.drag.DragBoundsEnforcer;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresConnectorView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasHandlerRegistrationControl;
@@ -41,6 +42,9 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
+import org.kie.workbench.common.stunner.core.client.shape.view.IsConnector;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -60,6 +64,7 @@ public class ControlPointControlImpl
     private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     private final IControlPointsAcceptor cpAcceptor;
     private CommandManagerProvider<AbstractCanvasHandler> commandManagerProvider;
+    public static final int DRAG_BOUNDS_MARGIN = 10;
 
     @Inject
     public ControlPointControlImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory) {
@@ -77,6 +82,22 @@ public class ControlPointControlImpl
     @Override
     @SuppressWarnings("unchecked")
     public void register(final Element element) {
+        final Shape<?> shape = canvasHandler.getCanvas().getShape(element.getUUID());
+        if (checkNotRegistered(element) && isConnector(shape) && supportsControlPoints(shape)) {
+            //set the connector drag bounds to avoid dragging control points outside canvas
+            DragBoundsEnforcer
+                    .forShape(shape.getShapeView())
+                    .withMargin(DRAG_BOUNDS_MARGIN)
+                    .enforce(canvasHandler.getDiagram().getGraph());
+        }
+    }
+
+    private boolean isConnector(Shape<?> shape) {
+        return shape.getShapeView() instanceof IsConnector;
+    }
+
+    private boolean supportsControlPoints(Shape<?> shape) {
+        return shape.getShapeView() instanceof HasControlPoints;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
@@ -36,8 +36,8 @@ import com.ait.lienzo.client.core.shape.wires.ILocationAcceptor;
 import com.ait.lienzo.client.core.shape.wires.SelectionManager;
 import com.ait.lienzo.client.core.shape.wires.WiresContainer;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
+import org.kie.workbench.common.stunner.client.lienzo.components.drag.DragBoundsEnforcer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
@@ -55,7 +55,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasDragBounds;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasEventHandlers;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseEnterEvent;
@@ -95,7 +94,7 @@ public class LocationControlImpl
     private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     private final Event<ShapeLocationsChangedEvent> shapeLocationsChangedEvent;
     private CommandManagerProvider<AbstractCanvasHandler> commandManagerProvider;
-    private double[] boundsConstraint;
+    private Bounds boundsConstraint;
     private final Collection<String> selectedIDs = new LinkedList<>();
 
     protected LocationControlImpl() {
@@ -196,9 +195,7 @@ public class LocationControlImpl
 
             // Drag & constraints.
             shape.getShapeView().setDragEnabled(true);
-            if (shape.getShapeView() instanceof HasDragBounds) {
-                ensureDragConstraints((HasDragBounds<?>) shape.getShapeView());
-            }
+            ensureDragConstraints(shape.getShapeView());
 
             if (shape.getShapeView() instanceof HasEventHandlers) {
                 final HasEventHandlers hasEventHandlers = (HasEventHandlers) shape.getShapeView();
@@ -303,30 +300,20 @@ public class LocationControlImpl
     }
 
     @SuppressWarnings("unchecked")
-    private void ensureDragConstraints(final HasDragBounds<?> shapeView) {
+    private void ensureDragConstraints(final ShapeView shapeView) {
         if (null == boundsConstraint) {
             boundsConstraint = getLocationBounds();
             // Selection multiple bounding constraints.
-            ifSelectionManager(s -> s.getControl().setBoundsConstraint(new BoundingBox(boundsConstraint[0],
-                                                                                       boundsConstraint[1],
-                                                                                       boundsConstraint[2],
-                                                                                       boundsConstraint[3])));
+            ifSelectionManager(s-> DragBoundsEnforcer.forSelectionManager(s).enforce(boundsConstraint));
         }
         // Shape drag bounds.
-        shapeView.setDragBounds(boundsConstraint[0],
-                                boundsConstraint[1],
-                                boundsConstraint[2],
-                                boundsConstraint[3]);
+        DragBoundsEnforcer.forShape(shapeView).enforce(boundsConstraint);
     }
 
     @SuppressWarnings("unchecked")
-    private double[] getLocationBounds() {
+    private Bounds getLocationBounds() {
         final Graph<DefinitionSet, ? extends Node> graph = canvasHandler.getDiagram().getGraph();
-        final Bounds bounds = graph.getContent().getBounds();
-        return new double[]{bounds.getUpperLeft().getX(),
-                bounds.getUpperLeft().getY(),
-                bounds.getLowerRight().getX(),
-                bounds.getLowerRight().getY()};
+        return graph.getContent().getBounds();
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/DragBoundsEnforcer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/DragBoundsEnforcer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.components.drag;
+
+import java.util.Optional;
+
+import com.ait.lienzo.client.core.shape.wires.SelectionManager;
+import com.ait.lienzo.client.core.types.BoundingBox;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasDragBounds;
+import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
+
+public class DragBoundsEnforcer {
+
+    private final Optional<ShapeView> shape;
+    private final Optional<SelectionManager> selectionManager;
+    private double[] bounds;
+    private int margin = 0;
+
+    private DragBoundsEnforcer(ShapeView shape, SelectionManager selectionManager) {
+        this.selectionManager = Optional.ofNullable(selectionManager);
+        this.shape = Optional.ofNullable(shape);
+    }
+
+    public static DragBoundsEnforcer forShape(final ShapeView shape) {
+        return new DragBoundsEnforcer(shape, null);
+    }
+
+    public static DragBoundsEnforcer forSelectionManager(final SelectionManager selectionManager) {
+        return new DragBoundsEnforcer(null, selectionManager);
+    }
+
+    public DragBoundsEnforcer withMargin(final int margin) {
+        this.margin = margin;
+        return this;
+    }
+
+    public void enforce(Bounds bounds) {
+        this.bounds = parseBounds(bounds);
+        enforce();
+    }
+
+    public void enforce(Graph<DefinitionSet, ? extends Node> graph) {
+        this.bounds = parseBounds(graph.getContent().getBounds());
+        enforce();
+    }
+
+    private void enforce() {
+        selectionManager
+                .map(SelectionManager::getControl)
+                .ifPresent(control -> control.setBoundsConstraint(new BoundingBox(bounds[0],
+                                                                                  bounds[1],
+                                                                                  bounds[2],
+                                                                                  bounds[3])));
+        shape.filter(s -> s instanceof HasDragBounds)
+                .map(s -> (HasDragBounds) s)
+                .ifPresent(s -> s.setDragBounds(bounds[0], bounds[1], bounds[2], bounds[3]));
+    }
+
+    private double[] parseBounds(Bounds bounds) {
+        return new double[]{
+                bounds.getUpperLeft().getX() + margin,
+                bounds.getUpperLeft().getY() + margin,
+                bounds.getLowerRight().getX() + margin,
+                bounds.getLowerRight().getY() + margin};
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorView.java
@@ -36,11 +36,13 @@ import com.ait.lienzo.client.core.shape.wires.WiresConnection;
 import com.ait.lienzo.client.core.shape.wires.WiresConnector;
 import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.lienzo.client.core.types.DragBounds;
 import com.ait.lienzo.client.core.types.Shadow;
 import com.ait.lienzo.shared.core.types.ColorName;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresUtils;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.LienzoShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasDragBounds;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasManageableControlPoints;
 import org.kie.workbench.common.stunner.core.client.shape.view.IsConnector;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
@@ -56,7 +58,8 @@ public class WiresConnectorView<T> extends WiresConnector
         implements
         LienzoShapeView<T>,
         IsConnector<T>,
-        HasManageableControlPoints<T> {
+        HasManageableControlPoints<T>,
+        HasDragBounds<T> {
 
     protected String uuid;
 
@@ -572,5 +575,17 @@ public class WiresConnectorView<T> extends WiresConnector
     @Override
     public void setUserData(Object userData) {
         getDirectionalLine().setUserData(userData);
+    }
+
+    @Override
+    public T setDragBounds(double x0, double y0, double x1, double y1) {
+        getGroup().setDragBounds(new DragBounds(x0, y0, x1, y1));
+        return cast();
+    }
+
+    @Override
+    public T unsetDragBounds() {
+        getGroup().setDragBounds(null);
+        return cast();
     }
 }


### PR DESCRIPTION
Now it is now possible to move bend points of a connector outside of the canvas area.
Note: I inserted a margin of 10px to avoid the bend point to be dropped exactly on the canvas bounds that was not easy to drag it back into the canvas.

@LuboTerifaj 
@wmedvede (adding you to help on the review since @romartin is on PTO)

related:
https://github.com/kiegroup/lienzo-core/pull/57