### PR TITLE
JBPM-7645 Stunner: New Marshallers - task w/ docked node in subprocess

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -112,7 +112,13 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
 
     public void addChildElement(PropertyWriter p) {
         this.childElements.put(p.getElement().getId(), p);
-        process.getFlowElements().add(p.getFlowElement());
+        // compatibility fix: boundary events should always occur at the bottom
+        // otherwise they will be drawn at an incorrect position on load
+        if (p instanceof BoundaryEventPropertyWriter) {
+            process.getFlowElements().add(p.getFlowElement());
+        } else {
+            process.getFlowElements().add(0, p.getFlowElement());
+        }
 
         ElementParameters simulationParameters = p.getSimulationParameters();
         if (simulationParameters != null) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -29,6 +29,8 @@ import bpsim.Scenario;
 import bpsim.ScenarioParameters;
 import org.eclipse.bpmn2.Documentation;
 import org.eclipse.bpmn2.ExtensionAttributeValue;
+import org.eclipse.bpmn2.FlowElementsContainer;
+import org.eclipse.bpmn2.ItemDefinition;
 import org.eclipse.bpmn2.LaneSet;
 import org.eclipse.bpmn2.Process;
 import org.eclipse.bpmn2.Property;
@@ -111,24 +113,16 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
     }
 
     public void addChildElement(PropertyWriter p) {
-        this.childElements.put(p.getElement().getId(), p);
-        // compatibility fix: boundary events should always occur at the bottom
-        // otherwise they will be drawn at an incorrect position on load
-        if (p instanceof BoundaryEventPropertyWriter) {
-            process.getFlowElements().add(p.getFlowElement());
-        } else {
-            process.getFlowElements().add(0, p.getFlowElement());
-        }
-
-        ElementParameters simulationParameters = p.getSimulationParameters();
-        if (simulationParameters != null) {
-            this.simulationParameters.add(simulationParameters);
-        }
+        Processes.addChildElement(
+                p,
+                childElements,
+                process,
+                simulationParameters,
+                itemDefinitions,
+                rootElements);
 
         addChildShape(p.getShape());
         addChildEdge(p.getEdge());
-        this.itemDefinitions.addAll(p.getItemDefinitions());
-        this.rootElements.addAll(p.rootElements);
 
         if (p instanceof SubProcessPropertyWriter) {
             Collection<BasePropertyWriter> childElements =

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -29,8 +29,6 @@ import bpsim.Scenario;
 import bpsim.ScenarioParameters;
 import org.eclipse.bpmn2.Documentation;
 import org.eclipse.bpmn2.ExtensionAttributeValue;
-import org.eclipse.bpmn2.FlowElementsContainer;
-import org.eclipse.bpmn2.ItemDefinition;
 import org.eclipse.bpmn2.LaneSet;
 import org.eclipse.bpmn2.Process;
 import org.eclipse.bpmn2.Property;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/Processes.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/Processes.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import bpsim.ElementParameters;
+import org.eclipse.bpmn2.FlowElementsContainer;
+import org.eclipse.bpmn2.ItemDefinition;
+import org.eclipse.bpmn2.RootElement;
+
+class Processes {
+    static void addChildElement(
+            PropertyWriter p,
+            Map<String, BasePropertyWriter> childElements,
+            FlowElementsContainer process,
+            Collection<ElementParameters> simulationParameters,
+            List<ItemDefinition> itemDefinitions,
+            List<RootElement> rootElements) {
+        childElements.put(p.getElement().getId(), p);
+        // compatibility fix: boundary events should always occur at the bottom
+        // otherwise they will be drawn at an incorrect position on load
+        if (p instanceof BoundaryEventPropertyWriter) {
+            process.getFlowElements().add(p.getFlowElement());
+        } else {
+            process.getFlowElements().add(0, p.getFlowElement());
+        }
+
+        ElementParameters sp = p.getSimulationParameters();
+        if (sp!= null) {
+            simulationParameters.add(sp);
+        }
+        itemDefinitions.addAll(p.getItemDefinitions());
+        rootElements.addAll(p.rootElements);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriter.java
@@ -53,23 +53,14 @@ public class SubProcessPropertyWriter extends ActivityPropertyWriter implements 
     }
 
     public void addChildElement(PropertyWriter p) {
-        this.childElements.put(p.getElement().getId(), p);
-        // compatibility fix: boundary events should always occur at the bottom
-        // otherwise they will be drawn at an incorrect position on load
-        if (p instanceof BoundaryEventPropertyWriter) {
-            process.getFlowElements().add(p.getFlowElement());
-        } else {
-            process.getFlowElements().add(0, p.getFlowElement());
-        }
         p.setParent(this);
-
-        ElementParameters simulationParameters = p.getSimulationParameters();
-        if (simulationParameters != null) {
-            this.simulationParameters.add(simulationParameters);
-        }
-
-        this.itemDefinitions.addAll(p.itemDefinitions);
-        this.rootElements.addAll(p.rootElements);
+        Processes.addChildElement(
+                p,
+                childElements,
+                process,
+                simulationParameters,
+                itemDefinitions,
+                rootElements);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriter.java
@@ -54,7 +54,13 @@ public class SubProcessPropertyWriter extends ActivityPropertyWriter implements 
 
     public void addChildElement(PropertyWriter p) {
         this.childElements.put(p.getElement().getId(), p);
-        process.getFlowElements().add(p.getFlowElement());
+        // compatibility fix: boundary events should always occur at the bottom
+        // otherwise they will be drawn at an incorrect position on load
+        if (p instanceof BoundaryEventPropertyWriter) {
+            process.getFlowElements().add(p.getFlowElement());
+        } else {
+            process.getFlowElements().add(0, p.getFlowElement());
+        }
         p.setParent(this);
 
         ElementParameters simulationParameters = p.getSimulationParameters();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriterTest.java
@@ -16,39 +16,28 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
 
-import org.eclipse.bpmn2.Process;
-import org.eclipse.bpmn2.di.BPMNEdge;
-import org.eclipse.bpmn2.di.BPMNShape;
+import org.eclipse.bpmn2.SubProcess;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
-import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.di;
 
-public class ProcessPropertyWriterTest {
+public class SubProcessPropertyWriterTest {
 
-    ProcessPropertyWriter p ;
+    SubProcessPropertyWriter p ;
     FlatVariableScope variableScope;
 
     @Before
     public void before() {
         this.variableScope = new FlatVariableScope();
-        this.p = new ProcessPropertyWriter(
-                bpmn2.createProcess(), variableScope);
-    }
-
-    @Test
-    public void setIdWithWhitespace() {
-        p.setId("some weird   id \t");
-        Process process = p.getProcess();
-        assertThat(process.getId()).isEqualTo("someweirdid");
+        this.p = new SubProcessPropertyWriter(
+                bpmn2.createSubProcess(), variableScope);
     }
 
     @Test
     public void addChildElement() {
-        Process process = p.getProcess();
+        SubProcess process = (SubProcess) p.getElement();
 
         BoundaryEventPropertyWriter boundaryEventPropertyWriter =
                 new BoundaryEventPropertyWriter(bpmn2.createBoundaryEvent(), variableScope);
@@ -64,23 +53,4 @@ public class ProcessPropertyWriterTest {
         assertThat(process.getFlowElements().get(1)).isEqualTo(boundaryEventPropertyWriter.getFlowElement());
     }
 
-    @Test
-    public void addChildShape() {
-        BPMNShape bpmnShape = di.createBPMNShape();
-        bpmnShape.setId("a");
-        p.addChildShape(bpmnShape);
-        assertThatThrownBy(() -> p.addChildShape(bpmnShape))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot add the same shape twice");
-    }
-
-    @Test
-    public void addChildEdge() {
-        BPMNEdge bpmnEdge = di.createBPMNEdge();
-        bpmnEdge.setId("a");
-        p.addChildEdge(bpmnEdge);
-        assertThatThrownBy(() -> p.addChildEdge(bpmnEdge))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot add the same edge twice");
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
@@ -136,6 +136,8 @@ public abstract class BPMNDiagramMarshallerBase {
     private CloneManager cloneManager;
     @Mock
     private FactoryManager applicationFactoryManager;
+    @Mock
+    protected GraphCommandManager commandManager;
 
     private EdgeFactory<Object> connectionEdgeFactory;
     private NodeFactory<Object> viewNodeFactory;
@@ -329,9 +331,6 @@ public abstract class BPMNDiagramMarshallerBase {
                 new NodeFactoryImpl(definitionUtils)
         );
 
-        GraphCommandManagerImpl commandManager = new GraphCommandManagerImpl(null,
-                                                                             null,
-                                                                             null);
         GraphCommandFactory commandFactory = new GraphCommandFactory();
 
         // The tested BPMN marshaller.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
@@ -109,6 +109,7 @@ import org.kie.workbench.common.stunner.core.rule.RuleSet;
 import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
+import org.mockito.Spy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -136,8 +137,9 @@ public abstract class BPMNDiagramMarshallerBase {
     private CloneManager cloneManager;
     @Mock
     private FactoryManager applicationFactoryManager;
-    @Mock
-    protected GraphCommandManager commandManager;
+    @Spy
+    protected GraphCommandManager commandManager =
+            new GraphCommandManagerImpl(null, null, null);
 
     private EdgeFactory<Object> connectionEdgeFactory;
     private NodeFactory<Object> viewNodeFactory;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/intermediate/DockedEventsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/events/intermediate/DockedEventsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.events.intermediate;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.BPMNDiagramMarshallerBase;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.command.impl.UpdateElementPositionCommand;
+import org.mockito.ArgumentCaptor;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DockedEventsTest extends BPMNDiagramMarshallerBase {
+
+    private static final String JBPM_7645 = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/JBPM_7645.bpmn";
+
+    @Before
+    public void before() {
+        init();
+    }
+
+    @Test
+    public void testDockedElementProcessingOrder() throws Exception {
+        final String TASK_ID = "_02DDF5FF-E1E4-4DA3-9971-70CFB158A08C";
+        final String DOCKED_NODE_ID = "_6A26F0A2-3368-4769-B9E9-A6290530ED8F";
+
+        Diagram<Graph, Metadata> diagram = unmarshall(newMarshaller, JBPM_7645);
+
+        ArgumentCaptor<Command> cmd = ArgumentCaptor.forClass(Command.class);
+        verify(commandManager, times(8)).execute(any(), cmd.capture());
+        List<Command> commands = cmd.getAllValues();
+        List<UpdateElementPositionCommand> posCmds = commands.stream()
+                .filter(UpdateElementPositionCommand.class::isInstance)
+                .map(UpdateElementPositionCommand.class::cast)
+                .collect(toList());
+        assertThat(posCmds.get(0).getNode().getUUID()).isEqualTo(TASK_ID);
+        assertThat(posCmds.get(1).getNode().getUUID()).isEqualTo(DOCKED_NODE_ID);
+    }
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/JBPM_7645.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/JBPM_7645.bpmn
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:drools="http://www.jboss.org/drools" id="_7K3JkKRjEeimWcuZ5UDpfg" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:process id="my-project.my" drools:packageName="com.myspace.my_project" drools:version="1.0" drools:adHoc="false" name="my" isExecutable="true">
+
+    <bpmn2:subProcess id="_02DDF5FF-E1E4-4DA3-9971-70CFB158A08C" name="Sub-process">
+
+      <!-- boundary event should be processed after the task -->
+      <bpmn2:boundaryEvent id="_D37CB404-5190-4CF4-92A1-E5BDBFDD3276"
+                           drools:boundaryca="true"
+                           drools:dockerinfo="126.0^61.0|"
+                           name="Event"
+                           attachedToRef="_6A26F0A2-3368-4769-B9E9-A6290530ED8F">
+
+        <bpmn2:timerEventDefinition id="_7K3JlqRjEeimWcuZ5UDpfg"/>
+      </bpmn2:boundaryEvent>
+
+      <bpmn2:businessRuleTask id="_6A26F0A2-3368-4769-B9E9-A6290530ED8F" name="Task">
+      </bpmn2:businessRuleTask>
+
+    </bpmn2:subProcess>
+  </bpmn2:process>
+
+  <bpmndi:BPMNDiagram id="_7K3Jl6RjEeimWcuZ5UDpfg">
+    <bpmndi:BPMNPlane id="_7K3JmKRjEeimWcuZ5UDpfg" bpmnElement="my-project.my">
+      <bpmndi:BPMNShape id="shape__02DDF5FF-E1E4-4DA3-9971-70CFB158A08C" bpmnElement="_02DDF5FF-E1E4-4DA3-9971-70CFB158A08C">
+        <dc:Bounds height="253.0" width="653.0" x="301.0" y="157.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__D37CB404-5190-4CF4-92A1-E5BDBFDD3276" bpmnElement="_D37CB404-5190-4CF4-92A1-E5BDBFDD3276">
+        <dc:Bounds height="56.0" width="56.0" x="753.0" y="375.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__6A26F0A2-3368-4769-B9E9-A6290530ED8F" bpmnElement="_6A26F0A2-3368-4769-B9E9-A6290530ED8F">
+        <dc:Bounds height="102.0" width="154.0" x="354.0" y="185.0"/>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_7K3JmaRjEeimWcuZ5UDpfg" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_7K3JkKRjEeimWcuZ5UDpfg</bpmn2:source>
+    <bpmn2:target>_7K3JkKRjEeimWcuZ5UDpfg</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
This fixes the issue. 

Please notice that the underlying issue is that processing nodes in the sequence coming from the XML may lead to unexpected results, when the ordering is not the "right" one. In this case, we had 2 issues

**Marshalling**. Docked nodes are rendered (added) to the XML representation *before* the nodes they were docked to (e.g., the event before its parent task); the generated XML looked like this:

```xml
      <bpmn2:boundaryEvent id="_D37CB404-5190-4CF4-92A1-E5BDBFDD3276"
                           drools:boundaryca="true"
                           drools:dockerinfo="126.0^61.0|"
                           name="Event"
                           attachedToRef="_6A26F0A2-3368-4769-B9E9-A6290530ED8F">

        <bpmn2:timerEventDefinition id="_7K3JlqRjEeimWcuZ5UDpfg"/>
      </bpmn2:boundaryEvent>

      <bpmn2:businessRuleTask id="_6A26F0A2-3368-4769-B9E9-A6290530ED8F" name="Task">
      </bpmn2:businessRuleTask>
```

**Unmarshalling**.  As a rule of thumb, nodes are usually processed in the order they are read from XML; thus commands to the CommandManager, are issued in that specific order. Therefore, we were

1. adding a boundary event
2. setting its position
3. adding its parent task
4. updating its position

this somehow caused coordinates to be wrong/rendered wrong (I don't know exactly)

Please notice this is a bug (IMO this is a bug, we should not rely to the order of the serialization) both in the new and the old marshallers.

So, what we are doing now in the new marshallers is the following:

**Marshalling**: ensure that docked nodes (events) always come **after** other kind of nodes, both in processes and subprocesses. This should not be necessary, but it ensures backwards compatibility with the old marshallers

**Unmarshalling**: ensure that docked nodes are always processed **after** other nodes in processes and subprocesses. If they come *before* other nodes, we defer execution of their command (i.e. we reorder the converted nodes so that commands are sent in the right order)  

cc: @tiagodolphine @hasys @romartin 