### PR TITLE
Fix for ambiguous Dependency for CreateNodeAction in Stunner

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateNodeAction.java
@@ -51,6 +51,7 @@ import org.kie.workbench.common.stunner.core.util.UUID;
  * the source toolbox' element.
  */
 @Dependent
+@FlowActionsToolbox
 public class CreateNodeAction extends AbstractToolboxAction {
 
     static final String KEY_TITLE = "org.kie.workbench.common.stunner.core.client.toolbox.createNewNode";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactory.java
@@ -68,7 +68,7 @@ public class FlowActionsToolboxFactory
     public FlowActionsToolboxFactory(final DefinitionUtils definitionUtils,
                                      final ToolboxDomainLookups toolboxDomainLookups,
                                      final @Any ManagedInstance<CreateConnectorAction> createConnectorActions,
-                                     final @Any ManagedInstance<CreateNodeAction> createNodeActions,
+                                     final @Any @FlowActionsToolbox ManagedInstance<CreateNodeAction> createNodeActions,
                                      final @Any @FlowActionsToolbox ManagedInstance<ActionsToolboxView> views) {
         this(definitionUtils,
              toolboxDomainLookups,


### PR DESCRIPTION
Hi @manstis,

there is a fix for Stunner (any selection or adding new nodes to the canvas lead to error see below).

I considered to use existing `FlowActionsToolbox` instead of new `BPMNFlowActionsToolbox`, but it looks like `FlowActionsToolbox` already in use by both DMN and Process designers, so in my opinion it's better to create new annotation.

Also I am not sure how to test this kinds of issues. I guess so far only Selenium can catch it, am I right?

<details>
  <summary>Error log</summary>
  <pre>Uncaught exception: Exception caught: Exception caught: CDI Event exception: CommandType=CDIEvent, BeanType=org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent, BeanReference=org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent@8561, FromClient=1 sent to [unavailable] Caused by: Exception caught: CDI Event exception: CommandType=CDIEvent, BeanType=org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent, BeanReference=org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent@8561, FromClient=1 sent to [unavailable] Caused by: CDI Event exception: CommandType=CDIEvent, BeanType=org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent, BeanReference=org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent@8561, FromClient=1 sent to [unavailable] Caused by: Multiple beans matched org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeAction with qualifiers { javax.enterprise.inject.Any }
Found:
  [type=org.kie.workbench.common.dmn.client.canvas.controls.toolbox.CreateNodeAction, qualifiers=[@Any, @org.kie.workbench.common.dmn.client.canvas.controls.toolbox.DMNFlowActionsToolbox()]]
  [type=org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeAction, qualifiers=[@Default, @Any]]</pre>
</details>

Issue caused by https://github.com/kiegroup/kie-wb-distributions/commit/7c83f874ae8cd639df6773e5849d1a0275ae90e3#diff-ca1c8eed94bc8cf68737b6c8a9676397

CC @jomarko @wmedvede @evacchi @LuboTerifaj @romartin 