### PR TITLE
DROOLS-2777: Guided Decision Table is changing date field value based on the timezone

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/preferences/ApplicationPreferences.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/preferences/ApplicationPreferences.java
@@ -30,40 +30,44 @@ public class ApplicationPreferences {
     public static final String DEFAULT_COUNTRY = "drools.defaultcountry";
     public static final String KIE_VERSION_PROPERTY_NAME = "kie_version";
     public static final String KIE_PRODUCTIZED = "kie_productized";
+    public static final String KIE_TIMEZONE_OFFSET = "kie_timezone_offset";
 
-    public static ApplicationPreferences instance = new ApplicationPreferences( Collections.<String, String>emptyMap() );
+    public static ApplicationPreferences instance = new ApplicationPreferences(Collections.<String, String>emptyMap());
     private Map<String, String> preferences = Collections.<String, String>emptyMap();
 
-    private ApplicationPreferences( Map<String, String> preferences ) {
+    private ApplicationPreferences(Map<String, String> preferences) {
         this.preferences = preferences;
     }
 
-    public static void setUp( Map<String, String> map ) {
-        instance = new ApplicationPreferences( map );
+    public static void setUp(Map<String, String> map) {
+        instance = new ApplicationPreferences(map);
     }
 
-    public static boolean getBooleanPref( String name ) {
-        return Boolean.parseBoolean( instance.preferences.get( name ) );
+    public static boolean getBooleanPref(String name) {
+        return Boolean.parseBoolean(instance.preferences.get(name));
     }
 
-    public static String getStringPref( String name ) {
-        return instance.preferences.get( name );
+    public static String getStringPref(String name) {
+        return instance.preferences.get(name);
     }
 
     public static String getDroolsDateFormat() {
-        return getStringPref( DATE_FORMAT );
+        return getStringPref(DATE_FORMAT);
     }
 
     public static String getDroolsDateTimeFormat() {
-        return getStringPref( DATE_TIME_FORMAT );
+        return getStringPref(DATE_TIME_FORMAT);
     }
 
     public static String getCurrentDroolsVersion() {
-        return instance.preferences.get( KIE_VERSION_PROPERTY_NAME );
+        return instance.preferences.get(KIE_VERSION_PROPERTY_NAME);
+    }
+
+    public static int getKieTimezoneOffset() {
+        return Integer.parseInt(instance.preferences.get(KIE_TIMEZONE_OFFSET));
     }
 
     public static boolean isProductized() {
-        return Boolean.parseBoolean( instance.preferences.get( KIE_PRODUCTIZED ) );
+        return Boolean.parseBoolean(instance.preferences.get(KIE_PRODUCTIZED));
     }
-
 }

--- a/kie-wb-common-services/kie-wb-common-services-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-services-backend/pom.xml
@@ -488,6 +488,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/KieTimeZonePreferencesLoader.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/KieTimeZonePreferencesLoader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.backend.preferences;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.guvnor.common.services.backend.preferences.ApplicationPreferencesLoader;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+
+public class KieTimeZonePreferencesLoader implements ApplicationPreferencesLoader {
+
+    @Override
+    public Map<String, String> load() {
+
+        final Map<String, String> preferences = new HashMap<>();
+        final int offset = getOffset();
+        final String offsetValue = Integer.toString(offset);
+
+        preferences.put(ApplicationPreferences.KIE_TIMEZONE_OFFSET, offsetValue);
+
+        return preferences;
+    }
+
+    private int getOffset() {
+        final TimeZone timeZone = getTimeZone();
+        return timeZone.getOffset(0);
+    }
+
+    private TimeZone getTimeZone() {
+        final String timezone = getSystemPropertyTimeZone();
+
+        if (timezone == null || timezone.isEmpty()) {
+            return TimeZone.getDefault();
+        } else {
+            return TimeZone.getTimeZone(timezone);
+        }
+    }
+
+    String getSystemPropertyTimeZone() {
+        return System.getProperty("user.timezone");
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/preferences/KieTimeZonePreferencesLoaderTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/preferences/KieTimeZonePreferencesLoaderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.backend.preferences;
+
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.gwtbootstrap3.client.ui.Modal;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.KIE_TIMEZONE_OFFSET;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@PrepareForTest({KieTimeZonePreferencesLoader.class, TimeZone.class})
+@RunWith(PowerMockRunner.class)
+public class KieTimeZonePreferencesLoaderTest {
+
+    private KieTimeZonePreferencesLoader loader;
+
+    @Before
+    public void setup() {
+        loader = spy(new KieTimeZonePreferencesLoader());
+    }
+
+    @Test
+    public void testGetTimeZoneWhenTimeZoneIsHST() {
+        doReturn("HST").when(loader).getSystemPropertyTimeZone();
+
+        assertEquals("-36000000", getLoaderOffset());
+    }
+
+    @Test
+    public void testGetTimeZoneWhenTimeZoneIsAmericaSaoPaulo() {
+        doReturn("America/Sao_Paulo").when(loader).getSystemPropertyTimeZone();
+
+        assertEquals("-10800000", getLoaderOffset());
+    }
+
+    @Test
+    public void testGetTimeZoneWhenTimeZoneIsNotSet() {
+        doReturn("").when(loader).getSystemPropertyTimeZone();
+
+        final TimeZone timeZone = mock(TimeZone.class);
+        final int expectedOffset = 36000000;
+
+        mockStatic(TimeZone.class);
+        when(TimeZone.getDefault()).thenReturn(timeZone);
+        when(timeZone.getOffset(anyInt())).thenReturn(expectedOffset);
+
+        assertEquals(String.valueOf(expectedOffset), getLoaderOffset());
+    }
+
+    private String getLoaderOffset() {
+        final Map<String, String> preferences = loader.load();
+        return preferences.get(KIE_TIMEZONE_OFFSET);
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
@@ -301,6 +301,18 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/util/TimeZoneUtils.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/util/TimeZoneUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.util;
+
+import java.util.Date;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.i18n.client.TimeZone;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+
+import static com.google.gwt.i18n.client.TimeZone.createTimeZone;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.getKieTimezoneOffset;
+
+public class TimeZoneUtils {
+
+    private final static String DATE_FORMAT = ApplicationPreferences.getDroolsDateFormat();
+
+    public final static DateTimeFormat FORMATTER = DateTimeFormat.getFormat(DATE_FORMAT);
+
+    public static Date convertFromServerTimeZone(final Date date) {
+        return FORMATTER.parse(formatWithServerTimeZone(date));
+    }
+
+    public static Date convertToServerTimeZone(final Date date) {
+        final String convertedDate = internalFormatter().format(date, createTimeZone(getClientOffset(date)));
+        return internalFormatter().parse(convertedDate);
+    }
+
+    public static String formatWithServerTimeZone(final Date date) {
+        return FORMATTER.format(date, getTimeZone());
+    }
+
+    static int getClientOffset(final Date date) {
+
+        final int standardOffset = getTimeZone().getStandardOffset();
+        final int timezoneOffset = date.getTimezoneOffset();
+        final int timeZoneOffsetInMinutes = standardOffset - (timezoneOffset * 2);
+
+        return -timeZoneOffsetInMinutes;
+    }
+
+    public static TimeZone getTimeZone() {
+        return createTimeZone(-getKieTimezoneOffsetInMinutes());
+    }
+
+    public static DateTimeFormat internalFormatter() {
+        return DateTimeFormat.getFormat("MM-dd-yyyy HH:mm:ss");
+    }
+
+    private static int getKieTimezoneOffsetInMinutes() {
+        final int offsetInMilliseconds = getKieTimezoneOffset();
+        return offsetInMilliseconds / 1000 / 60;
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/util/TimeZoneUtilsTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/util/TimeZoneUtilsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.util;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.i18n.client.TimeZone;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.KIE_TIMEZONE_OFFSET;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class TimeZoneUtilsTest {
+
+    private DateTimeFormat dateTimeFormat;
+
+    @Before
+    public void setup() {
+
+        final String offsetInMilliseconds = "10800000";
+
+        ApplicationPreferences.setUp(new HashMap<String, String>() {{
+            put(KIE_TIMEZONE_OFFSET, offsetInMilliseconds);
+        }});
+
+        dateTimeFormat = mock(DateTimeFormat.class);
+
+        mockStatic(DateTimeFormat.class);
+        when(DateTimeFormat.getFormat(anyString())).thenReturn(dateTimeFormat);
+    }
+
+    @Test
+    @PrepareForTest({DateTimeFormat.class})
+    public void testGetTimeZone() {
+
+        final String expectedId = "Etc/GMT-3";
+        final int expectedOffsetInMinutes = -180;
+        final TimeZone timeZone = TimeZoneUtils.getTimeZone();
+
+        assertEquals(expectedId, timeZone.getID());
+        assertEquals(expectedOffsetInMinutes, timeZone.getStandardOffset());
+    }
+
+    @Test
+    @PrepareForTest({TimeZoneUtils.class, DateTimeFormat.class})
+    public void testFormatWithServerTimeZone() {
+
+        final Date date = mock(Date.class);
+        final TimeZone timeZone = mock(TimeZone.class);
+        final String expectedFormat = "01-01-1900";
+
+        mockStatic(TimeZoneUtils.class);
+        when(TimeZoneUtils.getTimeZone()).thenReturn(timeZone);
+        when(TimeZoneUtils.formatWithServerTimeZone(any(Date.class))).thenCallRealMethod();
+
+        when(dateTimeFormat.format(eq(date), eq(timeZone))).thenReturn(expectedFormat);
+
+        final String actualFormat = TimeZoneUtils.formatWithServerTimeZone(date);
+
+        assertEquals(expectedFormat, actualFormat);
+    }
+
+    @Test
+    @PrepareForTest({TimeZoneUtils.class, DateTimeFormat.class})
+    public void testConvertFromServerTimeZone() {
+
+        final Date date = mock(Date.class);
+        final Date expectedDate = mock(Date.class);
+        final String parsedDate = "01-01-1900";
+
+        mockStatic(TimeZoneUtils.class);
+        when(TimeZoneUtils.formatWithServerTimeZone(date)).thenReturn(parsedDate);
+        when(TimeZoneUtils.convertFromServerTimeZone(any(Date.class))).thenCallRealMethod();
+
+        when(dateTimeFormat.parse(parsedDate)).thenReturn(expectedDate);
+
+        final Date actualDate = TimeZoneUtils.convertFromServerTimeZone(date);
+
+        assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    @PrepareForTest({TimeZoneUtils.class, DateTimeFormat.class})
+    public void testConvertToServerTimeZone() {
+
+        final Date date = mock(Date.class);
+        final Date expectedDate = mock(Date.class);
+        final TimeZone timeZone = mock(TimeZone.class);
+        final ArgumentCaptor<TimeZone> captorTimeZone = ArgumentCaptor.forClass(TimeZone.class);
+        final String convertedDate = "01-01-1900";
+        final DateTimeFormat internalFormat = mock(DateTimeFormat.class);
+        final int expectedClientOffset = -60;
+
+        mockStatic(TimeZoneUtils.class);
+        when(TimeZoneUtils.getTimeZone()).thenReturn(timeZone);
+        when(TimeZoneUtils.internalFormatter()).thenReturn(internalFormat);
+        when(TimeZoneUtils.getClientOffset(date)).thenReturn(expectedClientOffset);
+        when(TimeZoneUtils.convertToServerTimeZone(any(Date.class))).thenCallRealMethod();
+
+        when(internalFormat.format(eq(date), captorTimeZone.capture())).thenReturn(convertedDate);
+        when(internalFormat.parse(convertedDate)).thenReturn(expectedDate);
+
+        final Date actualDate = TimeZoneUtils.convertToServerTimeZone(date);
+
+        assertEquals(expectedClientOffset, captorTimeZone.getValue().getStandardOffset());
+        assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    @PrepareForTest({TimeZoneUtils.class, DateTimeFormat.class})
+    public void testGetClientOffset() {
+
+        final Date date = mock(Date.class);
+        final TimeZone timeZone = mock(TimeZone.class);
+        final int serverSideOffSet = -180;
+        final int dateOffSet = -120;
+        final int expectedOffset = -60;
+
+        mockStatic(TimeZoneUtils.class);
+        when(TimeZoneUtils.getTimeZone()).thenReturn(timeZone);
+        when(TimeZoneUtils.getClientOffset(any(Date.class))).thenCallRealMethod();
+
+        when(timeZone.getStandardOffset()).thenReturn(serverSideOffSet);
+        when(date.getTimezoneOffset()).thenReturn(dateOffSet);
+
+        final int actualOffset = TimeZoneUtils.getClientOffset(date);
+
+        assertEquals(expectedOffset, actualOffset);
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/AbstractCellFactory.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/AbstractCellFactory.java
@@ -93,9 +93,8 @@ public abstract class AbstractCellFactory<T> {
 
     // Make a new Cell for Date columns
     protected DecoratedGridCellValueAdaptor<Date> makeDateCell() {
-        return new DecoratedGridCellValueAdaptor<Date>( new PopupDateEditCell( DATE_FORMAT,
-                                                                               isReadOnly ),
-                                                        eventBus );
+        return new DecoratedGridCellValueAdaptor<Date>(new PopupDateEditCell(isReadOnly),
+                                                       eventBus);
     }
 
     // Make a new Cell for Numeric columns

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCell.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCell.java
@@ -17,13 +17,20 @@ package org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells;
 
 import java.util.Date;
 
+import com.google.gwt.cell.client.ValueUpdater;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.text.shared.SafeHtmlRenderer;
 import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
+import org.kie.workbench.common.widgets.client.util.TimeZoneUtils;
 import org.uberfire.ext.widgets.common.client.common.DatePicker;
+
+import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.FORMATTER;
+import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.convertFromServerTimeZone;
+import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.formatWithServerTimeZone;
 
 /**
  * A Popup Date Editor.
@@ -31,18 +38,13 @@ import org.uberfire.ext.widgets.common.client.common.DatePicker;
 public class PopupDateEditCell extends AbstractPopupEditCell<Date, Date> {
 
     private final DatePicker datePicker;
-    private final DateTimeFormat format;
 
-    public PopupDateEditCell( DateTimeFormat format,
-                              boolean isReadOnly ) {
-        super( isReadOnly );
-        if ( format == null ) {
-            throw new IllegalArgumentException( "format == null" );
-        }
+    public PopupDateEditCell(final boolean isReadOnly) {
 
-        this.format = format;
-        this.datePicker = new DatePicker();
-        datePicker.setFormat( format.getPattern() );
+        super(isReadOnly);
+
+        this.datePicker = GWT.create(DatePicker.class);
+        datePicker.setFormat(getPattern());
 
         // See https://issues.jboss.org/browse/GUVNOR-2322
         // The DatePicker was being closed, before the ValueChangeHandler invoked, in response to the
@@ -69,27 +71,30 @@ public class PopupDateEditCell extends AbstractPopupEditCell<Date, Date> {
     }
 
     @Override
-    public void render( Context context,
-                        Date value,
-                        SafeHtmlBuilder sb ) {
-        if ( value != null ) {
-            sb.append( renderer.render( format.format( value ) ) );
+    public void render(Context context,
+                       Date value,
+                       SafeHtmlBuilder sb) {
+        if (value != null) {
+            sb.append(getRenderer().render(formatWithServerTimeZone(value)));
         }
     }
 
     // Commit the change
     @Override
     protected void commit() {
+        final Date date = convertToServerTimeZone(getDatePicker().getValue());
+        setValue(lastContext,
+                 lastParent,
+                 date);
 
-        // Update value
-        Date date = datePicker.getValue();
-        setValue( lastContext,
-                  lastParent,
-                  date );
-        if ( valueUpdater != null ) {
-            valueUpdater.update( date );
+        if (getValueUpdater() != null) {
+            getValueUpdater().update(date);
         }
         panel.hide();
+    }
+
+    Date convertToServerTimeZone(final Date value) {
+        return TimeZoneUtils.convertToServerTimeZone(value);
     }
 
     // Start editing the cell
@@ -110,18 +115,33 @@ public class PopupDateEditCell extends AbstractPopupEditCell<Date, Date> {
                              month,
                              dom );
         }
-        datePicker.setValue( date );
+        getDatePicker().setValue(convertFromServerTimeZone(date));
 
-        panel.setPopupPositionAndShow( new PositionCallback() {
-            public void setPosition( int offsetWidth,
-                                     int offsetHeight ) {
-                panel.setPopupPosition( parent.getAbsoluteLeft()
-                                                + offsetX,
-                                        parent.getAbsoluteTop()
-                                                + offsetY );
+        panel.setPopupPositionAndShow(new PositionCallback() {
+            public void setPosition(int offsetWidth,
+                                    int offsetHeight) {
+                panel.setPopupPosition(parent.getAbsoluteLeft()
+                                               + offsetX,
+                                       parent.getAbsoluteTop()
+                                               + offsetY);
             }
         } );
 
     }
 
+    String getPattern() {
+        return FORMATTER.getPattern();
+    }
+
+    DatePicker getDatePicker() {
+        return datePicker;
+    }
+
+    ValueUpdater<Date> getValueUpdater() {
+        return valueUpdater;
+    }
+
+    SafeHtmlRenderer<String> getRenderer() {
+        return renderer;
+    }
 }

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/test/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCellTest.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/test/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCellTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import com.google.gwt.cell.client.Cell;
+import com.google.gwt.cell.client.ValueUpdater;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.text.shared.SafeHtmlRenderer;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.DATE_FORMAT;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.KIE_TIMEZONE_OFFSET;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class PopupDateEditCellTest {
+
+    private static final String TEST_DATE_FORMAT = "MM-dd-yyyy HH:mm:ss Z";
+
+    @GwtMock
+    private DatePicker datePicker;
+
+    @GwtMock
+    private ValueUpdater<Date> valueUpdater;
+
+    @GwtMock
+    private SafeHtmlRenderer<String> renderer;
+
+    @Captor
+    private ArgumentCaptor<Date> dateCaptor;
+
+    private PopupDateEditCell cell;
+
+    @Before
+    public void setup() {
+        ApplicationPreferences.setUp(new HashMap<String, String>() {{
+            put(KIE_TIMEZONE_OFFSET, "10800000");
+            put(DATE_FORMAT, TEST_DATE_FORMAT);
+        }});
+
+        cell = spy(new PopupDateEditCell(false) {
+
+            @Override
+            DatePicker getDatePicker() {
+                return PopupDateEditCellTest.this.datePicker;
+            }
+
+            @Override
+            ValueUpdater<Date> getValueUpdater() {
+                return PopupDateEditCellTest.this.valueUpdater;
+            }
+
+            @Override
+            SafeHtmlRenderer<String> getRenderer() {
+                return PopupDateEditCellTest.this.renderer;
+            }
+
+            @Override
+            public void setValue(final Context context,
+                                 final Element parent,
+                                 final Date value) {
+                // Nothing.
+            }
+        });
+    }
+
+    @Test
+    public void testStartEditing() {
+
+        final Cell.Context context = mock(Cell.Context.class);
+        final Element parent = mock(Element.class);
+        final Date expectedDate = makeDate("04-01-2018 00:00:00 -0300");
+
+        cell.startEditing(context, parent, expectedDate);
+
+        verify(datePicker).setValue(dateCaptor.capture());
+
+        final Date actualDate = dateCaptor.getValue();
+
+        assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void testCommit() {
+
+        final Date clientDate = makeDate("04-01-2018 00:00:00 -0300");
+        final Date serverDate = makeDate("04-01-2018 06:00:00 +0300");
+
+        when(datePicker.getValue()).thenReturn(clientDate);
+        doReturn(serverDate).when(cell).convertToServerTimeZone(clientDate);
+
+        cell.commit();
+
+        verify(cell).setValue(any(Cell.Context.class), any(Element.class), eq(serverDate));
+        verify(valueUpdater).update(eq(serverDate));
+    }
+
+    @Test
+    public void testCommitWhenValueUpdaterIsNull() {
+
+        final Date clientDate = makeDate("04-01-2018 00:00:00 -0300");
+        final Date serverDate = makeDate("04-01-2018 06:00:00 +0300");
+
+        when(datePicker.getValue()).thenReturn(clientDate);
+        doReturn(null).when(cell).getValueUpdater();
+        doReturn(serverDate).when(cell).convertToServerTimeZone(clientDate);
+
+        cell.commit();
+
+        verify(cell).setValue(any(Cell.Context.class), any(Element.class), eq(serverDate));
+        verify(valueUpdater, never()).update(any(Date.class));
+    }
+
+    @Test
+    public void testRender() {
+
+        final Cell.Context context = mock(Cell.Context.class);
+        final SafeHtmlBuilder safeHtmlBuilder = mock(SafeHtmlBuilder.class);
+        final Date clientDate = makeDate("05-01-2018 18:00:00 -0300");
+        final String serverDate = "05-02-2018 00:00:00 +0300";
+
+        cell.render(context, clientDate, safeHtmlBuilder);
+
+        verify(renderer).render(eq(serverDate));
+    }
+
+    @Test
+    public void testRenderWhenValueIsNull() {
+
+        final Cell.Context context = mock(Cell.Context.class);
+        final SafeHtmlBuilder safeHtmlBuilder = mock(SafeHtmlBuilder.class);
+
+        cell.render(context, null, safeHtmlBuilder);
+
+        verify(renderer, never()).render(anyString());
+    }
+
+    @Test
+    public void testGetPattern() {
+        assertEquals(TEST_DATE_FORMAT, cell.getPattern());
+    }
+
+    private Date makeDate(final String dateString) {
+        return format().parse(dateString);
+    }
+
+    private DateTimeFormat format() {
+        return DateTimeFormat.getFormat(TEST_DATE_FORMAT);
+    }
+}


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/DROOLS-2777

---

Demo:
- First, we need to set the `user.timezone` property:
![1](https://user-images.githubusercontent.com/1079279/44177253-5ba47d00-a0ed-11e8-8ca4-a77f6d42166e.gif)

- ..and then, we can change the timezone to **"Europe/Vilnius"** in the server (`systemsetup -settimezone Europe/Vilnius`):
![2](https://user-images.githubusercontent.com/1079279/44177259-5e9f6d80-a0ed-11e8-9995-9c20e6c74274.gif)

- ..or even change to **"Europe/Prague"** (`systemsetup -settimezone Europe/Prague`):
![3](https://user-images.githubusercontent.com/1079279/44177261-6232f480-a0ed-11e8-9fe4-2f277ca6057f.gif)

..the client side is always using the timezone from the server (from `user.timezone`), so the displayed value will always be consistent.

cc @etirelli 

---

Part of an ensemble:
- https://github.com/kiegroup/kie-wb-common/pull/2038
- https://github.com/kiegroup/drools-wb/pull/911
