### PR TITLE
Stunner: Marshallers - Generate IDs iff null and element is x-referenced

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/BPMNDirectDiagramMarshaller.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/BPMNDirectDiagramMarshaller.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.eclipse.bpmn2.Bpmn2Package;
 import org.eclipse.bpmn2.Definitions;
 import org.eclipse.bpmn2.DocumentRoot;
-import org.eclipse.bpmn2.util.Bpmn2Resource;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -109,7 +108,7 @@ public class BPMNDirectDiagramMarshaller implements DiagramMarshaller<Graph, Met
     public String marshall(final Diagram<Graph, Metadata> diagram) throws IOException {
         LOG.debug("Starting diagram marshalling...");
 
-        Bpmn2Resource resource = createBpmn2Resource();
+        Resource resource = createBpmn2Resource();
 
         // we start converting from the root, then pull out the result
         DefinitionsConverter definitionsConverter =
@@ -133,7 +132,7 @@ public class BPMNDirectDiagramMarshaller implements DiagramMarshaller<Graph, Met
         }
     }
 
-    private String renderToString(Bpmn2Resource resource) throws IOException {
+    private String renderToString(Resource resource) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         resource.save(outputStream, new HashMap<>());
         return StringEscapeUtils.unescapeHtml4(
@@ -188,7 +187,7 @@ public class BPMNDirectDiagramMarshaller implements DiagramMarshaller<Graph, Met
         return diagram.getGraph();
     }
 
-    private Bpmn2Resource createBpmn2Resource() {
+    private Resource createBpmn2Resource() {
         DroolsFactoryImpl.init();
         BpsimFactoryImpl.init();
 
@@ -199,9 +198,8 @@ public class BPMNDirectDiagramMarshaller implements DiagramMarshaller<Graph, Met
                 .put("bpmn2",
                      new JBPMBpmn2ResourceFactoryImpl());
 
-        Bpmn2Resource resource =
-                (Bpmn2Resource) rSet.createResource(
-                        URI.createURI("virtual.bpmn2"));
+        Resource resource = rSet.createResource(
+                URI.createURI("virtual.bpmn2"));
 
         rSet.getResources().add(resource);
         return resource;
@@ -219,15 +217,14 @@ public class BPMNDirectDiagramMarshaller implements DiagramMarshaller<Graph, Met
         final ResourceSet resourceSet = new ResourceSetImpl();
         Resource.Factory.Registry resourceFactoryRegistry = resourceSet.getResourceFactoryRegistry();
         resourceFactoryRegistry.getExtensionToFactoryMap().put(
-                Resource.Factory.Registry.DEFAULT_EXTENSION, new JBPMBpmn2ResourceFactoryImpl());
+                Resource.Factory.Registry.DEFAULT_EXTENSION, new Bpmn2ResourceFactory());
 
         EPackage.Registry packageRegistry = resourceSet.getPackageRegistry();
         packageRegistry.put("http://www.omg.org/spec/BPMN/20100524/MODEL", Bpmn2Package.eINSTANCE);
         packageRegistry.put("http://www.jboss.org/drools", DroolsPackage.eINSTANCE);
 
-        final JBPMBpmn2ResourceImpl resource =
-                (JBPMBpmn2ResourceImpl) resourceSet
-                        .createResource(URI.createURI("inputStream://dummyUriWithValidSuffix.xml"));
+        final Bpmn2Resource resource = (Bpmn2Resource) resourceSet
+                .createResource(URI.createURI("inputStream://dummyUriWithValidSuffix.xml"));
 
         resource.getDefaultLoadOptions()
                 .put(JBPMBpmn2ResourceImpl.OPTION_ENCODING, "UTF-8");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/Bpmn2Resource.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/Bpmn2Resource.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend;
+
+import java.util.Iterator;
+
+import org.eclipse.bpmn2.Definitions;
+import org.eclipse.bpmn2.util.ImportHelper;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.kie.workbench.common.stunner.bpmn.backend.legacy.resource.JBPMBpmn2ResourceImpl;
+
+public class Bpmn2Resource extends JBPMBpmn2ResourceImpl {
+
+    public Bpmn2Resource(URI uri) {
+        super(uri);
+    }
+
+    /**
+     * Prepares this resource for saving.
+     * <p>
+     * Sets all ID attributes of cross-referenced objects
+     * that are not yet set, to a generated UUID. Do not set if only referenced
+     * by their container.
+     */
+    @Override
+    protected void prepareSave() {
+        EObject cur;
+        Definitions thisDefinitions = ImportHelper.getDefinitions(this);
+        setIdEvenIfSet(thisDefinitions);
+        for (Iterator<EObject> iter = getAllContents(); iter.hasNext(); ) {
+            cur = iter.next();
+
+            for (EObject referenced : cur.eCrossReferences()) {
+                if (referenced.eContainer() != cur) {
+                    setIdIfNotSet(referenced);
+                }
+                if (thisDefinitions != null) {
+                    Resource refResource = referenced.eResource();
+                    if (refResource != null && refResource != this) {
+                        createImportIfNecessary(thisDefinitions, refResource);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/Bpmn2ResourceFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/Bpmn2ResourceFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import bpsim.impl.BpsimFactoryImpl;
+import org.eclipse.bpmn2.Definitions;
+import org.eclipse.bpmn2.util.ImportHelper;
+import org.eclipse.bpmn2.util.OnlyContainmentTypeInfo;
+import org.eclipse.bpmn2.util.XmlExtendedMetadata;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.ExtendedMetaData;
+import org.eclipse.emf.ecore.xmi.XMLResource;
+import org.eclipse.emf.ecore.xmi.impl.ElementHandlerImpl;
+import org.jboss.drools.impl.DroolsFactoryImpl;
+import org.kie.workbench.common.stunner.bpmn.backend.legacy.resource.JBPMBpmn2ResourceFactoryImpl;
+import org.kie.workbench.common.stunner.bpmn.backend.legacy.resource.JBPMBpmn2ResourceImpl;
+
+public class Bpmn2ResourceFactory extends JBPMBpmn2ResourceFactoryImpl {
+
+    @Override
+    public Bpmn2Resource createResource(URI uri) {
+        DroolsFactoryImpl.init();
+        BpsimFactoryImpl.init();
+        Bpmn2Resource result = new Bpmn2Resource(uri);
+        ExtendedMetaData extendedMetadata = new XmlExtendedMetadata();
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_EXTENDED_META_DATA,
+                                           extendedMetadata);
+        result.getDefaultLoadOptions().put(XMLResource.OPTION_EXTENDED_META_DATA,
+                                           extendedMetadata);
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_SAVE_TYPE_INFORMATION,
+                                           new OnlyContainmentTypeInfo());
+        result.getDefaultLoadOptions().put(XMLResource.OPTION_USE_ENCODED_ATTRIBUTE_STYLE,
+                                           Boolean.TRUE);
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_USE_ENCODED_ATTRIBUTE_STYLE,
+                                           Boolean.TRUE);
+        result.getDefaultLoadOptions().put(XMLResource.OPTION_USE_LEXICAL_HANDLER,
+                                           Boolean.TRUE);
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_ELEMENT_HANDLER,
+                                           new ElementHandlerImpl(true));
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_ENCODING,
+                                           "UTF-8");
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_USE_CACHED_LOOKUP_TABLE,
+                                           new ArrayList<Object>());
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_DEFER_IDREF_RESOLUTION,
+                                           true);
+        result.getDefaultSaveOptions().put(XMLResource.OPTION_PROCESS_DANGLING_HREF,
+                                           XMLResource.OPTION_PROCESS_DANGLING_HREF_RECORD);
+        return result;
+    }
+}
+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/Bpmn2ResourceFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/Bpmn2ResourceFactory.java
@@ -17,22 +17,16 @@
 package org.kie.workbench.common.stunner.bpmn.backend;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 
 import bpsim.impl.BpsimFactoryImpl;
-import org.eclipse.bpmn2.Definitions;
-import org.eclipse.bpmn2.util.ImportHelper;
 import org.eclipse.bpmn2.util.OnlyContainmentTypeInfo;
 import org.eclipse.bpmn2.util.XmlExtendedMetadata;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.ExtendedMetaData;
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.ElementHandlerImpl;
 import org.jboss.drools.impl.DroolsFactoryImpl;
 import org.kie.workbench.common.stunner.bpmn.backend.legacy.resource.JBPMBpmn2ResourceFactoryImpl;
-import org.kie.workbench.common.stunner.bpmn.backend.legacy.resource.JBPMBpmn2ResourceImpl;
 
 public class Bpmn2ResourceFactory extends JBPMBpmn2ResourceFactoryImpl {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
@@ -26,13 +26,11 @@ import org.eclipse.bpmn2.Bpmn2Package;
 import org.eclipse.bpmn2.Definitions;
 import org.eclipse.bpmn2.util.Bpmn2ResourceImpl;
 import org.eclipse.bpmn2.util.ImportHelper;
-import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.XMLLoad;
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.XMLSave;
@@ -107,7 +105,7 @@ public class JBPMBpmn2ResourceImpl extends Bpmn2ResourceImpl {
 
     /**
      * Prepares this resource for saving.
-     *
+     * <p>
      * Sets all ID attributes of cross-referenced objects
      * that are not yet set, to a generated UUID. Do not set if only referenced
      * by their container.
@@ -117,7 +115,7 @@ public class JBPMBpmn2ResourceImpl extends Bpmn2ResourceImpl {
         EObject cur;
         Definitions thisDefinitions = ImportHelper.getDefinitions(this);
         setIdEvenIfSet(thisDefinitions);
-        for (Iterator<EObject> iter = getAllContents(); iter.hasNext();) {
+        for (Iterator<EObject> iter = getAllContents(); iter.hasNext(); ) {
             cur = iter.next();
 
             for (EObject referenced : cur.eCrossReferences()) {
@@ -133,7 +131,6 @@ public class JBPMBpmn2ResourceImpl extends Bpmn2ResourceImpl {
             }
         }
     }
-
 
     class DiagnosticWrappedException extends WrappedException implements Diagnostic {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
@@ -112,6 +112,7 @@ public class JBPMBpmn2ResourceImpl extends Bpmn2ResourceImpl {
      * that are not yet set, to a generated UUID. Do not set if only referenced
      * by their container.
      */
+    @Override
     protected void prepareSave() {
         EObject cur;
         Definitions thisDefinitions = ImportHelper.getDefinitions(this);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
@@ -19,18 +19,14 @@ package org.kie.workbench.common.stunner.bpmn.backend.legacy.resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.bpmn2.Bpmn2Package;
-import org.eclipse.bpmn2.Definitions;
 import org.eclipse.bpmn2.util.Bpmn2ResourceImpl;
-import org.eclipse.bpmn2.util.ImportHelper;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.xmi.XMLLoad;
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.XMLSave;
@@ -101,35 +97,6 @@ public class JBPMBpmn2ResourceImpl extends Bpmn2ResourceImpl {
                 }
             }
         };
-    }
-
-    /**
-     * Prepares this resource for saving.
-     * <p>
-     * Sets all ID attributes of cross-referenced objects
-     * that are not yet set, to a generated UUID. Do not set if only referenced
-     * by their container.
-     */
-    @Override
-    protected void prepareSave() {
-        EObject cur;
-        Definitions thisDefinitions = ImportHelper.getDefinitions(this);
-        setIdEvenIfSet(thisDefinitions);
-        for (Iterator<EObject> iter = getAllContents(); iter.hasNext(); ) {
-            cur = iter.next();
-
-            for (EObject referenced : cur.eCrossReferences()) {
-                if (referenced.eContainer() != cur) {
-                    setIdIfNotSet(referenced);
-                }
-                if (thisDefinitions != null) {
-                    Resource refResource = referenced.eResource();
-                    if (refResource != null && refResource != this) {
-                        createImportIfNecessary(thisDefinitions, refResource);
-                    }
-                }
-            }
-        }
     }
 
     class DiagnosticWrappedException extends WrappedException implements Diagnostic {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/legacy/resource/JBPMBpmn2ResourceImpl.java
@@ -19,14 +19,20 @@ package org.kie.workbench.common.stunner.bpmn.backend.legacy.resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.bpmn2.Bpmn2Package;
+import org.eclipse.bpmn2.Definitions;
 import org.eclipse.bpmn2.util.Bpmn2ResourceImpl;
+import org.eclipse.bpmn2.util.ImportHelper;
+import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.XMLLoad;
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.XMLSave;
@@ -98,6 +104,35 @@ public class JBPMBpmn2ResourceImpl extends Bpmn2ResourceImpl {
             }
         };
     }
