### PR TITLE
[AF-1254]: Examples Import and Project import logic split to improve readability and to remove unwanted behavior

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-structure-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/model/ExamplesModel.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/model/ExamplesModel.java
@@ -26,7 +26,7 @@ public class ExamplesModel {
 
     private ExampleRepository sourceRepository;
     private ExampleOrganizationalUnit targetOrganizationalUnit;
-    private List<ExampleProject> projects = new ArrayList<ExampleProject>();
+    private List<ImportProject> projects = new ArrayList<ImportProject>();
 
     public ExampleRepository getSourceRepository() {
         return sourceRepository;
@@ -44,7 +44,7 @@ public class ExamplesModel {
         this.targetOrganizationalUnit = targetOrganizationalUnit;
     }
 
-    public List<ExampleProject> getProjects() {
+    public List<ImportProject> getProjects() {
         return projects;
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/model/ImportProject.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/model/ImportProject.java
@@ -24,33 +24,38 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 import org.uberfire.backend.vfs.Path;
 
 @Portable
-public class ExampleProject {
+public class ImportProject {
 
     private Path root;
     private String name;
     private String description;
+    private String origin;
     private List<String> tags;
     private List<ExampleProjectError> errors;
 
-    public ExampleProject(final @MapsTo("root") Path root,
-                          final @MapsTo("name") String name,
-                          final @MapsTo("description") String description,
-                          final @MapsTo("tags") List<String> tags,
-                          final @MapsTo("errors") List<ExampleProjectError> errors) {
+    public ImportProject(final @MapsTo("root") Path root,
+                         final @MapsTo("name") String name,
+                         final @MapsTo("description") String description,
+                         final @MapsTo("origin") String origin,
+                         final @MapsTo("tags") List<String> tags,
+                         final @MapsTo("errors") List<ExampleProjectError> errors) {
         this.root = root;
         this.name = name;
         this.description = description;
+        this.origin = origin;
         this.tags = tags;
         this.errors = errors;
     }
 
-    public ExampleProject(Path root,
-                          String name,
-                          String description,
-                          List<String> tags) {
+    public ImportProject(Path root,
+                         String name,
+                         String description,
+                         String origin,
+                         List<String> tags) {
         this(root,
              name,
              description,
+             origin,
              tags,
              new ArrayList<>());
     }
@@ -76,11 +81,11 @@ public class ExampleProject {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ExampleProject)) {
+        if (!(o instanceof ImportProject)) {
             return false;
         }
 
-        ExampleProject that = (ExampleProject) o;
+        ImportProject that = (ImportProject) o;
 
         if (!root.equals(that.root)) {
             return false;
@@ -99,6 +104,8 @@ public class ExampleProject {
         int result = root.hashCode();
         result = 31 * result + name.hashCode();
         result = ~~result;
+        result = 31 * result + origin.hashCode();
+        result = ~~result;
         result = 31 * result + (tags != null ? tags.hashCode() : 0);
         result = ~~result;
         result = 31 * result + (description != null ? description.hashCode() : 0);
@@ -108,5 +115,9 @@ public class ExampleProject {
 
     public List<ExampleProjectError> getErrors() {
         return errors;
+    }
+
+    public String getOrigin() {
+        return origin;
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/service/ExamplesService.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/service/ExamplesService.java
@@ -22,13 +22,14 @@ import java.util.Set;
 import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeEvent;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.screens.examples.model.ExampleOrganizationalUnit;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleRepository;
 import org.kie.workbench.common.screens.examples.model.ExamplesMetaData;
 import org.uberfire.commons.lifecycle.PriorityDisposable;
 
 @Remote
-public interface ExamplesService extends PriorityDisposable {
+public interface ExamplesService extends ImportService,
+                                         PriorityDisposable {
 
     String EXAMPLES_SYSTEM_PROPERTY = "org.kie.demo";
 
@@ -36,8 +37,8 @@ public interface ExamplesService extends PriorityDisposable {
 
     ExampleRepository getPlaygroundRepository();
 
-    Set<ExampleProject> getProjects(final ExampleRepository repository);
-
     WorkspaceProjectContextChangeEvent setupExamples(final ExampleOrganizationalUnit exampleTargetOU,
-                                            final List<ExampleProject> exampleProjects);
+                                                     final List<ImportProject> importProjects);
+
+    Set<ImportProject> getExampleProjects();
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/service/ImportService.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/service/ImportService.java
@@ -1,37 +1,29 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package org.kie.workbench.common.screens.library.client.screens.importrepository;
+package org.kie.workbench.common.screens.examples.service;
 
 import java.util.Set;
 
 import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.model.ExampleRepository;
+import org.uberfire.commons.lifecycle.PriorityDisposable;
 
-public class ImportProjectsSetupEvent {
+public interface ImportService extends PriorityDisposable {
 
-    private Set<ImportProject> projects;
-
-    public ImportProjectsSetupEvent() {
-    }
-
-    public ImportProjectsSetupEvent(final Set<ImportProject> projects) {
-        this.projects = projects;
-    }
-
-    public Set<ImportProject> getProjects() {
-        return projects;
-    }
+    Set<ImportProject> getProjects(final ExampleRepository repository);
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/service/ProjectImportService.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/service/ProjectImportService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.screens.examples.service;
+
+import java.util.List;
+
+import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeEvent;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.uberfire.commons.lifecycle.PriorityDisposable;
+
+@Remote
+public interface ProjectImportService extends ImportService,
+                                              PriorityDisposable {
+
+    WorkspaceProjectContextChangeEvent importProjects(final OrganizationalUnit activeOU,
+                                                      final List<ImportProject> projects);
+
+    WorkspaceProject importProject(final OrganizationalUnit activeOU,
+                                   final ImportProject projects);
+
+    WorkspaceProject importProject(final OrganizationalUnit targetOU,
+                                   final String repositoryURL,
+                                   final String username,
+                                   final String password);
+}

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/validation/ImportProjectValidator.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/validation/ImportProjectValidator.java
@@ -21,31 +21,31 @@ import java.util.Optional;
 
 import org.guvnor.common.services.project.model.POM;
 import org.guvnor.common.services.project.service.POMService;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
 
-public abstract class ExampleProjectValidator {
+public abstract class ImportProjectValidator {
 
     public static final String POM_XML = "pom.xml";
-    private Logger logger = LoggerFactory.getLogger(ExampleProjectValidator.class);
+    private Logger logger = LoggerFactory.getLogger(ImportProjectValidator.class);
 
-    public Optional<ExampleProjectError> validate(ExampleProject exampleProject) {
+    public Optional<ExampleProjectError> validate(ImportProject importProject) {
         if (logger.isDebugEnabled()) {
             logger.debug("Validation project [{}]",
-                         exampleProject.getName());
+                         importProject.getName());
         }
 
-        Path rootPath = exampleProject.getRoot();
+        Path rootPath = importProject.getRoot();
 
         Optional<ExampleProjectError> error = this.getError(rootPath);
 
         if (logger.isDebugEnabled() && error.isPresent()) {
             logger.debug("Error found [{} - {} - {}]",
-                         exampleProject.getName(),
+                         importProject.getName(),
                          error.get().getId(),
                          error.get().getDescription());
         }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/validation/ImportProjectValidators.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/main/java/org/kie/workbench/common/screens/examples/validation/ImportProjectValidators.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.screens.examples.validation;
 
 import java.util.List;
 
-public interface ExampleProjectValidators {
+public interface ImportProjectValidators {
 
-    List<ExampleProjectValidator> getValidators();
+    List<ImportProjectValidator> getValidators();
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/test/java/org/kie/workbench/common/screens/examples/validation/ImportProjectValidatorTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/src/test/java/org/kie/workbench/common/screens/examples/validation/ImportProjectValidatorTest.java
@@ -23,7 +23,7 @@ import org.guvnor.common.services.project.service.POMService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -35,31 +35,31 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExampleProjectValidatorTest {
+public class ImportProjectValidatorTest {
 
-    private ExampleProjectValidator exampleProjectValidator;
+    private ImportProjectValidator importProjectValidator;
 
     @Mock
     private POMService pomService;
 
     @Mock
-    private ExampleProject exampleProject;
+    private ImportProject importProject;
 
     @Captor
     private ArgumentCaptor<Path> pathCaptor;
 
     @Before
     public void setUp() {
-        this.exampleProjectValidator = spy(new TestValidator());
+        this.importProjectValidator = spy(new TestValidator());
     }
 
     @Test
     public void testGetPomWithFinalSlash() {
         Path path = mock(Path.class);
         when(path.toURI()).thenReturn("/");
-        when(this.exampleProject.getRoot()).thenReturn(path);
-        this.exampleProjectValidator.getPom(this.pomService,
-                                            path);
+        when(this.importProject.getRoot()).thenReturn(path);
+        this.importProjectValidator.getPom(this.pomService,
+                                           path);
 
         verify(this.pomService).load(pathCaptor.capture());
         assertEquals("/pom.xml",
@@ -70,16 +70,16 @@ public class ExampleProjectValidatorTest {
     public void testGetPomWithoutFinalSlash() {
         Path path = mock(Path.class);
         when(path.toURI()).thenReturn("/testPath");
-        when(this.exampleProject.getRoot()).thenReturn(path);
-        this.exampleProjectValidator.getPom(this.pomService,
-                                            path);
+        when(this.importProject.getRoot()).thenReturn(path);
+        this.importProjectValidator.getPom(this.pomService,
+                                           path);
 
         verify(this.pomService).load(pathCaptor.capture());
         assertEquals("/testPath/pom.xml",
                      pathCaptor.getValue().toURI());
     }
 
-    private class TestValidator extends ExampleProjectValidator {
+    private class TestValidator extends ImportProjectValidator {
 
         @Override
         protected Optional<ExampleProjectError> getError(Path projectPath) {

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/pom.xml
@@ -139,6 +139,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-backend</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-api</artifactId>
     </dependency>

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/BaseProjectImportService.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/BaseProjectImportService.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.screens.examples.backend.server;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.guvnor.common.services.project.model.Module;
+import org.guvnor.common.services.project.model.POM;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.project.service.WorkspaceProjectService;
+import org.guvnor.common.services.shared.metadata.MetadataService;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.guvnor.structure.repositories.Branch;
+import org.guvnor.structure.repositories.EnvironmentParameters;
+import org.guvnor.structure.repositories.Repository;
+import org.guvnor.structure.repositories.impl.git.GitRepository;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
+import org.kie.workbench.common.screens.examples.model.ExampleRepository;
+import org.kie.workbench.common.screens.examples.service.ImportService;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidator;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidators;
+import org.kie.workbench.common.screens.projecteditor.model.ProjectScreenModel;
+import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
+import org.kie.workbench.common.services.shared.project.KieModuleService;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+
+import static java.util.stream.Collectors.toList;
+import static org.guvnor.structure.repositories.EnvironmentParameters.MIRROR;
+import static org.guvnor.structure.repositories.EnvironmentParameters.SCHEME;
+import static org.guvnor.structure.server.config.ConfigType.REPOSITORY;
+
+public abstract class BaseProjectImportService implements ImportService {
+
+    private static final String PROJECT_DESCRIPTON = "project.description";
+    protected IOService ioService;
+    protected MetadataService metadataService;
+    protected ImportProjectValidators validators;
+    protected ConfigurationFactory configurationFactory;
+    protected KieModuleService moduleService;
+    protected WorkspaceProjectService projectService;
+    protected ProjectScreenService projectScreenService;
+
+    public BaseProjectImportService(final IOService ioService,
+                                    final MetadataService metadataService,
+                                    final ImportProjectValidators validators,
+                                    final ConfigurationFactory configurationFactory,
+                                    final KieModuleService moduleService,
+                                    final WorkspaceProjectService projectService,
+                                    final ProjectScreenService projectScreenService) {
+        this.ioService = ioService;
+
+        this.metadataService = metadataService;
+        this.validators = validators;
+        this.configurationFactory = configurationFactory;
+        this.moduleService = moduleService;
+        this.projectService = projectService;
+        this.projectScreenService = projectScreenService;
+    }
+
+    protected String getRepositoryAlias(String url) {
+        String alias = url;
+        alias = alias.substring(alias.lastIndexOf('/') + 1);
+        final int lastDotIndex = alias.lastIndexOf('.');
+        if (lastDotIndex > 0) {
+            alias = alias.substring(0,
+                                    lastDotIndex);
+        }
+        return alias;
+    }
+
+    protected List<String> getTags(final Module module) {
+        List<String> tags = metadataService.getTags(module.getPomXMLPath());
+        tags.sort(String::compareTo);
+        return tags;
+    }
+
+    protected Set<ImportProject> convert(final Branch branch,
+                                         final ExampleRepository repository) {
+        final Set<Module> modules = moduleService.getAllModules(branch);
+        return modules.stream()
+                .map(p -> makeExampleProject(p,
+                                             repository))
+                .collect(Collectors.toSet());
+    }
+
+    protected ImportProject makeExampleProject(final Module module,
+                                               ExampleRepository repository) {
+        final String description = readDescription(module);
+        final List<String> tags = getTags(module);
+
+        return new ImportProject(module.getRootPath(),
+                                 module.getModuleName(),
+                                 description,
+                                 repository.getUrl(),
+                                 tags);
+    }
+
+    protected String readDescription(final Module module) {
+        final Path root = module.getRootPath();
+        final POM pom = module.getPom();
+        final org.uberfire.java.nio.file.Path nioRoot = Paths.convert(root);
+        final org.uberfire.java.nio.file.Path nioDescription = nioRoot.resolve(PROJECT_DESCRIPTON);
+        String description = "Example '" + module.getModuleName() + "' module";
+
+        if (ioService.exists(nioDescription)) {
+            description = ioService.readAllString(nioDescription);
+        } else if (pom != null
+                && pom.getDescription() != null
+                && !pom.getDescription().isEmpty()) {
+            description = pom.getDescription();
+        }
+
+        if (description != null) {
+            return description.replaceAll("\\s+",
+                                          " ");
+        }
+
+        return description;
+    }
+
+    protected Set<ImportProject> validateProjects(Set<ImportProject> projects) {
+        return projects
+                .stream()
+                .map(project -> {
+                    List<ExampleProjectError> errors = getValidators().stream()
+                            .map(exampleProjectValidation -> exampleProjectValidation.validate(project))
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .collect(toList());
+                    return new ImportProject(project.getRoot(),
+                                             project.getName(),
+                                             project.getDescription(),
+                                             project.getOrigin(),
+                                             project.getTags(),
+                                             errors);
+                })
+                .collect(Collectors.toSet());
+    }
+
+    protected ConfigGroup createConfigGroup(String alias,
+                                            Map<String, Object> env) {
+        ConfigGroup repositoryConfig = configurationFactory.newConfigGroup(REPOSITORY,
+                                                                           "system",
+                                                                           alias,
+                                                                           "");
+
+        for (final Map.Entry<String, Object> entry : env.entrySet()) {
+            repositoryConfig.addConfigItem(configurationFactory.newConfigItem(entry.getKey(),
+                                                                              entry.getValue()));
+        }
+
+        repositoryConfig.addConfigItem(configurationFactory.newConfigItem(EnvironmentParameters.AVOID_INDEX,
+                                                                          "true"));
+
+        repositoryConfig.addConfigItem(configurationFactory.newConfigItem(EnvironmentParameters.SPACE,
+                                                                          "system"));
+
+        return repositoryConfig;
+    }
+
+    protected Map<String, Object> buildGitEnv(String url,
+                                                  String username,
+                                                  String password,
+                                                  boolean mirror) {
+        return new HashMap<String, Object>() {{
+            put("origin",
+                url);
+            put(SCHEME,
+                GitRepository.SCHEME.toString());
+            put("replaceIfExists",
+                true);
+            put("username",
+                username);
+            put("password",
+                password);
+            put(MIRROR,
+                mirror);
+        }};
+    }
+
+    protected WorkspaceProject renameIfNecessary(final OrganizationalUnit ou,
+                                                 final WorkspaceProject project) {
+
+        String name = project.getName();
+        Collection<WorkspaceProject> projectsWithSameName = projectService.getAllWorkspaceProjectsByName(ou,
+                                                                                                         name);
+
+        if (projectsWithSameName.size() > 1) {
+            name = this.projectService.createFreshProjectName(ou,
+                                                              project.getName());
+        }
+
+        if (!name.equals(project.getName())) {
+            final Path pomXMLPath = project.getMainModule().getPomXMLPath();
+            final ProjectScreenModel model = projectScreenService.load(pomXMLPath);
+            model.getPOM().setName(name);
+            projectScreenService.save(pomXMLPath,
+                                      model,
+                                      "");
+            return projectService.resolveProject(pomXMLPath);
+        }
+
+        return project;
+    }
+
+    @Override
+    public Set<ImportProject> getProjects(final ExampleRepository repository) {
+
+        if (repository == null) {
+            return Collections.emptySet();
+        }
+        final String repositoryURL = repository.getUrl();
+        if (repositoryURL == null || repositoryURL.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        Repository gitRepository = resolveGitRepository(repository);
+
+        if (gitRepository == null) {
+            return Collections.emptySet();
+        }
+
+        Set<ImportProject> importProjects = convert(gitRepository.getBranch("master").get(),
+                                                    repository);
+        return validateProjects(importProjects);
+    }
+
+    protected List<ImportProjectValidator> getValidators() {
+        return this.validators.getValidators();
+    }
+
+    protected abstract Repository resolveGitRepository(final ExampleRepository exampleRepository);
+}

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImpl.java
@@ -21,18 +21,12 @@ import java.io.FileOutputStream;
 import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.SimpleFileVisitor;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -43,52 +37,37 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeEvent;
 import org.guvnor.common.services.project.events.NewProjectEvent;
-import org.guvnor.common.services.project.model.Module;
-import org.guvnor.common.services.project.model.POM;
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.guvnor.common.services.shared.metadata.MetadataService;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
-import org.guvnor.structure.repositories.EnvironmentParameters;
 import org.guvnor.structure.repositories.Repository;
 import org.guvnor.structure.repositories.RepositoryCopier;
-import org.guvnor.structure.repositories.impl.git.GitRepository;
 import org.guvnor.structure.server.config.ConfigGroup;
 import org.guvnor.structure.server.config.ConfigurationFactory;
 import org.guvnor.structure.server.repositories.RepositoryFactory;
 import org.jboss.errai.bus.server.annotations.Service;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.screens.examples.model.ExampleOrganizationalUnit;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
-import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleRepository;
 import org.kie.workbench.common.screens.examples.model.ExamplesMetaData;
 import org.kie.workbench.common.screens.examples.service.ExamplesService;
-import org.kie.workbench.common.screens.examples.validation.ExampleProjectValidator;
-import org.kie.workbench.common.screens.examples.validation.ExampleProjectValidators;
-import org.kie.workbench.common.screens.projecteditor.model.ProjectScreenModel;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidators;
 import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Paths;
-import org.uberfire.backend.vfs.Path;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.IOException;
 
-import static java.util.stream.Collectors.toList;
-import static org.guvnor.structure.repositories.EnvironmentParameters.MIRROR;
-import static org.guvnor.structure.repositories.EnvironmentParameters.SCHEME;
-import static org.guvnor.structure.server.config.ConfigType.REPOSITORY;
-
 @Service
 @ApplicationScoped
-public class ExamplesServiceImpl implements ExamplesService {
+public class ExamplesServiceImpl extends BaseProjectImportService implements ExamplesService {
 
     private static final Logger logger = LoggerFactory.getLogger(ExamplesServiceImpl.class);
-
-    private static final String PROJECT_DESCRIPTON = "project.description";
 
     private static final String KIE_WB_PLAYGROUND_ZIP = "org/kie/kie-wb-playground/kie-wb-playground.zip";
     private final Set<Repository> clonedRepositories = new HashSet<>();
@@ -103,11 +82,7 @@ public class ExamplesServiceImpl implements ExamplesService {
     private MetadataService metadataService;
     private ExampleRepository playgroundRepository;
     private ProjectScreenService projectScreenService;
-    private ExampleProjectValidators validators;
-
-    public ExamplesServiceImpl() {
-        //Zero-parameter Constructor for CDI proxies
-    }
+    private ImportProjectValidators validators;
 
     @Inject
     public ExamplesServiceImpl(final @Named("ioStrategy") IOService ioService,
@@ -120,7 +95,16 @@ public class ExamplesServiceImpl implements ExamplesService {
                                final MetadataService metadataService,
                                final Event<NewProjectEvent> newProjectEvent,
                                final ProjectScreenService projectScreenService,
-                               final ExampleProjectValidators validators) {
+                               final ImportProjectValidators validators) {
+
+        super(ioService,
+              metadataService,
+              validators,
+              configurationFactory,
+              moduleService,
+              projectService,
+              projectScreenService);
+
         this.ioService = ioService;
         this.configurationFactory = configurationFactory;
         this.repositoryFactory = repositoryFactory;
@@ -204,7 +188,7 @@ public class ExamplesServiceImpl implements ExamplesService {
                                          });
     }
 
-    String resolveRepositoryUrl(final String playgroundDirectoryPath) {
+    protected String resolveRepositoryUrl(final String playgroundDirectoryPath) {
         if ("\\".equals(getFileSeparator())) {
             return "file:///" + playgroundDirectoryPath.replaceAll("\\\\",
                                                                    "/");
@@ -224,50 +208,7 @@ public class ExamplesServiceImpl implements ExamplesService {
     }
 
     @Override
-    public Set<ExampleProject> getProjects(final ExampleRepository repository) {
-        if (repository == null) {
-            return Collections.emptySet();
-        }
-        final String repositoryURL = repository.getUrl();
-        if (repositoryURL == null || repositoryURL.trim().isEmpty()) {
-            return Collections.emptySet();
-        }
-
-        // Avoid cloning playground repository multiple times
-        Repository gitRepository = resolveGitRepository(repository);
-
-        if (gitRepository == null) {
-            return Collections.emptySet();
-        }
-
-        final Set<Module> modules = moduleService.getAllModules(gitRepository.getBranch("master").get());
-        Set<ExampleProject> exampleProjects = convert(modules);
-        return validateProjects(exampleProjects);
-    }
-
-    private Set<ExampleProject> validateProjects(Set<ExampleProject> exampleProjects) {
-        return exampleProjects
-                .stream()
-                .map(exampleProject -> {
-                    List<ExampleProjectError> errors = getValidators().stream()
-                            .map(exampleProjectValidation -> exampleProjectValidation.validate(exampleProject))
-                            .filter(Optional::isPresent)
-                            .map(Optional::get)
-                            .collect(toList());
-                    return new ExampleProject(exampleProject.getRoot(),
-                                              exampleProject.getName(),
-                                              exampleProject.getDescription(),
-                                              exampleProject.getTags(),
-                                              errors);
-                })
-                .collect(Collectors.toSet());
-    }
-
-    protected List<ExampleProjectValidator> getValidators() {
-        return this.validators.getValidators();
-    }
-
-    Repository resolveGitRepository(final ExampleRepository exampleRepository) {
+    protected Repository resolveGitRepository(final ExampleRepository exampleRepository) {
         if (exampleRepository.equals(playgroundRepository)) {
             return clonedRepositories.stream().filter(r -> exampleRepository.getUrl().equals(r.getEnvironment().get("origin"))).findFirst().orElseGet(() -> cloneRepository(exampleRepository.getUrl()));
         } else {
@@ -286,40 +227,17 @@ public class ExamplesServiceImpl implements ExamplesService {
     private Repository cloneRepository(final String repositoryURL,
                                        final String userName,
                                        final String password) {
-        Repository repository = null;
         try {
-            final String alias = getExampleAlias(repositoryURL);
-            final Map<String, Object> env = new HashMap<String, Object>() {{
-                put("origin",
-                    repositoryURL);
-                put(SCHEME,
-                    GitRepository.SCHEME.toString());
-                put("replaceIfExists",
-                    true);
-                put("username",
-                    userName);
-                put("password",
-                    password);
-                put(MIRROR,
-                    false);
-            }};
+            final String alias = getRepositoryAlias(repositoryURL);
+            final Map<String, Object> env = this.buildGitEnv(repositoryURL,
+                                                             userName,
+                                                             password,
+                                                             false);
 
-            final ConfigGroup repositoryConfig = configurationFactory.newConfigGroup(REPOSITORY,
-                                                                                     "system",
-                                                                                     alias,
-                                                                                     "");
-            for (final Map.Entry<String, Object> entry : env.entrySet()) {
-                repositoryConfig.addConfigItem(configurationFactory.newConfigItem(entry.getKey(),
-                                                                                  entry.getValue()));
-            }
+            final ConfigGroup repositoryConfig = this.createConfigGroup(alias,
+                                                                        env);
 
-            repositoryConfig.addConfigItem(configurationFactory.newConfigItem(EnvironmentParameters.AVOID_INDEX,
-                                                                              "true"));
-
-            repositoryConfig.addConfigItem(configurationFactory.newConfigItem(EnvironmentParameters.SPACE,
-                                                                              "system"));
-
-            repository = repositoryFactory.newRepository(repositoryConfig);
+            Repository repository = repositoryFactory.newRepository(repositoryConfig);
             clonedRepositories.add(repository);
             return repository;
         } catch (final Exception e) {
@@ -329,135 +247,39 @@ public class ExamplesServiceImpl implements ExamplesService {
         }
     }
 
-    String getExampleAlias(final String repositoryURL) {
-        String alias = repositoryURL;
-        alias = alias.substring(alias.lastIndexOf("/") + 1);
-        final int lastDotIndex = alias.lastIndexOf('.');
-        if (lastDotIndex > 0) {
-            alias = alias.substring(0,
-                                    lastDotIndex);
-        }
-        return "examples-" + alias;
+    @Override
+    protected String getRepositoryAlias(final String repositoryURL) {
+        return "examples-" + super.getRepositoryAlias(repositoryURL);
     }
 
     String getFileSeparator() {
         return FileSystems.getDefault().getSeparator();
     }
 
-    private Set<ExampleProject> convert(final Set<Module> modules) {
-        return modules.stream()
-                .map(p -> makeExampleProject(p))
-                .collect(Collectors.toSet());
-    }
-
-    private ExampleProject makeExampleProject(final Module module) {
-        final String description = readDescription(module);
-        final List<String> tags = getTags(module);
-
-        return new ExampleProject(module.getRootPath(),
-                                  module.getModuleName(),
-                                  description,
-                                  tags);
-    }
-
-    private String readDescription(final Module module) {
-        final Path root = module.getRootPath();
-        final POM pom = module.getPom();
-        final org.uberfire.java.nio.file.Path nioRoot = Paths.convert(root);
-        final org.uberfire.java.nio.file.Path nioDescription = nioRoot.resolve(PROJECT_DESCRIPTON);
-        String description = "Example '" + module.getModuleName() + "' module";
-
-        if (ioService.exists(nioDescription)) {
-            description = ioService.readAllString(nioDescription);
-        } else if (pom != null
-                && pom.getDescription() != null
-                && !pom.getDescription().isEmpty()) {
-            description = pom.getDescription();
-        }
-
-        if (description != null) {
-            return description.replaceAll("[\\s]+",
-                                          " ");
-        }
-
-        return description;
-    }
-
-    private List<String> getTags(final Module module) {
-        List<String> tags = metadataService.getTags(module.getPomXMLPath());
-        tags.sort(String::compareTo);
-        return tags;
-    }
-
     @Override
     public WorkspaceProjectContextChangeEvent setupExamples(final ExampleOrganizationalUnit exampleTargetOU,
-                                                            final List<ExampleProject> exampleProjects) {
+                                                            final List<ImportProject> importProjects) {
         PortablePreconditions.checkNotNull("exampleTargetOU",
                                            exampleTargetOU);
         PortablePreconditions.checkNotNull("exampleProjects",
-                                           exampleProjects);
+                                           importProjects);
         PortablePreconditions.checkCondition("Must have at least one ExampleProject",
-                                             exampleProjects.size() > 0);
+                                             importProjects.size() > 0);
 
         //Retrieve or create Organizational Unit
         final String targetOUName = exampleTargetOU.getName();
         final OrganizationalUnit targetOU = getOrganizationalUnit(targetOUName);
-
-        WorkspaceProject firstExampleProject = null;
-
-        for (final ExampleProject exampleProject : exampleProjects) {
-            try {
-                final Repository targetRepository = repositoryCopier.copy(targetOU,
-                                                                          exampleProject.getName(),
-                                                                          exampleProject.getRoot());
-
-                // Signal creation of new Project (Creation of OU and Repository, if applicable,
-                // are already handled in the corresponding services).
-                WorkspaceProject project = projectService.resolveProject(targetRepository);
-                project = renameIfNecessary(targetOU,
-                                            project);
-                newProjectEvent.fire(new NewProjectEvent(project));
-
-                //Store first new example project
-                if (firstExampleProject == null) {
-                    firstExampleProject = project;
-                }
-            } catch (IOException ioe) {
-                logger.error("Unable to create Example(s).",
-                             ioe);
-            }
-        }
-
-        return new WorkspaceProjectContextChangeEvent(firstExampleProject,
-                                                      firstExampleProject.getMainModule());
+        return this.importProjects(targetOU,
+                                   importProjects);
     }
 
-    private WorkspaceProject renameIfNecessary(final OrganizationalUnit ou,
-                                               final WorkspaceProject project) {
-
-        String name = project.getName();
-        Collection<WorkspaceProject> projectsWithSameName = projectService.getAllWorkspaceProjectsByName(ou,
-                                                                                                         name);
-
-        if (projectsWithSameName.size() > 1) {
-            name = this.projectService.createFreshProjectName(ou,
-                                                              project.getName());
-        }
-
-        if (!name.equals(project.getName())) {
-            final Path pomXMLPath = project.getMainModule().getPomXMLPath();
-            final ProjectScreenModel model = projectScreenService.load(pomXMLPath);
-            model.getPOM().setName(name);
-            projectScreenService.save(pomXMLPath,
-                                      model,
-                                      "");
-            return projectService.resolveProject(pomXMLPath);
-        }
-
-        return project;
+    @Override
+    public Set<ImportProject> getExampleProjects() {
+        ExampleRepository repos = this.getPlaygroundRepository();
+        return this.getProjects(repos);
     }
 
-    private OrganizationalUnit getOrganizationalUnit(String targetOUName) {
+    protected OrganizationalUnit getOrganizationalUnit(String targetOUName) {
         OrganizationalUnit targetOU = ouService.getOrganizationalUnit(targetOUName);
         if (targetOU == null) {
             targetOU = createOrganizationalUnit(targetOUName);
@@ -465,7 +287,7 @@ public class ExamplesServiceImpl implements ExamplesService {
         return targetOU;
     }
 
-    private OrganizationalUnit createOrganizationalUnit(final String name) {
+    protected OrganizationalUnit createOrganizationalUnit(final String name) {
         final OrganizationalUnit ou = ouService.createOrganizationalUnit(name,
                                                                          "",
                                                                          "");
@@ -498,5 +320,37 @@ public class ExamplesServiceImpl implements ExamplesService {
 
     void setPlaygroundRepository(final ExampleRepository playgroundRepository) {
         this.playgroundRepository = playgroundRepository;
+    }
+
+    protected WorkspaceProjectContextChangeEvent importProjects(OrganizationalUnit targetOU,
+                                                                List<ImportProject> projects) {
+
+        WorkspaceProject firstExampleProject = null;
+
+        for (final ImportProject importProject : projects) {
+            try {
+                final Repository targetRepository = repositoryCopier.copy(targetOU,
+                                                                          "example-" + importProject.getName(),
+                                                                          importProject.getRoot());
+
+                // Signal creation of new Project (Creation of OU and Repository, if applicable,
+                // are already handled in the corresponding services).
+                WorkspaceProject project = projectService.resolveProject(targetRepository);
+                project = renameIfNecessary(targetOU,
+                                            project);
+                newProjectEvent.fire(new NewProjectEvent(project));
+
+                //Store first new example project
+                if (firstExampleProject == null) {
+                    firstExampleProject = project;
+                }
+            } catch (IOException ioe) {
+                logger.error("Unable to create Example(s).",
+                             ioe);
+            }
+        }
+
+        return new WorkspaceProjectContextChangeEvent(firstExampleProject,
+                                                      firstExampleProject.getMainModule());
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.screens.examples.backend.server;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.common.services.project.backend.server.utils.PathUtil;
+import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeEvent;
+import org.guvnor.common.services.project.events.NewProjectEvent;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.project.service.WorkspaceProjectService;
+import org.guvnor.common.services.shared.metadata.MetadataService;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.guvnor.structure.repositories.Repository;
+import org.guvnor.structure.repositories.RepositoryEnvironmentConfigurations;
+import org.guvnor.structure.repositories.RepositoryService;
+import org.guvnor.structure.repositories.impl.git.GitRepository;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.guvnor.structure.server.repositories.RepositoryFactory;
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.model.ExampleRepository;
+import org.kie.workbench.common.screens.examples.service.ProjectImportService;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidators;
+import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
+import org.kie.workbench.common.services.shared.project.KieModuleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.NoSuchFileException;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@ApplicationScoped
+public class ProjectImportServiceImpl extends BaseProjectImportService implements ProjectImportService {
+
+    private static final Pattern STRIP_DOT_GIT = Pattern.compile("\\.git$");
+
+    private Logger logger = LoggerFactory.getLogger(ProjectImportServiceImpl.class);
+    private RepositoryFactory repositoryFactory;
+    private final PathUtil pathUtil;
+    private final Event<NewProjectEvent> newProjectEvent;
+    private final RepositoryService repoService;
+
+    private final Set<Repository> clonedRepositories = new HashSet<>();
+
+    @Inject
+    public ProjectImportServiceImpl(final @Named("ioStrategy") IOService ioService,
+                                    final MetadataService metadataService,
+                                    final ConfigurationFactory configurationFactory,
+                                    final RepositoryFactory repositoryFactory,
+                                    final KieModuleService moduleService,
+                                    final ImportProjectValidators validators,
+                                    final PathUtil pathUtil,
+                                    final WorkspaceProjectService projectService,
+                                    final ProjectScreenService projectScreenService,
+                                    final Event<NewProjectEvent> newProjectEvent,
+                                    final RepositoryService repoService) {
+
+        super(ioService,
+              metadataService,
+              validators,
+              configurationFactory,
+              moduleService,
+              projectService,
+              projectScreenService);
+        this.repositoryFactory = repositoryFactory;
+        this.pathUtil = pathUtil;
+        this.newProjectEvent = newProjectEvent;
+        this.repoService = repoService;
+    }
+
+    @Override
+    protected Repository resolveGitRepository(ExampleRepository repository) {
+
+        try {
+            String url = repository.getUrl();
+            final String alias = getRepositoryAlias(url);
+            final Map<String, Object> env = this.buildGitEnv(url,
+                                                             repository.getUserName(),
+                                                             repository.getPassword(),
+                                                             true);
+
+            final ConfigGroup repositoryConfig = createConfigGroup(alias,
+                                                                   env);
+
+            Repository repo = repositoryFactory.newRepository(repositoryConfig);
+            clonedRepositories.add(repo);
+            return repo;
+        } catch (final Exception e) {
+            logger.error("Error during create repository",
+                         e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+
+    @Override
+    public void dispose() {
+        for (final Repository repository : clonedRepositories) {
+            try {
+                if (repository.getDefaultBranch().isPresent()) {
+                    ioService.delete(Paths.convert(repository.getDefaultBranch().get().getPath()).getFileSystem().getPath(null));
+                }
+            } catch (Exception e) {
+                logger.warn("Unable to remove transient Repository '" + repository.getAlias() + "'.",
+                            e);
+            }
+        }
+    }
+
+    @Override
+    public WorkspaceProjectContextChangeEvent importProjects(OrganizationalUnit activeOU,
+                                                             List<ImportProject> projects) {
+
+        PortablePreconditions.checkNotNull("activeOU",
+                                           activeOU);
+        PortablePreconditions.checkNotNull("projects",
+                                           projects);
+        PortablePreconditions.checkCondition("Must have at least one Project",
+                                             projects.size() > 0);
+
+        List<WorkspaceProject> importedProjects = projects.stream()
+                .map(exampleProject -> {
+                    WorkspaceProject project = this.importProject(activeOU,
+                                                                  exampleProject);
+                    return this.renameIfNecessary(activeOU,
+                                                  project);
+                })
+                .collect(Collectors.toList());
+
+        if (importedProjects.size() == 1) {
+            final WorkspaceProject importedProject = importedProjects.get(0);
+            return new WorkspaceProjectContextChangeEvent(importedProject,
+                                                          importedProject.getMainModule());
+        } else {
+            return new WorkspaceProjectContextChangeEvent(activeOU);
+        }
+    }
+
+    @Override
+    public WorkspaceProject importProject(final OrganizationalUnit organizationalUnit,
+                                          final ImportProject importProject) {
+        final org.uberfire.java.nio.file.Path rootPath = getProjectRoot(importProject);
+        String origin = importProject.getOrigin();
+        if (pathUtil.convert(importProject.getRoot()).equals(rootPath)) {
+            return importProject(organizationalUnit,
+                                 origin,
+                                 null,
+                                 null);
+        } else {
+            final RepositoryEnvironmentConfigurations configurations = new RepositoryEnvironmentConfigurations();
+            configurations.setInit(false);
+            configurations.setOrigin(origin);
+            configurations.setBranches(getBranches(rootPath,
+                                                   importProject.getRoot()));
+            configurations.setMirror(false);
+            final String subdirectoryPath = pathUtil.stripRepoNameAndSpace(pathUtil.stripProtocolAndBranch(importProject.getRoot().toURI()));
+            configurations.setSubdirectory(subdirectoryPath);
+
+            final Repository importedRepo = repoService.createRepository(organizationalUnit,
+                                                                         GitRepository.SCHEME.toString(),
+                                                                         importProject.getName(),
+                                                                         configurations);
+
+            // Signal creation of new Project (Creation of OU and Repository, if applicable,
+            // are already handled in the corresponding services).
+            final WorkspaceProject project = projectService.resolveProject(importedRepo);
+            newProjectEvent.fire(new NewProjectEvent(project));
+
+            return project;
+        }
+    }
+
+    @Override
+    public WorkspaceProject importProject(final OrganizationalUnit targetOU,
+                                          final String repositoryURL,
+                                          final String username,
+                                          final String password) {
+        final RepositoryEnvironmentConfigurations config = new RepositoryEnvironmentConfigurations();
+        config.setOrigin(repositoryURL);
+        if (username != null && password != null) {
+            config.setUserName(username);
+            config.setPassword(password);
+        }
+
+        final String targetProjectName = inferProjectName(repositoryURL);
+
+        final Repository repo = repoService.createRepository(targetOU,
+                                                             GitRepository.SCHEME.toString(),
+                                                             targetProjectName,
+                                                             config);
+        return projectService.resolveProject(repo);
+    }
+
+    private List<String> getBranches(final org.uberfire.java.nio.file.Path rootPath,
+                                     final Path projectPath) {
+        final FileSystem fs = rootPath.getFileSystem();
+        final String exampleRootPath = pathUtil.stripRepoNameAndSpace(pathUtil.stripProtocolAndBranch(projectPath.toURI()));
+        return StreamSupport.stream(fs.getRootDirectories().spliterator(),
+                                    false)
+                .filter(root -> exists(root.resolve(exampleRootPath)))
+                .map(pathUtil::convert)
+                .map(root -> pathUtil.extractBranch(root.toURI()))
+                .flatMap(oBranch -> oBranch.map(Stream::of).orElse(Stream.empty()))
+                .collect(toList());
+    }
+
+    private boolean exists(org.uberfire.java.nio.file.Path path) {
+        try {
+            final FileSystemProvider provider = path.getFileSystem().provider();
+            provider.readAttributes(path,
+                                    BasicFileAttributes.class);
+
+            return true;
+        } catch (NoSuchFileException nfe) {
+            return false;
+        }
+    }
+
+    private String inferProjectName(String repositoryURL) {
+        return Optional.of(repositoryURL)
+                .map(url -> java.nio.file.Paths.get(repositoryURL))
+                .map(path -> path.getFileName().toString())
+                .map(fileName -> STRIP_DOT_GIT.matcher(fileName))
+                .map(matcher -> matcher.replaceFirst(""))
+                .orElse("new-project");
+    }
+
+    private org.uberfire.java.nio.file.Path getProjectRoot(final ImportProject importProject) {
+        return Stream.iterate(pathUtil.convert(importProject.getRoot()),
+                              p -> p.getParent())
+                .filter(p -> p != null && p.getParent() == null)
+                .findFirst()
+                .get();
+    }
+}
+

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/validation/CheckModulesValidator.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/validation/CheckModulesValidator.java
@@ -24,14 +24,14 @@ import javax.inject.Inject;
 import org.guvnor.common.services.project.model.POM;
 import org.guvnor.common.services.project.service.POMService;
 import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
-import org.kie.workbench.common.screens.examples.validation.ExampleProjectValidator;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidator;
 import org.uberfire.backend.vfs.Path;
 
 /**
  * Validates if Project POM contains any module. No modules should be found to be a valid project.
  */
 @ApplicationScoped
-public class CheckModulesValidator extends ExampleProjectValidator {
+public class CheckModulesValidator extends ImportProjectValidator {
 
     private POMService pomService;
 

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/validation/ImportProjectValidatorsImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/validation/ImportProjectValidatorsImpl.java
@@ -19,25 +19,24 @@ package org.kie.workbench.common.screens.examples.backend.validation;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import com.google.common.collect.Lists;
-import org.kie.workbench.common.screens.examples.validation.ExampleProjectValidator;
-import org.kie.workbench.common.screens.examples.validation.ExampleProjectValidators;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidator;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidators;
 
 @ApplicationScoped
-public class ExampleProjectValidatorsImpl implements ExampleProjectValidators {
+public class ImportProjectValidatorsImpl implements ImportProjectValidators {
 
-    private List<ExampleProjectValidator> validators;
+    private List<ImportProjectValidator> validators;
 
-    public ExampleProjectValidatorsImpl() {
+    public ImportProjectValidatorsImpl() {
     }
 
     @Inject
-    public ExampleProjectValidatorsImpl(Instance<ExampleProjectValidator> validators) {
+    public ImportProjectValidatorsImpl(Instance<ImportProjectValidator> validators) {
 
         if (validators == null) {
             this.validators = new ArrayList<>();
@@ -47,7 +46,7 @@ public class ExampleProjectValidatorsImpl implements ExampleProjectValidators {
     }
 
     @Override
-    public List<ExampleProjectValidator> getValidators() {
+    public List<ImportProjectValidator> getValidators() {
         return this.validators;
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImplCheckNoIndexConfigTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ExamplesServiceImplCheckNoIndexConfigTest.java
@@ -35,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.examples.model.ExampleRepository;
-import org.kie.workbench.common.screens.examples.validation.ExampleProjectValidators;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidators;
 import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
 import org.mockito.Mock;
@@ -94,7 +94,7 @@ public class ExamplesServiceImplCheckNoIndexConfigTest {
     private SessionInfo sessionInfo;
 
     @Mock
-    private ExampleProjectValidators validators;
+    private ImportProjectValidators validators;
 
     private ExamplesServiceImpl service;
 

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ImportUtils.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ImportUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.screens.examples.backend.server;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.guvnor.structure.repositories.Branch;
+import org.guvnor.structure.repositories.impl.git.GitRepository;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.spaces.Space;
+
+import static org.mockito.Mockito.*;
+
+public class ImportUtils {
+
+    public static GitRepository makeGitRepository() {
+        final GitRepository repository = new GitRepository("guvnorng-playground",
+                                                           new Space("space"));
+
+        final Map<String, Branch> branches = Collections.singletonMap("master",
+                                                                      new Branch("master",
+                                                                                 mock(Path.class)));
+        repository.setBranches(branches);
+
+        return repository;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImplTest.java
@@ -1,0 +1,543 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.screens.examples.backend.server;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.enterprise.event.Event;
+
+import org.guvnor.common.services.project.backend.server.utils.PathUtil;
+import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeEvent;
+import org.guvnor.common.services.project.events.NewProjectEvent;
+import org.guvnor.common.services.project.model.Module;
+import org.guvnor.common.services.project.model.POM;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.project.service.WorkspaceProjectService;
+import org.guvnor.common.services.shared.metadata.MetadataService;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
+import org.guvnor.structure.organizationalunit.impl.OrganizationalUnitImpl;
+import org.guvnor.structure.repositories.Branch;
+import org.guvnor.structure.repositories.Repository;
+import org.guvnor.structure.repositories.RepositoryEnvironmentConfigurations;
+import org.guvnor.structure.repositories.RepositoryService;
+import org.guvnor.structure.repositories.impl.git.GitRepository;
+import org.guvnor.structure.server.config.ConfigGroup;
+import org.guvnor.structure.server.config.ConfigType;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.guvnor.structure.server.repositories.RepositoryFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.examples.model.ExampleRepository;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.validation.ImportProjectValidators;
+import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
+import org.kie.workbench.common.services.shared.project.KieModule;
+import org.kie.workbench.common.services.shared.project.KieModuleService;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
+import org.uberfire.java.nio.fs.jgit.JGitPathImpl;
+import org.uberfire.spaces.Space;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.*;
+import static org.kie.workbench.common.screens.examples.backend.server.ImportUtils.makeGitRepository;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectImportServiceImplTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private ConfigurationFactory configurationFactory;
+
+    @Mock
+    private RepositoryFactory repositoryFactory;
+
+    @Mock
+    private KieModuleService moduleService;
+
+    @Mock
+    private OrganizationalUnitService ouService;
+
+    @Mock
+    private MetadataService metadataService;
+
+    @Mock
+    private WorkspaceProjectService projectService;
+
+    @Mock
+    private ProjectScreenService projectScreenService;
+
+    private ProjectImportServiceImpl service;
+
+    @Mock
+    private ImportProjectValidators validators;
+
+    @Mock
+    private PathUtil pathUtil;
+
+    private final PathUtil realPathUtil = new PathUtil();
+
+    @Mock
+    private Event<NewProjectEvent> newProjectEvent;
+
+    @Mock
+    private RepositoryService repoService;
+
+    @Before
+    public void setup() {
+        service = spy(new ProjectImportServiceImpl(ioService,
+                                                   metadataService,
+                                                   configurationFactory,
+                                                   repositoryFactory,
+                                                   moduleService,
+                                                   validators,
+                                                   pathUtil,
+                                                   projectService,
+                                                   projectScreenService,
+                                                   newProjectEvent,
+                                                   repoService));
+
+        when(configurationFactory.newConfigGroup(any(ConfigType.class),
+                                                 anyString(),
+                                                 anyString(),
+                                                 anyString())).thenReturn(mock(ConfigGroup.class));
+    }
+
+    @Test
+    public void testGetProjects_NullRepository() {
+        final Set<ImportProject> modules = service.getProjects(null);
+        assertNotNull(modules);
+        assertEquals(0,
+                     modules.size());
+    }
+
+    @Test
+    public void testGetProjects_NullRepositoryUrl() {
+        final Set<ImportProject> modules = service.getProjects(new ExampleRepository(null));
+        assertNotNull(modules);
+        assertEquals(0,
+                     modules.size());
+    }
+
+    @Test
+    public void testGetProjects_EmptyRepositoryUrl() {
+        final Set<ImportProject> modules = service.getProjects(new ExampleRepository(""));
+        assertNotNull(modules);
+        assertEquals(0,
+                     modules.size());
+    }
+
+    @Test
+    public void testGetProjects_WhiteSpaceRepositoryUrl() {
+        final Set<ImportProject> modules = service.getProjects(new ExampleRepository("   "));
+        assertNotNull(modules);
+        assertEquals(0,
+                     modules.size());
+    }
+
+    @Test
+    public void testGetProjects_DefaultDescription() {
+        final Path moduleRoot = mock(Path.class);
+        final KieModule module = mock(KieModule.class);
+        when(module.getRootPath()).thenReturn(moduleRoot);
+        when(module.getModuleName()).thenReturn("module1");
+        when(moduleRoot.toURI()).thenReturn("default:///module1");
+        when(metadataService.getTags(any(Path.class))).thenReturn(Arrays.asList("tag1",
+                                                                                "tag2"));
+
+        final GitRepository repository = makeGitRepository();
+        when(repositoryFactory.newRepository(any(ConfigGroup.class))).thenReturn(repository);
+        when(moduleService.getAllModules(any(Branch.class))).thenReturn(new HashSet<Module>() {{
+            add(module);
+        }});
+
+        String origin = "https://github.com/guvnorngtestuser1/guvnorng-playground.git";
+        final Set<ImportProject> modules = service.getProjects(new ExampleRepository(origin));
+        assertNotNull(modules);
+        assertEquals(1,
+                     modules.size());
+        assertTrue(modules.contains(new ImportProject(moduleRoot,
+                                                      "module1",
+                                                      "Example 'module1' module",
+                                                      origin,
+                                                      Arrays.asList("tag1",
+                                                                    "tag2"))));
+    }
+
+    @Test
+    public void testGetProjects_CustomDescription() {
+        final Path moduleRoot = mock(Path.class);
+        final KieModule module = mock(KieModule.class);
+        when(module.getRootPath()).thenReturn(moduleRoot);
+        when(module.getModuleName()).thenReturn("module1");
+        when(moduleRoot.toURI()).thenReturn("default:///module1");
+        when(ioService.exists(any(org.uberfire.java.nio.file.Path.class))).thenReturn(true);
+        when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn("This is custom description.\n\n This is a new line.");
+        when(metadataService.getTags(any(Path.class))).thenReturn(Arrays.asList("tag1",
+                                                                                "tag2"));
+
+        final GitRepository repository = makeGitRepository();
+        when(repositoryFactory.newRepository(any(ConfigGroup.class))).thenReturn(repository);
+        when(moduleService.getAllModules(any(Branch.class))).thenReturn(new HashSet<Module>() {{
+            add(module);
+        }});
+
+        String origin = "https://github.com/guvnorngtestuser1/guvnorng-playground.git";
+        final Set<ImportProject> modules = service.getProjects(new ExampleRepository(origin));
+        assertNotNull(modules);
+        assertEquals(1,
+                     modules.size());
+        assertTrue(modules.contains(new ImportProject(moduleRoot,
+                                                      "module1",
+                                                      "This is custom description. This is a new line.",
+                                                      origin,
+                                                      Arrays.asList("tag1",
+                                                                    "tag2"))));
+    }
+
+    @Test
+    public void testGetProjects_PomDescription() {
+        final Path moduleRoot = mock(Path.class);
+        final POM pom = mock(POM.class);
+        final KieModule module = mock(KieModule.class);
+        when(pom.getDescription()).thenReturn("pom description");
+        when(module.getRootPath()).thenReturn(moduleRoot);
+        when(module.getModuleName()).thenReturn("module1");
+        when(module.getPom()).thenReturn(pom);
+        when(moduleRoot.toURI()).thenReturn("default:///module1");
+        when(metadataService.getTags(any(Path.class))).thenReturn(Arrays.asList("tag1",
+                                                                                "tag2"));
+
+        final GitRepository repository = makeGitRepository();
+        when(repositoryFactory.newRepository(any(ConfigGroup.class))).thenReturn(repository);
+        when(moduleService.getAllModules(any(Branch.class))).thenReturn(new HashSet<Module>() {{
+            add(module);
+        }});
+
+        String origin = "https://github.com/guvnorngtestuser1/guvnorng-playground.git";
+        final Set<ImportProject> modules = service.getProjects(new ExampleRepository(origin));
+        assertNotNull(modules);
+        assertEquals(1,
+                     modules.size());
+        assertTrue(modules.contains(new ImportProject(moduleRoot,
+                                                      "module1",
+                                                      "pom description",
+                                                      origin,
+                                                      Arrays.asList("tag1",
+                                                                    "tag2"))));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testImportProjects_NullOrganizationalUnit() {
+        service.importProjects(null,
+                               mock(List.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testImportProjects_NullModule() {
+        service.importProjects(mock(OrganizationalUnit.class),
+                               null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testImportProjects_ZeroModules() {
+        service.importProjects(mock(OrganizationalUnit.class),
+                               Collections.emptyList());
+    }
+
+    @Test
+    public void testImportProjects_ProjectImport() {
+        final OrganizationalUnit ou = mock(OrganizationalUnit.class);
+        final ImportProject exProject1 = mock(ImportProject.class);
+        final ImportProject exProject2 = mock(ImportProject.class);
+        final List<ImportProject> exProjects = Arrays.asList(exProject1,
+                                                             exProject2);
+        final GitRepository repository1 = mock(GitRepository.class);
+        final Path repositoryRoot = mock(Path.class);
+        final Path module1Root = mock(Path.class);
+        final Path module2Root = mock(Path.class);
+
+        when(ou.getName()).thenReturn("ou");
+        when(exProject1.getName()).thenReturn("project1");
+        when(exProject1.getRoot()).thenReturn(module1Root);
+        when(exProject2.getName()).thenReturn("project2");
+        when(exProject2.getRoot()).thenReturn(module2Root);
+
+        when(repository1.getBranch("dev_branch")).thenReturn(Optional.of(new Branch("dev_branch",
+                                                                                    repositoryRoot)));
+        final Optional<Branch> master = Optional.of(new Branch("master",
+                                                               PathFactory.newPath("testFile",
+                                                                                   "file:///")));
+        when(repository1.getDefaultBranch()).thenReturn(master);
+
+        when(repositoryRoot.toURI()).thenReturn("default:///");
+        when(module1Root.toURI()).thenReturn("default:///module1");
+        when(module2Root.toURI()).thenReturn("default:///module2");
+
+        when(ouService.getOrganizationalUnit(eq("ou"))).thenReturn(ou);
+
+        WorkspaceProject project1 = mock(WorkspaceProject.class);
+        when(project1.getName()).thenReturn("project1");
+        when(project1.getBranch()).thenReturn(master.get());
+
+        WorkspaceProject project2 = mock(WorkspaceProject.class);
+        when(project2.getName()).thenReturn("project2");
+        when(project2.getBranch()).thenReturn(master.get());
+
+        doReturn(project1).when(service).importProject(eq(ou),
+                                                       eq(exProject1));
+
+        doReturn(project2).when(service).importProject(eq(ou),
+                                                       eq(exProject2));
+        final WorkspaceProject project = spy(new WorkspaceProject());
+        doReturn("project").when(project).getName();
+        doReturn(project).when(projectService).resolveProject(repository1);
+
+        final WorkspaceProjectContextChangeEvent event = service.importProjects(ou,
+                                                                                exProjects);
+
+        assertEquals(ou,
+                     event.getOrganizationalUnit());
+        assertEquals(null,
+                     event.getWorkspaceProject());
+
+        verify(ouService,
+               never()).createOrganizationalUnit(eq("ou"),
+                                                 eq(""),
+                                                 eq(""));
+        verify(service,
+               times(2)).importProject(eq(ou),
+                                       any());
+    }
+
+    @Test
+    public void importProjectWithCredentialsTest() {
+        final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
+        final Repository repo = mock(Repository.class);
+        final WorkspaceProject project = mock(WorkspaceProject.class);
+
+        final String repositoryURL = "file:///some/path/to/fake-repo.git";
+        final String username = "fakeUser";
+        final String password = "fakePassword";
+
+        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
+
+        when(repoService.createRepository(any(),
+                                          any(),
+                                          any(),
+                                          configCaptor.capture())).thenReturn(repo);
+        when(projectService.resolveProject(any(Repository.class))).thenReturn(project);
+
+        final WorkspaceProject observedProject = service.importProject(organizationalUnit,
+                                                                       repositoryURL,
+                                                                       username,
+                                                                       password);
+
+        verify(repoService).createRepository(same(organizationalUnit),
+                                             eq(GitRepository.SCHEME.toString()),
+                                             eq("fake-repo"),
+                                             any());
+        RepositoryEnvironmentConfigurations observedConfig = configCaptor.getValue();
+        assertEquals(username,
+                     observedConfig.getUserName());
+        assertEquals(password,
+                     observedConfig.getPassword());
+        assertEquals(repositoryURL,
+                     observedConfig.getOrigin());
+
+        verify(projectService).resolveProject(same(repo));
+
+        assertSame(project,
+                   observedProject);
+    }
+
+    @Test
+    public void importProjectWithoutCredentialsTest() {
+        final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
+        final Repository repo = mock(Repository.class);
+        final WorkspaceProject project = mock(WorkspaceProject.class);
+
+        final String repositoryURL = "file:///some/path/to/fake-repo.git";
+        final String username = null;
+        final String password = null;
+
+        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
+
+        when(repoService.createRepository(any(),
+                                          any(),
+                                          any(),
+                                          configCaptor.capture())).thenReturn(repo);
+        when(projectService.resolveProject(any(Repository.class))).thenReturn(project);
+
+        final WorkspaceProject observedProject = service.importProject(organizationalUnit,
+                                                                       repositoryURL,
+                                                                       username,
+                                                                       password);
+
+        verify(repoService).createRepository(same(organizationalUnit),
+                                             eq(GitRepository.SCHEME.toString()),
+                                             eq("fake-repo"),
+                                             any());
+        RepositoryEnvironmentConfigurations observedConfig = configCaptor.getValue();
+        assertEquals(username,
+                     observedConfig.getUserName());
+        assertEquals(password,
+                     observedConfig.getPassword());
+        assertEquals(repositoryURL,
+                     observedConfig.getOrigin());
+
+        verify(projectService).resolveProject(same(repo));
+
+        assertSame(project,
+                   observedProject);
+    }
+
+    @Test
+    public void importDefaultProjectTest() {
+        final OrganizationalUnit organizationalUnit = new OrganizationalUnitImpl("myteam",
+                                                                                 "admin",
+                                                                                 "org.whatever");
+        organizationalUnit.getRepositories();
+
+        final Path exampleRoot = mock(Path.class);
+        final org.uberfire.java.nio.file.Path exampleRootNioPath = mock(org.uberfire.java.nio.file.Path.class);
+        when(pathUtil.convert(exampleRoot)).thenReturn(exampleRootNioPath);
+        String repoURL = "file:///some/repo/url";
+        final ImportProject importProject = new ImportProject(exampleRoot,
+                                                              "example",
+                                                              "description",
+                                                              repoURL,
+                                                              emptyList());
+
+        when(pathUtil.getNiogitRepoPath(any())).thenReturn(repoURL);
+
+        final Repository repository = new GitRepository("example",
+                                                        new Space("myteam"));
+        final WorkspaceProject project = new WorkspaceProject(organizationalUnit,
+                                                              repository,
+                                                              new Branch("master",
+                                                                         mock(Path.class)),
+                                                              new Module());
+        when(projectService.resolveProject(repository)).thenReturn(project);
+        when(repoService.createRepository(same(organizationalUnit),
+                                          eq(GitRepository.SCHEME.toString()),
+                                          any(),
+                                          any())).thenReturn(repository);
+
+        final WorkspaceProject importedProject = service.importProject(organizationalUnit,
+                                                                       importProject);
+
+        assertSame(project,
+                   importedProject);
+        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configsCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
+        verify(repoService).createRepository(same(organizationalUnit),
+                                             eq(GitRepository.SCHEME.toString()),
+                                             any(),
+                                             configsCaptor.capture());
+        final RepositoryEnvironmentConfigurations configs = configsCaptor.getValue();
+        assertEquals(repoURL,
+                     configs.getOrigin());
+        assertNull(configs.getSubdirectory());
+        verify(projectService).resolveProject(repository);
+    }
+
+    @Test
+    public void importProjectInSubdirectory() {
+        final OrganizationalUnit organizationalUnit = new OrganizationalUnitImpl("myteam",
+                                                                                 "admin",
+                                                                                 "org.whatever");
+        organizationalUnit.getRepositories();
+
+        final String exampleURI = "default://master@system/repo/example";
+        final Path exampleRoot = PathFactory.newPath("example",
+                                                     exampleURI);
+        final JGitFileSystem fs = mock(JGitFileSystem.class);
+        final FileSystemProvider provider = mock(FileSystemProvider.class);
+        when(fs.provider()).thenReturn(provider);
+        final org.uberfire.java.nio.file.Path exampleRootNioPath = JGitPathImpl.create(fs,
+                                                                                       "/example",
+                                                                                       "master@system/repo",
+                                                                                       true);
+        final org.uberfire.java.nio.file.Path repoRoot = exampleRootNioPath.getParent();
+        when(fs.getRootDirectories()).thenReturn(() -> Stream.of(repoRoot).iterator());
+        when(pathUtil.convert(exampleRoot)).thenReturn(exampleRootNioPath);
+        when(pathUtil.stripProtocolAndBranch(any())).then(inv -> realPathUtil.stripProtocolAndBranch(inv.getArgumentAt(0,
+                                                                                                                       String.class)));
+        when(pathUtil.stripRepoNameAndSpace(any())).then(inv -> realPathUtil.stripRepoNameAndSpace(inv.getArgumentAt(0,
+                                                                                                                     String.class)));
+        when(pathUtil.convert(any(org.uberfire.java.nio.file.Path.class))).then(inv -> realPathUtil.convert(inv.getArgumentAt(0,
+                                                                                                                              org.uberfire.java.nio.file.Path.class)));
+        when(pathUtil.extractBranch(any())).then(inv -> realPathUtil.extractBranch(inv.getArgumentAt(0,
+                                                                                                     String.class)));
+
+        String repoURL = "file:///some/repo/url";
+        final ImportProject importProject = new ImportProject(exampleRoot,
+                                                              "example",
+                                                              "description",
+                                                              repoURL,
+                                                              emptyList());
+
+        when(pathUtil.getNiogitRepoPath(any())).thenReturn(repoURL);
+
+        final Repository repository = new GitRepository("example",
+                                                        new Space("myteam"));
+        final WorkspaceProject project = new WorkspaceProject(organizationalUnit,
+                                                              repository,
+                                                              new Branch("master",
+                                                                         mock(Path.class)),
+                                                              new Module());
+        when(projectService.resolveProject(repository)).thenReturn(project);
+        when(repoService.createRepository(same(organizationalUnit),
+                                          eq(GitRepository.SCHEME.toString()),
+                                          any(),
+                                          any())).thenReturn(repository);
+
+        final WorkspaceProject importedProject = service.importProject(organizationalUnit,
+                                                                       importProject);
+
+        assertSame(project,
+                   importedProject);
+        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configsCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
+        verify(repoService).createRepository(same(organizationalUnit),
+                                             eq(GitRepository.SCHEME.toString()),
+                                             any(),
+                                             configsCaptor.capture());
+        final RepositoryEnvironmentConfigurations configs = configsCaptor.getValue();
+        assertEquals(repoURL,
+                     configs.getOrigin());
+        assertEquals("example",
+                     configs.getSubdirectory());
+        verify(projectService).resolveProject(repository);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/validation/CheckModulesValidationTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/validation/CheckModulesValidationTest.java
@@ -26,7 +26,7 @@ import org.guvnor.common.services.project.service.POMService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -45,7 +45,7 @@ public class CheckModulesValidationTest {
     private POMService pomService;
 
     @Mock
-    private ExampleProject exampleProject;
+    private ImportProject importProject;
 
     @Mock
     private POM pom;
@@ -54,7 +54,7 @@ public class CheckModulesValidationTest {
     public void setUp() {
         Path path = mock(Path.class);
         when(path.toURI()).thenReturn("/");
-        when(this.exampleProject.getRoot()).thenReturn(path);
+        when(this.importProject.getRoot()).thenReturn(path);
         when(this.pomService.load(any())).thenReturn(this.pom);
 
         this.validator = new CheckModulesValidator(this.pomService);
@@ -63,7 +63,7 @@ public class CheckModulesValidationTest {
     @Test
     public void testProjectHasNoModules() {
         when(this.pom.getModules()).thenReturn(Collections.EMPTY_LIST);
-        Optional<ExampleProjectError> error = this.validator.validate(exampleProject);
+        Optional<ExampleProjectError> error = this.validator.validate(importProject);
         assertFalse(error.isPresent());
     }
 
@@ -71,7 +71,7 @@ public class CheckModulesValidationTest {
     public void testProjectHasModules() {
         when(this.pom.getModules()).thenReturn(Arrays.asList("aModule"));
 
-        Optional<ExampleProjectError> error = this.validator.validate(exampleProject);
+        Optional<ExampleProjectError> error = this.validator.validate(importProject);
         assertTrue(error.isPresent());
         assertEquals(CheckModulesValidator.class.getCanonicalName(),
                      error.get().getId());

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/model/ExamplesWizardModel.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/model/ExamplesWizardModel.java
@@ -17,7 +17,7 @@
 package org.kie.workbench.common.screens.examples.client.wizard.model;
 
 import org.kie.soup.commons.validation.PortablePreconditions;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleRepository;
 import org.kie.workbench.common.screens.examples.model.ExamplesModel;
 
@@ -42,12 +42,12 @@ public class ExamplesWizardModel extends ExamplesModel {
         this.selectedBranch = selectedBranch;
     }
 
-    public void addProject(final ExampleProject project) {
+    public void addProject(final ImportProject project) {
         getProjects().add(PortablePreconditions.checkNotNull("project",
                                                              project));
     }
 
-    public void removeProject(final ExampleProject project) {
+    public void removeProject(final ImportProject project) {
         getProjects().remove(PortablePreconditions.checkNotNull("project",
                                                                 project));
     }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectItemView.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectItemView.java
@@ -20,13 +20,13 @@ import com.google.gwt.event.dom.client.HasMouseOutHandlers;
 import com.google.gwt.event.dom.client.HasMouseOverHandlers;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.user.client.ui.IsWidget;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 
 public interface ProjectItemView extends IsWidget,
                                          HasMouseOverHandlers,
                                          HasMouseOutHandlers,
                                          HasValueChangeHandlers<Boolean> {
 
-    void setProject( final ExampleProject project, boolean selected );
+    void setProject(final ImportProject project, boolean selected );
 
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectItemViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectItemViewImpl.java
@@ -38,7 +38,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 
 @Dependent
 @Templated
@@ -78,7 +78,7 @@ public class ProjectItemViewImpl extends Composite implements ProjectItemView {
     }
 
     @Override
-    public void setProject(final ExampleProject project,
+    public void setProject(final ImportProject project,
                            boolean selected) {
         final SafeHtmlBuilder shb = new SafeHtmlBuilder();
         shb.appendEscaped(project.getName());

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPage.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPage.java
@@ -37,7 +37,7 @@ import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.screens.examples.client.resources.i18n.ExamplesScreenConstants;
 import org.kie.workbench.common.screens.examples.client.wizard.pages.BaseExamplesWizardPage;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleRepository;
 import org.kie.workbench.common.screens.examples.service.ExamplesService;
 import org.uberfire.client.callbacks.Callback;
@@ -54,7 +54,7 @@ public class ProjectPage extends BaseExamplesWizardPage implements ProjectPageVi
     private FetchRepositoryView fetchingRepositoryView;
     private Event<WizardPageSelectedEvent> pageSelectedEvent;
 
-    private List<ExampleProject> exampleProjects;
+    private List<ImportProject> importProjects;
     private Set<String> tags = new HashSet<>();
 
     public ProjectPage() {
@@ -93,7 +93,7 @@ public class ProjectPage extends BaseExamplesWizardPage implements ProjectPageVi
     public void destroy() {
         projectsView.destroy();
 
-        exampleProjects = null;
+        importProjects = null;
         tags.clear();
     }
 
@@ -126,17 +126,17 @@ public class ProjectPage extends BaseExamplesWizardPage implements ProjectPageVi
     }
 
     private void fetchRepository(final ExampleRepository selectedRepository) {
-        examplesService.call(new RemoteCallback<Set<ExampleProject>>() {
+        examplesService.call(new RemoteCallback<Set<ImportProject>>() {
                                  @Override
-                                 public void callback(final Set<ExampleProject> projects) {
+                                 public void callback(final Set<ImportProject> projects) {
                                      activeView = projectsView;
                                      model.getProjects().clear();
                                      model.setSourceRepository(selectedRepository);
 
-                                     final List<ExampleProject> sortedProjects = sort(projects);
+                                     final List<ImportProject> sortedProjects = sort(projects);
 
                                      projectsView.setProjectsInRepository(sortedProjects);
-                                     exampleProjects = sortedProjects;
+                                     importProjects = sortedProjects;
 
                                      pageSelectedEvent.fire(new WizardPageSelectedEvent(ProjectPage.this));
                                  }
@@ -153,13 +153,13 @@ public class ProjectPage extends BaseExamplesWizardPage implements ProjectPageVi
                              }).getProjects(selectedRepository);
     }
 
-    private List<ExampleProject> sort(final Set<ExampleProject> projects) {
-        final List<ExampleProject> sortedProjects = new ArrayList<ExampleProject>(projects);
+    private List<ImportProject> sort(final Set<ImportProject> projects) {
+        final List<ImportProject> sortedProjects = new ArrayList<ImportProject>(projects);
         Collections.sort(sortedProjects,
-                         new Comparator<ExampleProject>() {
+                         new Comparator<ImportProject>() {
                              @Override
-                             public int compare(final ExampleProject o1,
-                                                final ExampleProject o2) {
+                             public int compare(final ImportProject o1,
+                                                final ImportProject o2) {
                                  return o1.getName().compareTo(o2.getName());
                              }
                          });
@@ -177,19 +177,19 @@ public class ProjectPage extends BaseExamplesWizardPage implements ProjectPageVi
     }
 
     @Override
-    public void addProject(final ExampleProject project) {
+    public void addProject(final ImportProject project) {
         model.addProject(project);
         pageStatusChangedEvent.fire(new WizardPageStatusChangeEvent(this));
     }
 
     @Override
-    public void removeProject(final ExampleProject project) {
+    public void removeProject(final ImportProject project) {
         model.removeProject(project);
         pageStatusChangedEvent.fire(new WizardPageStatusChangeEvent(this));
     }
 
     @Override
-    public boolean isProjectSelected(ExampleProject project) {
+    public boolean isProjectSelected(ImportProject project) {
         return model.getProjects().contains(project);
     }
 
@@ -216,7 +216,7 @@ public class ProjectPage extends BaseExamplesWizardPage implements ProjectPageVi
     }
 
     private void updateProjectsInRepository(final Collection<String> tags) {
-        List<ExampleProject> resultList = exampleProjects.stream()
+        List<ImportProject> resultList = importProjects.stream()
                 .filter(p -> tags.stream().allMatch(userTag -> p.getTags().stream().anyMatch(projectTag -> projectTag.toLowerCase().contains(userTag.toLowerCase()))))
                 .sorted((o1, o2) -> o1.getName().compareTo(o2.getName()))
                 .collect(Collectors.toList());
@@ -228,7 +228,7 @@ public class ProjectPage extends BaseExamplesWizardPage implements ProjectPageVi
     @Override
     public void removeAllTags() {
         tags.clear();
-        projectsView.setProjectsInRepository(exampleProjects);
+        projectsView.setProjectsInRepository(importProjects);
         pageSelectedEvent.fire(new WizardPageSelectedEvent(ProjectPage.this));
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPageView.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPageView.java
@@ -18,18 +18,18 @@ package org.kie.workbench.common.screens.examples.client.wizard.pages.project;
 
 import java.util.List;
 
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.uberfire.client.mvp.UberView;
 
 public interface ProjectPageView extends UberView<ProjectPage> {
 
     interface Presenter {
 
-        void addProject(final ExampleProject project);
+        void addProject(final ImportProject project);
 
-        void removeProject(final ExampleProject project);
+        void removeProject(final ImportProject project);
 
-        boolean isProjectSelected(final ExampleProject project);
+        boolean isProjectSelected(final ImportProject project);
 
         void addTag(final String tag);
 
@@ -42,7 +42,7 @@ public interface ProjectPageView extends UberView<ProjectPage> {
 
     void initialise();
 
-    void setProjectsInRepository(final List<ExampleProject> projects);
+    void setProjectsInRepository(final List<ImportProject> projects);
 
     void destroy();
 }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPageViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/main/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPageViewImpl.java
@@ -37,7 +37,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 
 @Dependent
 @Templated
@@ -83,9 +83,9 @@ public class ProjectPageViewImpl extends Composite implements ProjectPageView {
     }
 
     @Override
-    public void setProjectsInRepository(final List<ExampleProject> projects) {
+    public void setProjectsInRepository(final List<ImportProject> projects) {
         this.projects.removeAllChildren();
-        for (ExampleProject project : projects) {
+        for (ImportProject project : projects) {
             final ProjectItemView w = makeProjectWidget(project);
             this.projects.appendChild(w.asWidget().getElement());
         }
@@ -98,7 +98,7 @@ public class ProjectPageViewImpl extends Composite implements ProjectPageView {
         tagList.removeAllChildren();
     }
 
-    private ProjectItemView makeProjectWidget(final ExampleProject project) {
+    private ProjectItemView makeProjectWidget(final ImportProject project) {
         final ProjectItemView projectItemView = projectItemViewInstance.get();
         projectItemView.setProject(project,
                                    presenter.isProjectSelected(project));

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/test/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPageTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-client/src/test/java/org/kie/workbench/common/screens/examples/client/wizard/pages/project/ProjectPageTest.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.examples.client.wizard.model.ExamplesWizardModel;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleRepository;
 import org.kie.workbench.common.screens.examples.service.ExamplesService;
 import org.mockito.ArgumentCaptor;
@@ -94,21 +94,23 @@ public class ProjectPageTest {
     private Caller<ExamplesService> examplesServiceCaller = new CallerMock<ExamplesService>(examplesService);
 
     @Captor
-    private ArgumentCaptor<List<ExampleProject>> projectsArgumentCaptor;
+    private ArgumentCaptor<List<ImportProject>> projectsArgumentCaptor;
 
     private ProjectPage page;
 
     private ExamplesWizardModel model;
 
-    private ExampleProject project1 = new ExampleProject(mock(Path.class),
-                                                         "project1",
-                                                         "",
-                                                         Arrays.asList("tag1",
+    private ImportProject project1 = new ImportProject(mock(Path.class),
+                                                       "project1",
+                                                       "",
+                                                       EXAMPLE_REPOSITORY,
+                                                       Arrays.asList("tag1",
                                                                        "tag2"));
-    private ExampleProject project2 = new ExampleProject(mock(Path.class),
-                                                         "project2",
-                                                         "",
-                                                         Arrays.asList("tag2",
+    private ImportProject project2 = new ImportProject(mock(Path.class),
+                                                       "project2",
+                                                       "",
+                                                       EXAMPLE_REPOSITORY,
+                                                       Arrays.asList("tag2",
                                                                        "tag3"));
 
     @Before
@@ -183,7 +185,7 @@ public class ProjectPageTest {
 
     @Test
     public void testPrepareView_NewRepositorySelected() {
-        when(examplesService.getProjects(any(ExampleRepository.class))).thenReturn(new HashSet<ExampleProject>() {{
+        when(examplesService.getProjects(any(ExampleRepository.class))).thenReturn(new HashSet<ImportProject>() {{
             add(project1);
             add(project2);
         }});
@@ -200,7 +202,7 @@ public class ProjectPageTest {
 
         verify(projectsView,
                times(1)).setProjectsInRepository(projectsArgumentCaptor.capture());
-        final List<ExampleProject> sortedProjects = projectsArgumentCaptor.getValue();
+        final List<ImportProject> sortedProjects = projectsArgumentCaptor.getValue();
         assertNotNull(sortedProjects);
         assertEquals(2,
                      sortedProjects.size());
@@ -226,10 +228,11 @@ public class ProjectPageTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testIsComplete_SelectedProjects() {
-        model.addProject(new ExampleProject(mock(Path.class),
-                                            "",
-                                            "",
-                                            Collections.EMPTY_LIST));
+        model.addProject(new ImportProject(mock(Path.class),
+                                           "",
+                                           "",
+                                           EXAMPLE_REPOSITORY,
+                                           Collections.EMPTY_LIST));
         final Callback<Boolean> callback = mock(Callback.class);
         page.isComplete(callback);
 
@@ -239,7 +242,7 @@ public class ProjectPageTest {
 
     @Test
     public void testAddProject() {
-        page.addProject(mock(ExampleProject.class));
+        page.addProject(mock(ImportProject.class));
         assertEquals(1,
                      model.getProjects().size());
         verify(pageStatusChangedEvent,
@@ -248,7 +251,7 @@ public class ProjectPageTest {
 
     @Test
     public void testRemoveProject() {
-        final ExampleProject project = mock(ExampleProject.class);
+        final ImportProject project = mock(ImportProject.class);
         model.addProject(project);
         page.removeProject(project);
         assertEquals(0,
@@ -259,7 +262,7 @@ public class ProjectPageTest {
 
     @Test
     public void testIsProjectSelected_Selected() {
-        final ExampleProject project = mock(ExampleProject.class);
+        final ImportProject project = mock(ImportProject.class);
         model.addProject(project);
 
         assertTrue(page.isProjectSelected(project));
@@ -267,7 +270,7 @@ public class ProjectPageTest {
 
     @Test
     public void testIsProjectSelected_NotSelected() {
-        final ExampleProject project = mock(ExampleProject.class);
+        final ImportProject project = mock(ImportProject.class);
 
         assertFalse(page.isProjectSelected(project));
     }
@@ -285,7 +288,7 @@ public class ProjectPageTest {
     }
 
     private void initExampleProjects() {
-        when(examplesService.getProjects(any(ExampleRepository.class))).thenReturn(new HashSet<ExampleProject>() {{
+        when(examplesService.getProjects(any(ExampleRepository.class))).thenReturn(new HashSet<ImportProject>() {{
             add(project1);
             add(project2);
         }});

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/LibraryService.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/LibraryService.java
@@ -26,7 +26,7 @@ import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.project.service.DeploymentMode;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.jboss.errai.bus.server.annotations.Remote;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 
 @Remote
 public interface LibraryService {
@@ -61,28 +61,7 @@ public interface LibraryService {
 
     Boolean hasAssets(final WorkspaceProject project);
 
-    /**
-     * Imports a project from a repository with full history (i.e. `git clone ${repositoryURL}`).
-     */
-    WorkspaceProject importProject(OrganizationalUnit targetOU, String repositoryURL, String username, String password);
-
-    /**
-     * @see #importProject(OrganizationalUnit, ExampleProject)
-     */
-    List<WorkspaceProject> importProjects(OrganizationalUnit targetOU, List<ExampleProject> projects);
-
-    /**
-     * Imports a project (preserving history) from the given {@link ExampleProject}.
-     */
-    WorkspaceProject importProject(OrganizationalUnit targetOU, ExampleProject example);
-
-    Set<ExampleProject> getExampleProjects();
-
-    Set<ExampleProject> getProjects(final String repositoryUrl);
-
-    Set<ExampleProject> getProjects(final String repositoryUrl,
-                                    final String userName,
-                                    final String password);
+    Set<ImportProject> getExampleProjects();
 
     List<OrganizationalUnit> getOrganizationalUnits();
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import javax.enterprise.event.Event;
 
@@ -38,17 +37,14 @@ import org.guvnor.common.services.project.service.DeploymentMode;
 import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
-import org.guvnor.structure.organizationalunit.impl.OrganizationalUnitImpl;
 import org.guvnor.structure.repositories.Branch;
 import org.guvnor.structure.repositories.Repository;
-import org.guvnor.structure.repositories.RepositoryEnvironmentConfigurations;
 import org.guvnor.structure.repositories.RepositoryService;
-import org.guvnor.structure.repositories.impl.git.GitRepository;
 import org.guvnor.structure.security.RepositoryAction;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleRepository;
 import org.kie.workbench.common.screens.examples.service.ExamplesService;
 import org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceHelper;
@@ -72,18 +68,12 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.backend.vfs.PathFactory;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.NoSuchFileException;
-import org.uberfire.java.nio.file.spi.FileSystemProvider;
-import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
-import org.uberfire.java.nio.fs.jgit.JGitPathImpl;
 import org.uberfire.paging.PageResponse;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.security.authz.AuthorizationManager;
-import org.uberfire.spaces.Space;
 
-import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -210,20 +200,21 @@ public class LibraryServiceImplTest {
                                                     projectService,
                                                     moduleService,
                                                     examplesService,
-                                                    repositoryService,
                                                     ioService,
                                                     internalPreferences,
                                                     socialUserRepositoryAPI,
-                                                    indexOracle,
-                                                    newProjectEvent,
-                                                    pathUtil
+                                                    indexOracle
         ));
     }
 
     @Test
     public void queryingUnindexedProjectGivesUnindexedResult() throws Exception {
-        Branch branch = new Branch("fake-branch", mockPath("default:///a/b/c"));
-        final WorkspaceProject project = new WorkspaceProject(ou1, repo1, branch, mock(Module.class));
+        Branch branch = new Branch("fake-branch",
+                                   mockPath("default:///a/b/c"));
+        final WorkspaceProject project = new WorkspaceProject(ou1,
+                                                              repo1,
+                                                              branch,
+                                                              mock(Module.class));
         when(indexOracle.isIndexed(project)).thenReturn(false);
         when(ioService.exists(any())).thenReturn(true);
 
@@ -234,7 +225,8 @@ public class LibraryServiceImplTest {
                                                                 Collections.emptyList());
 
         AssetQueryResult result = libraryService.getProjectAssets(query);
-        assertEquals(ResultType.Unindexed, result.getResultType());
+        assertEquals(ResultType.Unindexed,
+                     result.getResultType());
         assertFalse(result.getAssetInfos().isPresent());
     }
 
@@ -279,8 +271,10 @@ public class LibraryServiceImplTest {
 
         final LibraryInfo libraryInfo = libraryService.getLibraryInfo(ou1);
 
-        assertEquals(1, libraryInfo.getProjects().size());
-        assertSame(project2, libraryInfo.getProjects().iterator().next());
+        assertEquals(1,
+                     libraryInfo.getProjects().size());
+        assertSame(project2,
+                   libraryInfo.getProjects().iterator().next());
     }
 
     @Test
@@ -350,7 +344,10 @@ public class LibraryServiceImplTest {
     @Test
     public void emptyFirstPage() throws Exception {
         final Branch branch = mock(Branch.class);
-        final WorkspaceProject project = spy(new WorkspaceProject(ou1, repo1, branch, null));
+        final WorkspaceProject project = spy(new WorkspaceProject(ou1,
+                                                                  repo1,
+                                                                  branch,
+                                                                  null));
         final Path path = mock(Path.class);
 
         when(branch.getPath()).thenReturn(path);
@@ -393,10 +390,10 @@ public class LibraryServiceImplTest {
 
         final Branch branch = mock(Branch.class);
         final Path path = mockPath("file://the_project");
-        final WorkspaceProject project =  spy(new WorkspaceProject(mock(OrganizationalUnit.class),
-                                                               repo1,
-                                                               branch,
-                                                               null));
+        final WorkspaceProject project = spy(new WorkspaceProject(mock(OrganizationalUnit.class),
+                                                                  repo1,
+                                                                  branch,
+                                                                  null));
 
         when(branch.getPath()).thenReturn(path);
 
@@ -471,7 +468,8 @@ public class LibraryServiceImplTest {
 
         final AssetQueryResult result = libraryService.getProjectAssets(query);
 
-        assertEquals(ResultType.Normal, result.getResultType());
+        assertEquals(ResultType.Normal,
+                     result.getResultType());
         assertTrue(result.getAssetInfos().isPresent());
         List<AssetInfo> projectAssets = result.getAssetInfos().get();
         assertTrue(projectAssets.isEmpty());
@@ -554,14 +552,14 @@ public class LibraryServiceImplTest {
         System.setProperty("org.kie.project.examples.repository.url",
                            "importProjectsUrl");
 
-        final Set<ExampleProject> exampleProjects = new HashSet<>();
-        exampleProjects.add(mock(ExampleProject.class));
-        doReturn(exampleProjects).when(examplesService).getProjects(new ExampleRepository("importProjectsUrl"));
+        final Set<ImportProject> importProjects = new HashSet<>();
+        importProjects.add(mock(ImportProject.class));
+        doReturn(importProjects).when(examplesService).getProjects(new ExampleRepository("importProjectsUrl"));
 
-        final Set<ExampleProject> loadedExampleProjects = libraryService.getExampleProjects();
+        final Set<ImportProject> loadedImportProjects = libraryService.getExampleProjects();
 
-        assertEquals(exampleProjects,
-                     loadedExampleProjects);
+        assertEquals(importProjects,
+                     loadedImportProjects);
     }
 
     @Test
@@ -572,148 +570,14 @@ public class LibraryServiceImplTest {
         final ExampleRepository playgroundRepository = new ExampleRepository("playgroundRepositoryUrl");
         doReturn(playgroundRepository).when(examplesService).getPlaygroundRepository();
 
-        final Set<ExampleProject> exampleProjects = new HashSet<>();
-        exampleProjects.add(mock(ExampleProject.class));
-        doReturn(exampleProjects).when(examplesService).getProjects(playgroundRepository);
+        final Set<ImportProject> importProjects = new HashSet<>();
+        importProjects.add(mock(ImportProject.class));
+        doReturn(importProjects).when(examplesService).getProjects(playgroundRepository);
 
-        final Set<ExampleProject> loadedExampleProjects = libraryService.getExampleProjects();
+        final Set<ImportProject> loadedImportProjects = libraryService.getExampleProjects();
 
-        assertEquals(exampleProjects,
-                     loadedExampleProjects);
-    }
-
-    @Test
-    public void importProjectWithCredentialsTest() {
-        final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
-        final Repository repo = mock(Repository.class);
-        final WorkspaceProject project = mock(WorkspaceProject.class);
-
-        final String repositoryURL = "file:///some/path/to/fake-repo.git";
-        final String username = "fakeUser";
-        final String password = "fakePassword";
-
-        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
-
-        when(repositoryService.createRepository(any(), any(), any(), configCaptor.capture())).thenReturn(repo);
-        when(projectService.resolveProject(any(Repository.class))).thenReturn(project);
-
-        final WorkspaceProject observedProject = libraryService.importProject(organizationalUnit, repositoryURL, username, password);
-
-        verify(repositoryService).createRepository(same(organizationalUnit), eq(GitRepository.SCHEME.toString()), eq("fake-repo"), any());
-        RepositoryEnvironmentConfigurations observedConfig = configCaptor.getValue();
-        assertEquals(username, observedConfig.getUserName());
-        assertEquals(password, observedConfig.getPassword());
-        assertEquals(repositoryURL, observedConfig.getOrigin());
-
-        verify(projectService).resolveProject(same(repo));
-
-        assertSame(project, observedProject);
-    }
-
-    @Test
-    public void importProjectWithoutCredentialsTest() {
-        final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
-        final Repository repo = mock(Repository.class);
-        final WorkspaceProject project = mock(WorkspaceProject.class);
-
-        final String repositoryURL = "file:///some/path/to/fake-repo.git";
-        final String username = null;
-        final String password = null;
-
-        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
-
-        when(repositoryService.createRepository(any(), any(), any(), configCaptor.capture())).thenReturn(repo);
-        when(projectService.resolveProject(any(Repository.class))).thenReturn(project);
-
-        final WorkspaceProject observedProject = libraryService.importProject(organizationalUnit, repositoryURL, username, password);
-
-        verify(repositoryService).createRepository(same(organizationalUnit), eq(GitRepository.SCHEME.toString()), eq("fake-repo"), any());
-        RepositoryEnvironmentConfigurations observedConfig = configCaptor.getValue();
-        assertEquals(username, observedConfig.getUserName());
-        assertEquals(password, observedConfig.getPassword());
-        assertEquals(repositoryURL, observedConfig.getOrigin());
-
-        verify(projectService).resolveProject(same(repo));
-
-        assertSame(project, observedProject);
-    }
-
-    @Test
-    public void importDefaultProjectTest() {
-        final OrganizationalUnit organizationalUnit = new OrganizationalUnitImpl("myteam", "admin", "org.whatever");
-        organizationalUnit.getRepositories();
-
-        final Path exampleRoot = mock(Path.class);
-        final org.uberfire.java.nio.file.Path exampleRootNioPath = mock(org.uberfire.java.nio.file.Path.class);
-        when(pathUtil.convert(exampleRoot)).thenReturn(exampleRootNioPath);
-        final ExampleProject exampleProject = new ExampleProject(exampleRoot, "example", "description", emptyList());
-
-        String repoURL = "file:///some/repo/url";
-        when(pathUtil.getNiogitRepoPath(any())).thenReturn(repoURL);
-
-        final Repository repository = new GitRepository("example", new Space("myteam"));
-        final WorkspaceProject project = new WorkspaceProject(organizationalUnit,
-                                                              repository,
-                                                              new Branch("master", mock(Path.class)),
-                                                              new Module());
-        when(projectService.resolveProject(repository)).thenReturn(project);
-        when(repositoryService.createRepository(same(organizationalUnit), eq(GitRepository.SCHEME.toString()), any(), any())).thenReturn(repository);
-
-        final WorkspaceProject importedProject = libraryService.importProject(organizationalUnit,
-                                                                              exampleProject);
-
-        assertSame(project, importedProject);
-        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configsCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
-        verify(repositoryService).createRepository(same(organizationalUnit), eq(GitRepository.SCHEME.toString()), any(), configsCaptor.capture());
-        final RepositoryEnvironmentConfigurations configs = configsCaptor.getValue();
-        assertEquals(repoURL, configs.getOrigin());
-        assertNull(configs.getSubdirectory());
-        verify(projectService).resolveProject(repository);
-    }
-
-    @Test
-    public void importProjectInSubdirectory() {
-        final OrganizationalUnit organizationalUnit = new OrganizationalUnitImpl("myteam", "admin", "org.whatever");
-        organizationalUnit.getRepositories();
-
-
-        final String exampleURI = "default://master@system/repo/example";
-        final Path exampleRoot = PathFactory.newPath("example", exampleURI);
-        final JGitFileSystem fs = mock(JGitFileSystem.class);
-        final FileSystemProvider provider = mock(FileSystemProvider.class);
-        when(fs.provider()).thenReturn(provider);
-        final org.uberfire.java.nio.file.Path exampleRootNioPath = JGitPathImpl.create(fs, "/example", "master@system/repo", true);
-        final org.uberfire.java.nio.file.Path repoRoot = exampleRootNioPath.getParent();
-        when(fs.getRootDirectories()).thenReturn(() -> Stream.of(repoRoot).iterator());
-        when(pathUtil.convert(exampleRoot)).thenReturn(exampleRootNioPath);
-        when(pathUtil.stripProtocolAndBranch(any())).then(inv -> realPathUtil.stripProtocolAndBranch(inv.getArgumentAt(0, String.class)));
-        when(pathUtil.stripRepoNameAndSpace(any())).then(inv -> realPathUtil.stripRepoNameAndSpace(inv.getArgumentAt(0, String.class)));
-        when(pathUtil.convert(any(org.uberfire.java.nio.file.Path.class))).then(inv -> realPathUtil.convert(inv.getArgumentAt(0, org.uberfire.java.nio.file.Path.class)));
-        when(pathUtil.extractBranch(any())).then(inv -> realPathUtil.extractBranch(inv.getArgumentAt(0, String.class)));
-
-        final ExampleProject exampleProject = new ExampleProject(exampleRoot, "example", "description", emptyList());
-
-        String repoURL = "file:///some/repo/url";
-        when(pathUtil.getNiogitRepoPath(any())).thenReturn(repoURL);
-
-        final Repository repository = new GitRepository("example", new Space("myteam"));
-        final WorkspaceProject project = new WorkspaceProject(organizationalUnit,
-                                                              repository,
-                                                              new Branch("master", mock(Path.class)),
-                                                              new Module());
-        when(projectService.resolveProject(repository)).thenReturn(project);
-        when(repositoryService.createRepository(same(organizationalUnit), eq(GitRepository.SCHEME.toString()), any(), any())).thenReturn(repository);
-
-        final WorkspaceProject importedProject = libraryService.importProject(organizationalUnit,
-                                                                              exampleProject);
-
-        assertSame(project, importedProject);
-        final ArgumentCaptor<RepositoryEnvironmentConfigurations> configsCaptor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
-        verify(repositoryService).createRepository(same(organizationalUnit), eq(GitRepository.SCHEME.toString()), any(), configsCaptor.capture());
-        final RepositoryEnvironmentConfigurations configs = configsCaptor.getValue();
-        assertEquals(repoURL, configs.getOrigin());
-        assertEquals("example", configs.getSubdirectory());
-        verify(projectService).resolveProject(repository);
+        assertEquals(importProjects,
+                     loadedImportProjects);
     }
 
     @Test

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ExamplesImportPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ExamplesImportPresenter.java
@@ -1,0 +1,71 @@
+package org.kie.workbench.common.screens.library.client.screens.importrepository;
+
+import java.util.List;
+import java.util.Set;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
+import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeEvent;
+import org.jboss.errai.bus.client.api.messaging.Message;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.screens.examples.model.ExampleOrganizationalUnit;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.service.ExamplesService;
+import org.kie.workbench.common.screens.library.client.resources.i18n.LibraryConstants;
+import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
+import org.kie.workbench.common.screens.library.client.widgets.example.ExampleProjectWidget;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.kie.workbench.common.screens.library.client.screens.importrepository.Source.Kind.EXAMPLE;
+
+@Source(EXAMPLE)
+public class ExamplesImportPresenter extends ImportPresenter {
+
+    private final Caller<ExamplesService> examplesService;
+
+    @Inject
+    public ExamplesImportPresenter(final ImportPresenter.View view,
+                                   final LibraryPlaces libraryPlaces,
+                                   final ManagedInstance<ExampleProjectWidget> tileWidgets,
+                                   final Caller<ExamplesService> examplesService,
+                                   final WorkspaceProjectContext projectContext,
+                                   final Event<NotificationEvent> notificationEvent,
+                                   final Event<WorkspaceProjectContextChangeEvent> projectContextChangeEvent,
+                                   final Elemental2DomUtil elemental2DomUtil,
+                                   final TranslationService ts) {
+
+        super(view,
+              libraryPlaces,
+              tileWidgets,
+              projectContext,
+              notificationEvent,
+              projectContextChangeEvent,
+              elemental2DomUtil,
+              ts.getTranslation(LibraryConstants.TrySamples));
+        this.examplesService = examplesService;
+    }
+
+    @Override
+    protected void loadProjects(PlaceRequest placeRequest,
+                                RemoteCallback<Set<ImportProject>> callback) {
+        view.showBusyIndicator(view.getLoadingMessage());
+        examplesService.call(callback,
+                             loadingErrorCallback()).getExampleProjects();
+    }
+
+    @Override
+    protected void importProjects(List<ImportProject> projects,
+                                  RemoteCallback<WorkspaceProjectContextChangeEvent> callback,
+                                  ErrorCallback<Message> errorCallback) {
+        examplesService.call(callback,
+                             errorCallback).setupExamples(new ExampleOrganizationalUnit(activeOrganizationalUnit().getName()),
+                                                          projects);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ExternalImportPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ExternalImportPresenter.java
@@ -1,0 +1,71 @@
+package org.kie.workbench.common.screens.library.client.screens.importrepository;
+
+import java.util.List;
+import java.util.Set;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
+import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeEvent;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.jboss.errai.bus.client.api.messaging.Message;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.service.ProjectImportService;
+import org.kie.workbench.common.screens.library.client.resources.i18n.LibraryConstants;
+import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
+import org.kie.workbench.common.screens.library.client.widgets.example.ExampleProjectWidget;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.kie.workbench.common.screens.library.client.screens.importrepository.Source.Kind.EXTERNAL;
+
+@Source(EXTERNAL)
+public class ExternalImportPresenter extends ImportPresenter {
+
+    private final TranslationService ts;
+    private final Caller<ProjectImportService> importService;
+
+    @Inject
+    public ExternalImportPresenter(ImportPresenter.View view,
+                                   LibraryPlaces libraryPlaces,
+                                   Caller<ProjectImportService> importService,
+                                   ManagedInstance<ExampleProjectWidget> tileWidgets,
+                                   WorkspaceProjectContext projectContext,
+                                   Event<NotificationEvent> notificationEvent,
+                                   Event<WorkspaceProjectContextChangeEvent> projectContextChangeEvent,
+                                   Elemental2DomUtil elemental2DomUtil,
+                                   TranslationService ts) {
+        super(view,
+              libraryPlaces,
+              tileWidgets,
+              projectContext,
+              notificationEvent,
+              projectContextChangeEvent,
+              elemental2DomUtil,
+              ts.getTranslation(LibraryConstants.ImportProjects));
+        this.importService = importService;
+        this.ts = ts;
+    }
+
+    @Override
+    protected void loadProjects(PlaceRequest placeRequest,
+                                RemoteCallback<Set<ImportProject>> callback) {
+        // Projects are loaded by CDI event that calls setupEvents. Nothing to do here.
+    }
+
+    @Override
+    protected void importProjects(List<ImportProject> projects,
+                                  RemoteCallback<WorkspaceProjectContextChangeEvent> callback,
+                                  ErrorCallback<Message> errorCallback) {
+        final OrganizationalUnit activeOU = activeOrganizationalUnit();
+        this.importService.call((WorkspaceProjectContextChangeEvent event) -> callback.callback(event),
+                                errorCallback).importProjects(activeOU,
+                                                              projects);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportProjectsScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportProjectsScreen.java
@@ -51,7 +51,7 @@ public class ImportProjectsScreen {
 
     @WorkbenchPartTitle
     public String getTitle() {
-        return "Try Samples Screen";
+        return this.presenter.getView().getTitle();
     }
 
     @WorkbenchPartView

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportProjectsView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportProjectsView.java
@@ -90,11 +90,6 @@ public class ImportProjectsView implements ImportPresenter.View,
     }
 
     @Override
-    public String getTrySamplesLabel() {
-        return ts.format(LibraryConstants.TrySamples);
-    }
-
-    @Override
     public String getNoProjectsToImportMessage() {
         return ts.format(LibraryConstants.NoProjectsToImport);
     }
@@ -117,6 +112,11 @@ public class ImportProjectsView implements ImportPresenter.View,
     @Override
     public String getImportProjectsSuccessMessage() {
         return ts.format(LibraryConstants.ImportProjectsSuccess);
+    }
+
+    @Override
+    public String getTitle() {
+        return this.title.getTextContent();
     }
 
     @EventHandler("filter-text")

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenter.java
@@ -17,17 +17,16 @@
 package org.kie.workbench.common.screens.library.client.screens.importrepository;
 
 import java.util.Set;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
-import org.kie.workbench.common.screens.library.api.LibraryService;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.model.ExampleRepository;
+import org.kie.workbench.common.screens.examples.service.ProjectImportService;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
 import org.uberfire.client.mvp.UberElement;
-import org.uberfire.ext.widgets.common.client.callbacks.DefaultErrorCallback;
 import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
 
 public class ImportRepositoryPopUpPresenter {
@@ -56,17 +55,17 @@ public class ImportRepositoryPopUpPresenter {
 
     private View view;
 
-    private Caller<LibraryService> libraryService;
+    private Caller<ProjectImportService> importService;
 
     private LibraryPlaces libraryPlaces;
 
     @Inject
     public ImportRepositoryPopUpPresenter(final View view,
                                           final LibraryPlaces libraryPlaces,
-                                          final Caller<LibraryService> libraryService) {
+                                          final Caller<ProjectImportService> importService) {
         this.view = view;
         this.libraryPlaces = libraryPlaces;
-        this.libraryService = libraryService;
+        this.importService = importService;
     }
 
     @PostConstruct
@@ -86,20 +85,22 @@ public class ImportRepositoryPopUpPresenter {
         }
 
         view.showBusyIndicator(view.getLoadingMessage());
-        libraryService.call((Set<ExampleProject> projects) -> {
-                                view.hideBusyIndicator();
-                                if (projects.isEmpty()) {
-                                    view.showError(view.getNoProjectsToImportMessage());
-                                } else {
-                                    view.hide();
-                                    libraryPlaces.goToExternalImportPresenter(projects);
-                                }
-
-        }, (Message message, Throwable throwable) -> {
-                view.hideBusyIndicator();
-                view.showError(view.getNoProjectsToImportMessage());
-                return false;
-        }).getProjects(repositoryUrl, view.getUserName(), view.getPassword());
+        importService.call((Set<ImportProject> projects) -> {
+                               view.hideBusyIndicator();
+                               if (projects.isEmpty()) {
+                                   view.showError(view.getNoProjectsToImportMessage());
+                               } else {
+                                   view.hide();
+                                   libraryPlaces.goToExternalImportPresenter(projects);
+                               }
+                           },
+                           (Message message, Throwable throwable) -> {
+                               view.hideBusyIndicator();
+                               view.showError(view.getNoProjectsToImportMessage());
+                               return false;
+                           }).getProjects(new ExampleRepository(repositoryUrl,
+                                                                view.getUserName(),
+                                                                view.getPassword()));
     }
 
     public void cancel() {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/Source.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/Source.java
@@ -3,17 +3,24 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ *
+ */
 
 package org.kie.workbench.common.screens.library.client.screens.importrepository;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
@@ -22,20 +29,15 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import javax.inject.Qualifier;
-
-
 @Qualifier
 @Documented
 @Retention(RUNTIME)
 @Target({TYPE, FIELD, METHOD, PARAMETER, ANNOTATION_TYPE})
 public @interface Source {
-    public static enum Kind {
-        EXAMPLE, EXTERNAL
+
+    enum Kind {
+        EXAMPLE,
+        EXTERNAL
     }
 
     Kind value();

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/samples/ImportExamplesProjectsScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/samples/ImportExamplesProjectsScreen.java
@@ -18,17 +18,15 @@ package org.kie.workbench.common.screens.library.client.screens.samples;
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.screens.library.client.screens.importrepository.Source;
 import org.kie.workbench.common.screens.library.client.perspective.LibraryPerspective;
 import org.kie.workbench.common.screens.library.client.screens.importrepository.ImportPresenter;
-import org.kie.workbench.common.screens.library.client.screens.importrepository.Source;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
-
-import static org.kie.workbench.common.screens.library.client.screens.importrepository.Source.Kind.EXAMPLE;
 
 @WorkbenchScreen(identifier = LibraryPlaces.IMPORT_SAMPLE_PROJECTS_SCREEN,
         owningPerspective = LibraryPerspective.class)
@@ -37,7 +35,7 @@ public class ImportExamplesProjectsScreen {
     private ImportPresenter presenter;
 
     @Inject
-    public ImportExamplesProjectsScreen(final @Source(EXAMPLE) ImportPresenter presenter) {
+    public ImportExamplesProjectsScreen(final @Source(Source.Kind.EXAMPLE) ImportPresenter presenter) {
         this.presenter = presenter;
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -51,7 +50,8 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.security.shared.exception.UnauthorizedException;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.soup.commons.validation.PortablePreconditions;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.library.client.screens.importrepository.Source;
 import org.kie.workbench.common.screens.explorer.client.utils.Utils;
 import org.kie.workbench.common.screens.library.api.LibraryService;
 import org.kie.workbench.common.screens.library.api.ProjectAssetListUpdated;
@@ -63,7 +63,6 @@ import org.kie.workbench.common.screens.library.client.perspective.LibraryPerspe
 import org.kie.workbench.common.screens.library.client.resources.i18n.LibraryConstants;
 import org.kie.workbench.common.screens.library.client.screens.importrepository.ImportProjectsSetupEvent;
 import org.kie.workbench.common.screens.library.client.screens.importrepository.ImportRepositoryPopUpPresenter;
-import org.kie.workbench.common.screens.library.client.screens.importrepository.Source;
 import org.kie.workbench.common.screens.library.client.screens.project.close.CloseUnsavedProjectAssetsPopUpPresenter;
 import org.kie.workbench.common.screens.library.client.widgets.library.LibraryToolbarPresenter;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
@@ -92,8 +91,6 @@ import org.uberfire.preferences.shared.impl.PreferenceScopeResolutionStrategyInf
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.events.ResourceDeletedEvent;
 import org.uberfire.workbench.model.impl.PartDefinitionImpl;
-
-import static org.kie.workbench.common.screens.library.client.screens.importrepository.Source.Kind.EXTERNAL;
 
 @ApplicationScoped
 public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
@@ -206,7 +203,7 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
                          final ManagedInstance<ImportRepositoryPopUpPresenter> importRepositoryPopUpPresenters,
                          final @Routed Event<ProjectAssetListUpdated> assetListUpdatedEvent,
                          final CloseUnsavedProjectAssetsPopUpPresenter closeUnsavedProjectAssetsPopUpPresenter,
-                         final @Source(EXTERNAL) Event<ImportProjectsSetupEvent> importProjectsSetupEvent) {
+                         final @Source(Source.Kind.EXTERNAL) Event<ImportProjectsSetupEvent> importProjectsSetupEvent) {
         this.breadcrumbs = breadcrumbs;
         this.ts = ts;
         this.projectMetricsEvent = projectMetricsEvent;
@@ -716,7 +713,7 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
         importRepositoryPopUpPresenter.show();
     }
 
-    public void goToExternalImportPresenter(final Set<ExampleProject> projects) {
+    public void goToExternalImportPresenter(final Set<ImportProject> projects) {
         closeAllPlacesOrNothing(() -> {
             // TODO add title
             final DefaultPlaceRequest placeRequest = new DefaultPlaceRequest(LibraryPlaces.IMPORT_PROJECTS_SCREEN);
@@ -839,10 +836,9 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
         closingLibraryPlaces = false;
     }
 
-    public WorkspaceProjectContext getWorkbenchContext(){
+    public WorkspaceProjectContext getWorkbenchContext() {
         return projectContext;
     }
-
 
     public WorkspaceProject getActiveWorkspace() {
         return this.projectContext.getActiveWorkspaceProject().orElseThrow(() -> new IllegalStateException("No active workspace project found"));
@@ -861,7 +857,8 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
                 closeAllPlacesOrNothing(this::goToProject);
             }
 
-            if (Utils.hasModuleChanged(previous.getModule(), current.getModule())) {
+            if (Utils.hasModuleChanged(previous.getModule(),
+                                       current.getModule())) {
                 setupLibraryBreadCrumbs(projectContext.getActiveWorkspaceProject().get());
             }
         }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/example/ExampleProjectWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/example/ExampleProjectWidget.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
 import org.kie.workbench.common.screens.library.client.widgets.example.errors.ExampleProjectErrorPresenter;
 import org.kie.workbench.common.screens.library.client.widgets.example.errors.ExampleProjectOkPresenter;
@@ -44,7 +44,7 @@ public class ExampleProjectWidget {
         void setDisabled();
     }
 
-    private ExampleProject model;
+    private ImportProject model;
     private boolean selected;
 
     private final ExampleProjectWidget.View view;
@@ -60,12 +60,12 @@ public class ExampleProjectWidget {
         this.exampleProjectErrorPresenter = exampleProjectErrorPresenter;
     }
 
-    public void init(final ExampleProject exampleProject) {
+    public void init(final ImportProject importProject) {
         this.view.init(this);
-        this.model = exampleProject;
-        view.setup(exampleProject.getName(),
-                   exampleProject.getDescription(),
-                   this.buildErrors(exampleProject));
+        this.model = importProject;
+        view.setup(importProject.getName(),
+                   importProject.getDescription(),
+                   this.buildErrors(importProject));
         this.disableViewIfHasErrors();
     }
 
@@ -99,8 +99,8 @@ public class ExampleProjectWidget {
         }
     }
 
-    private HTMLElement buildErrors(ExampleProject exampleProject) {
-        List<ExampleProjectError> errors = exampleProject.getErrors();
+    private HTMLElement buildErrors(ImportProject importProject) {
+        List<ExampleProjectError> errors = importProject.getErrors();
         if (errors.isEmpty()) {
             return this.exampleProjectOkPresenter.getView().getElement();
         } else {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenterTest.java
@@ -20,8 +20,8 @@ import org.jboss.errai.common.client.api.Caller;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
-import org.kie.workbench.common.screens.library.api.LibraryService;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
+import org.kie.workbench.common.screens.examples.service.ProjectImportService;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -48,18 +48,18 @@ public class ImportRepositoryPopUpPresenterTest {
     private LibraryPlaces libraryPlaces;
 
     @Mock
-    private LibraryService libraryService;
+    private ProjectImportService libraryService;
 
-    private Caller<LibraryService> libraryServiceCaller;
+    private Caller<ProjectImportService> importServiceCaller;
 
     private ImportRepositoryPopUpPresenter presenter;
 
     @Before
     public void setup() {
-        libraryServiceCaller = new CallerMock<>(libraryService);
+        importServiceCaller = new CallerMock<>(libraryService);
         presenter = new ImportRepositoryPopUpPresenter(view,
                                                        libraryPlaces,
-                                                       libraryServiceCaller);
+                                                       importServiceCaller);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ImportRepositoryPopUpPresenterTest {
     public void importRepositoryTest() {
         String repoUrl = "repoUrl";
         doReturn(repoUrl).when(view).getRepositoryURL();
-        when(libraryService.getProjects(eq(repoUrl), any(), any())).thenReturn(singleton(mock(ExampleProject.class)));
+        when(libraryService.getProjects(any())).thenReturn(singleton(mock(ImportProject.class)));
 
         presenter.importRepository();
 
@@ -91,7 +91,7 @@ public class ImportRepositoryPopUpPresenterTest {
 
     @Test
     public void importInvalidRepositoryTest() {
-        doThrow(new RuntimeException()).when(libraryService).getProjects(any(), any(), any());
+        doThrow(new RuntimeException()).when(libraryService).getProjects(any());
         doReturn("repoUrl").when(view).getRepositoryURL();
 
         presenter.importRepository();
@@ -103,7 +103,7 @@ public class ImportRepositoryPopUpPresenterTest {
 
     @Test
     public void importEmptyRepositoryTest() {
-        when(libraryService.getProjects(any(), any(), any())).thenReturn(emptySet());
+        when(libraryService.getProjects(any())).thenReturn(emptySet());
         doReturn("repoUrl").when(view).getRepositoryURL();
 
         presenter.importRepository();

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/samples/ExampleImportPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/samples/ExampleImportPresenterTest.java
@@ -27,15 +27,16 @@ import org.guvnor.common.services.project.context.WorkspaceProjectContextChangeE
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.service.ExamplesService;
 import org.kie.workbench.common.screens.library.api.LibraryService;
+import org.kie.workbench.common.screens.library.client.screens.importrepository.ExamplesImportPresenter;
 import org.kie.workbench.common.screens.library.client.screens.importrepository.ImportPresenter;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
-import org.kie.workbench.common.screens.library.client.widgets.common.TileWidget;
 import org.kie.workbench.common.screens.library.client.widgets.example.ExampleProjectWidget;
 import org.kie.workbench.common.screens.library.client.widgets.example.errors.ExampleProjectErrorPresenter;
 import org.kie.workbench.common.screens.library.client.widgets.example.errors.ExampleProjectOkPresenter;
@@ -98,15 +99,15 @@ public class ExampleImportPresenterTest {
 
         doReturn(tileWidget).when(tileWidgets).get();
 
-        importPresenter = ImportPresenter.examplesImportPresenter(view,
-                                                                  libraryPlaces,
-                                                                  libraryServiceCaller,
-                                                                  tileWidgets,
-                                                                  examplesServiceCaller,
-                                                                  mock(WorkspaceProjectContext.class),
-                                                                  notificationEvent,
-                                                                  projectContextChangeEvent,
-                                                                  new Elemental2DomUtil());
+        importPresenter = new ExamplesImportPresenter(view,
+                                                      libraryPlaces,
+                                                      tileWidgets,
+                                                      examplesServiceCaller,
+                                                      mock(WorkspaceProjectContext.class),
+                                                      notificationEvent,
+                                                      projectContextChangeEvent,
+                                                      new Elemental2DomUtil(),
+                                                      mock(TranslationService.class));
     }
 
     @Test
@@ -124,26 +125,30 @@ public class ExampleImportPresenterTest {
 
     @Test
     public void filterProjectsTest() {
-        Set<ExampleProject> projects = new HashSet<>();
-        projects.add(new ExampleProject(mock(Path.class),
-                                        "p1a",
-                                        "p1a description",
-                                        null));
-        projects.add(new ExampleProject(mock(Path.class),
-                                        "p3b",
-                                        "p3b description",
-                                        null));
-        projects.add(new ExampleProject(mock(Path.class),
-                                        "p2a",
-                                        "p2a description",
-                                        null));
-        doReturn(projects).when(libraryService).getExampleProjects();
+        Set<ImportProject> projects = new HashSet<>();
+        projects.add(new ImportProject(mock(Path.class),
+                                       "p1a",
+                                       "p1a description",
+                                       "git@git.com",
+                                       null));
+        projects.add(new ImportProject(mock(Path.class),
+                                       "p3b",
+                                       "p3b description",
+                                       "git@git.com",
+                                       null));
+        projects.add(new ImportProject(mock(Path.class),
+                                       "p2a",
+                                       "p2a description",
+                                       "git@git.com",
+                                       null));
+        doReturn(projects).when(examplesService).getExampleProjects();
 
         Map<String, String> params = new HashMap<>();
         params.put("repositoryUrl",
                    "repoUrl");
         importPresenter.onStartup(new DefaultPlaceRequest(LibraryPlaces.PROJECT_SCREEN,
                                                           params));
+
         final List<ExampleProjectWidget> filteredProjects = importPresenter.filterProjects("a");
 
         assertEquals(2,

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
@@ -47,7 +47,7 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.explorer.model.URIStructureExplorerModel;
 import org.kie.workbench.common.screens.library.api.LibraryService;
 import org.kie.workbench.common.screens.library.api.ProjectAssetListUpdated;
@@ -732,11 +732,12 @@ public class LibraryPlacesTest {
         final PartDefinitionImpl part = new PartDefinitionImpl(trySamplesScreen);
         part.setSelectable(false);
 
-        final Set<ExampleProject> projects = singleton(new ExampleProject(PathFactory.newPath("example",
-                                                                                              "default://master@system/repo/example"),
-                                                                          "example",
-                                                                          "description",
-                                                                          emptyList()));
+        final Set<ImportProject> projects = singleton(new ImportProject(PathFactory.newPath("example",
+                                                                                            "default://master@system/repo/example"),
+                                                                        "example",
+                                                                        "description",
+                                                                        "git@git.com",
+                                                                        emptyList()));
         libraryPlaces.goToExternalImportPresenter(projects);
 
         verify(placeManager).goTo(eq(part),

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/widgets/example/ImportProjectWidgetTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/widgets/example/ImportProjectWidgetTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.examples.model.ExampleProject;
+import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.model.ExampleProjectError;
 import org.kie.workbench.common.screens.library.client.widgets.example.errors.ExampleProjectErrorPresenter;
 import org.kie.workbench.common.screens.library.client.widgets.example.errors.ExampleProjectOkPresenter;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExampleProjectWidgetTest {
+public class ImportProjectWidgetTest {
 
     public static final String EXAMPLE_PROJECT_NAME = "Test Example Project";
     public static final String EXAMPLE_PROJECT_DESCRIPTION = "Example Project Description";
@@ -52,7 +52,7 @@ public class ExampleProjectWidgetTest {
     private ExampleProjectErrorPresenter exampleProjectErrorPresenter;
 
     @Mock
-    private ExampleProject exampleProject;
+    private ImportProject importProject;
 
     private ExampleProjectWidget widget;
     private List<ExampleProjectError> errors;
@@ -62,8 +62,8 @@ public class ExampleProjectWidgetTest {
         this.widget = new ExampleProjectWidget(this.view,
                                                this.exampleProjectOkPresenter,
                                                this.exampleProjectErrorPresenter);
-        when(exampleProject.getName()).thenReturn(EXAMPLE_PROJECT_NAME);
-        when(exampleProject.getDescription()).thenReturn(EXAMPLE_PROJECT_DESCRIPTION);
+        when(importProject.getName()).thenReturn(EXAMPLE_PROJECT_NAME);
+        when(importProject.getDescription()).thenReturn(EXAMPLE_PROJECT_DESCRIPTION);
 
         errors = Arrays.asList(new ExampleProjectError("AnId",
                                                        "An Error Description"));
@@ -71,8 +71,8 @@ public class ExampleProjectWidgetTest {
 
     @Test
     public void testProjectContainErrors() {
-        when(this.exampleProject.getErrors()).thenReturn(this.errors);
-        this.widget.init(this.exampleProject);
+        when(this.importProject.getErrors()).thenReturn(this.errors);
+        this.widget.init(this.importProject);
 
         verify(this.exampleProjectOkPresenter,
                never()).getView();
@@ -91,8 +91,8 @@ public class ExampleProjectWidgetTest {
 
     @Test
     public void testProjectNotContainsErrors() {
-        when(this.exampleProject.getErrors()).thenReturn(Collections.emptyList());
-        this.widget.init(this.exampleProject);
+        when(this.importProject.getErrors()).thenReturn(Collections.emptyList());
+        this.widget.init(this.importProject);
 
         verify(this.exampleProjectErrorPresenter,
                never())
@@ -109,8 +109,8 @@ public class ExampleProjectWidgetTest {
 
     @Test
     public void testSelectOkProject() {
-        when(this.exampleProject.getErrors()).thenReturn(Collections.emptyList());
-        this.widget.init(this.exampleProject);
+        when(this.importProject.getErrors()).thenReturn(Collections.emptyList());
+        this.widget.init(this.importProject);
 
         this.widget.select();
 
@@ -129,8 +129,8 @@ public class ExampleProjectWidgetTest {
 
     @Test
     public void testSelectErrorProject() {
-        when(this.exampleProject.getErrors()).thenReturn(errors);
-        this.widget.init(this.exampleProject);
+        when(this.importProject.getErrors()).thenReturn(errors);
+        this.widget.init(this.importProject);
 
         this.widget.select();
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/widgets/example/errors/ImportProjectErrorPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/widgets/example/errors/ImportProjectErrorPresenterTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExampleProjectErrorPresenterTest {
+public class ImportProjectErrorPresenterTest {
 
     public static final String VALIDATOR = "Validator";
     public static final String VALIDATOR_ID = "org.id.with.dots." + VALIDATOR;


### PR DESCRIPTION
Created ProjectImportService to separate behavior from ExampleService. Also importProject from LibraryService moved to ProjectImportService

Related to:
* https://github.com/kiegroup/jbpm-wb/pull/1190