### PR TITLE
DROOLS-2832 DMN support for DMN v1.2 serialization

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNModelInstrumentedBase.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNModelInstrumentedBase.java
@@ -36,9 +36,9 @@ public abstract class DMNModelInstrumentedBase implements DMNDefinition {
     @Portable
     public enum Namespace {
 
-        FEEL("feel", org.kie.dmn.model.v1_1.DMNModelInstrumentedBase.URI_FEEL),
-        DMN("dmn", org.kie.dmn.model.v1_1.DMNModelInstrumentedBase.URI_DMN),
-        KIE("kie", org.kie.dmn.model.v1_1.DMNModelInstrumentedBase.URI_KIE);
+        FEEL("feel", org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_FEEL),
+        DMN("dmn", org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_DMN),
+        KIE("kie", org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_KIE);
 
         private String prefix;
         private String uri;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
@@ -34,7 +34,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.marshalling.server.ServerMarshalling;
-import org.kie.dmn.backend.marshalling.v1_1.DMNMarshallerFactory;
+import org.kie.dmn.backend.marshalling.v1_1.xstream.XStreamMarshaller;
 import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Association;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
@@ -114,7 +114,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         this.bkmConverter = new BusinessKnowledgeModelConverter(factoryManager);
         this.knowledgeSourceConverter = new KnowledgeSourceConverter(factoryManager);
         this.textAnnotationConverter = new TextAnnotationConverter(factoryManager);
-        this.marshaller = DMNMarshallerFactory.newMarshallerWithExtensions(Arrays.asList(new DDExtensionsRegister()));
+        this.marshaller = new XStreamMarshaller(Arrays.asList(new DDExtensionsRegister())); // generic marshaller will be eventually: DMNMarshallerFactory.newMarshallerWithExtensions(Arrays.asList(new DDExtensionsRegister()));
     }
 
     @Deprecated
@@ -130,7 +130,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         return result;
     }
 