+
+    /**
+     * Prepares this resource for saving.
+     *
+     * Sets all ID attributes of cross-referenced objects
+     * that are not yet set, to a generated UUID. Do not set if only referenced
+     * by their container.
+     */
+    protected void prepareSave() {
+        EObject cur;
+        Definitions thisDefinitions = ImportHelper.getDefinitions(this);
+        setIdEvenIfSet(thisDefinitions);
+        for (Iterator<EObject> iter = getAllContents(); iter.hasNext();) {
+            cur = iter.next();
+
+            for (EObject referenced : cur.eCrossReferences()) {
+                if (referenced.eContainer() != cur) {
+                    setIdIfNotSet(referenced);
+                }
+                if (thisDefinitions != null) {
+                    Resource refResource = referenced.eResource();
+                    if (refResource != null && refResource != this) {
+                        createImportIfNecessary(thisDefinitions, refResource);
+                    }
+                }
+            }
+        }
+    }
+
 
     class DiagnosticWrappedException extends WrappedException implements Diagnostic {
 


### PR DESCRIPTION
This patch modifies the behavior of the marshallers so that they only generate IDs when they are unset but the element is still x-referenced. It's not a final solution, but the number of generated IDs is much more limited (close to none!)

**all tests are passing**, but interactive testing required. This patch affects both new and old marshallers. We can also customize it to affect new marshallers only (as you can see, it's an extremely small patch!)

cc @romartin @hasys 
I can't remember the JIRA for this but I'm pretty sure it exists, so please edit the title of this PR accordingly