### PR TITLE
DROOLS-2827: [DMN Designer] SVG produced for each save operation

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommand.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.client.commands;
+package org.kie.workbench.common.dmn.client.commands.general;
 
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
-import org.kie.workbench.common.dmn.client.commands.general.BaseClearExpressionCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainerUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
@@ -30,7 +30,7 @@ import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
-import org.kie.workbench.common.dmn.client.commands.ClearExpressionTypeCommand;
+import org.kie.workbench.common.dmn.client.commands.general.ClearExpressionTypeCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionEditorColumn;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommandTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.client.commands;
+package org.kie.workbench.common.dmn.client.commands.general;
 
 import java.util.Optional;
 
@@ -22,7 +22,6 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
-import org.kie.workbench.common.dmn.client.commands.general.BaseClearExpressionCommandTest;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainerUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
@@ -32,7 +32,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
-import org.kie.workbench.common.dmn.client.commands.ClearExpressionTypeCommand;
+import org.kie.workbench.common.dmn.client.commands.general.ClearExpressionTypeCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectEditorMenuSessionItems.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNProjectEditorMenuSessionItems.java
@@ -20,8 +20,8 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.dmn.project.client.session.DMNEditorSessionCommands;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
-import org.kie.workbench.common.stunner.project.client.session.EditorSessionCommands;
 
 @Dependent
 @Typed(DMNProjectEditorMenuSessionItems.class)