-    private static Optional<org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram> findDMNDiagram(org.kie.dmn.model.v1_1.Definitions dmnXml) {
+    private static Optional<org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram> findDMNDiagram(org.kie.dmn.model.v1x.Definitions dmnXml) {
         if (dmnXml.getExtensionElements() == null) {
             return Optional.empty();
         }
@@ -150,24 +150,24 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
     @Override
     public Graph unmarshall(final Metadata metadata,
                             final InputStream input) throws IOException {
-        org.kie.dmn.model.v1_1.Definitions dmnXml = marshaller.unmarshal(new InputStreamReader(input));
+        org.kie.dmn.model.v1x.Definitions dmnXml = marshaller.unmarshal(new InputStreamReader(input));
 
-        Map<String, Entry<org.kie.dmn.model.v1_1.DRGElement, Node>> elems = dmnXml.getDrgElement().stream().collect(Collectors.toMap(org.kie.dmn.model.v1_1.DRGElement::getId,
+        Map<String, Entry<org.kie.dmn.model.v1x.DRGElement, Node>> elems = dmnXml.getDrgElement().stream().collect(Collectors.toMap(org.kie.dmn.model.v1x.DRGElement::getId,
                                                                                                                                      dmn -> new SimpleEntry<>(dmn,
                                                                                                                                                               dmnToStunner(dmn))));
 
         Optional<org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram> dmnDDDiagram = findDMNDiagram(dmnXml);
 
-        for (Entry<org.kie.dmn.model.v1_1.DRGElement, Node> kv : elems.values()) {
-            org.kie.dmn.model.v1_1.DRGElement elem = kv.getKey();
+        for (Entry<org.kie.dmn.model.v1x.DRGElement, Node> kv : elems.values()) {
+            org.kie.dmn.model.v1x.DRGElement elem = kv.getKey();
             Node currentNode = kv.getValue();
 
             ddExtAugmentStunner(dmnDDDiagram, currentNode);
 
             // DMN spec table 2: Requirements connection rules
-            if (elem instanceof org.kie.dmn.model.v1_1.Decision) {
-                org.kie.dmn.model.v1_1.Decision decision = (org.kie.dmn.model.v1_1.Decision) elem;
-                for (org.kie.dmn.model.v1_1.InformationRequirement ir : decision.getInformationRequirement()) {
+            if (elem instanceof org.kie.dmn.model.v1x.Decision) {
+                org.kie.dmn.model.v1x.Decision decision = (org.kie.dmn.model.v1x.Decision) elem;
+                for (org.kie.dmn.model.v1x.InformationRequirement ir : decision.getInformationRequirement()) {
                     if (ir.getRequiredInput() != null) {
                         String reqInputID = getId(ir.getRequiredInput());
                         Node requiredNode = elems.get(reqInputID).getValue();
@@ -189,7 +189,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                         setConnectionMagnets(myEdge);
                     }
                 }
-                for (org.kie.dmn.model.v1_1.KnowledgeRequirement kr : decision.getKnowledgeRequirement()) {
+                for (org.kie.dmn.model.v1x.KnowledgeRequirement kr : decision.getKnowledgeRequirement()) {
                     String reqInputID = getId(kr.getRequiredKnowledge());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -199,7 +199,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-                for (org.kie.dmn.model.v1_1.AuthorityRequirement kr : decision.getAuthorityRequirement()) {
+                for (org.kie.dmn.model.v1x.AuthorityRequirement kr : decision.getAuthorityRequirement()) {
                     String reqInputID = getId(kr.getRequiredAuthority());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -209,9 +209,9 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-            } else if (elem instanceof org.kie.dmn.model.v1_1.BusinessKnowledgeModel) {
-                org.kie.dmn.model.v1_1.BusinessKnowledgeModel bkm = (org.kie.dmn.model.v1_1.BusinessKnowledgeModel) elem;
-                for (org.kie.dmn.model.v1_1.KnowledgeRequirement kr : bkm.getKnowledgeRequirement()) {
+            } else if (elem instanceof org.kie.dmn.model.v1x.BusinessKnowledgeModel) {
+                org.kie.dmn.model.v1x.BusinessKnowledgeModel bkm = (org.kie.dmn.model.v1x.BusinessKnowledgeModel) elem;
+                for (org.kie.dmn.model.v1x.KnowledgeRequirement kr : bkm.getKnowledgeRequirement()) {
                     String reqInputID = getId(kr.getRequiredKnowledge());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -221,7 +221,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-                for (org.kie.dmn.model.v1_1.AuthorityRequirement kr : bkm.getAuthorityRequirement()) {
+                for (org.kie.dmn.model.v1x.AuthorityRequirement kr : bkm.getAuthorityRequirement()) {
                     String reqInputID = getId(kr.getRequiredAuthority());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -231,9 +231,9 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-            } else if (elem instanceof org.kie.dmn.model.v1_1.KnowledgeSource) {
-                org.kie.dmn.model.v1_1.KnowledgeSource ks = (org.kie.dmn.model.v1_1.KnowledgeSource) elem;
-                for (org.kie.dmn.model.v1_1.AuthorityRequirement ir : ks.getAuthorityRequirement()) {
+            } else if (elem instanceof org.kie.dmn.model.v1x.KnowledgeSource) {
+                org.kie.dmn.model.v1x.KnowledgeSource ks = (org.kie.dmn.model.v1x.KnowledgeSource) elem;
+                for (org.kie.dmn.model.v1x.AuthorityRequirement ir : ks.getAuthorityRequirement()) {
                     if (ir.getRequiredInput() != null) {
                         String reqInputID = getId(ir.getRequiredInput());
                         Node requiredNode = elems.get(reqInputID).getValue();
@@ -268,12 +268,14 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
             }
         }
 
-        Map<String, Node<View<TextAnnotation>, ?>> textAnnotations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.v1_1.TextAnnotation.class::isInstance).map(org.kie.dmn.model.v1_1.TextAnnotation.class::cast).collect(Collectors.toMap(org.kie.dmn.model.v1_1.TextAnnotation::getId,
+        Map<String, Node<View<TextAnnotation>, ?>> textAnnotations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.v1x.TextAnnotation.class::isInstance).map(org.kie.dmn.model.v1x.TextAnnotation.class::cast)
+                                                                           .collect(Collectors.toMap(org.kie.dmn.model.v1x.TextAnnotation::getId,
                                                                                                                                                                                                                                                    textAnnotationConverter::nodeFromDMN));
         textAnnotations.values().forEach(n -> ddExtAugmentStunner(dmnDDDiagram, n));
 
-        List<org.kie.dmn.model.v1_1.Association> associations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.v1_1.Association.class::isInstance).map(org.kie.dmn.model.v1_1.Association.class::cast).collect(Collectors.toList());
-        for (org.kie.dmn.model.v1_1.Association a : associations) {
+        List<org.kie.dmn.model.v1x.Association> associations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.v1x.Association.class::isInstance).map(org.kie.dmn.model.v1x.Association.class::cast).collect(
+                                                                                                                                                                                                                    Collectors.toList());
+        for (org.kie.dmn.model.v1x.Association a : associations) {
             String sourceId = getId(a.getSourceRef());
             Node sourceNode = Optional.ofNullable(elems.get(sourceId)).map(Entry::getValue).orElse(textAnnotations.get(sourceId));
 
@@ -319,20 +321,20 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                     false).filter(n -> n.getContent().getDefinition() instanceof DMNDiagram).findFirst().orElseThrow(() -> new UnsupportedOperationException("TODO"));
     }
 
-    private String getId(org.kie.dmn.model.v1_1.DMNElementReference er) {
+    private String getId(org.kie.dmn.model.v1x.DMNElementReference er) {
         String href = er.getHref();
         return href.contains("#") ? href.substring(href.indexOf('#') + 1) : href;
     }
 
-    private Node dmnToStunner(org.kie.dmn.model.v1_1.DRGElement dmn) {
-        if (dmn instanceof org.kie.dmn.model.v1_1.InputData) {
-            return inputDataConverter.nodeFromDMN((org.kie.dmn.model.v1_1.InputData) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.Decision) {
-            return decisionConverter.nodeFromDMN((org.kie.dmn.model.v1_1.Decision) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.BusinessKnowledgeModel) {
-            return bkmConverter.nodeFromDMN((org.kie.dmn.model.v1_1.BusinessKnowledgeModel) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.KnowledgeSource) {
-            return knowledgeSourceConverter.nodeFromDMN((org.kie.dmn.model.v1_1.KnowledgeSource) dmn);
+    private Node dmnToStunner(org.kie.dmn.model.v1x.DRGElement dmn) {
+        if (dmn instanceof org.kie.dmn.model.v1x.InputData) {
+            return inputDataConverter.nodeFromDMN((org.kie.dmn.model.v1x.InputData) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.Decision) {
+            return decisionConverter.nodeFromDMN((org.kie.dmn.model.v1x.Decision) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.BusinessKnowledgeModel) {
+            return bkmConverter.nodeFromDMN((org.kie.dmn.model.v1x.BusinessKnowledgeModel) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.KnowledgeSource) {
+            return knowledgeSourceConverter.nodeFromDMN((org.kie.dmn.model.v1x.KnowledgeSource) dmn);
         } else {
             throw new UnsupportedOperationException("TODO"); // TODO 
         }
@@ -378,15 +380,21 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
     public String marshall(final Diagram<Graph, Metadata> diagram) throws IOException {
         Graph<?, Node<View, ?>> g = diagram.getGraph();
 
-        Map<String, org.kie.dmn.model.v1_1.DRGElement> nodes = new HashMap<>();
-        Map<String, org.kie.dmn.model.v1_1.TextAnnotation> textAnnotations = new HashMap<>();
+        Map<String, org.kie.dmn.model.v1x.DRGElement> nodes = new HashMap<>();
+        Map<String, org.kie.dmn.model.v1x.TextAnnotation> textAnnotations = new HashMap<>();
 
         @SuppressWarnings("unchecked")
         Node<View<DMNDiagram>, ?> dmnDiagramRoot = (Node<View<DMNDiagram>, ?>) findDMNDiagramRoot(g);
         Definitions definitionsStunnerPojo = dmnDiagramRoot.getContent().getDefinition().getDefinitions();
-        org.kie.dmn.model.v1_1.Definitions definitions = DefinitionsConverter.dmnFromWB(definitionsStunnerPojo);
+        org.kie.dmn.model.v1x.Definitions definitions = DefinitionsConverter.dmnFromWB(definitionsStunnerPojo);
         if (definitions.getExtensionElements() == null) {
-            definitions.setExtensionElements(new org.kie.dmn.model.v1_1.Definitions.ExtensionElements());
+            if (definitions instanceof org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase) {
+                definitions.setExtensionElements(new org.kie.dmn.model.v1_1.TDMNElement.TExtensionElements());
+            } else if (definitions instanceof org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase) {
+                definitions.setExtensionElements(new org.kie.dmn.model.v1_2.TDMNElement.TExtensionElements());
+            } else {
+                definitions.setExtensionElements(new org.kie.dmn.model.v1_2.TDMNElement.TExtensionElements());
+            }
         }
         org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram dmnDDDMNDiagram = new org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram();
         definitions.getExtensionElements().getAny().add(dmnDDDMNDiagram);
@@ -405,7 +413,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                         textAnnotationConverter.dmnFromNode((Node<View<TextAnnotation>, ?>) node));
                     dmnDDDMNDiagram.getAny().add(stunnerToDDExt((View<? extends DMNElement>) view));
 
-                    List<org.kie.dmn.model.v1_1.Association> associations = AssociationConverter.dmnFromWB((Node<View<TextAnnotation>, ?>) node);
+                    List<org.kie.dmn.model.v1x.Association> associations = AssociationConverter.dmnFromWB((Node<View<TextAnnotation>, ?>) node);
                     definitions.getArtifact().addAll(associations);
                 }
             }
@@ -534,7 +542,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         }
     }
 
-    private org.kie.dmn.model.v1_1.DRGElement stunnerToDMN(final Node<?, ?> node) {
+    private org.kie.dmn.model.v1x.DRGElement stunnerToDMN(final Node<?, ?> node) {
         if (node.getContent() instanceof View<?>) {
             View<?> view = (View<?>) node.getContent();
             if (view.getDefinition() instanceof InputData) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
@@ -130,7 +130,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         return result;
     }
 
-    private static Optional<org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram> findDMNDiagram(org.kie.dmn.model.v1x.Definitions dmnXml) {
+    private static Optional<org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram> findDMNDiagram(org.kie.dmn.model.api.Definitions dmnXml) {
         if (dmnXml.getExtensionElements() == null) {
             return Optional.empty();
         }
@@ -150,24 +150,24 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
     @Override
     public Graph unmarshall(final Metadata metadata,
                             final InputStream input) throws IOException {
-        org.kie.dmn.model.v1x.Definitions dmnXml = marshaller.unmarshal(new InputStreamReader(input));
+        org.kie.dmn.model.api.Definitions dmnXml = marshaller.unmarshal(new InputStreamReader(input));
 
-        Map<String, Entry<org.kie.dmn.model.v1x.DRGElement, Node>> elems = dmnXml.getDrgElement().stream().collect(Collectors.toMap(org.kie.dmn.model.v1x.DRGElement::getId,
+        Map<String, Entry<org.kie.dmn.model.api.DRGElement, Node>> elems = dmnXml.getDrgElement().stream().collect(Collectors.toMap(org.kie.dmn.model.api.DRGElement::getId,
                                                                                                                                      dmn -> new SimpleEntry<>(dmn,
                                                                                                                                                               dmnToStunner(dmn))));
 
         Optional<org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram> dmnDDDiagram = findDMNDiagram(dmnXml);
 
-        for (Entry<org.kie.dmn.model.v1x.DRGElement, Node> kv : elems.values()) {
-            org.kie.dmn.model.v1x.DRGElement elem = kv.getKey();
+        for (Entry<org.kie.dmn.model.api.DRGElement, Node> kv : elems.values()) {
+            org.kie.dmn.model.api.DRGElement elem = kv.getKey();
             Node currentNode = kv.getValue();
 
             ddExtAugmentStunner(dmnDDDiagram, currentNode);
 
             // DMN spec table 2: Requirements connection rules
-            if (elem instanceof org.kie.dmn.model.v1x.Decision) {
-                org.kie.dmn.model.v1x.Decision decision = (org.kie.dmn.model.v1x.Decision) elem;
-                for (org.kie.dmn.model.v1x.InformationRequirement ir : decision.getInformationRequirement()) {
+            if (elem instanceof org.kie.dmn.model.api.Decision) {
+                org.kie.dmn.model.api.Decision decision = (org.kie.dmn.model.api.Decision) elem;
+                for (org.kie.dmn.model.api.InformationRequirement ir : decision.getInformationRequirement()) {
                     if (ir.getRequiredInput() != null) {
                         String reqInputID = getId(ir.getRequiredInput());
                         Node requiredNode = elems.get(reqInputID).getValue();
@@ -189,7 +189,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                         setConnectionMagnets(myEdge);
                     }
                 }
-                for (org.kie.dmn.model.v1x.KnowledgeRequirement kr : decision.getKnowledgeRequirement()) {
+                for (org.kie.dmn.model.api.KnowledgeRequirement kr : decision.getKnowledgeRequirement()) {
                     String reqInputID = getId(kr.getRequiredKnowledge());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -199,7 +199,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-                for (org.kie.dmn.model.v1x.AuthorityRequirement kr : decision.getAuthorityRequirement()) {
+                for (org.kie.dmn.model.api.AuthorityRequirement kr : decision.getAuthorityRequirement()) {
                     String reqInputID = getId(kr.getRequiredAuthority());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -209,9 +209,9 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-            } else if (elem instanceof org.kie.dmn.model.v1x.BusinessKnowledgeModel) {
-                org.kie.dmn.model.v1x.BusinessKnowledgeModel bkm = (org.kie.dmn.model.v1x.BusinessKnowledgeModel) elem;
-                for (org.kie.dmn.model.v1x.KnowledgeRequirement kr : bkm.getKnowledgeRequirement()) {
+            } else if (elem instanceof org.kie.dmn.model.api.BusinessKnowledgeModel) {
+                org.kie.dmn.model.api.BusinessKnowledgeModel bkm = (org.kie.dmn.model.api.BusinessKnowledgeModel) elem;
+                for (org.kie.dmn.model.api.KnowledgeRequirement kr : bkm.getKnowledgeRequirement()) {
                     String reqInputID = getId(kr.getRequiredKnowledge());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -221,7 +221,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-                for (org.kie.dmn.model.v1x.AuthorityRequirement kr : bkm.getAuthorityRequirement()) {
+                for (org.kie.dmn.model.api.AuthorityRequirement kr : bkm.getAuthorityRequirement()) {
                     String reqInputID = getId(kr.getRequiredAuthority());
                     Node requiredNode = elems.get(reqInputID).getValue();
                     Edge myEdge = factoryManager.newElement(UUID.uuid(),
@@ -231,9 +231,9 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                 currentNode);
                     setConnectionMagnets(myEdge);
                 }
-            } else if (elem instanceof org.kie.dmn.model.v1x.KnowledgeSource) {
-                org.kie.dmn.model.v1x.KnowledgeSource ks = (org.kie.dmn.model.v1x.KnowledgeSource) elem;
-                for (org.kie.dmn.model.v1x.AuthorityRequirement ir : ks.getAuthorityRequirement()) {
+            } else if (elem instanceof org.kie.dmn.model.api.KnowledgeSource) {
+                org.kie.dmn.model.api.KnowledgeSource ks = (org.kie.dmn.model.api.KnowledgeSource) elem;
+                for (org.kie.dmn.model.api.AuthorityRequirement ir : ks.getAuthorityRequirement()) {
                     if (ir.getRequiredInput() != null) {
                         String reqInputID = getId(ir.getRequiredInput());
                         Node requiredNode = elems.get(reqInputID).getValue();
@@ -268,14 +268,14 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
             }
         }
 
-        Map<String, Node<View<TextAnnotation>, ?>> textAnnotations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.v1x.TextAnnotation.class::isInstance).map(org.kie.dmn.model.v1x.TextAnnotation.class::cast)
-                                                                           .collect(Collectors.toMap(org.kie.dmn.model.v1x.TextAnnotation::getId,
+        Map<String, Node<View<TextAnnotation>, ?>> textAnnotations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.api.TextAnnotation.class::isInstance).map(org.kie.dmn.model.api.TextAnnotation.class::cast)
+                                                                           .collect(Collectors.toMap(org.kie.dmn.model.api.TextAnnotation::getId,
                                                                                                                                                                                                                                                    textAnnotationConverter::nodeFromDMN));
         textAnnotations.values().forEach(n -> ddExtAugmentStunner(dmnDDDiagram, n));
 
-        List<org.kie.dmn.model.v1x.Association> associations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.v1x.Association.class::isInstance).map(org.kie.dmn.model.v1x.Association.class::cast).collect(
+        List<org.kie.dmn.model.api.Association> associations = dmnXml.getArtifact().stream().filter(org.kie.dmn.model.api.Association.class::isInstance).map(org.kie.dmn.model.api.Association.class::cast).collect(
                                                                                                                                                                                                                     Collectors.toList());
-        for (org.kie.dmn.model.v1x.Association a : associations) {
+        for (org.kie.dmn.model.api.Association a : associations) {
             String sourceId = getId(a.getSourceRef());
             Node sourceNode = Optional.ofNullable(elems.get(sourceId)).map(Entry::getValue).orElse(textAnnotations.get(sourceId));
 
@@ -321,20 +321,20 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                     false).filter(n -> n.getContent().getDefinition() instanceof DMNDiagram).findFirst().orElseThrow(() -> new UnsupportedOperationException("TODO"));
     }
 
-    private String getId(org.kie.dmn.model.v1x.DMNElementReference er) {
+    private String getId(org.kie.dmn.model.api.DMNElementReference er) {
         String href = er.getHref();
         return href.contains("#") ? href.substring(href.indexOf('#') + 1) : href;
     }
 
-    private Node dmnToStunner(org.kie.dmn.model.v1x.DRGElement dmn) {
-        if (dmn instanceof org.kie.dmn.model.v1x.InputData) {
-            return inputDataConverter.nodeFromDMN((org.kie.dmn.model.v1x.InputData) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.Decision) {
-            return decisionConverter.nodeFromDMN((org.kie.dmn.model.v1x.Decision) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.BusinessKnowledgeModel) {
-            return bkmConverter.nodeFromDMN((org.kie.dmn.model.v1x.BusinessKnowledgeModel) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.KnowledgeSource) {
-            return knowledgeSourceConverter.nodeFromDMN((org.kie.dmn.model.v1x.KnowledgeSource) dmn);
+    private Node dmnToStunner(org.kie.dmn.model.api.DRGElement dmn) {
+        if (dmn instanceof org.kie.dmn.model.api.InputData) {
+            return inputDataConverter.nodeFromDMN((org.kie.dmn.model.api.InputData) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.Decision) {
+            return decisionConverter.nodeFromDMN((org.kie.dmn.model.api.Decision) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.BusinessKnowledgeModel) {
+            return bkmConverter.nodeFromDMN((org.kie.dmn.model.api.BusinessKnowledgeModel) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.KnowledgeSource) {
+            return knowledgeSourceConverter.nodeFromDMN((org.kie.dmn.model.api.KnowledgeSource) dmn);
         } else {
             throw new UnsupportedOperationException("TODO"); // TODO 
         }
@@ -380,13 +380,13 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
     public String marshall(final Diagram<Graph, Metadata> diagram) throws IOException {
         Graph<?, Node<View, ?>> g = diagram.getGraph();
 
-        Map<String, org.kie.dmn.model.v1x.DRGElement> nodes = new HashMap<>();
-        Map<String, org.kie.dmn.model.v1x.TextAnnotation> textAnnotations = new HashMap<>();
+        Map<String, org.kie.dmn.model.api.DRGElement> nodes = new HashMap<>();
+        Map<String, org.kie.dmn.model.api.TextAnnotation> textAnnotations = new HashMap<>();
 
         @SuppressWarnings("unchecked")
         Node<View<DMNDiagram>, ?> dmnDiagramRoot = (Node<View<DMNDiagram>, ?>) findDMNDiagramRoot(g);
         Definitions definitionsStunnerPojo = dmnDiagramRoot.getContent().getDefinition().getDefinitions();
-        org.kie.dmn.model.v1x.Definitions definitions = DefinitionsConverter.dmnFromWB(definitionsStunnerPojo);
+        org.kie.dmn.model.api.Definitions definitions = DefinitionsConverter.dmnFromWB(definitionsStunnerPojo);
         if (definitions.getExtensionElements() == null) {
             if (definitions instanceof org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase) {
                 definitions.setExtensionElements(new org.kie.dmn.model.v1_1.TDMNElement.TExtensionElements());
@@ -413,7 +413,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                                         textAnnotationConverter.dmnFromNode((Node<View<TextAnnotation>, ?>) node));
                     dmnDDDMNDiagram.getAny().add(stunnerToDDExt((View<? extends DMNElement>) view));
 
-                    List<org.kie.dmn.model.v1x.Association> associations = AssociationConverter.dmnFromWB((Node<View<TextAnnotation>, ?>) node);
+                    List<org.kie.dmn.model.api.Association> associations = AssociationConverter.dmnFromWB((Node<View<TextAnnotation>, ?>) node);
                     definitions.getArtifact().addAll(associations);
                 }
             }
@@ -542,7 +542,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         }
     }
 
-    private org.kie.dmn.model.v1x.DRGElement stunnerToDMN(final Node<?, ?> node) {
+    private org.kie.dmn.model.api.DRGElement stunnerToDMN(final Node<?, ?> node) {
         if (node.getContent() instanceof View<?>) {
             View<?> view = (View<?>) node.getContent();
             if (view.getDefinition() instanceof InputData) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
@@ -28,12 +28,12 @@ import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 public class AssociationConverter {
 
-    public static List<org.kie.dmn.model.v1_1.Association> dmnFromWB(final Node<View<TextAnnotation>, ?> node) {
+    public static List<org.kie.dmn.model.v1x.Association> dmnFromWB(final Node<View<TextAnnotation>, ?> node) {
         TextAnnotation ta = node.getContent().getDefinition();
-        org.kie.dmn.model.v1_1.DMNElementReference ta_elementReference = new org.kie.dmn.model.v1_1.DMNElementReference();
+        org.kie.dmn.model.v1x.DMNElementReference ta_elementReference = new org.kie.dmn.model.v1_1.TDMNElementReference();
         ta_elementReference.setHref(new StringBuilder("#").append(ta.getId().getValue()).toString());
 
-        List<org.kie.dmn.model.v1_1.Association> result = new ArrayList<>();
+        List<org.kie.dmn.model.v1x.Association> result = new ArrayList<>();
 
         List<Edge<?, ?>> inEdges = (List<Edge<?, ?>>) node.getInEdges();
         for (Edge<?, ?> e : inEdges) {
@@ -42,10 +42,10 @@ public class AssociationConverter {
                 View<?> view = (View<?>) sourceNode.getContent();
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
-                    org.kie.dmn.model.v1_1.DMNElementReference sourceRef = new org.kie.dmn.model.v1_1.DMNElementReference();
+                    org.kie.dmn.model.v1x.DMNElementReference sourceRef = new org.kie.dmn.model.v1_1.TDMNElementReference();
                     sourceRef.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
 
-                    org.kie.dmn.model.v1_1.Association adding = new org.kie.dmn.model.v1_1.Association();
+                    org.kie.dmn.model.v1x.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
                     adding.setId(((View<Association>) e.getContent()).getDefinition().getId().getValue());
                     adding.setDescription(((View<Association>) e.getContent()).getDefinition().getDescription().getValue());
                     adding.setSourceRef(sourceRef);
@@ -61,10 +61,10 @@ public class AssociationConverter {
                 View<?> view = (View<?>) targetNode.getContent();
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
-                    org.kie.dmn.model.v1_1.DMNElementReference targetRef = new org.kie.dmn.model.v1_1.DMNElementReference();
+                    org.kie.dmn.model.v1x.DMNElementReference targetRef = new org.kie.dmn.model.v1_1.TDMNElementReference();
                     targetRef.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
 
-                    org.kie.dmn.model.v1_1.Association adding = new org.kie.dmn.model.v1_1.Association();
+                    org.kie.dmn.model.v1x.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
                     adding.setId(((View<Association>) e.getContent()).getDefinition().getId().getValue());
                     adding.setDescription(((View<Association>) e.getContent()).getDefinition().getDescription().getValue());
                     adding.setSourceRef(ta_elementReference);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
@@ -28,12 +28,12 @@ import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 public class AssociationConverter {
 
-    public static List<org.kie.dmn.model.v1x.Association> dmnFromWB(final Node<View<TextAnnotation>, ?> node) {
+    public static List<org.kie.dmn.model.api.Association> dmnFromWB(final Node<View<TextAnnotation>, ?> node) {
         TextAnnotation ta = node.getContent().getDefinition();
-        org.kie.dmn.model.v1x.DMNElementReference ta_elementReference = new org.kie.dmn.model.v1_1.TDMNElementReference();
+        org.kie.dmn.model.api.DMNElementReference ta_elementReference = new org.kie.dmn.model.v1_1.TDMNElementReference();
         ta_elementReference.setHref(new StringBuilder("#").append(ta.getId().getValue()).toString());
 
-        List<org.kie.dmn.model.v1x.Association> result = new ArrayList<>();
+        List<org.kie.dmn.model.api.Association> result = new ArrayList<>();
 
         List<Edge<?, ?>> inEdges = (List<Edge<?, ?>>) node.getInEdges();
         for (Edge<?, ?> e : inEdges) {
@@ -42,10 +42,10 @@ public class AssociationConverter {
                 View<?> view = (View<?>) sourceNode.getContent();
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
-                    org.kie.dmn.model.v1x.DMNElementReference sourceRef = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                    org.kie.dmn.model.api.DMNElementReference sourceRef = new org.kie.dmn.model.v1_1.TDMNElementReference();
                     sourceRef.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
 
-                    org.kie.dmn.model.v1x.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
+                    org.kie.dmn.model.api.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
                     adding.setId(((View<Association>) e.getContent()).getDefinition().getId().getValue());
                     adding.setDescription(((View<Association>) e.getContent()).getDefinition().getDescription().getValue());
                     adding.setSourceRef(sourceRef);
@@ -61,10 +61,10 @@ public class AssociationConverter {
                 View<?> view = (View<?>) targetNode.getContent();
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
-                    org.kie.dmn.model.v1x.DMNElementReference targetRef = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                    org.kie.dmn.model.api.DMNElementReference targetRef = new org.kie.dmn.model.v1_1.TDMNElementReference();
                     targetRef.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
 
-                    org.kie.dmn.model.v1x.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
+                    org.kie.dmn.model.api.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
                     adding.setId(((View<Association>) e.getContent()).getDefinition().getId().getValue());
                     adding.setDescription(((View<Association>) e.getContent()).getDefinition().getDescription().getValue());
                     adding.setSourceRef(ta_elementReference);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 
 public class BindingPropertyConverter {
 
-    public static Binding wbFromDMN(final org.kie.dmn.model.v1x.Binding dmn) {
+    public static Binding wbFromDMN(final org.kie.dmn.model.api.Binding dmn) {
         if (dmn == null) {
             return null;
         }
@@ -35,11 +35,11 @@ public class BindingPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.Binding dmnFromWB(final Binding wb) {
+    public static org.kie.dmn.model.api.Binding dmnFromWB(final Binding wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.Binding result = new org.kie.dmn.model.v1_1.TBinding();
+        org.kie.dmn.model.api.Binding result = new org.kie.dmn.model.v1_1.TBinding();
         result.setParameter(InformationItemPropertyConverter.dmnFromWB(wb.getParameter()));
         result.setExpression(ExpressionPropertyConverter.dmnFromWB(wb.getExpression()));
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 
 public class BindingPropertyConverter {
 
-    public static Binding wbFromDMN(final org.kie.dmn.model.v1_1.Binding dmn) {
+    public static Binding wbFromDMN(final org.kie.dmn.model.v1x.Binding dmn) {
         if (dmn == null) {
             return null;
         }
@@ -35,11 +35,11 @@ public class BindingPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.Binding dmnFromWB(final Binding wb) {
+    public static org.kie.dmn.model.v1x.Binding dmnFromWB(final Binding wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.Binding result = new org.kie.dmn.model.v1_1.Binding();
+        org.kie.dmn.model.v1x.Binding result = new org.kie.dmn.model.v1_1.TBinding();
         result.setParameter(InformationItemPropertyConverter.dmnFromWB(wb.getParameter()));
         result.setExpression(ExpressionPropertyConverter.dmnFromWB(wb.getExpression()));
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dmn.model.v1_1.BusinessKnowledgeModel, org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel> {
+public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dmn.model.v1x.BusinessKnowledgeModel, org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel> {
 
     private FactoryManager factoryManager;
 
@@ -44,7 +44,7 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
     }
 
     @Override
-    public Node<View<BusinessKnowledgeModel>, ?> nodeFromDMN(final org.kie.dmn.model.v1_1.BusinessKnowledgeModel dmn) {
+    public Node<View<BusinessKnowledgeModel>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.BusinessKnowledgeModel dmn) {
         @SuppressWarnings("unchecked")
         Node<View<BusinessKnowledgeModel>, ?> node = (Node<View<BusinessKnowledgeModel>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                                        BusinessKnowledgeModel.class).asNode();
@@ -66,9 +66,9 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
     }
 
     @Override
-    public org.kie.dmn.model.v1_1.BusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node) {
+    public org.kie.dmn.model.v1x.BusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node) {
         BusinessKnowledgeModel source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1_1.BusinessKnowledgeModel result = new org.kie.dmn.model.v1_1.BusinessKnowledgeModel();
+        org.kie.dmn.model.v1x.BusinessKnowledgeModel result = new org.kie.dmn.model.v1_1.TBusinessKnowledgeModel();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());
@@ -83,14 +83,14 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
                     if (drgElement instanceof BusinessKnowledgeModel) {
-                        org.kie.dmn.model.v1_1.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.KnowledgeRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.TKnowledgeRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredKnowledge(ri);
                         result.getKnowledgeRequirement().add(iReq);
                     } else if (drgElement instanceof KnowledgeSource) {
-                        org.kie.dmn.model.v1_1.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.AuthorityRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredAuthority(ri);
                         result.getAuthorityRequirement().add(iReq);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dmn.model.v1x.BusinessKnowledgeModel, org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel> {
+public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dmn.model.api.BusinessKnowledgeModel, org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel> {
 
     private FactoryManager factoryManager;
 
@@ -44,7 +44,7 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
     }
 
     @Override
-    public Node<View<BusinessKnowledgeModel>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.BusinessKnowledgeModel dmn) {
+    public Node<View<BusinessKnowledgeModel>, ?> nodeFromDMN(final org.kie.dmn.model.api.BusinessKnowledgeModel dmn) {
         @SuppressWarnings("unchecked")
         Node<View<BusinessKnowledgeModel>, ?> node = (Node<View<BusinessKnowledgeModel>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                                        BusinessKnowledgeModel.class).asNode();
@@ -66,9 +66,9 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
     }
 
     @Override
-    public org.kie.dmn.model.v1x.BusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node) {
+    public org.kie.dmn.model.api.BusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node) {
         BusinessKnowledgeModel source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1x.BusinessKnowledgeModel result = new org.kie.dmn.model.v1_1.TBusinessKnowledgeModel();
+        org.kie.dmn.model.api.BusinessKnowledgeModel result = new org.kie.dmn.model.v1_1.TBusinessKnowledgeModel();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());
@@ -83,14 +83,14 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
                     if (drgElement instanceof BusinessKnowledgeModel) {
-                        org.kie.dmn.model.v1x.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.TKnowledgeRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.TKnowledgeRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredKnowledge(ri);
                         result.getKnowledgeRequirement().add(iReq);
                     } else if (drgElement instanceof KnowledgeSource) {
-                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredAuthority(ri);
                         result.getAuthorityRequirement().add(iReq);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 
 public class ContextEntryPropertyConverter {
 
-    public static ContextEntry wbFromDMN(final org.kie.dmn.model.v1_1.ContextEntry dmn) {
+    public static ContextEntry wbFromDMN(final org.kie.dmn.model.v1x.ContextEntry dmn) {
         InformationItem variable = InformationItemPropertyConverter.wbFromDMN(dmn.getVariable());
         Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
 
@@ -32,11 +32,11 @@ public class ContextEntryPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.ContextEntry dmnFromWB(final ContextEntry wb) {
-        org.kie.dmn.model.v1_1.ContextEntry result = new org.kie.dmn.model.v1_1.ContextEntry();
+    public static org.kie.dmn.model.v1x.ContextEntry dmnFromWB(final ContextEntry wb) {
+        org.kie.dmn.model.v1x.ContextEntry result = new org.kie.dmn.model.v1_1.TContextEntry();
 
-        org.kie.dmn.model.v1_1.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
-        org.kie.dmn.model.v1_1.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        org.kie.dmn.model.v1x.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
+        org.kie.dmn.model.v1x.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
 
         result.setVariable(variable);
         result.setExpression(expression);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 
 public class ContextEntryPropertyConverter {
 
-    public static ContextEntry wbFromDMN(final org.kie.dmn.model.v1x.ContextEntry dmn) {
+    public static ContextEntry wbFromDMN(final org.kie.dmn.model.api.ContextEntry dmn) {
         InformationItem variable = InformationItemPropertyConverter.wbFromDMN(dmn.getVariable());
         Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
 
@@ -32,11 +32,11 @@ public class ContextEntryPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.ContextEntry dmnFromWB(final ContextEntry wb) {
-        org.kie.dmn.model.v1x.ContextEntry result = new org.kie.dmn.model.v1_1.TContextEntry();
+    public static org.kie.dmn.model.api.ContextEntry dmnFromWB(final ContextEntry wb) {
+        org.kie.dmn.model.api.ContextEntry result = new org.kie.dmn.model.v1_1.TContextEntry();
 
-        org.kie.dmn.model.v1x.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
-        org.kie.dmn.model.v1x.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        org.kie.dmn.model.api.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
+        org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
 
         result.setVariable(variable);
         result.setExpression(expression);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
@@ -24,28 +24,28 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class ContextPropertyConverter {
 
-    public static Context wbFromDMN(final org.kie.dmn.model.v1_1.Context dmn) {
+    public static Context wbFromDMN(final org.kie.dmn.model.v1x.Context dmn) {
         Id id = new Id(dmn.getId());
         Description description = new Description(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
         Context result = new Context(id,
                                      description,
                                      typeRef);
-        for (org.kie.dmn.model.v1_1.ContextEntry ce : dmn.getContextEntry()) {
+        for (org.kie.dmn.model.v1x.ContextEntry ce : dmn.getContextEntry()) {
             ContextEntry ceConverted = ContextEntryPropertyConverter.wbFromDMN(ce);
             result.getContextEntry().add(ceConverted);
         }
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.Context dmnFromWB(final Context wb) {
-        org.kie.dmn.model.v1_1.Context result = new org.kie.dmn.model.v1_1.Context();
+    public static org.kie.dmn.model.v1x.Context dmnFromWB(final Context wb) {
+        org.kie.dmn.model.v1x.Context result = new org.kie.dmn.model.v1_1.TContext();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
         for (ContextEntry ce : wb.getContextEntry()) {
-            org.kie.dmn.model.v1_1.ContextEntry ceConverted = ContextEntryPropertyConverter.dmnFromWB(ce);
+            org.kie.dmn.model.v1x.ContextEntry ceConverted = ContextEntryPropertyConverter.dmnFromWB(ce);
             result.getContextEntry().add(ceConverted);
         }
         return result;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
@@ -24,28 +24,28 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class ContextPropertyConverter {
 
-    public static Context wbFromDMN(final org.kie.dmn.model.v1x.Context dmn) {
+    public static Context wbFromDMN(final org.kie.dmn.model.api.Context dmn) {
         Id id = new Id(dmn.getId());
         Description description = new Description(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
         Context result = new Context(id,
                                      description,
                                      typeRef);
-        for (org.kie.dmn.model.v1x.ContextEntry ce : dmn.getContextEntry()) {
+        for (org.kie.dmn.model.api.ContextEntry ce : dmn.getContextEntry()) {
             ContextEntry ceConverted = ContextEntryPropertyConverter.wbFromDMN(ce);
             result.getContextEntry().add(ceConverted);
         }
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.Context dmnFromWB(final Context wb) {
-        org.kie.dmn.model.v1x.Context result = new org.kie.dmn.model.v1_1.TContext();
+    public static org.kie.dmn.model.api.Context dmnFromWB(final Context wb) {
+        org.kie.dmn.model.api.Context result = new org.kie.dmn.model.v1_1.TContext();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
         for (ContextEntry ce : wb.getContextEntry()) {
-            org.kie.dmn.model.v1x.ContextEntry ceConverted = ContextEntryPropertyConverter.dmnFromWB(ce);
+            org.kie.dmn.model.api.ContextEntry ceConverted = ContextEntryPropertyConverter.dmnFromWB(ce);
             result.getContextEntry().add(ceConverted);
         }
         return result;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
@@ -38,7 +38,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1_1.Decision, org.kie.workbench.common.dmn.api.definition.v1_1.Decision> {
+public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1x.Decision, org.kie.workbench.common.dmn.api.definition.v1_1.Decision> {
 
     private FactoryManager factoryManager;
 
@@ -48,7 +48,7 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1_1.D
     }
 
     @Override
-    public Node<View<Decision>, ?> nodeFromDMN(final org.kie.dmn.model.v1_1.Decision dmn) {
+    public Node<View<Decision>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.Decision dmn) {
         @SuppressWarnings("unchecked")
         Node<View<Decision>, ?> node = (Node<View<Decision>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                            Decision.class).asNode();
@@ -72,9 +72,9 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1_1.D
     }
 
     @Override
-    public org.kie.dmn.model.v1_1.Decision dmnFromNode(final Node<View<Decision>, ?> node) {
+    public org.kie.dmn.model.v1x.Decision dmnFromNode(final Node<View<Decision>, ?> node) {
         Decision source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1_1.Decision d = new org.kie.dmn.model.v1_1.Decision();
+        org.kie.dmn.model.v1x.Decision d = new org.kie.dmn.model.v1_1.TDecision();
         d.setId(source.getId().getValue());
         d.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         d.setName(source.getName().getValue());
@@ -89,26 +89,26 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1_1.D
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
                     if (drgElement instanceof Decision) {
-                        org.kie.dmn.model.v1_1.InformationRequirement iReq = new org.kie.dmn.model.v1_1.InformationRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.InformationRequirement iReq = new org.kie.dmn.model.v1_1.TInformationRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredDecision(ri);
                         d.getInformationRequirement().add(iReq);
                     } else if (drgElement instanceof BusinessKnowledgeModel) {
-                        org.kie.dmn.model.v1_1.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.KnowledgeRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.TKnowledgeRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredKnowledge(ri);
                         d.getKnowledgeRequirement().add(iReq);
                     } else if (drgElement instanceof KnowledgeSource) {
-                        org.kie.dmn.model.v1_1.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.AuthorityRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredAuthority(ri);
                         d.getAuthorityRequirement().add(iReq);
                     } else if (drgElement instanceof InputData) {
-                        org.kie.dmn.model.v1_1.InformationRequirement iReq = new org.kie.dmn.model.v1_1.InformationRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.InformationRequirement iReq = new org.kie.dmn.model.v1_1.TInformationRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredInput(ri);
                         d.getInformationRequirement().add(iReq);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
@@ -38,7 +38,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1x.Decision, org.kie.workbench.common.dmn.api.definition.v1_1.Decision> {
+public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.Decision, org.kie.workbench.common.dmn.api.definition.v1_1.Decision> {
 
     private FactoryManager factoryManager;
 
@@ -48,7 +48,7 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1x.De
     }
 
     @Override
-    public Node<View<Decision>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.Decision dmn) {
+    public Node<View<Decision>, ?> nodeFromDMN(final org.kie.dmn.model.api.Decision dmn) {
         @SuppressWarnings("unchecked")
         Node<View<Decision>, ?> node = (Node<View<Decision>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                            Decision.class).asNode();
@@ -72,9 +72,9 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1x.De
     }
 
     @Override
-    public org.kie.dmn.model.v1x.Decision dmnFromNode(final Node<View<Decision>, ?> node) {
+    public org.kie.dmn.model.api.Decision dmnFromNode(final Node<View<Decision>, ?> node) {
         Decision source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1x.Decision d = new org.kie.dmn.model.v1_1.TDecision();
+        org.kie.dmn.model.api.Decision d = new org.kie.dmn.model.v1_1.TDecision();
         d.setId(source.getId().getValue());
         d.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         d.setName(source.getName().getValue());
@@ -89,26 +89,26 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.v1x.De
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
                     if (drgElement instanceof Decision) {
-                        org.kie.dmn.model.v1x.InformationRequirement iReq = new org.kie.dmn.model.v1_1.TInformationRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.InformationRequirement iReq = new org.kie.dmn.model.v1_1.TInformationRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredDecision(ri);
                         d.getInformationRequirement().add(iReq);
                     } else if (drgElement instanceof BusinessKnowledgeModel) {
-                        org.kie.dmn.model.v1x.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.TKnowledgeRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.KnowledgeRequirement iReq = new org.kie.dmn.model.v1_1.TKnowledgeRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredKnowledge(ri);
                         d.getKnowledgeRequirement().add(iReq);
                     } else if (drgElement instanceof KnowledgeSource) {
-                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredAuthority(ri);
                         d.getAuthorityRequirement().add(iReq);
                     } else if (drgElement instanceof InputData) {
-                        org.kie.dmn.model.v1x.InformationRequirement iReq = new org.kie.dmn.model.v1_1.TInformationRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.InformationRequirement iReq = new org.kie.dmn.model.v1_1.TInformationRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredInput(ri);
                         d.getInformationRequirement().add(iReq);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 
 public class DecisionRulePropertyConverter {
 
-    public static DecisionRule wbFromDMN(final org.kie.dmn.model.v1x.DecisionRule dmn) {
+    public static DecisionRule wbFromDMN(final org.kie.dmn.model.api.DecisionRule dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         
@@ -32,18 +32,18 @@ public class DecisionRulePropertyConverter {
         result.setId(id);
         result.setDescription(description);
 
-        for (org.kie.dmn.model.v1x.UnaryTests ie : dmn.getInputEntry()) {
+        for (org.kie.dmn.model.api.UnaryTests ie : dmn.getInputEntry()) {
             result.getInputEntry().add(UnaryTestsPropertyConverter.wbFromDMN(ie));
         }
-        for (org.kie.dmn.model.v1x.LiteralExpression oe : dmn.getOutputEntry()) {
+        for (org.kie.dmn.model.api.LiteralExpression oe : dmn.getOutputEntry()) {
             result.getOutputEntry().add(LiteralExpressionPropertyConverter.wbFromDMN(oe));
         }
 
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.DecisionRule dmnFromWB(final DecisionRule wb) {
-        org.kie.dmn.model.v1x.DecisionRule result = new org.kie.dmn.model.v1_1.TDecisionRule();
+    public static org.kie.dmn.model.api.DecisionRule dmnFromWB(final DecisionRule wb) {
+        org.kie.dmn.model.api.DecisionRule result = new org.kie.dmn.model.v1_1.TDecisionRule();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 
 public class DecisionRulePropertyConverter {
 
-    public static DecisionRule wbFromDMN(final org.kie.dmn.model.v1_1.DecisionRule dmn) {
+    public static DecisionRule wbFromDMN(final org.kie.dmn.model.v1x.DecisionRule dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         
@@ -32,18 +32,18 @@ public class DecisionRulePropertyConverter {
         result.setId(id);
         result.setDescription(description);
 
-        for (org.kie.dmn.model.v1_1.UnaryTests ie : dmn.getInputEntry()) {
+        for (org.kie.dmn.model.v1x.UnaryTests ie : dmn.getInputEntry()) {
             result.getInputEntry().add(UnaryTestsPropertyConverter.wbFromDMN(ie));
         }
-        for (org.kie.dmn.model.v1_1.LiteralExpression oe : dmn.getOutputEntry()) {
+        for (org.kie.dmn.model.v1x.LiteralExpression oe : dmn.getOutputEntry()) {
             result.getOutputEntry().add(LiteralExpressionPropertyConverter.wbFromDMN(oe));
         }
 
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.DecisionRule dmnFromWB(final DecisionRule wb) {
-        org.kie.dmn.model.v1_1.DecisionRule result = new org.kie.dmn.model.v1_1.DecisionRule();
+    public static org.kie.dmn.model.v1x.DecisionRule dmnFromWB(final DecisionRule wb) {
+        org.kie.dmn.model.v1x.DecisionRule result = new org.kie.dmn.model.v1_1.TDecisionRule();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionTablePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionTablePropertyConverter.java
@@ -29,7 +29,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class DecisionTablePropertyConverter {
 
-    public static DecisionTable wbFromDMN(final org.kie.dmn.model.v1_1.DecisionTable dmn) {
+    public static DecisionTable wbFromDMN(final org.kie.dmn.model.v1x.DecisionTable dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
@@ -39,13 +39,13 @@ public class DecisionTablePropertyConverter {
         result.setDescription(description);
         result.setTypeRef(typeRef);
 
-        for (org.kie.dmn.model.v1_1.InputClause input : dmn.getInput()) {
+        for (org.kie.dmn.model.v1x.InputClause input : dmn.getInput()) {
             result.getInput().add(InputClausePropertyConverter.wbFromDMN(input));
         }
-        for (org.kie.dmn.model.v1_1.OutputClause input : dmn.getOutput()) {
+        for (org.kie.dmn.model.v1x.OutputClause input : dmn.getOutput()) {
             result.getOutput().add(OutputClausePropertyConverter.wbFromDMN(input));
         }
-        for (org.kie.dmn.model.v1_1.DecisionRule dr : dmn.getRule()) {
+        for (org.kie.dmn.model.v1x.DecisionRule dr : dmn.getRule()) {
             result.getRule().add(DecisionRulePropertyConverter.wbFromDMN(dr));
         }
         if (dmn.getHitPolicy() != null) {
@@ -63,8 +63,8 @@ public class DecisionTablePropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.DecisionTable dmnFromWB(final DecisionTable wb) {
-        org.kie.dmn.model.v1_1.DecisionTable result = new org.kie.dmn.model.v1_1.DecisionTable();
+    public static org.kie.dmn.model.v1x.DecisionTable dmnFromWB(final DecisionTable wb) {
+        org.kie.dmn.model.v1x.DecisionTable result = new org.kie.dmn.model.v1_1.TDecisionTable();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(), result::setTypeRef);
@@ -79,13 +79,13 @@ public class DecisionTablePropertyConverter {
             result.getRule().add(DecisionRulePropertyConverter.dmnFromWB(dr));
         }
         if (wb.getHitPolicy() != null) {
-            result.setHitPolicy(org.kie.dmn.model.v1_1.HitPolicy.fromValue(wb.getHitPolicy().value()));
+            result.setHitPolicy(org.kie.dmn.model.v1x.HitPolicy.fromValue(wb.getHitPolicy().value()));
         }
         if (wb.getAggregation() != null) {
-            result.setAggregation(org.kie.dmn.model.v1_1.BuiltinAggregator.fromValue(wb.getAggregation().value()));
+            result.setAggregation(org.kie.dmn.model.v1x.BuiltinAggregator.fromValue(wb.getAggregation().value()));
         }
         if (wb.getPreferredOrientation() != null) {
-            result.setPreferredOrientation(org.kie.dmn.model.v1_1.DecisionTableOrientation.fromValue(wb.getPreferredOrientation().value()));
+            result.setPreferredOrientation(org.kie.dmn.model.v1x.DecisionTableOrientation.fromValue(wb.getPreferredOrientation().value()));
         }
 
         result.setOutputLabel(wb.getOutputLabel());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionTablePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionTablePropertyConverter.java
@@ -29,7 +29,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class DecisionTablePropertyConverter {
 
-    public static DecisionTable wbFromDMN(final org.kie.dmn.model.v1x.DecisionTable dmn) {
+    public static DecisionTable wbFromDMN(final org.kie.dmn.model.api.DecisionTable dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
@@ -39,13 +39,13 @@ public class DecisionTablePropertyConverter {
         result.setDescription(description);
         result.setTypeRef(typeRef);
 
-        for (org.kie.dmn.model.v1x.InputClause input : dmn.getInput()) {
+        for (org.kie.dmn.model.api.InputClause input : dmn.getInput()) {
             result.getInput().add(InputClausePropertyConverter.wbFromDMN(input));
         }
-        for (org.kie.dmn.model.v1x.OutputClause input : dmn.getOutput()) {
+        for (org.kie.dmn.model.api.OutputClause input : dmn.getOutput()) {
             result.getOutput().add(OutputClausePropertyConverter.wbFromDMN(input));
         }
-        for (org.kie.dmn.model.v1x.DecisionRule dr : dmn.getRule()) {
+        for (org.kie.dmn.model.api.DecisionRule dr : dmn.getRule()) {
             result.getRule().add(DecisionRulePropertyConverter.wbFromDMN(dr));
         }
         if (dmn.getHitPolicy() != null) {
@@ -63,8 +63,8 @@ public class DecisionTablePropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.DecisionTable dmnFromWB(final DecisionTable wb) {
-        org.kie.dmn.model.v1x.DecisionTable result = new org.kie.dmn.model.v1_1.TDecisionTable();
+    public static org.kie.dmn.model.api.DecisionTable dmnFromWB(final DecisionTable wb) {
+        org.kie.dmn.model.api.DecisionTable result = new org.kie.dmn.model.v1_1.TDecisionTable();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(), result::setTypeRef);
@@ -79,13 +79,13 @@ public class DecisionTablePropertyConverter {
             result.getRule().add(DecisionRulePropertyConverter.dmnFromWB(dr));
         }
         if (wb.getHitPolicy() != null) {
-            result.setHitPolicy(org.kie.dmn.model.v1x.HitPolicy.fromValue(wb.getHitPolicy().value()));
+            result.setHitPolicy(org.kie.dmn.model.api.HitPolicy.fromValue(wb.getHitPolicy().value()));
         }
         if (wb.getAggregation() != null) {
-            result.setAggregation(org.kie.dmn.model.v1x.BuiltinAggregator.fromValue(wb.getAggregation().value()));
+            result.setAggregation(org.kie.dmn.model.api.BuiltinAggregator.fromValue(wb.getAggregation().value()));
         }
         if (wb.getPreferredOrientation() != null) {
-            result.setPreferredOrientation(org.kie.dmn.model.v1x.DecisionTableOrientation.fromValue(wb.getPreferredOrientation().value()));
+            result.setPreferredOrientation(org.kie.dmn.model.api.DecisionTableOrientation.fromValue(wb.getPreferredOrientation().value()));
         }
 
         result.setOutputLabel(wb.getOutputLabel());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
@@ -27,7 +27,7 @@ import org.kie.workbench.common.stunner.core.util.UUID;
 
 public class DefinitionsConverter {
 
-    public static Definitions wbFromDMN(final org.kie.dmn.model.v1x.Definitions dmn) {
+    public static Definitions wbFromDMN(final org.kie.dmn.model.api.Definitions dmn) {
         if (dmn == null) {
             return null;
         }
@@ -42,23 +42,23 @@ public class DefinitionsConverter {
         result.setDescription(description);
         result.getNsContext().putAll(dmn.getNsContext());
 
-        for (org.kie.dmn.model.v1x.ItemDefinition itemDef : dmn.getItemDefinition()) {
+        for (org.kie.dmn.model.api.ItemDefinition itemDef : dmn.getItemDefinition()) {
             ItemDefinition itemDefConvered = ItemDefinitionPropertyConverter.wbFromDMN(itemDef);
             result.getItemDefinition().add(itemDefConvered);
         }
 
-        for (org.kie.dmn.model.v1x.Import i : dmn.getImport()) {
+        for (org.kie.dmn.model.api.Import i : dmn.getImport()) {
             result.getImport().add(ImportConverter.nodeFromDMN(i));
         }
 
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.Definitions dmnFromWB(final Definitions wb) {
+    public static org.kie.dmn.model.api.Definitions dmnFromWB(final Definitions wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.Definitions result = new org.kie.dmn.model.v1_1.TDefinitions();
+        org.kie.dmn.model.api.Definitions result = new org.kie.dmn.model.v1_1.TDefinitions();
 
         // TODO currently DMN wb UI does not offer feature to set these required DMN properties, setting some hardcoded defaults for now.
         String defaultId = (wb.getId() != null) ? wb.getId().getValue() : UUID.uuid();
@@ -72,7 +72,7 @@ public class DefinitionsConverter {
         result.getNsContext().putAll(wb.getNsContext());
 
         for (ItemDefinition itemDef : wb.getItemDefinition()) {
-            org.kie.dmn.model.v1x.ItemDefinition itemDefConvered = ItemDefinitionPropertyConverter.dmnFromWB(itemDef);
+            org.kie.dmn.model.api.ItemDefinition itemDefConvered = ItemDefinitionPropertyConverter.dmnFromWB(itemDef);
             result.getItemDefinition().add(itemDefConvered);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
@@ -27,7 +27,7 @@ import org.kie.workbench.common.stunner.core.util.UUID;
 
 public class DefinitionsConverter {
 
-    public static Definitions wbFromDMN(final org.kie.dmn.model.v1_1.Definitions dmn) {
+    public static Definitions wbFromDMN(final org.kie.dmn.model.v1x.Definitions dmn) {
         if (dmn == null) {
             return null;
         }
@@ -42,23 +42,23 @@ public class DefinitionsConverter {
         result.setDescription(description);
         result.getNsContext().putAll(dmn.getNsContext());
 
-        for (org.kie.dmn.model.v1_1.ItemDefinition itemDef : dmn.getItemDefinition()) {
+        for (org.kie.dmn.model.v1x.ItemDefinition itemDef : dmn.getItemDefinition()) {
             ItemDefinition itemDefConvered = ItemDefinitionPropertyConverter.wbFromDMN(itemDef);
             result.getItemDefinition().add(itemDefConvered);
         }
 
-        for (org.kie.dmn.model.v1_1.Import i : dmn.getImport()) {
+        for (org.kie.dmn.model.v1x.Import i : dmn.getImport()) {
             result.getImport().add(ImportConverter.nodeFromDMN(i));
         }
 
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.Definitions dmnFromWB(final Definitions wb) {
+    public static org.kie.dmn.model.v1x.Definitions dmnFromWB(final Definitions wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.Definitions result = new org.kie.dmn.model.v1_1.Definitions();
+        org.kie.dmn.model.v1x.Definitions result = new org.kie.dmn.model.v1_1.TDefinitions();
 
         // TODO currently DMN wb UI does not offer feature to set these required DMN properties, setting some hardcoded defaults for now.
         String defaultId = (wb.getId() != null) ? wb.getId().getValue() : UUID.uuid();
@@ -72,7 +72,7 @@ public class DefinitionsConverter {
         result.getNsContext().putAll(wb.getNsContext());
 
         for (ItemDefinition itemDef : wb.getItemDefinition()) {
-            org.kie.dmn.model.v1_1.ItemDefinition itemDefConvered = ItemDefinitionPropertyConverter.dmnFromWB(itemDef);
+            org.kie.dmn.model.v1x.ItemDefinition itemDefConvered = ItemDefinitionPropertyConverter.dmnFromWB(itemDef);
             result.getItemDefinition().add(itemDefConvered);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
@@ -27,39 +27,39 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
 
 public class ExpressionPropertyConverter {
 
-    public static Expression wbFromDMN(final org.kie.dmn.model.v1x.Expression dmn) {
+    public static Expression wbFromDMN(final org.kie.dmn.model.api.Expression dmn) {
         // SPECIAL CASE: to represent a partially edited DMN file.
         // consider a LiteralExpression with null text as missing expression altogether.
-        if (dmn instanceof org.kie.dmn.model.v1x.LiteralExpression) {
-            org.kie.dmn.model.v1x.LiteralExpression literalExpression = (org.kie.dmn.model.v1x.LiteralExpression) dmn;
+        if (dmn instanceof org.kie.dmn.model.api.LiteralExpression) {
+            org.kie.dmn.model.api.LiteralExpression literalExpression = (org.kie.dmn.model.api.LiteralExpression) dmn;
             if (literalExpression.getText() == null) {
                 return null;
             }
         }
 
-        if (dmn instanceof org.kie.dmn.model.v1x.LiteralExpression) {
-            return LiteralExpressionPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.LiteralExpression) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.Context) {
-            return ContextPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.Context) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.Relation) {
-            return RelationPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.Relation) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.List) {
-            return ListPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.List) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.Invocation) {
-            return InvocationPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.Invocation) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.FunctionDefinition) {
-            return FunctionDefinitionPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.FunctionDefinition) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1x.DecisionTable) {
-            return DecisionTablePropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.DecisionTable) dmn);
+        if (dmn instanceof org.kie.dmn.model.api.LiteralExpression) {
+            return LiteralExpressionPropertyConverter.wbFromDMN((org.kie.dmn.model.api.LiteralExpression) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.Context) {
+            return ContextPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Context) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.Relation) {
+            return RelationPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Relation) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.List) {
+            return ListPropertyConverter.wbFromDMN((org.kie.dmn.model.api.List) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.Invocation) {
+            return InvocationPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Invocation) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.FunctionDefinition) {
+            return FunctionDefinitionPropertyConverter.wbFromDMN((org.kie.dmn.model.api.FunctionDefinition) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.api.DecisionTable) {
+            return DecisionTablePropertyConverter.wbFromDMN((org.kie.dmn.model.api.DecisionTable) dmn);
         }
         return null;
     }
 
-    public static org.kie.dmn.model.v1x.Expression dmnFromWB(final Expression wb) {
+    public static org.kie.dmn.model.api.Expression dmnFromWB(final Expression wb) {
         // SPECIAL CASE: to represent a partially edited DMN file.
         // reference above.
         if (wb == null) {
-            org.kie.dmn.model.v1x.LiteralExpression mockedExpression = new org.kie.dmn.model.v1_1.TLiteralExpression();
+            org.kie.dmn.model.api.LiteralExpression mockedExpression = new org.kie.dmn.model.v1_1.TLiteralExpression();
             return mockedExpression;
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
@@ -27,39 +27,39 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
 
 public class ExpressionPropertyConverter {
 
-    public static Expression wbFromDMN(final org.kie.dmn.model.v1_1.Expression dmn) {
+    public static Expression wbFromDMN(final org.kie.dmn.model.v1x.Expression dmn) {
         // SPECIAL CASE: to represent a partially edited DMN file.
         // consider a LiteralExpression with null text as missing expression altogether.
-        if (dmn instanceof org.kie.dmn.model.v1_1.LiteralExpression) {
-            org.kie.dmn.model.v1_1.LiteralExpression literalExpression = (org.kie.dmn.model.v1_1.LiteralExpression) dmn;
+        if (dmn instanceof org.kie.dmn.model.v1x.LiteralExpression) {
+            org.kie.dmn.model.v1x.LiteralExpression literalExpression = (org.kie.dmn.model.v1x.LiteralExpression) dmn;
             if (literalExpression.getText() == null) {
                 return null;
             }
         }
 
-        if (dmn instanceof org.kie.dmn.model.v1_1.LiteralExpression) {
-            return LiteralExpressionPropertyConverter.wbFromDMN((org.kie.dmn.model.v1_1.LiteralExpression) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.Context) {
-            return ContextPropertyConverter.wbFromDMN((org.kie.dmn.model.v1_1.Context) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.Relation) {
-            return RelationPropertyConverter.wbFromDMN((org.kie.dmn.model.v1_1.Relation) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.List) {
-            return ListPropertyConverter.wbFromDMN((org.kie.dmn.model.v1_1.List) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.Invocation) {
-            return InvocationPropertyConverter.wbFromDMN((org.kie.dmn.model.v1_1.Invocation) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.FunctionDefinition) {
-            return FunctionDefinitionPropertyConverter.wbFromDMN((org.kie.dmn.model.v1_1.FunctionDefinition) dmn);
-        } else if (dmn instanceof org.kie.dmn.model.v1_1.DecisionTable) {
-            return DecisionTablePropertyConverter.wbFromDMN((org.kie.dmn.model.v1_1.DecisionTable) dmn);
+        if (dmn instanceof org.kie.dmn.model.v1x.LiteralExpression) {
+            return LiteralExpressionPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.LiteralExpression) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.Context) {
+            return ContextPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.Context) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.Relation) {
+            return RelationPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.Relation) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.List) {
+            return ListPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.List) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.Invocation) {
+            return InvocationPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.Invocation) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.FunctionDefinition) {
+            return FunctionDefinitionPropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.FunctionDefinition) dmn);
+        } else if (dmn instanceof org.kie.dmn.model.v1x.DecisionTable) {
+            return DecisionTablePropertyConverter.wbFromDMN((org.kie.dmn.model.v1x.DecisionTable) dmn);
         }
         return null;
     }
 
-    public static org.kie.dmn.model.v1_1.Expression dmnFromWB(final Expression wb) {
+    public static org.kie.dmn.model.v1x.Expression dmnFromWB(final Expression wb) {
         // SPECIAL CASE: to represent a partially edited DMN file.
         // reference above.
         if (wb == null) {
-            org.kie.dmn.model.v1_1.LiteralExpression mockedExpression = new org.kie.dmn.model.v1_1.LiteralExpression();
+            org.kie.dmn.model.v1x.LiteralExpression mockedExpression = new org.kie.dmn.model.v1_1.TLiteralExpression();
             return mockedExpression;
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
@@ -30,7 +30,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class FunctionDefinitionPropertyConverter {
 
-    public static FunctionDefinition wbFromDMN(final org.kie.dmn.model.v1x.FunctionDefinition dmn) {
+    public static FunctionDefinition wbFromDMN(final org.kie.dmn.model.api.FunctionDefinition dmn) {
         if (dmn == null) {
             return null;
         }
@@ -49,7 +49,7 @@ public class FunctionDefinitionPropertyConverter {
             result.getAdditionalAttributes().put(convertedQName, kv.getValue());
         }
 
-        for (org.kie.dmn.model.v1x.InformationItem ii : dmn.getFormalParameter()) {
+        for (org.kie.dmn.model.api.InformationItem ii : dmn.getFormalParameter()) {
             InformationItem iiConverted = InformationItemPropertyConverter.wbFromDMN(ii);
             result.getFormalParameter().add(iiConverted);
         }
@@ -57,11 +57,11 @@ public class FunctionDefinitionPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.FunctionDefinition dmnFromWB(final FunctionDefinition wb) {
+    public static org.kie.dmn.model.api.FunctionDefinition dmnFromWB(final FunctionDefinition wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.FunctionDefinition result = new org.kie.dmn.model.v1_1.TFunctionDefinition();
+        org.kie.dmn.model.api.FunctionDefinition result = new org.kie.dmn.model.v1_1.TFunctionDefinition();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
@@ -86,7 +86,7 @@ public class FunctionDefinitionPropertyConverter {
         }
 
         for (InformationItem ii : wb.getFormalParameter()) {
-            org.kie.dmn.model.v1x.InformationItem iiConverted = InformationItemPropertyConverter.dmnFromWB(ii);
+            org.kie.dmn.model.api.InformationItem iiConverted = InformationItemPropertyConverter.dmnFromWB(ii);
             result.getFormalParameter().add(iiConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
@@ -30,7 +30,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class FunctionDefinitionPropertyConverter {
 
-    public static FunctionDefinition wbFromDMN(final org.kie.dmn.model.v1_1.FunctionDefinition dmn) {
+    public static FunctionDefinition wbFromDMN(final org.kie.dmn.model.v1x.FunctionDefinition dmn) {
         if (dmn == null) {
             return null;
         }
@@ -49,7 +49,7 @@ public class FunctionDefinitionPropertyConverter {
             result.getAdditionalAttributes().put(convertedQName, kv.getValue());
         }
 
-        for (org.kie.dmn.model.v1_1.InformationItem ii : dmn.getFormalParameter()) {
+        for (org.kie.dmn.model.v1x.InformationItem ii : dmn.getFormalParameter()) {
             InformationItem iiConverted = InformationItemPropertyConverter.wbFromDMN(ii);
             result.getFormalParameter().add(iiConverted);
         }
@@ -57,11 +57,11 @@ public class FunctionDefinitionPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.FunctionDefinition dmnFromWB(final FunctionDefinition wb) {
+    public static org.kie.dmn.model.v1x.FunctionDefinition dmnFromWB(final FunctionDefinition wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.FunctionDefinition result = new org.kie.dmn.model.v1_1.FunctionDefinition();
+        org.kie.dmn.model.v1x.FunctionDefinition result = new org.kie.dmn.model.v1_1.TFunctionDefinition();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
@@ -86,7 +86,7 @@ public class FunctionDefinitionPropertyConverter {
         }
 
         for (InformationItem ii : wb.getFormalParameter()) {
-            org.kie.dmn.model.v1_1.InformationItem iiConverted = InformationItemPropertyConverter.dmnFromWB(ii);
+            org.kie.dmn.model.v1x.InformationItem iiConverted = InformationItemPropertyConverter.dmnFromWB(ii);
             result.getFormalParameter().add(iiConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public final class ImportConverter {
 
-  public static Import nodeFromDMN(org.kie.dmn.model.v1x.Import source) {
+  public static Import nodeFromDMN(org.kie.dmn.model.api.Import source) {
     LocationURI locationURI = new LocationURI(source.getLocationURI());
     Import result = new Import(source.getNamespace(), locationURI, source.getImportType());
     Map<QName, String> additionalAttributes = new HashMap<>();
@@ -35,8 +35,8 @@ public final class ImportConverter {
     return result;
   }
 
-  public static org.kie.dmn.model.v1x.Import dmnFromNode(Import source) {
-    org.kie.dmn.model.v1x.Import result = new org.kie.dmn.model.v1_1.TImport();
+  public static org.kie.dmn.model.api.Import dmnFromNode(Import source) {
+    org.kie.dmn.model.api.Import result = new org.kie.dmn.model.v1_1.TImport();
     result.setImportType(source.getImportType());
     result.setLocationURI(source.getLocationURI().getValue());
     result.setNamespace(source.getNamespace());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public final class ImportConverter {
 
-  public static Import nodeFromDMN(org.kie.dmn.model.v1_1.Import source) {
+  public static Import nodeFromDMN(org.kie.dmn.model.v1x.Import source) {
     LocationURI locationURI = new LocationURI(source.getLocationURI());
     Import result = new Import(source.getNamespace(), locationURI, source.getImportType());
     Map<QName, String> additionalAttributes = new HashMap<>();
@@ -35,8 +35,8 @@ public final class ImportConverter {
     return result;
   }
 
-  public static org.kie.dmn.model.v1_1.Import dmnFromNode(Import source) {
-    org.kie.dmn.model.v1_1.Import result = new org.kie.dmn.model.v1_1.Import();
+  public static org.kie.dmn.model.v1x.Import dmnFromNode(Import source) {
+    org.kie.dmn.model.v1x.Import result = new org.kie.dmn.model.v1_1.TImport();
     result.setImportType(source.getImportType());
     result.setLocationURI(source.getLocationURI().getValue());
     result.setNamespace(source.getNamespace());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
@@ -21,7 +21,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
 
 public class ImportedValuesConverter {
 
-    public static ImportedValues wbFromDMN(final org.kie.dmn.model.v1x.ImportedValues dmn) {
+    public static ImportedValues wbFromDMN(final org.kie.dmn.model.api.ImportedValues dmn) {
         if (dmn == null) {
             return null;
         }
@@ -38,11 +38,11 @@ public class ImportedValuesConverter {
         return wb;
     }
 
-    public static org.kie.dmn.model.v1x.ImportedValues wbFromDMN(final ImportedValues wb) {
+    public static org.kie.dmn.model.api.ImportedValues wbFromDMN(final ImportedValues wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.ImportedValues dmn = new org.kie.dmn.model.v1_1.TImportedValues();
+        org.kie.dmn.model.api.ImportedValues dmn = new org.kie.dmn.model.v1_1.TImportedValues();
         dmn.setNamespace(wb.getNamespace());
         dmn.setLocationURI(wb.getLocationURI().getValue());
         dmn.setImportType(wb.getImportType());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
@@ -21,7 +21,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
 
 public class ImportedValuesConverter {
 
-    public static ImportedValues wbFromDMN(final org.kie.dmn.model.v1_1.ImportedValues dmn) {
+    public static ImportedValues wbFromDMN(final org.kie.dmn.model.v1x.ImportedValues dmn) {
         if (dmn == null) {
             return null;
         }
@@ -38,11 +38,11 @@ public class ImportedValuesConverter {
         return wb;
     }
 
-    public static org.kie.dmn.model.v1_1.ImportedValues wbFromDMN(final ImportedValues wb) {
+    public static org.kie.dmn.model.v1x.ImportedValues wbFromDMN(final ImportedValues wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.ImportedValues dmn = new org.kie.dmn.model.v1_1.ImportedValues();
+        org.kie.dmn.model.v1x.ImportedValues dmn = new org.kie.dmn.model.v1_1.TImportedValues();
         dmn.setNamespace(wb.getNamespace());
         dmn.setLocationURI(wb.getLocationURI().getValue());
         dmn.setImportType(wb.getImportType());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class InformationItemPropertyConverter {
 
-    public static InformationItem wbFromDMN(final org.kie.dmn.model.v1_1.InformationItem dmn) {
+    public static InformationItem wbFromDMN(final org.kie.dmn.model.v1x.InformationItem dmn) {
         if (dmn == null) {
             return null;
         }
@@ -39,11 +39,11 @@ public class InformationItemPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.InformationItem dmnFromWB(final InformationItem wb) {
+    public static org.kie.dmn.model.v1x.InformationItem dmnFromWB(final InformationItem wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.InformationItem result = new org.kie.dmn.model.v1_1.InformationItem();
+        org.kie.dmn.model.v1x.InformationItem result = new org.kie.dmn.model.v1_1.TInformationItem();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setName(wb.getName().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class InformationItemPropertyConverter {
 
-    public static InformationItem wbFromDMN(final org.kie.dmn.model.v1x.InformationItem dmn) {
+    public static InformationItem wbFromDMN(final org.kie.dmn.model.api.InformationItem dmn) {
         if (dmn == null) {
             return null;
         }
@@ -39,11 +39,11 @@ public class InformationItemPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.InformationItem dmnFromWB(final InformationItem wb) {
+    public static org.kie.dmn.model.api.InformationItem dmnFromWB(final InformationItem wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.InformationItem result = new org.kie.dmn.model.v1_1.TInformationItem();
+        org.kie.dmn.model.api.InformationItem result = new org.kie.dmn.model.v1_1.TInformationItem();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setName(wb.getName().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 
 public class InputClausePropertyConverter {
 
-    public static InputClause wbFromDMN(final org.kie.dmn.model.v1_1.InputClause dmn) {
+    public static InputClause wbFromDMN(final org.kie.dmn.model.v1x.InputClause dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         LiteralExpression inputExpression = LiteralExpressionPropertyConverter.wbFromDMN(dmn.getInputExpression());
@@ -35,8 +35,8 @@ public class InputClausePropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.InputClause dmnFromWB(final InputClause wb) {
-        org.kie.dmn.model.v1_1.InputClause result = new org.kie.dmn.model.v1_1.InputClause();
+    public static org.kie.dmn.model.v1x.InputClause dmnFromWB(final InputClause wb) {
+        org.kie.dmn.model.v1x.InputClause result = new org.kie.dmn.model.v1_1.TInputClause();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setInputExpression(LiteralExpressionPropertyConverter.dmnFromWB(wb.getInputExpression()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 
 public class InputClausePropertyConverter {
 
-    public static InputClause wbFromDMN(final org.kie.dmn.model.v1x.InputClause dmn) {
+    public static InputClause wbFromDMN(final org.kie.dmn.model.api.InputClause dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         LiteralExpression inputExpression = LiteralExpressionPropertyConverter.wbFromDMN(dmn.getInputExpression());
@@ -35,8 +35,8 @@ public class InputClausePropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.InputClause dmnFromWB(final InputClause wb) {
-        org.kie.dmn.model.v1x.InputClause result = new org.kie.dmn.model.v1_1.TInputClause();
+    public static org.kie.dmn.model.api.InputClause dmnFromWB(final InputClause wb) {
+        org.kie.dmn.model.api.InputClause result = new org.kie.dmn.model.v1_1.TInputClause();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setInputExpression(LiteralExpressionPropertyConverter.dmnFromWB(wb.getInputExpression()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
@@ -28,7 +28,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class InputDataConverter implements NodeConverter<org.kie.dmn.model.v1x.InputData, org.kie.workbench.common.dmn.api.definition.v1_1.InputData> {
+public class InputDataConverter implements NodeConverter<org.kie.dmn.model.api.InputData, org.kie.workbench.common.dmn.api.definition.v1_1.InputData> {
 
     private FactoryManager factoryManager;
 
@@ -38,7 +38,7 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.v1x.I
     }
 
     @Override
-    public Node<View<InputData>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.InputData dmn) {
+    public Node<View<InputData>, ?> nodeFromDMN(final org.kie.dmn.model.api.InputData dmn) {
         @SuppressWarnings("unchecked")
         Node<View<InputData>, ?> node = (Node<View<InputData>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                              InputData.class).asNode();
@@ -58,9 +58,9 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.v1x.I
     }
 
     @Override
-    public org.kie.dmn.model.v1x.InputData dmnFromNode(final Node<View<InputData>, ?> node) {
+    public org.kie.dmn.model.api.InputData dmnFromNode(final Node<View<InputData>, ?> node) {
         InputData source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1x.InputData result = new org.kie.dmn.model.v1_1.TInputData();
+        org.kie.dmn.model.api.InputData result = new org.kie.dmn.model.v1_1.TInputData();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
@@ -28,7 +28,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class InputDataConverter implements NodeConverter<org.kie.dmn.model.v1_1.InputData, org.kie.workbench.common.dmn.api.definition.v1_1.InputData> {
+public class InputDataConverter implements NodeConverter<org.kie.dmn.model.v1x.InputData, org.kie.workbench.common.dmn.api.definition.v1_1.InputData> {
 
     private FactoryManager factoryManager;
 
@@ -38,7 +38,7 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.v1_1.
     }
 
     @Override
-    public Node<View<InputData>, ?> nodeFromDMN(final org.kie.dmn.model.v1_1.InputData dmn) {
+    public Node<View<InputData>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.InputData dmn) {
         @SuppressWarnings("unchecked")
         Node<View<InputData>, ?> node = (Node<View<InputData>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                              InputData.class).asNode();
@@ -58,9 +58,9 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.v1_1.
     }
 
     @Override
-    public org.kie.dmn.model.v1_1.InputData dmnFromNode(final Node<View<InputData>, ?> node) {
+    public org.kie.dmn.model.v1x.InputData dmnFromNode(final Node<View<InputData>, ?> node) {
         InputData source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1_1.InputData result = new org.kie.dmn.model.v1_1.InputData();
+        org.kie.dmn.model.v1x.InputData result = new org.kie.dmn.model.v1_1.TInputData();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class InvocationPropertyConverter {
 
-    public static Invocation wbFromDMN(final org.kie.dmn.model.v1_1.Invocation dmn) {
+    public static Invocation wbFromDMN(final org.kie.dmn.model.v1x.Invocation dmn) {
         if (dmn == null) {
             return null;
         }
@@ -41,7 +41,7 @@ public class InvocationPropertyConverter {
         Expression convertedExpression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
         result.setExpression(convertedExpression);
 
-        for (org.kie.dmn.model.v1_1.Binding b : dmn.getBinding()) {
+        for (org.kie.dmn.model.v1x.Binding b : dmn.getBinding()) {
             Binding bConverted = BindingPropertyConverter.wbFromDMN(b);
             result.getBinding().add(bConverted);
         }
@@ -49,21 +49,21 @@ public class InvocationPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.Invocation dmnFromWB(final Invocation wb) {
+    public static org.kie.dmn.model.v1x.Invocation dmnFromWB(final Invocation wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.Invocation result = new org.kie.dmn.model.v1_1.Invocation();
+        org.kie.dmn.model.v1x.Invocation result = new org.kie.dmn.model.v1_1.TInvocation();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 
-        org.kie.dmn.model.v1_1.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        org.kie.dmn.model.v1x.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
         result.setExpression(convertedExpression);
 
         for (Binding b : wb.getBinding()) {
-            org.kie.dmn.model.v1_1.Binding bConverted = BindingPropertyConverter.dmnFromWB(b);
+            org.kie.dmn.model.v1x.Binding bConverted = BindingPropertyConverter.dmnFromWB(b);
             result.getBinding().add(bConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class InvocationPropertyConverter {
 
-    public static Invocation wbFromDMN(final org.kie.dmn.model.v1x.Invocation dmn) {
+    public static Invocation wbFromDMN(final org.kie.dmn.model.api.Invocation dmn) {
         if (dmn == null) {
             return null;
         }
@@ -41,7 +41,7 @@ public class InvocationPropertyConverter {
         Expression convertedExpression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
         result.setExpression(convertedExpression);
 
-        for (org.kie.dmn.model.v1x.Binding b : dmn.getBinding()) {
+        for (org.kie.dmn.model.api.Binding b : dmn.getBinding()) {
             Binding bConverted = BindingPropertyConverter.wbFromDMN(b);
             result.getBinding().add(bConverted);
         }
@@ -49,21 +49,21 @@ public class InvocationPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.Invocation dmnFromWB(final Invocation wb) {
+    public static org.kie.dmn.model.api.Invocation dmnFromWB(final Invocation wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.Invocation result = new org.kie.dmn.model.v1_1.TInvocation();
+        org.kie.dmn.model.api.Invocation result = new org.kie.dmn.model.v1_1.TInvocation();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 
-        org.kie.dmn.model.v1x.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        org.kie.dmn.model.api.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
         result.setExpression(convertedExpression);
 
         for (Binding b : wb.getBinding()) {
-            org.kie.dmn.model.v1x.Binding bConverted = BindingPropertyConverter.dmnFromWB(b);
+            org.kie.dmn.model.api.Binding bConverted = BindingPropertyConverter.dmnFromWB(b);
             result.getBinding().add(bConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ItemDefinitionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ItemDefinitionPropertyConverter.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class ItemDefinitionPropertyConverter {
 
-    public static ItemDefinition wbFromDMN(final org.kie.dmn.model.v1_1.ItemDefinition dmn) {
+    public static ItemDefinition wbFromDMN(final org.kie.dmn.model.v1x.ItemDefinition dmn) {
         if (dmn == null) {
             return null;
         }
@@ -46,7 +46,7 @@ public class ItemDefinitionPropertyConverter {
         UnaryTests utConverted = UnaryTestsPropertyConverter.wbFromDMN(dmn.getAllowedValues());
         result.setAllowedValues(utConverted);
 
-        for (org.kie.dmn.model.v1_1.ItemDefinition child : dmn.getItemComponent()) {
+        for (org.kie.dmn.model.v1x.ItemDefinition child : dmn.getItemComponent()) {
             ItemDefinition convertedChild = ItemDefinitionPropertyConverter.wbFromDMN(child);
             result.getItemComponent().add(convertedChild);
         }
@@ -54,11 +54,11 @@ public class ItemDefinitionPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.ItemDefinition dmnFromWB(final ItemDefinition wb) {
+    public static org.kie.dmn.model.v1x.ItemDefinition dmnFromWB(final ItemDefinition wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.ItemDefinition result = new org.kie.dmn.model.v1_1.ItemDefinition();
+        org.kie.dmn.model.v1x.ItemDefinition result = new org.kie.dmn.model.v1_1.TItemDefinition();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setName(wb.getName().getValue());
@@ -71,7 +71,7 @@ public class ItemDefinitionPropertyConverter {
         result.setAllowedValues(UnaryTestsPropertyConverter.dmnFromWB(wb.getAllowedValues()));
 
         for (ItemDefinition child : wb.getItemComponent()) {
-            org.kie.dmn.model.v1_1.ItemDefinition convertedChild = ItemDefinitionPropertyConverter.dmnFromWB(child);
+            org.kie.dmn.model.v1x.ItemDefinition convertedChild = ItemDefinitionPropertyConverter.dmnFromWB(child);
             result.getItemComponent().add(convertedChild);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ItemDefinitionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ItemDefinitionPropertyConverter.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class ItemDefinitionPropertyConverter {
 
-    public static ItemDefinition wbFromDMN(final org.kie.dmn.model.v1x.ItemDefinition dmn) {
+    public static ItemDefinition wbFromDMN(final org.kie.dmn.model.api.ItemDefinition dmn) {
         if (dmn == null) {
             return null;
         }
@@ -46,7 +46,7 @@ public class ItemDefinitionPropertyConverter {
         UnaryTests utConverted = UnaryTestsPropertyConverter.wbFromDMN(dmn.getAllowedValues());
         result.setAllowedValues(utConverted);
 
-        for (org.kie.dmn.model.v1x.ItemDefinition child : dmn.getItemComponent()) {
+        for (org.kie.dmn.model.api.ItemDefinition child : dmn.getItemComponent()) {
             ItemDefinition convertedChild = ItemDefinitionPropertyConverter.wbFromDMN(child);
             result.getItemComponent().add(convertedChild);
         }
@@ -54,11 +54,11 @@ public class ItemDefinitionPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.ItemDefinition dmnFromWB(final ItemDefinition wb) {
+    public static org.kie.dmn.model.api.ItemDefinition dmnFromWB(final ItemDefinition wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.ItemDefinition result = new org.kie.dmn.model.v1_1.TItemDefinition();
+        org.kie.dmn.model.api.ItemDefinition result = new org.kie.dmn.model.v1_1.TItemDefinition();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setName(wb.getName().getValue());
@@ -71,7 +71,7 @@ public class ItemDefinitionPropertyConverter {
         result.setAllowedValues(UnaryTestsPropertyConverter.dmnFromWB(wb.getAllowedValues()));
 
         for (ItemDefinition child : wb.getItemComponent()) {
-            org.kie.dmn.model.v1x.ItemDefinition convertedChild = ItemDefinitionPropertyConverter.dmnFromWB(child);
+            org.kie.dmn.model.api.ItemDefinition convertedChild = ItemDefinitionPropertyConverter.dmnFromWB(child);
             result.getItemComponent().add(convertedChild);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model.v1_1.KnowledgeSource, org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource> {
+public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model.v1x.KnowledgeSource, org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource> {
 
     private FactoryManager factoryManager;
 
@@ -45,7 +45,7 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
     }
 
     @Override
-    public Node<View<KnowledgeSource>, ?> nodeFromDMN(final org.kie.dmn.model.v1_1.KnowledgeSource dmn) {
+    public Node<View<KnowledgeSource>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.KnowledgeSource dmn) {
         @SuppressWarnings("unchecked")
         Node<View<KnowledgeSource>, ?> node = (Node<View<KnowledgeSource>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                          KnowledgeSource.class).asNode();
@@ -67,9 +67,9 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
     }
 
     @Override
-    public org.kie.dmn.model.v1_1.KnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node) {
+    public org.kie.dmn.model.v1x.KnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node) {
         KnowledgeSource source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1_1.KnowledgeSource result = new org.kie.dmn.model.v1_1.KnowledgeSource();
+        org.kie.dmn.model.v1x.KnowledgeSource result = new org.kie.dmn.model.v1_1.TKnowledgeSource();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());
@@ -84,20 +84,20 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
                     if (drgElement instanceof Decision) {
-                        org.kie.dmn.model.v1_1.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.AuthorityRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredDecision(ri);
                         result.getAuthorityRequirement().add(iReq);
                     } else if (drgElement instanceof KnowledgeSource) {
-                        org.kie.dmn.model.v1_1.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.AuthorityRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredAuthority(ri);
                         result.getAuthorityRequirement().add(iReq);
                     } else if (drgElement instanceof InputData) {
-                        org.kie.dmn.model.v1_1.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.AuthorityRequirement();
-                        org.kie.dmn.model.v1_1.DMNElementReference ri = new org.kie.dmn.model.v1_1.DMNElementReference();
+                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredInput(ri);
                         result.getAuthorityRequirement().add(iReq);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model.v1x.KnowledgeSource, org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource> {
+public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model.api.KnowledgeSource, org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource> {
 
     private FactoryManager factoryManager;
 
@@ -45,7 +45,7 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
     }
 
     @Override
-    public Node<View<KnowledgeSource>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.KnowledgeSource dmn) {
+    public Node<View<KnowledgeSource>, ?> nodeFromDMN(final org.kie.dmn.model.api.KnowledgeSource dmn) {
         @SuppressWarnings("unchecked")
         Node<View<KnowledgeSource>, ?> node = (Node<View<KnowledgeSource>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                          KnowledgeSource.class).asNode();
@@ -67,9 +67,9 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
     }
 
     @Override
-    public org.kie.dmn.model.v1x.KnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node) {
+    public org.kie.dmn.model.api.KnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node) {
         KnowledgeSource source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1x.KnowledgeSource result = new org.kie.dmn.model.v1_1.TKnowledgeSource();
+        org.kie.dmn.model.api.KnowledgeSource result = new org.kie.dmn.model.v1_1.TKnowledgeSource();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());
@@ -84,20 +84,20 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
                 if (view.getDefinition() instanceof DRGElement) {
                     DRGElement drgElement = (DRGElement) view.getDefinition();
                     if (drgElement instanceof Decision) {
-                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredDecision(ri);
                         result.getAuthorityRequirement().add(iReq);
                     } else if (drgElement instanceof KnowledgeSource) {
-                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredAuthority(ri);
                         result.getAuthorityRequirement().add(iReq);
                     } else if (drgElement instanceof InputData) {
-                        org.kie.dmn.model.v1x.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
-                        org.kie.dmn.model.v1x.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
+                        org.kie.dmn.model.api.AuthorityRequirement iReq = new org.kie.dmn.model.v1_1.TAuthorityRequirement();
+                        org.kie.dmn.model.api.DMNElementReference ri = new org.kie.dmn.model.v1_1.TDMNElementReference();
                         ri.setHref(new StringBuilder("#").append(drgElement.getId().getValue()).toString());
                         iReq.setRequiredInput(ri);
                         result.getAuthorityRequirement().add(iReq);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
@@ -26,13 +26,13 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class ListPropertyConverter {
 
-    public static List wbFromDMN(final org.kie.dmn.model.v1_1.List dmn) {
+    public static List wbFromDMN(final org.kie.dmn.model.v1x.List dmn) {
         Id id = new Id(dmn.getId());
         Description description = new Description(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
 
         java.util.List<Expression> expression = new ArrayList<>();
-        for (org.kie.dmn.model.v1_1.Expression e : dmn.getExpression()) {
+        for (org.kie.dmn.model.v1x.Expression e : dmn.getExpression()) {
             Expression eConverted = ExpressionPropertyConverter.wbFromDMN(e);
             expression.add(eConverted);
         }
@@ -41,15 +41,15 @@ public class ListPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.List dmnFromWB(final List wb) {
-        org.kie.dmn.model.v1_1.List result = new org.kie.dmn.model.v1_1.List();
+    public static org.kie.dmn.model.v1x.List dmnFromWB(final List wb) {
+        org.kie.dmn.model.v1x.List result = new org.kie.dmn.model.v1_1.TList();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 
         for (Expression e : wb.getExpression()) {
-            org.kie.dmn.model.v1_1.Expression eConverted = ExpressionPropertyConverter.dmnFromWB(e);
+            org.kie.dmn.model.v1x.Expression eConverted = ExpressionPropertyConverter.dmnFromWB(e);
             result.getExpression().add(eConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
@@ -26,13 +26,13 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class ListPropertyConverter {
 
-    public static List wbFromDMN(final org.kie.dmn.model.v1x.List dmn) {
+    public static List wbFromDMN(final org.kie.dmn.model.api.List dmn) {
         Id id = new Id(dmn.getId());
         Description description = new Description(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
 
         java.util.List<Expression> expression = new ArrayList<>();
-        for (org.kie.dmn.model.v1x.Expression e : dmn.getExpression()) {
+        for (org.kie.dmn.model.api.Expression e : dmn.getExpression()) {
             Expression eConverted = ExpressionPropertyConverter.wbFromDMN(e);
             expression.add(eConverted);
         }
@@ -41,15 +41,15 @@ public class ListPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.List dmnFromWB(final List wb) {
-        org.kie.dmn.model.v1x.List result = new org.kie.dmn.model.v1_1.TList();
+    public static org.kie.dmn.model.api.List dmnFromWB(final List wb) {
+        org.kie.dmn.model.api.List result = new org.kie.dmn.model.v1_1.TList();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 
         for (Expression e : wb.getExpression()) {
-            org.kie.dmn.model.v1x.Expression eConverted = ExpressionPropertyConverter.dmnFromWB(e);
+            org.kie.dmn.model.api.Expression eConverted = ExpressionPropertyConverter.dmnFromWB(e);
             result.getExpression().add(eConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class LiteralExpressionPropertyConverter {
 
-    public static LiteralExpression wbFromDMN(final org.kie.dmn.model.v1_1.LiteralExpression dmn) {
+    public static LiteralExpression wbFromDMN(final org.kie.dmn.model.v1x.LiteralExpression dmn) {
         if (dmn == null) {
             return null;
         }
@@ -43,11 +43,11 @@ public class LiteralExpressionPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.LiteralExpression dmnFromWB(final LiteralExpression wb) {
+    public static org.kie.dmn.model.v1x.LiteralExpression dmnFromWB(final LiteralExpression wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.LiteralExpression result = new org.kie.dmn.model.v1_1.LiteralExpression();
+        org.kie.dmn.model.v1x.LiteralExpression result = new org.kie.dmn.model.v1_1.TLiteralExpression();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class LiteralExpressionPropertyConverter {
 
-    public static LiteralExpression wbFromDMN(final org.kie.dmn.model.v1x.LiteralExpression dmn) {
+    public static LiteralExpression wbFromDMN(final org.kie.dmn.model.api.LiteralExpression dmn) {
         if (dmn == null) {
             return null;
         }
@@ -43,11 +43,11 @@ public class LiteralExpressionPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.LiteralExpression dmnFromWB(final LiteralExpression wb) {
+    public static org.kie.dmn.model.api.LiteralExpression dmnFromWB(final LiteralExpression wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.LiteralExpression result = new org.kie.dmn.model.v1_1.TLiteralExpression();
+        org.kie.dmn.model.api.LiteralExpression result = new org.kie.dmn.model.v1_1.TLiteralExpression();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/NodeConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/NodeConverter.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.dmn.backend.definition.v1_1;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-interface NodeConverter<D extends org.kie.dmn.model.v1x.DMNModelInstrumentedBase, W extends org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase> {
+interface NodeConverter<D extends org.kie.dmn.model.api.DMNModelInstrumentedBase, W extends org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase> {
 
     Node<View<W>, ?> nodeFromDMN(final D source);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/NodeConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/NodeConverter.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.dmn.backend.definition.v1_1;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-interface NodeConverter<D extends org.kie.dmn.model.v1_1.DMNModelInstrumentedBase, W extends org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase> {
+interface NodeConverter<D extends org.kie.dmn.model.v1x.DMNModelInstrumentedBase, W extends org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase> {
 
     Node<View<W>, ?> nodeFromDMN(final D source);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class OutputClausePropertyConverter {
 
-    public static OutputClause wbFromDMN(final org.kie.dmn.model.v1x.OutputClause dmn) {
+    public static OutputClause wbFromDMN(final org.kie.dmn.model.api.OutputClause dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         UnaryTests outputValues = UnaryTestsPropertyConverter.wbFromDMN(dmn.getOutputValues());
@@ -43,8 +43,8 @@ public class OutputClausePropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.OutputClause dmnFromWB(final OutputClause wb) {
-        org.kie.dmn.model.v1x.OutputClause result = new org.kie.dmn.model.v1_1.TOutputClause();
+    public static org.kie.dmn.model.api.OutputClause dmnFromWB(final OutputClause wb) {
+        org.kie.dmn.model.api.OutputClause result = new org.kie.dmn.model.v1_1.TOutputClause();
         result.setId(wb.getId().getValue());
         result.setName(wb.getName());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class OutputClausePropertyConverter {
 
-    public static OutputClause wbFromDMN(final org.kie.dmn.model.v1_1.OutputClause dmn) {
+    public static OutputClause wbFromDMN(final org.kie.dmn.model.v1x.OutputClause dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         UnaryTests outputValues = UnaryTestsPropertyConverter.wbFromDMN(dmn.getOutputValues());
@@ -43,8 +43,8 @@ public class OutputClausePropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.OutputClause dmnFromWB(final OutputClause wb) {
-        org.kie.dmn.model.v1_1.OutputClause result = new org.kie.dmn.model.v1_1.OutputClause();
+    public static org.kie.dmn.model.v1x.OutputClause dmnFromWB(final OutputClause wb) {
+        org.kie.dmn.model.v1x.OutputClause result = new org.kie.dmn.model.v1_1.TOutputClause();
         result.setId(wb.getId().getValue());
         result.setName(wb.getName());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
@@ -27,13 +27,13 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class RelationPropertyConverter {
 
-    public static Relation wbFromDMN(final org.kie.dmn.model.v1x.Relation dmn) {
+    public static Relation wbFromDMN(final org.kie.dmn.model.api.Relation dmn) {
         Id id = new Id(dmn.getId());
         Description description = new Description(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
 
-        List<org.kie.dmn.model.v1x.InformationItem> column = dmn.getColumn();
-        List<org.kie.dmn.model.v1x.List> row = dmn.getRow();
+        List<org.kie.dmn.model.api.InformationItem> column = dmn.getColumn();
+        List<org.kie.dmn.model.api.List> row = dmn.getRow();
 
         List<InformationItem> convertedColumn = column.stream().map(InformationItemPropertyConverter::wbFromDMN).collect(Collectors.toList());
         List<org.kie.workbench.common.dmn.api.definition.v1_1.List> convertedRow = row.stream().map(ListPropertyConverter::wbFromDMN).collect(Collectors.toList());
@@ -42,20 +42,20 @@ public class RelationPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.Relation dmnFromWB(final Relation wb) {
-        org.kie.dmn.model.v1x.Relation result = new org.kie.dmn.model.v1_1.TRelation();
+    public static org.kie.dmn.model.api.Relation dmnFromWB(final Relation wb) {
+        org.kie.dmn.model.api.Relation result = new org.kie.dmn.model.v1_1.TRelation();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 
         for (InformationItem iitem : wb.getColumn()) {
-            org.kie.dmn.model.v1x.InformationItem iitemConverted = InformationItemPropertyConverter.dmnFromWB(iitem);
+            org.kie.dmn.model.api.InformationItem iitemConverted = InformationItemPropertyConverter.dmnFromWB(iitem);
             result.getColumn().add(iitemConverted);
         }
 
         for (org.kie.workbench.common.dmn.api.definition.v1_1.List list : wb.getRow()) {
-            org.kie.dmn.model.v1x.List listConverted = ListPropertyConverter.dmnFromWB(list);
+            org.kie.dmn.model.api.List listConverted = ListPropertyConverter.dmnFromWB(list);
             result.getRow().add(listConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
@@ -27,13 +27,13 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public class RelationPropertyConverter {
 
-    public static Relation wbFromDMN(final org.kie.dmn.model.v1_1.Relation dmn) {
+    public static Relation wbFromDMN(final org.kie.dmn.model.v1x.Relation dmn) {
         Id id = new Id(dmn.getId());
         Description description = new Description(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
 
-        List<org.kie.dmn.model.v1_1.InformationItem> column = dmn.getColumn();
-        List<org.kie.dmn.model.v1_1.List> row = dmn.getRow();
+        List<org.kie.dmn.model.v1x.InformationItem> column = dmn.getColumn();
+        List<org.kie.dmn.model.v1x.List> row = dmn.getRow();
 
         List<InformationItem> convertedColumn = column.stream().map(InformationItemPropertyConverter::wbFromDMN).collect(Collectors.toList());
         List<org.kie.workbench.common.dmn.api.definition.v1_1.List> convertedRow = row.stream().map(ListPropertyConverter::wbFromDMN).collect(Collectors.toList());
@@ -42,20 +42,20 @@ public class RelationPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.Relation dmnFromWB(final Relation wb) {
-        org.kie.dmn.model.v1_1.Relation result = new org.kie.dmn.model.v1_1.Relation();
+    public static org.kie.dmn.model.v1x.Relation dmnFromWB(final Relation wb) {
+        org.kie.dmn.model.v1x.Relation result = new org.kie.dmn.model.v1_1.TRelation();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 
         for (InformationItem iitem : wb.getColumn()) {
-            org.kie.dmn.model.v1_1.InformationItem iitemConverted = InformationItemPropertyConverter.dmnFromWB(iitem);
+            org.kie.dmn.model.v1x.InformationItem iitemConverted = InformationItemPropertyConverter.dmnFromWB(iitem);
             result.getColumn().add(iitemConverted);
         }
 
         for (org.kie.workbench.common.dmn.api.definition.v1_1.List list : wb.getRow()) {
-            org.kie.dmn.model.v1_1.List listConverted = ListPropertyConverter.dmnFromWB(list);
+            org.kie.dmn.model.v1x.List listConverted = ListPropertyConverter.dmnFromWB(list);
             result.getRow().add(listConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
@@ -28,7 +28,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.v1_1.TextAnnotation, org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation> {
+public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.v1x.TextAnnotation, org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation> {
 
     private FactoryManager factoryManager;
 
@@ -38,7 +38,7 @@ public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.
     }
 
     @Override
-    public Node<View<TextAnnotation>, ?> nodeFromDMN(final org.kie.dmn.model.v1_1.TextAnnotation dmn) {
+    public Node<View<TextAnnotation>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.TextAnnotation dmn) {
         @SuppressWarnings("unchecked")
         Node<View<TextAnnotation>, ?> node = (Node<View<TextAnnotation>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                        TextAnnotation.class).asNode();
@@ -58,9 +58,9 @@ public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.
     }
 
     @Override
-    public org.kie.dmn.model.v1_1.TextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node) {
+    public org.kie.dmn.model.v1x.TextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node) {
         TextAnnotation source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1_1.TextAnnotation result = new org.kie.dmn.model.v1_1.TextAnnotation();
+        org.kie.dmn.model.v1x.TextAnnotation result = new org.kie.dmn.model.v1_1.TTextAnnotation();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setText(source.getText().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
@@ -28,7 +28,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
-public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.v1x.TextAnnotation, org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation> {
+public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.api.TextAnnotation, org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation> {
 
     private FactoryManager factoryManager;
 
@@ -38,7 +38,7 @@ public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.
     }
 
     @Override
-    public Node<View<TextAnnotation>, ?> nodeFromDMN(final org.kie.dmn.model.v1x.TextAnnotation dmn) {
+    public Node<View<TextAnnotation>, ?> nodeFromDMN(final org.kie.dmn.model.api.TextAnnotation dmn) {
         @SuppressWarnings("unchecked")
         Node<View<TextAnnotation>, ?> node = (Node<View<TextAnnotation>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                        TextAnnotation.class).asNode();
@@ -58,9 +58,9 @@ public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.
     }
 
     @Override
-    public org.kie.dmn.model.v1x.TextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node) {
+    public org.kie.dmn.model.api.TextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node) {
         TextAnnotation source = node.getContent().getDefinition();
-        org.kie.dmn.model.v1x.TextAnnotation result = new org.kie.dmn.model.v1_1.TTextAnnotation();
+        org.kie.dmn.model.api.TextAnnotation result = new org.kie.dmn.model.v1_1.TTextAnnotation();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setText(source.getText().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 
 public class UnaryTestsPropertyConverter {
 
-    public static UnaryTests wbFromDMN(final org.kie.dmn.model.v1_1.UnaryTests dmn) {
+    public static UnaryTests wbFromDMN(final org.kie.dmn.model.v1x.UnaryTests dmn) {
         if (dmn == null) {
             return null;
         }
@@ -33,11 +33,11 @@ public class UnaryTestsPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1_1.UnaryTests dmnFromWB(final UnaryTests wb) {
+    public static org.kie.dmn.model.v1x.UnaryTests dmnFromWB(final UnaryTests wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1_1.UnaryTests result = new org.kie.dmn.model.v1_1.UnaryTests();
+        org.kie.dmn.model.v1x.UnaryTests result = new org.kie.dmn.model.v1_1.TUnaryTests();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         result.setText(wb.getText());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 
 public class UnaryTestsPropertyConverter {
 
-    public static UnaryTests wbFromDMN(final org.kie.dmn.model.v1x.UnaryTests dmn) {
+    public static UnaryTests wbFromDMN(final org.kie.dmn.model.api.UnaryTests dmn) {
         if (dmn == null) {
             return null;
         }
@@ -33,11 +33,11 @@ public class UnaryTestsPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.v1x.UnaryTests dmnFromWB(final UnaryTests wb) {
+    public static org.kie.dmn.model.api.UnaryTests dmnFromWB(final UnaryTests wb) {
         if (wb == null) {
             return null;
         }
-        org.kie.dmn.model.v1x.UnaryTests result = new org.kie.dmn.model.v1_1.TUnaryTests();
+        org.kie.dmn.model.api.UnaryTests result = new org.kie.dmn.model.v1_1.TUnaryTests();
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         result.setText(wb.getText());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DDExtensionsRegister.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DDExtensionsRegister.java
@@ -21,7 +21,7 @@ import javax.xml.namespace.QName;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.QNameMap;
 import org.kie.dmn.api.marshalling.v1_1.DMNExtensionRegister;
-import org.kie.dmn.model.v1x.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 
 public class DDExtensionsRegister implements DMNExtensionRegister {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DDExtensionsRegister.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DDExtensionsRegister.java
@@ -21,7 +21,7 @@ import javax.xml.namespace.QName;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.QNameMap;
 import org.kie.dmn.api.marshalling.v1_1.DMNExtensionRegister;
-import org.kie.dmn.model.v1_1.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1x.DMNModelInstrumentedBase;
 
 public class DDExtensionsRegister implements DMNExtensionRegister {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -60,7 +60,7 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.ast.DecisionNode;
 import org.kie.dmn.backend.marshalling.v1_1.xstream.XStreamMarshaller;
 import org.kie.dmn.core.util.KieHelper;
-import org.kie.dmn.model.v1x.Definitions;
+import org.kie.dmn.model.api.Definitions;
 import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Association;
 import org.kie.workbench.common.dmn.api.definition.v1_1.AuthorityRequirement;
@@ -928,8 +928,8 @@ public class DMNMarshallerTest {
         final DMNModel dmnModel = runtime.getModels().get(0);
 
         final DecisionNode dmnDecision = dmnModel.getDecisions().iterator().next();
-        assertTrue(dmnDecision.getDecision().getExpression() instanceof org.kie.dmn.model.v1x.FunctionDefinition);
-        final org.kie.dmn.model.v1x.FunctionDefinition dmnFunction = (org.kie.dmn.model.v1x.FunctionDefinition) dmnDecision.getDecision().getExpression();
+        assertTrue(dmnDecision.getDecision().getExpression() instanceof org.kie.dmn.model.api.FunctionDefinition);
+        final org.kie.dmn.model.api.FunctionDefinition dmnFunction = (org.kie.dmn.model.api.FunctionDefinition) dmnDecision.getDecision().getExpression();
         assertTrue(dmnFunction.getAdditionalAttributes().containsKey(org.kie.dmn.model.v1_1.TFunctionDefinition.KIND_QNAME));
         assertEquals("J",
                      dmnFunction.getAdditionalAttributes().get(org.kie.dmn.model.v1_1.TFunctionDefinition.KIND_QNAME));
@@ -1002,10 +1002,10 @@ public class DMNMarshallerTest {
 
         DecisionNode d0 = dmnModel.getDecisionById("_653b3426-933a-4050-9568-ab2a66b43c36");
         // the identified DMN Decision is composed of a DMN Context where the first context-entry value is a literal expression missing text (text is null).
-        org.kie.dmn.model.v1x.Context d0c = (org.kie.dmn.model.v1x.Context) d0.getDecision().getExpression();
-        org.kie.dmn.model.v1x.Expression contextEntryValue = d0c.getContextEntry().get(0).getExpression();
-        assertTrue(contextEntryValue instanceof org.kie.dmn.model.v1x.LiteralExpression);
-        assertEquals(null, ((org.kie.dmn.model.v1x.LiteralExpression) contextEntryValue).getText());
+        org.kie.dmn.model.api.Context d0c = (org.kie.dmn.model.api.Context) d0.getDecision().getExpression();
+        org.kie.dmn.model.api.Expression contextEntryValue = d0c.getContextEntry().get(0).getExpression();
+        assertTrue(contextEntryValue instanceof org.kie.dmn.model.api.LiteralExpression);
+        assertEquals(null, ((org.kie.dmn.model.api.LiteralExpression) contextEntryValue).getText());
 
         // -- Stunner side.
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -58,9 +58,9 @@ import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.api.core.ast.DecisionNode;
-import org.kie.dmn.backend.marshalling.v1_1.DMNMarshallerFactory;
+import org.kie.dmn.backend.marshalling.v1_1.xstream.XStreamMarshaller;
 import org.kie.dmn.core.util.KieHelper;
-import org.kie.dmn.model.v1_1.Definitions;
+import org.kie.dmn.model.v1x.Definitions;
 import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Association;
 import org.kie.workbench.common.dmn.api.definition.v1_1.AuthorityRequirement;
@@ -332,7 +332,7 @@ public class DMNMarshallerTest {
 
         // additionally, check DMN DD/DI for version 1.1
 
-        org.kie.dmn.api.marshalling.v1_1.DMNMarshaller dmnMarshaller = DMNMarshallerFactory.newMarshallerWithExtensions(Arrays.asList(new DDExtensionsRegister()));
+        org.kie.dmn.api.marshalling.v1_1.DMNMarshaller dmnMarshaller = new XStreamMarshaller(Arrays.asList(new DDExtensionsRegister()));
         Definitions definitions = dmnMarshaller.unmarshal(mString);
 
         assertNotNull(definitions.getExtensionElements());
@@ -928,11 +928,11 @@ public class DMNMarshallerTest {
         final DMNModel dmnModel = runtime.getModels().get(0);
 
         final DecisionNode dmnDecision = dmnModel.getDecisions().iterator().next();
-        assertTrue(dmnDecision.getDecision().getExpression() instanceof org.kie.dmn.model.v1_1.FunctionDefinition);
-        final org.kie.dmn.model.v1_1.FunctionDefinition dmnFunction = (org.kie.dmn.model.v1_1.FunctionDefinition) dmnDecision.getDecision().getExpression();
-        assertTrue(dmnFunction.getAdditionalAttributes().containsKey(org.kie.dmn.model.v1_1.FunctionDefinition.KIND_QNAME));
+        assertTrue(dmnDecision.getDecision().getExpression() instanceof org.kie.dmn.model.v1x.FunctionDefinition);
+        final org.kie.dmn.model.v1x.FunctionDefinition dmnFunction = (org.kie.dmn.model.v1x.FunctionDefinition) dmnDecision.getDecision().getExpression();
+        assertTrue(dmnFunction.getAdditionalAttributes().containsKey(org.kie.dmn.model.v1_1.TFunctionDefinition.KIND_QNAME));
         assertEquals("J",
-                     dmnFunction.getAdditionalAttributes().get(org.kie.dmn.model.v1_1.FunctionDefinition.KIND_QNAME));
+                     dmnFunction.getAdditionalAttributes().get(org.kie.dmn.model.v1_1.TFunctionDefinition.KIND_QNAME));
     }
 
     @Test
@@ -1002,10 +1002,10 @@ public class DMNMarshallerTest {
 
         DecisionNode d0 = dmnModel.getDecisionById("_653b3426-933a-4050-9568-ab2a66b43c36");
         // the identified DMN Decision is composed of a DMN Context where the first context-entry value is a literal expression missing text (text is null).
-        org.kie.dmn.model.v1_1.Context d0c = (org.kie.dmn.model.v1_1.Context) d0.getDecision().getExpression();
-        org.kie.dmn.model.v1_1.Expression contextEntryValue = d0c.getContextEntry().get(0).getExpression();
-        assertTrue(contextEntryValue instanceof org.kie.dmn.model.v1_1.LiteralExpression);
-        assertEquals(null, ((org.kie.dmn.model.v1_1.LiteralExpression) contextEntryValue).getText());
+        org.kie.dmn.model.v1x.Context d0c = (org.kie.dmn.model.v1x.Context) d0.getDecision().getExpression();
+        org.kie.dmn.model.v1x.Expression contextEntryValue = d0c.getContextEntry().get(0).getExpression();
+        assertTrue(contextEntryValue instanceof org.kie.dmn.model.v1x.LiteralExpression);
+        assertEquals(null, ((org.kie.dmn.model.v1x.LiteralExpression) contextEntryValue).getText());
 
         // -- Stunner side.
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/QNameConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/QNameConverterTest.java
@@ -41,7 +41,7 @@ public class QNameConverterTest {
 
     private static final String ENCODED_FEEL_DATE = "[][date][" + DMNModelInstrumentedBase.Namespace.FEEL.getPrefix() + "]";
 
-    private static final String ENCODED_DMN_UNKNOWN = "[" + org.kie.dmn.model.v1_1.DMNModelInstrumentedBase.URI_DMN + "]" +
+    private static final String ENCODED_DMN_UNKNOWN = "[" + org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_DMN + "]" +
             "[unknown]" +
             "[" + DMNModelInstrumentedBase.Namespace.DMN.getPrefix() + "]";
 
@@ -98,7 +98,7 @@ public class QNameConverterTest {
     public void testToWidgetValueWhenDMNDiagramDoesNotDefinesNameSpaces() {
         converter.setDMNModel(new Decision());
 
-        final String encoding = converter.toWidgetValue(new QName(org.kie.dmn.model.v1_1.DMNModelInstrumentedBase.URI_DMN,
+        final String encoding = converter.toWidgetValue(new QName(org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_DMN,
                                                                   "unknown",
                                                                   DMNModelInstrumentedBase.Namespace.DMN.getPrefix()));
         assertEquals(ENCODED_DMN_UNKNOWN, encoding);


### PR DESCRIPTION
Requires https://github.com/kiegroup/drools/pull/2018

This PR align to the kie model refactor using interfaces, in order to support in the engine DMN v1.1 and DMN v1.2, in order to continue support WB marshallers for DMN v1.1 as previously defined accordingly.

This PR does not provide WB marshalling for DMN v1.2.

/cc @etirelli @manstis @jomarko 