### PR TITLE
JBPM-7620: Stunner - NewMarshallers - Variable identifiers

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/Ids.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/Ids.java
@@ -34,8 +34,7 @@ public class Ids {
     }
 
     public static String typedIdentifier(String parentScopeId, String identifier) {
-        // TODO we cannot use this strategy until UI is migrated:
-        return "var_" + parentScopeId + "_" + identifier;
+        return identifier;
     }
 
     public static String dataInput(String parentId, String inputId) {
@@ -63,7 +62,7 @@ public class Ids {
     }
 
     public static String multiInstanceItemType(String parentId, String id) {
-        return parentId + "_multiInstanceItemType_"+id;
+        return parentId + "_multiInstanceItemType_" + id;
     }
 
     public static String messageItem(String name) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -2220,10 +2220,10 @@ public class BPMNDirectDiagramMarshallerTest {
 
         assertTrue(result.contains("<bpmn2:dataInput id=\"_FC6D8570-8C67-40C2-8B7B-953DE15765FB_input1InputX\" drools:dtype=\"String\" itemSubjectRef=\"__FC6D8570-8C67-40C2-8B7B-953DE15765FB_input1InputXItem\" name=\"input1\"/>"));
         assertTrue(result.contains("<bpmn2:dataOutput id=\"_FC6D8570-8C67-40C2-8B7B-953DE15765FB_output2OutputX\" drools:dtype=\"Float\" itemSubjectRef=\"__FC6D8570-8C67-40C2-8B7B-953DE15765FB_output2OutputXItem\" name=\"output2\"/>"));
-        assertTrue(result.contains("<bpmn2:sourceRef>var_Evaluation.ReusableSubprocess_pv1</bpmn2:sourceRef>"));
+        assertTrue(result.contains("<bpmn2:sourceRef>pv1</bpmn2:sourceRef>"));
         assertTrue(result.contains("<bpmn2:targetRef>_FC6D8570-8C67-40C2-8B7B-953DE15765FB_input1InputX</bpmn2:targetRef>"));
         assertTrue(result.contains("<bpmn2:sourceRef>_FC6D8570-8C67-40C2-8B7B-953DE15765FB_output2OutputX</bpmn2:sourceRef>"));
-        assertTrue(result.contains("<bpmn2:targetRef>var_Evaluation.ReusableSubprocess_pv2</bpmn2:targetRef>"));
+        assertTrue(result.contains("<bpmn2:targetRef>pv2</bpmn2:targetRef>"));
 
         String flatResult = result.replace(NEW_LINE,
                                            " ").replaceAll("( )+",
@@ -2748,7 +2748,6 @@ public class BPMNDirectDiagramMarshallerTest {
         assertEquals("Lanes test",
                      diagram.getMetadata().getTitle());
     }
-
 
     @Test
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Restore old behavior: IDs for variables are now non-namespaced as before, i.e. IDs==variable names. 
This should be backwards compatible with the old designer (although quite fragile, as we already know)