@@ -29,7 +29,7 @@ public class DMNProjectEditorMenuSessionItems extends AbstractProjectEditorMenuS
 
     @Inject
     public DMNProjectEditorMenuSessionItems(final DMNProjectDiagramEditorMenuItemsBuilder itemsBuilder,
-                                            final EditorSessionCommands sessionCommands) {
+                                            final DMNEditorSessionCommands sessionCommands) {
         super(itemsBuilder,
               sessionCommands);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommands.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommands.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.session;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.project.client.session.command.SaveDiagramSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.ManagedClientSessionCommands;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CopySelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CutSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToBpmnSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToJpgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPdfSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToSvgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
+import org.kie.workbench.common.stunner.project.client.session.EditorSessionCommands;
+
+@Dependent
+public class DMNEditorSessionCommands extends EditorSessionCommands {
+
+    @Inject
+    public DMNEditorSessionCommands(final ManagedClientSessionCommands commands) {
+        super(commands);
+    }
+
+    @PostConstruct
+    public void init() {
+        getCommands().register(VisitGraphSessionCommand.class)
+                .register(SwitchGridSessionCommand.class)
+                .register(ClearSessionCommand.class)
+                .register(DeleteSelectionSessionCommand.class)
+                .register(UndoSessionCommand.class)
+                .register(RedoSessionCommand.class)
+                .register(ValidateSessionCommand.class)
+                .register(ExportToPngSessionCommand.class)
+                .register(ExportToJpgSessionCommand.class)
+                .register(ExportToPdfSessionCommand.class)
+                .register(ExportToSvgSessionCommand.class)
+                .register(ExportToBpmnSessionCommand.class)
+                .register(CopySelectionSessionCommand.class)
+                .register(PasteSelectionSessionCommand.class)
+                .register(CutSelectionSessionCommand.class)
+                .register(SaveDiagramSessionCommand.class);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/command/SaveDiagramSessionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/command/SaveDiagramSessionCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.session.command;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+
+@Dependent
+public class SaveDiagramSessionCommand extends AbstractClientSessionCommand<EditorSession> {
+
+    public SaveDiagramSessionCommand() {
+        super(false);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V> void execute(final Callback<V> callback) {
+        //Do not automatically export a SVG diagram for the DMN Designer
+    }
+
+    @Override
+    public boolean accepts(final ClientSession session) {
+        return false;
+    }
+
+    /**
+     * This command is always disabled.
+     * @param enable Ignored.
+     */
+    @Override
+    protected void enable(final boolean enable) {
+        super.enable(false);
+    }
+
+    /**
+     * This command is always disabled.
+     * @param enabled Ignored.
+     */
+    @Override
+    protected void setEnabled(final boolean enabled) {
+        super.setEnabled(false);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommandsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommandsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.session;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.project.client.session.command.SaveDiagramSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CopySelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CutSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToBpmnSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToJpgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPdfSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToSvgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
+import org.kie.workbench.common.stunner.project.client.session.EditorSessionCommands;
+import org.kie.workbench.common.stunner.project.client.session.EditorSessionCommandsTest;
+import org.mockito.InOrder;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.inOrder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNEditorSessionCommandsTest extends EditorSessionCommandsTest {
+
+    @Override
+    protected EditorSessionCommands makeEditorSessionCommands() {
+        return new DMNEditorSessionCommands(commands);
+    }
+
+    @Test
+    public void testInit() {
+        editorSessionCommands.init();
+
+        final InOrder inOrder = inOrder(commands);
+
+        inOrder.verify(commands).register(VisitGraphSessionCommand.class);
+        inOrder.verify(commands).register(SwitchGridSessionCommand.class);
+        inOrder.verify(commands).register(ClearSessionCommand.class);
+        inOrder.verify(commands).register(DeleteSelectionSessionCommand.class);
+        inOrder.verify(commands).register(UndoSessionCommand.class);
+        inOrder.verify(commands).register(RedoSessionCommand.class);
+        inOrder.verify(commands).register(ValidateSessionCommand.class);
+        inOrder.verify(commands).register(ExportToPngSessionCommand.class);
+        inOrder.verify(commands).register(ExportToJpgSessionCommand.class);
+        inOrder.verify(commands).register(ExportToPdfSessionCommand.class);
+        inOrder.verify(commands).register(ExportToSvgSessionCommand.class);
+        inOrder.verify(commands).register(ExportToBpmnSessionCommand.class);
+        inOrder.verify(commands).register(CopySelectionSessionCommand.class);
+        inOrder.verify(commands).register(PasteSelectionSessionCommand.class);
+        inOrder.verify(commands).register(CutSelectionSessionCommand.class);
+        inOrder.verify(commands).register(SaveDiagramSessionCommand.class);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/session/command/SaveDiagramSessionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/session/command/SaveDiagramSessionCommandTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.session.command;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SaveDiagramSessionCommandTest {
+
+    @Mock
+    private ClientSession session;
+
+    @Mock
+    private ClientSessionCommand.Callback callback;
+
+    private SaveDiagramSessionCommand command;
+
+    @Before
+    public void setup() {
+        this.command = new SaveDiagramSessionCommand();
+    }
+
+    @Test
+    public void testExecute() {
+        command.execute();
+    }
+
+    @Test
+    public void testExecuteWithCallback() {
+        command.execute(callback);
+
+        Mockito.verifyNoMoreInteractions(callback);
+    }
+
+    @Test
+    public void testAccepts() {
+        assertFalse(command.accepts(session));
+    }
+
+    @Test
+    public void testEnable() {
+        command.enable(false);
+        assertFalse(command.isEnabled());
+
+        command.enable(false);
+        assertFalse(command.isEnabled());
+    }
+
+    @Test
+    public void testSetEnabled() {
+        command.setEnabled(false);
+        assertFalse(command.isEnabled());
+
+        command.setEnabled(false);
+        assertFalse(command.isEnabled());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/session/EditorSessionCommandsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/session/EditorSessionCommandsTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.project.client.session;
+
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.command.ManagedClientSessionCommands;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CopySelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.CutSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.DeleteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToBpmnSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToJpgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPdfSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToPngSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ExportToSvgSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSelectionSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SaveDiagramSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EditorSessionCommandsTest {
+
+    @Mock
+    protected ManagedClientSessionCommands commands;
+
+    @Mock
+    protected ClientSession session;
+
+    protected EditorSessionCommands editorSessionCommands;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        this.editorSessionCommands = makeEditorSessionCommands();
+
+        when(commands.register(any(Class.class))).thenReturn(commands);
+    }
+
+    protected EditorSessionCommands makeEditorSessionCommands() {
+        return new EditorSessionCommands(commands);
+    }
+
+    @Test
+    public void testInit() {
+        editorSessionCommands.init();
+
+        final InOrder inOrder = inOrder(commands);
+
+        inOrder.verify(commands).register(VisitGraphSessionCommand.class);
+        inOrder.verify(commands).register(SwitchGridSessionCommand.class);
+        inOrder.verify(commands).register(ClearSessionCommand.class);
+        inOrder.verify(commands).register(DeleteSelectionSessionCommand.class);
+        inOrder.verify(commands).register(UndoSessionCommand.class);
+        inOrder.verify(commands).register(RedoSessionCommand.class);
+        inOrder.verify(commands).register(ValidateSessionCommand.class);
+        inOrder.verify(commands).register(ExportToPngSessionCommand.class);
+        inOrder.verify(commands).register(ExportToJpgSessionCommand.class);
+        inOrder.verify(commands).register(ExportToPdfSessionCommand.class);
+        inOrder.verify(commands).register(ExportToSvgSessionCommand.class);
+        inOrder.verify(commands).register(ExportToBpmnSessionCommand.class);
+        inOrder.verify(commands).register(CopySelectionSessionCommand.class);
+        inOrder.verify(commands).register(PasteSelectionSessionCommand.class);
+        inOrder.verify(commands).register(CutSelectionSessionCommand.class);
+        inOrder.verify(commands).register(SaveDiagramSessionCommand.class);
+    }
+
+    @Test
+    public void testBind() {
+        editorSessionCommands.bind(session);
+
+        verify(commands).bind(session);
+    }
+
+    @Test
+    public void testGetCommands() {
+        assertEquals(commands, editorSessionCommands.getCommands());
+    }
+
+    @Test
+    public void testGetVisitGraphSessionCommand() {
+        editorSessionCommands.getVisitGraphSessionCommand();
+
+        verify(commands).get(0);
+    }
+
+    @Test
+    public void testGetSwitchGridSessionCommand() {
+        editorSessionCommands.getSwitchGridSessionCommand();
+
+        verify(commands).get(1);
+    }
+
+    @Test
+    public void testGetClearSessionCommand() {
+        editorSessionCommands.getClearSessionCommand();
+
+        verify(commands).get(2);
+    }
+
+    @Test
+    public void testGetDeleteSelectionSessionCommand() {
+        editorSessionCommands.getDeleteSelectionSessionCommand();
+
+        verify(commands).get(3);
+    }
+
+    @Test
+    public void testGetUndoSessionCommand() {
+        editorSessionCommands.getUndoSessionCommand();
+
+        verify(commands).get(4);
+    }
+
+    @Test
+    public void testGetRedoSessionCommand() {
+        editorSessionCommands.getRedoSessionCommand();
+
+        verify(commands).get(5);
+    }
+
+    @Test
+    public void testGetValidateSessionCommand() {
+        editorSessionCommands.getValidateSessionCommand();
+
+        verify(commands).get(6);
+    }
+
+    @Test
+    public void testGetExportToPngSessionCommand() {
+        editorSessionCommands.getExportToPngSessionCommand();
+
+        verify(commands).get(7);
+    }
+
+    @Test
+    public void testGetExportToJpgSessionCommand() {
+        editorSessionCommands.getExportToJpgSessionCommand();
+
+        verify(commands).get(8);
+    }
+
+    @Test
+    public void testGetExportToPdfSessionCommand() {
+        editorSessionCommands.getExportToPdfSessionCommand();
+
+        verify(commands).get(9);
+    }
+
+    @Test
+    public void testGetExportToSvgSessionCommand() {
+        editorSessionCommands.getExportToSvgSessionCommand();
+
+        verify(commands).get(10);
+    }
+
+    @Test
+    public void testGetExportToBpmnSessionCommand() {
+        editorSessionCommands.getExportToBpmnSessionCommand();
+
+        verify(commands).get(11);
+    }
+
+    @Test
+    public void testGetCopySelectionSessionCommand() {
+        editorSessionCommands.getCopySelectionSessionCommand();
+
+        verify(commands).get(12);
+    }
+
+    @Test
+    public void testGetPasteSelectionSessionCommand() {
+        editorSessionCommands.getPasteSelectionSessionCommand();
+
+        verify(commands).get(13);
+    }
+
+    @Test
+    public void testGetCutSelectionSessionCommand() {
+        editorSessionCommands.getCutSelectionSessionCommand();
+
+        verify(commands).get(14);
+    }
+
+    @Test
+    public void testGetSaveDiagramSessionCommand() {
+        editorSessionCommands.getSaveDiagramSessionCommand();
+
+        verify(commands).get(15);
+    }
+
+    @Test
+    public void testGet() {
+        IntStream.range(0, 15).forEach(i -> {
+            editorSessionCommands.get(i);
+            verify(commands).get(i);
+        });
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2827

This PR removes the automatic creation of diagram SVGs when the file is saved from DMN.