### PR TITLE
JBPM-7619: Stunner - New Marshallers: rename flag

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/README.md
@@ -4,7 +4,7 @@
     
     Disable with flag:
     
-        -Dbpmn.marshaller.experimental=false
+        -Dbpmn.marshaller.legacy=true
         
     - Entry point: `BPMNDirectDiagramMarshaller` which implements `BPMNDirectDiagramMarshaller` 
     - Actual unmarshalling from XML is delegated to Eclipse BPMN2 library

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/BPMNBackendService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/BPMNBackendService.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend;
 
-import java.util.Optional;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -34,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public class BPMNBackendService extends AbstractDefinitionSetService {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(BPMNBackendService.class);
-    private static final String MARSHALLER_EXPERIMENTAL_PROPERTY = "bpmn.marshaller.experimental";
+    private static final String MARSHALLER_LEGACY_PROPERTY = "bpmn.marshaller.legacy";
 
     private final BPMNDefinitionSetResourceType bpmnResourceType;
 
@@ -59,16 +57,14 @@ public class BPMNBackendService extends AbstractDefinitionSetService {
             final BPMNDiagramMarshaller bpmnDiagramMarshaller,
             final BPMNDirectDiagramMarshaller bpmnDirectDiagramMarshaller) {
 
-        Boolean enableExperimentalBpmnMarshaller = Optional.ofNullable(
-                System.getProperty(MARSHALLER_EXPERIMENTAL_PROPERTY))
-                .map(Boolean::parseBoolean)
-                .orElse(true);
+        Boolean useLegacyMarshaller =
+                Boolean.parseBoolean(System.getProperty(MARSHALLER_LEGACY_PROPERTY, "false"));
 
-        LOG.info("{} = {}", MARSHALLER_EXPERIMENTAL_PROPERTY, enableExperimentalBpmnMarshaller);
+        LOG.info("{} = {}", MARSHALLER_LEGACY_PROPERTY, useLegacyMarshaller);
 
-        return (enableExperimentalBpmnMarshaller) ?
-                bpmnDirectDiagramMarshaller :
-                bpmnDiagramMarshaller;
+        return (useLegacyMarshaller) ?
+                bpmnDiagramMarshaller :
+                bpmnDirectDiagramMarshaller;
     }
 
     @Override


### PR DESCRIPTION
Let's update the flag so that it is no longer "experimental", as per @krisv's suggestion

      -Dbpmn.marshaller.legacy=true

disables the new marshallers. Default: **false**; i.e., use the new marshallers.

cc: @hasys @LuboTerifaj 