### PR TITLE
JBPM-6840 - Stunner adding Case Roles support

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/IntegerTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/canvas/actions/IntegerTextBox.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.canvas.actions;
+
+import org.uberfire.ext.widgets.common.client.common.NumericIntegerTextBox;
+
+/**
+ * Custom {@link NumericIntegerTextBox} that allows empty value as a default value, instead of "0".
+ */
+public class IntegerTextBox extends NumericIntegerTextBox {
+
+    public IntegerTextBox() {
+        super(true);
+    }
+
+    @Override
+    protected String makeValidValue(String value) {
+        return "";
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -144,7 +144,6 @@
     </dependency>
 
     <!-- Test scope. -->
-
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
 import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dimensions.RectangleDimensionsSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
@@ -71,6 +72,12 @@ public class BPMNDiagramImpl implements BPMNDiagram {
     protected ProcessData processData;
 
     @PropertySet
+    @FormField(
+            afterElement = "diagramSet"
+    )
+    protected CaseManagementSet caseManagementSet;
+
+    @PropertySet
     private BackgroundSet backgroundSet;
 
     @PropertySet
@@ -91,6 +98,7 @@ public class BPMNDiagramImpl implements BPMNDiagram {
     public BPMNDiagramImpl() {
         this(new DiagramSet(),
              new ProcessData(),
+             new CaseManagementSet(),
              new BackgroundSet(),
              new FontSet(),
              new RectangleDimensionsSet(WIDTH,
@@ -99,6 +107,7 @@ public class BPMNDiagramImpl implements BPMNDiagram {
 
     public BPMNDiagramImpl(final @MapsTo("diagramSet") DiagramSet diagramSet,
                            final @MapsTo("processData") ProcessData processData,
+                           final @MapsTo("caseManagementSet") CaseManagementSet caseManagementSet,
                            final @MapsTo("backgroundSet") BackgroundSet backgroundSet,
                            final @MapsTo("fontSet") FontSet fontSet,
                            final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet) {
@@ -107,6 +116,7 @@ public class BPMNDiagramImpl implements BPMNDiagram {
         this.backgroundSet = backgroundSet;
         this.fontSet = fontSet;
         this.dimensionsSet = dimensionsSet;
+        this.caseManagementSet = caseManagementSet;
     }
 
     public String getCategory() {
@@ -131,6 +141,14 @@ public class BPMNDiagramImpl implements BPMNDiagram {
 
     public ProcessData getProcessData() {
         return processData;
+    }
+
+    public CaseManagementSet getCaseManagementSet() {
+        return caseManagementSet;
+    }
+
+    public void setCaseManagementSet(CaseManagementSet caseManagementSet) {
+        this.caseManagementSet = caseManagementSet;
     }
 
     public BackgroundSet getBackgroundSet() {
@@ -166,6 +184,7 @@ public class BPMNDiagramImpl implements BPMNDiagram {
     public int hashCode() {
         return HashUtil.combineHashCodes(diagramSet.hashCode(),
                                          processData.hashCode(),
+                                         caseManagementSet.hashCode(),
                                          backgroundSet.hashCode(),
                                          fontSet.hashCode(),
                                          dimensionsSet.hashCode());
@@ -177,6 +196,7 @@ public class BPMNDiagramImpl implements BPMNDiagram {
             BPMNDiagramImpl other = (BPMNDiagramImpl) o;
             return diagramSet.equals(other.diagramSet) &&
                     processData.equals(other.processData) &&
+                    caseManagementSet.equals(other.caseManagementSet) &&
                     backgroundSet.equals(other.backgroundSet) &&
                     fontSet.equals(other.fontSet) &&
                     dimensionsSet.equals(other.dimensionsSet);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition.property.cm;
+
+import javax.validation.Valid;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
+import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNPropertySet;
+import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldType;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
+
+@Portable
+@Bindable
+@PropertySet
+@FormDefinition(
+        policy = FieldPolicy.ONLY_MARKED,
+        startElement = "caseRoles"
+)
+public class CaseManagementSet implements BPMNPropertySet {
+
+    @Property
+    @FormField(
+            type = RolesEditorFieldType.class
+    )
+    @Valid
+    private CaseRoles caseRoles;
+
+    public CaseManagementSet() {
+        this(new CaseRoles());
+    }
+
+    public CaseManagementSet(final @MapsTo("caseRoles") CaseRoles caseRoles) {
+        this.caseRoles = caseRoles;
+    }
+
+    public CaseRoles getCaseRoles() {
+        return caseRoles;
+    }
+
+    public void setCaseRoles(CaseRoles caseRoles) {
+        this.caseRoles = caseRoles;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.combineHashCodes(caseRoles.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof CaseManagementSet) {
+            CaseManagementSet other = (CaseManagementSet) o;
+            return caseRoles.equals(other.caseRoles);
+        }
+        return false;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseRoles.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseRoles.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition.property.cm;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldValue;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.I18nMode;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNProperty;
+import org.kie.workbench.common.stunner.bpmn.definition.property.type.VariablesType;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.property.Type;
+import org.kie.workbench.common.stunner.core.definition.annotation.property.Value;
+import org.kie.workbench.common.stunner.core.definition.property.PropertyType;
+
+@Portable
+@Bindable
+@Property
+@FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
+public class CaseRoles implements BPMNProperty {
+
+    @Type
+    public static final PropertyType type = new VariablesType();
+
+    @Value
+    @FieldValue
+    private String value;
+
+    public CaseRoles() {
+        this("");
+    }
+
+    public CaseRoles(final String value) {
+        this.value = value;
+    }
+
+    public PropertyType getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        return (null != value) ? value.hashCode() : 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof CaseRoles) {
+            CaseRoles other = (CaseRoles) o;
+            return (null != value) ? value.equals(other.value) : null == other.value;
+        }
+        return false;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/cm/RolesEditorFieldDefinition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/cm/RolesEditorFieldDefinition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.model.cm;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.fields.shared.AbstractFieldDefinition;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+
+@Portable
+@Bindable
+public class RolesEditorFieldDefinition extends AbstractFieldDefinition {
+
+    public static final RolesEditorFieldType FIELD_TYPE = new RolesEditorFieldType();
+
+    private String defaultValue;
+
+    public RolesEditorFieldDefinition() {
+        super(String.class.getName());
+    }
+
+    @Override
+    public RolesEditorFieldType getFieldType() {
+        return FIELD_TYPE;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    protected void doCopyFrom(FieldDefinition other) {
+        if (other instanceof RolesEditorFieldDefinition) {
+            this.setDefaultValue(((RolesEditorFieldDefinition) other).getDefaultValue());
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/cm/RolesEditorFieldType.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/model/cm/RolesEditorFieldType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.model.cm;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.forms.model.FieldType;
+
+@Portable
+public class RolesEditorFieldType implements FieldType {
+
+    public static final String NAME = "RolesEditor";
+
+    @Override
+    public String getTypeName() {
+        return NAME;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/KeyValueSerializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/KeyValueSerializer.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.bpmn.forms.serializer;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -47,11 +48,14 @@ public class KeyValueSerializer {
         this.delimiterKeyValue = delimiterKeyValue;
     }
 
-    public <T> List<T> deserialize(String s, BiFunction<String, String, T> builder) {
-        return Stream.of(Optional.ofNullable(s).orElse("").split(delimiterRow))
-                .map(entry -> entry.split(delimiterKeyValue))
-                .map(entry -> builder.apply(entry[0],entry[1]))
-                .collect(Collectors.toList());
+    public <T> List<T> deserialize(String value, BiFunction<String, String, T> builder) {
+        return Optional.ofNullable(value)
+                .filter(s -> !s.isEmpty())
+                .map(s -> Stream.of(s.split(delimiterRow))
+                        .map(entry -> entry.split(delimiterKeyValue))
+                        .map(entry -> builder.apply(entry[0], entry[1]))
+                        .collect(Collectors.toList()))
+                .orElse(new ArrayList<>());
     }
 
     public <T> String serialize(Optional<List<T>> values, Function<T, Object> getKey, Function<T, Object> getValue) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/KeyValueSerializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/KeyValueSerializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.serializer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+@Dependent
+public class KeyValueSerializer {
+
+    protected static final String DELIMITER_ROWS = ",";
+    protected static final String DELIMITER_KEY_VALUE = ":";
+
+    private String delimiterRow;
+    private String delimiterKeyValue;
+
+    @Inject
+    public KeyValueSerializer() {
+        this.delimiterRow = DELIMITER_ROWS;
+        this.delimiterKeyValue = DELIMITER_KEY_VALUE;
+    }
+
+    protected KeyValueSerializer(String delimiterRow, String delimiterKeyValue) {
+        this.delimiterRow = delimiterRow;
+        this.delimiterKeyValue = delimiterKeyValue;
+    }
+
+    public <T> List<T> deserialize(String s, BiFunction<String, String, T> builder) {
+        return Stream.of(Optional.ofNullable(s).orElse("").split(delimiterRow))
+                .map(entry -> entry.split(delimiterKeyValue))
+                .map(entry -> builder.apply(entry[0],entry[1]))
+                .collect(Collectors.toList());
+    }
+
+    public <T> String serialize(Optional<List<T>> values, Function<T, Object> getKey, Function<T, Object> getValue) {
+        return values.orElse(Collections.emptyList())
+                .stream()
+                .map(row -> getKey.apply(row) + delimiterKeyValue + getValue.apply(row))
+                .collect(Collectors.joining(delimiterRow));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/cm/CaseRoleSerializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/cm/CaseRoleSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.serializer.cm;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
+import org.kie.workbench.common.stunner.bpmn.forms.serializer.KeyValueSerializer;
+
+/**
+ * This class is responsible to serialize a given Key-Value pair, indicating the Role and Cardinality, to be used on
+ * {@link CaseRoles} definition.
+ *
+ *
+ */
+@Dependent
+public class CaseRoleSerializer extends KeyValueSerializer {
+
+    @Inject
+    public CaseRoleSerializer() {
+        super(",", ":");
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/adf/processing/processors/fields/cm/RolesEditorFieldInitializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/adf/processing/processors/fields/cm/RolesEditorFieldInitializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.service.adf.processing.processors.fields.cm;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.FormGenerationContext;
+import org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.FieldInitializer;
+import org.kie.workbench.common.forms.adf.service.definitions.elements.FieldElement;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldDefinition;
+
+@Dependent
+public class RolesEditorFieldInitializer implements FieldInitializer<RolesEditorFieldDefinition> {
+
+    @Override
+    public boolean supports(FieldDefinition fieldDefinition) {
+        return fieldDefinition instanceof RolesEditorFieldDefinition;
+    }
+
+    @Override
+    public void initialize(RolesEditorFieldDefinition field,
+                           FieldElement fieldElement,
+                           FormGenerationContext context) {
+        field.setDefaultValue(fieldElement.getParams().getOrDefault("defaultValue",
+                                                                    ""));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/cm/RolesEditorFieldProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/cm/RolesEditorFieldProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.service.fieldProviders.cm;
+
+import javax.enterprise.inject.Model;
+
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.BasicTypeFieldProvider;
+import org.kie.workbench.common.forms.model.TypeInfo;
+import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldType;
+
+@Model
+public class RolesEditorFieldProvider extends BasicTypeFieldProvider<RolesEditorFieldDefinition> {
+
+    @Override
+    public Class<RolesEditorFieldType> getFieldType() {
+        return RolesEditorFieldType.class;
+    }
+
+    @Override
+    public String getFieldTypeName() {
+        return RolesEditorFieldDefinition.FIELD_TYPE.getTypeName();
+    }
+
+    @Override
+    public int getPriority() {
+        return 60000;
+    }
+
+    @Override
+    protected void doRegisterFields() {
+        registerPropertyType(String.class);
+    }
+
+    @Override
+    public RolesEditorFieldDefinition createFieldByType(TypeInfo typeInfo) {
+        return getDefaultField();
+    }
+
+    @Override
+    public RolesEditorFieldDefinition getDefaultField() {
+        return new RolesEditorFieldDefinition();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/cm/RolesEditorFieldProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/cm/RolesEditorFieldProvider.java
@@ -38,7 +38,7 @@ public class RolesEditorFieldProvider extends BasicTypeFieldProvider<RolesEditor
 
     @Override
     public int getPriority() {
-        return 60000;
+        return Integer.MAX_VALUE;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -380,6 +380,12 @@ org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVaria
 org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables.description=Variables for the Process
 
 #######################
+# Case Management
+#######################
+org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet.label=Case Management
+org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles.label=Case Roles
+
+#######################
 # SignalScopeProvider
 #######################
 org.kie.workbench.common.stunner.bpmn.client.dataproviders.default=Default

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/cm/CaseRoleSerializerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/serializer/cm/CaseRoleSerializerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.forms.serializer.cm;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CaseRoleSerializerTest {
+
+    private static final String SERIALIZED_ROLE = "role:1";
+
+    private Map.Entry<String, String> entry;
+
+    private List<Map.Entry> entries;
+
+    private CaseRoleSerializer tested;
+
+    @Before
+    public void setUp() throws Exception {
+        tested = new CaseRoleSerializer();
+        entry = new AbstractMap.SimpleEntry("role", "1");
+        entries = Arrays.asList(entry);
+    }
+
+    @Test
+    public void serialize() {
+        final String serialized = tested.serialize(Optional.of(entries), Map.Entry::getKey, Map.Entry::getValue);
+        assertEquals(serialized, SERIALIZED_ROLE);
+    }
+
+    @Test
+    public void deserialize() {
+        List<AbstractMap.SimpleEntry> deserialized = tested.deserialize(SERIALIZED_ROLE, (k, v) -> new AbstractMap.SimpleEntry(k, v));
+        assertEquals(deserialized, entries);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomElement.java
@@ -38,6 +38,7 @@ public class CustomElement<T> {
             return getStringValue(element).orElse(defaultValue);
         }
     };
+    public static final ElementDefinition<String> caseRole = new StringElement("customCaseRoles", "");
 
     private final ElementDefinition<T> elementDefinition;
     private final BaseElement element;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
@@ -22,6 +22,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Defi
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -70,6 +71,10 @@ public class RootProcessConverter {
 
         ProcessData processData = definition.getProcessData();
         p.setProcessVariables(processData.getProcessVariables());
+
+        //Case Management
+        final CaseRoles caseRoles = definition.getCaseManagementSet().getCaseRoles();
+        p.setCaseRoles(caseRoles);
 
         return p;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -46,6 +46,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.DeclarationList;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.ElementContainer;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables;
 
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
@@ -184,6 +185,10 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());
         });
+    }
+
+    public void setCaseRoles(CaseRoles roles) {
+        CustomElement.caseRole.of(process).set(roles.getValue());
     }
 
     public void addLaneSet(Collection<LanePropertyWriter> lanes) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
@@ -26,6 +26,8 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.Defini
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.ProcessPropertyReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.PropertyReaderFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.AdHoc;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.Executable;
@@ -95,7 +97,11 @@ public class RootProcessConverter {
                 new Version(e.getVersion()),
                 new AdHoc(e.isAdHoc()),
                 new ProcessInstanceDescription(e.getDescription()),
-                new Executable(process.isIsExecutable())
+                new Executable(process.isIsExecutable()))
+        );
+
+        definition.setCaseManagementSet(new CaseManagementSet(
+                new CaseRoles(e.getCaseRoles())
         ));
 
         definition.setProcessData(new ProcessData(

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessPropertyReader.java
@@ -25,6 +25,7 @@ import org.eclipse.bpmn2.Process;
 import org.eclipse.bpmn2.di.BPMNPlane;
 import org.eclipse.bpmn2.di.BPMNShape;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
@@ -63,6 +64,10 @@ public class ProcessPropertyReader extends BasePropertyReader {
 
     public String getProcessVariables() {
         return ProcessVariableReader.getProcessVariables(process.getProperties());
+    }
+
+    public String getCaseRoles() {
+        return CustomElement.caseRole.of(process).get();
     }
 
     public FlowElement getFlowElement(String id) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/DefinitionsConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/DefinitionsConverterTest.java
@@ -67,7 +67,5 @@ public class DefinitionsConverterTest {
 
         assertThat(definitions.getExporter()).isNotBlank();
         assertThat(definitions.getExporterVersion()).isNotBlank();
-
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.processes;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.bpmn2.Process;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.ConverterFactory;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.DefinitionsBuildingContext;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.FlowElementConverter;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.lanes.LaneConverter;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RootProcessConverterTest {
+
+    private RootProcessConverter converter;
+    private DefinitionsBuildingContext context;
+
+    @Mock
+    private PropertyWriterFactory propertyWriterFactory;
+
+    @Mock
+    private ConverterFactory converterFactory;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private Definition<BPMNDiagramImpl> content;
+
+    private BPMNDiagramImpl diagram;
+
+    @Mock
+    private CaseManagementSet caseManagementSet;
+
+    @Mock
+    private CaseRoles caseRoles;
+
+    @Mock
+    private ProcessPropertyWriter processPropertyWriter;
+
+    @Mock
+    private SubProcessConverter subProcessConverter;
+
+    @Mock
+    private FlowElementConverter viewDefinitionConverter;
+
+    @Mock
+    private LaneConverter laneConverter;
+
+    @Before
+    public void setUp() throws Exception {
+        diagram = new BPMNDiagramImpl();
+        diagram.setDiagramSet(new DiagramSet());
+        diagram.setCaseManagementSet(caseManagementSet);
+        context = new DefinitionsBuildingContext(node, Stream.of(new AbstractMap.SimpleEntry("uuid", node)).collect(Collectors.toMap(Map.Entry<String, Node>::getKey, Map.Entry<String, Node>::getValue))).withRootNode(node);
+        converter = new RootProcessConverter(context, propertyWriterFactory, converterFactory);
+
+        when(propertyWriterFactory.of(Matchers.any(Process.class))).thenReturn(processPropertyWriter);
+        when(node.getContent()).thenReturn(content);
+        when(content.getDefinition()).thenReturn(diagram);
+        when(caseManagementSet.getCaseRoles()).thenReturn(caseRoles);
+        when(converterFactory.subProcessConverter()).thenReturn(subProcessConverter);
+        when(converterFactory.viewDefinitionConverter()).thenReturn(viewDefinitionConverter);
+        when(converterFactory.laneConverter()).thenReturn(laneConverter);
+    }
+
+    @Test
+    public void convertProcessWithCaseRoles() {
+        final ProcessPropertyWriter propertyWriter = converter.convertProcess();
+        verify(propertyWriter).setCaseRoles(caseRoles);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -21,12 +21,17 @@ import org.eclipse.bpmn2.di.BPMNEdge;
 import org.eclipse.bpmn2.di.BPMNShape;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.di;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ProcessPropertyWriterTest {
 
     ProcessPropertyWriter p ;
@@ -82,5 +87,13 @@ public class ProcessPropertyWriterTest {
         assertThatThrownBy(() -> p.addChildEdge(bpmnEdge))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Cannot add the same edge twice");
+    }
+
+    @Test
+    public void caseRoles() {
+        CaseRoles caseRole = new CaseRoles("role");
+        p.setCaseRoles(caseRole);
+        String cdata = CustomElement.caseRole.of(p.getProcess()).get();
+        assertThat("role").isEqualTo(CustomElement.caseRole.stripCData(cdata));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -178,6 +178,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Uberfire & Errai. -->
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -278,11 +278,12 @@
     <!-- TODO:
     Lienzo mockito is not compatible with PowerMock, once running both
     in same classpath the build does not work - the use of power mock must be removed.
+    -->
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>lienzo-tests</artifactId>
       <scope>test</scope>
-    </dependency> -->
+    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
@@ -328,7 +329,6 @@
       <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRenderer.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
@@ -69,16 +68,6 @@ public class RolesEditorFieldRenderer extends FieldRenderer<RolesEditorFieldDefi
     }
 
     @Override
-    public void doSave() {
-        view.doSave();
-    }
-
-    @Override
-    public void notifyModelChanged() {
-        doSave();
-    }
-
-    @Override
     public List<KeyValueRow> deserialize(String value) {
         return serializer.deserialize(value, (k, v) -> new KeyValueRow(k, v));
     }
@@ -86,27 +75,5 @@ public class RolesEditorFieldRenderer extends FieldRenderer<RolesEditorFieldDefi
     @Override
     public String serialize(List<KeyValueRow> rows) {
         return serializer.serialize(Optional.ofNullable(rows), KeyValueRow::getKey, KeyValueRow::getValue);
-    }
-
-    @Override
-    public void add() {
-        final List<KeyValueRow> rows = view.getRows();
-        if (rows.isEmpty()) {
-            view.setTableDisplayStyle();
-        }
-        rows.add(new KeyValueRow());
-        RolesListItemWidgetView widget = view.getWidget(view.getRowsCount() - 1);
-        widget.setParentWidget(this);
-    }
-
-    @Override
-    public boolean isDuplicateName(String name) {
-        return view.getRows().stream().filter(row -> Objects.equals(row.getKey(), name)).count() > 1;
-    }
-
-    @Override
-    public void remove(KeyValueRow row) {
-        view.getRows().remove(row);
-        doSave();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRenderer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.serializer.cm.CaseRoleSerializer;
+
+@Dependent
+public class RolesEditorFieldRenderer extends FieldRenderer<RolesEditorFieldDefinition, DefaultFormGroup>
+        implements RolesEditorWidgetView.Presenter {
+
+    private RolesEditorWidgetView view;
+    private CaseRoleSerializer serializer;
+
+    @Inject
+    public RolesEditorFieldRenderer(RolesEditorWidgetView editor,
+                                    CaseRoleSerializer serializer) {
+        this.view = editor;
+        this.serializer = serializer;
+    }
+
+    @Override
+    public String getName() {
+        return RolesEditorFieldDefinition.FIELD_TYPE.getTypeName();
+    }
+
+    @Override
+    public String getSupportedCode() {
+        return RolesEditorFieldDefinition.FIELD_TYPE.getTypeName();
+    }
+
+    @Override
+    protected FormGroup getFormGroup(RenderMode renderMode) {
+        DefaultFormGroup formGroup = formGroupsInstance.get();
+        view.init(this);
+        formGroup.render(view.asWidget(), field);
+        return formGroup;
+    }
+
+    @Override
+    protected void setReadOnly(boolean readOnly) {
+        view.setReadOnly(readOnly);
+    }
+
+    @Override
+    public void doSave() {
+        view.doSave();
+    }
+
+    @Override
+    public void notifyModelChanged() {
+        doSave();
+    }
+
+    @Override
+    public List<KeyValueRow> deserialize(String value) {
+        return serializer.deserialize(value, (k, v) -> new KeyValueRow(k, v));
+    }
+
+    @Override
+    public String serialize(List<KeyValueRow> rows) {
+        return serializer.serialize(Optional.ofNullable(rows), KeyValueRow::getKey, KeyValueRow::getValue);
+    }
+
+    @Override
+    public void add() {
+        final List<KeyValueRow> rows = view.getRows();
+        if (rows.isEmpty()) {
+            view.setTableDisplayStyle();
+        }
+        rows.add(new KeyValueRow());
+        RolesListItemWidgetView widget = view.getWidget(view.getRowsCount() - 1);
+        widget.setParentWidget(this);
+    }
+
+    @Override
+    public boolean isDuplicateName(String name) {
+        return view.getRows().stream().filter(row -> Objects.equals(row.getKey(), name)).count() > 1;
+    }
+
+    @Override
+    public void remove(KeyValueRow row) {
+        view.getRows().remove(row);
+        doSave();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidget.html
@@ -32,8 +32,8 @@
                         </td>
                     </tr>
                     </thead>
-                    <tbody data-field="rows" id="rows">
-                    <tr id="tableRow">
+                    <tbody data-field="list">
+                    <tr data-field="tableRow" hidden="true">
                         <td style="width:46%">
                             <input type="text" class="form-control" data-field="roleInput"/>
                         </td>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidget.html
@@ -1,0 +1,63 @@
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+</head>
+
+<body>
+
+<div id="widget" class="input-group" style="width:100%">
+    <div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="table-responsive">
+                    <table class="table table-striped table-bordered" data-field="table">
+                        <thead>
+                        <tr>
+                            <th data-field="nameth" style="width:46%">
+                                Name
+                            </th>
+                            <th data-field="datatypeth" style="width:46%">
+                                Cardinality
+                            </th>
+                            <td style="width:8%">
+                                <button type="button" class="center-block" data-field="addButton"></button>
+                            </td>
+                        </tr>
+                        </thead>
+                        <tbody id="rows">
+                        <tr id="tableRow">
+                            <td style="width:46%">
+                                <input type="text" class="form-control" data-field="roleInput"/>
+                            </td>
+                            <td style="width:46%">
+                                <input type="text" class="form-control" data-field="cardinalityInput"/>
+                            </td>
+                            <td style="width:8%">
+                                <button type="button" class="center-block" data-field="deleteButton"></button>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+</body>
+</html>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidget.html
@@ -13,51 +13,40 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<!DOCTYPE html>
-<html lang="en">
-<head>
-</head>
 
-<body>
-
-<div id="widget" class="input-group" style="width:100%">
-    <div>
-        <div class="row">
-            <div class="col-md-12">
-                <div class="table-responsive">
-                    <table class="table table-striped table-bordered" data-field="table">
-                        <thead>
-                        <tr>
-                            <th data-field="nameth" style="width:46%">
-                                Name
-                            </th>
-                            <th data-field="datatypeth" style="width:46%">
-                                Cardinality
-                            </th>
-                            <td style="width:8%">
-                                <button type="button" class="center-block" data-field="addButton"></button>
-                            </td>
-                        </tr>
-                        </thead>
-                        <tbody id="rows">
-                        <tr id="tableRow">
-                            <td style="width:46%">
-                                <input type="text" class="form-control" data-field="roleInput"/>
-                            </td>
-                            <td style="width:46%">
-                                <input type="text" class="form-control" data-field="cardinalityInput"/>
-                            </td>
-                            <td style="width:8%">
-                                <button type="button" class="center-block" data-field="deleteButton"></button>
-                            </td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </div>
+<div class="input-group" style="width:100%" data-field="widget">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered" data-field="table">
+                    <thead>
+                    <tr>
+                        <th style="width:46%" data-i18n-key="Name">
+                            Name
+                        </th>
+                        <th style="width:46%" data-i18n-key="Cardinality">
+                            Cardinality
+                        </th>
+                        <td style="width:8%">
+                            <button type="button" class="center-block" data-field="addButton" data-i18n-key=""></button>
+                        </td>
+                    </tr>
+                    </thead>
+                    <tbody data-field="rows" id="rows">
+                    <tr id="tableRow">
+                        <td style="width:46%">
+                            <input type="text" class="form-control" data-field="roleInput"/>
+                        </td>
+                        <td style="width:46%">
+                            <input type="text" class="form-control" data-field="cardinalityInput"/>
+                        </td>
+                        <td style="width:8%">
+                            <button type="button" class="center-block" data-field="deleteButton"></button>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>
-
 </div>
-</body>
-</html>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetView.java
@@ -25,40 +25,32 @@ public interface RolesEditorWidgetView extends IsWidget {
 
     interface Presenter {
 
-        void doSave();
-
-        void notifyModelChanged();
-
         List<KeyValueRow> deserialize(final String s);
 
         String serialize(final List<KeyValueRow> rows);
-
-        void add();
-
-        boolean isDuplicateName(final String name);
-
-        void remove(final KeyValueRow row);
     }
 
     void init(final RolesEditorWidgetView.Presenter presenter);
 
     void doSave();
 
+    void notifyModelChanged();
+
     int getRowsCount();
-
-    void setTableDisplayStyle();
-
-    void setNoneDisplayStyle();
 
     void setRows(final List<KeyValueRow> rows);
 
     List<KeyValueRow> getRows();
 
-    RolesListItemWidgetView getWidget(final int index);
+    RolesListItemWidgetView getWidget(final KeyValueRow row);
+
+    RolesListItemWidgetView getWidget(int index);
 
     void setVisible(final boolean visible);
 
     void remove(final KeyValueRow row);
 
     void setReadOnly(final boolean readOnly);
+
+    boolean isDuplicateName(final String name);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetView.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import java.util.List;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+
+public interface RolesEditorWidgetView extends IsWidget {
+
+    interface Presenter {
+
+        void doSave();
+
+        void notifyModelChanged();
+
+        List<KeyValueRow> deserialize(final String s);
+
+        String serialize(final List<KeyValueRow> rows);
+
+        void add();
+
+        boolean isDuplicateName(final String name);
+
+        void remove(final KeyValueRow row);
+    }
+
+    void init(final RolesEditorWidgetView.Presenter presenter);
+
+    void doSave();
+
+    int getRowsCount();
+
+    void setTableDisplayStyle();
+
+    void setNoneDisplayStyle();
+
+    void setRows(final List<KeyValueRow> rows);
+
+    List<KeyValueRow> getRows();
+
+    RolesListItemWidgetView getWidget(final int index);
+
+    void setVisible(final boolean visible);
+
+    void remove(final KeyValueRow row);
+
+    void setReadOnly(final boolean readOnly);
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetView.java
@@ -42,8 +42,6 @@ public interface RolesEditorWidgetView extends IsWidget {
 
     List<KeyValueRow> getRows();
 
-    RolesListItemWidgetView getWidget(final KeyValueRow row);
-
     RolesListItemWidgetView getWidget(int index);
 
     void setVisible(final boolean visible);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImpl.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.TableCellElement;
+import com.google.gwt.dom.client.TableElement;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HasValue;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.ui.client.widget.ListWidget;
+import org.jboss.errai.ui.client.widget.Table;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.uberfire.workbench.events.NotificationEvent;
+
+@Dependent
+@Templated("RolesEditorWidget.html#widget")
+public class RolesEditorWidgetViewImpl extends Composite implements RolesEditorWidgetView,
+                                                                    HasValue<String> {
+
+    public static final String ROLE = "Role";
+    public static final String CARDINALITY = "Cardinality";
+    private String serializedRoles;
+
+    private Presenter presenter;
+
+    @Inject
+    @DataField("addButton")
+    protected Button addButton;
+
+    @DataField("table")
+    protected TableElement table = Document.get().createTableElement();
+
+    @DataField("nameth")
+    protected TableCellElement nameCol = Document.get().createTHElement();
+
+    @DataField("datatypeth")
+    protected TableCellElement cardinalityCol = Document.get().createTHElement();
+
+    private boolean readOnly = false;
+
+    public RolesEditorWidgetViewImpl() {
+
+    }
+
+    @Inject
+    @DataField("rows")
+    @Table(root = "tbody")
+    protected ListWidget<KeyValueRow, RolesListItemWidgetView> rows;
+
+    @Inject
+    protected Event<NotificationEvent> notification;
+
+    @Override
+    public String getValue() {
+        return serializedRoles;
+    }
+
+    @Override
+    public void setValue(final String value) {
+        doSetValue(value, false, true);
+    }
+
+    @Override
+    public void setValue(final String value,
+                         final boolean fireEvents) {
+        doSetValue(value, fireEvents, false);
+    }
+
+    protected void doSetValue(final String value,
+                              final boolean fireEvents,
+                              final boolean initializeView) {
+        final String oldValue = serializedRoles;
+        serializedRoles = value;
+        if (initializeView) {
+            initView();
+        }
+        if (fireEvents) {
+            ValueChangeEvent.fireIfNotEqual(this,
+                                            oldValue,
+                                            serializedRoles);
+        }
+        setReadOnly(readOnly);
+    }
+
+    @Override
+    public void doSave() {
+        String newValue = presenter.serialize(getRows());
+        setValue(newValue, true);
+    }
+
+    protected void initView() {
+        setRows(presenter.deserialize(serializedRoles));
+    }
+
+    @Override
+    public HandlerRegistration addValueChangeHandler(final ValueChangeHandler<String> handler) {
+        return addHandler(handler,
+                          ValueChangeEvent.getType());
+    }
+
+    @Override
+    public void init(final Presenter presenter) {
+        this.presenter = presenter;
+        addButton.setIcon(IconType.PLUS);
+        nameCol.setInnerText(ROLE);
+        cardinalityCol.setInnerText(CARDINALITY);
+    }
+
+    @Override
+    public void setReadOnly(final boolean readOnly) {
+        this.readOnly = readOnly;
+        addButton.setEnabled(!readOnly);
+        for (int i = 0; i < getRowsCount(); i++) {
+            getWidget(i).setReadOnly(readOnly);
+        }
+    }
+
+    @Override
+    public int getRowsCount() {
+        return rows.getValue().size();
+    }
+
+    @Override
+    public void setTableDisplayStyle() {
+        table.getStyle().setDisplay(Style.Display.TABLE);
+    }
+
+    @Override
+    public void setNoneDisplayStyle() {
+        table.getStyle().setDisplay(Style.Display.NONE);
+    }
+
+    @Override
+    public void setRows(final List<KeyValueRow> rows) {
+        this.rows.setValue(rows);
+        for (int i = 0; i < getRowsCount(); i++) {
+            RolesListItemWidgetView widget = getWidget(i);
+            widget.setParentWidget(presenter);
+        }
+    }
+
+    @Override
+    public List<KeyValueRow> getRows() {
+        return rows.getValue();
+    }
+
+    @Override
+    public RolesListItemWidgetView getWidget(final int index) {
+        return rows.getComponent(index);
+    }
+
+    @EventHandler("addButton")
+    public void handleAddVarButton(final ClickEvent e) {
+        presenter.add();
+    }
+
+    @Override
+    public void remove(final KeyValueRow row) {
+        presenter.remove(row);
+        if (getRows().isEmpty()) {
+            setNoneDisplayStyle();
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImpl.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -39,6 +40,7 @@ import org.jboss.errai.ui.shared.api.annotations.Bound;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.uberfire.workbench.events.NotificationEvent;
 
 @Dependent
@@ -105,7 +107,11 @@ public class RolesEditorWidgetViewImpl extends Composite implements RolesEditorW
 
     @Override
     public void doSave() {
-        presenter.map(p -> p.serialize(getRows())).ifPresent(newValue -> setValue(newValue, true));
+        presenter.map(p -> p.serialize(removeEmptyRoles(getRows()))).ifPresent(newValue -> setValue(newValue, true));
+    }
+
+    private List<KeyValueRow> removeEmptyRoles(List<KeyValueRow> roles) {
+        return roles.stream().filter(row -> !StringUtils.isBlank(row.getKey())).collect(Collectors.toList());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImpl.java
@@ -31,8 +31,11 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasValue;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.constants.IconType;
-import org.jboss.errai.ui.client.widget.ListWidget;
-import org.jboss.errai.ui.client.widget.Table;
+import org.jboss.errai.databinding.client.api.DataBinder;
+import org.jboss.errai.databinding.client.components.ListComponent;
+import org.jboss.errai.databinding.client.components.ListContainer;
+import org.jboss.errai.ui.shared.api.annotations.AutoBound;
+import org.jboss.errai.ui.shared.api.annotations.Bound;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
@@ -58,9 +61,14 @@ public class RolesEditorWidgetViewImpl extends Composite implements RolesEditorW
     }
 
     @Inject
-    @DataField("rows")
-    @Table(root = "tbody")
-    protected ListWidget<KeyValueRow, RolesListItemWidgetView> rows;
+    @AutoBound
+    protected DataBinder<List<KeyValueRow>> binder;
+
+    @Inject
+    @DataField("list")
+    @Bound
+    @ListContainer("tbody")
+    protected ListComponent<KeyValueRow, RolesListItemWidgetView> list;
 
     @Inject
     protected Event<NotificationEvent> notification;
@@ -132,12 +140,12 @@ public class RolesEditorWidgetViewImpl extends Composite implements RolesEditorW
 
     @Override
     public int getRowsCount() {
-        return Optional.ofNullable(rows.getValue()).map(List::size).orElse(0);
+        return Optional.ofNullable(getRows()).map(List::size).orElse(0);
     }
 
     @Override
     public void setRows(final List<KeyValueRow> rows) {
-        this.rows.setValue(rows);
+        binder.setModel(rows);
         for (int i = 0; i < getRowsCount(); i++) {
             RolesListItemWidgetView widget = getWidget(i);
             widget.setParentWidget(this);
@@ -146,27 +154,17 @@ public class RolesEditorWidgetViewImpl extends Composite implements RolesEditorW
 
     @Override
     public List<KeyValueRow> getRows() {
-        return rows.getValue();
-    }
-
-    @Override
-    public RolesListItemWidgetView getWidget(KeyValueRow row) {
-        return rows.getComponent(row);
+        return binder.getModel();
     }
 
     @Override
     public RolesListItemWidgetView getWidget(int index) {
-        return rows.getComponent(index);
+        return list.getComponent(index);
     }
 
     protected void handleAddVarButton() {
-        if (!getRows().isEmpty() && getRows().get(getRowsCount() - 1).getKey() == null) {
-            return;
-        }
-
-        final int index = getRowsCount();
-        getRows().add(new KeyValueRow());
-        final RolesListItemWidgetView widget = getWidget(index);
+        getRows().add(getRowsCount(), new KeyValueRow());
+        final RolesListItemWidgetView widget = getWidget(getRowsCount() - 1);
         widget.setParentWidget(this);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetView.java
@@ -16,15 +16,19 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
 
+import com.google.gwt.user.client.TakesValue;
+import org.jboss.errai.common.client.api.IsElement;
 import org.jboss.errai.ui.client.widget.HasModel;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable.VariableType;
 
-public interface RolesListItemWidgetView extends HasModel<KeyValueRow> {
+public interface RolesListItemWidgetView extends TakesValue<KeyValueRow>,
+                                                 HasModel<KeyValueRow>,
+                                                 IsElement {
 
     void init();
 
-    void setParentWidget(final RolesEditorWidgetView.Presenter parentWidget);
+    void setParentWidget(final RolesEditorWidgetView parentWidget);
 
     void notifyModelChanged();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetView.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import org.jboss.errai.ui.client.widget.HasModel;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable.VariableType;
+
+public interface RolesListItemWidgetView extends HasModel<KeyValueRow> {
+
+    void init();
+
+    void setParentWidget(final RolesEditorWidgetView.Presenter parentWidget);
+
+    void notifyModelChanged();
+
+    boolean isDuplicateName(final String name);
+
+    VariableType getVariableType();
+
+    void setReadOnly(final boolean readOnly);
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetViewImpl.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import java.util.Objects;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.databinding.client.api.DataBinder;
+import org.jboss.errai.ui.shared.api.annotations.AutoBound;
+import org.jboss.errai.ui.shared.api.annotations.Bound;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.stunner.bpmn.client.StunnerSpecific;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable.VariableType;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
+import org.uberfire.ext.widgets.common.client.common.NumericIntegerTextBox;
+import org.uberfire.workbench.events.NotificationEvent;
+
+@Templated("RolesEditorWidget.html#tableRow")
+public class RolesListItemWidgetViewImpl implements RolesListItemWidgetView {
+
+    public static final String INVALID_CHARACTERS_MESSAGE = "Invalid characters";
+    private static final String DUPLICATE_NAME_ERROR_MESSAGE = "A role with this name already exists";
+
+    @Inject
+    @AutoBound
+    protected DataBinder<KeyValueRow> row;
+
+    @Inject
+    @Bound(property = "key")
+    @DataField("roleInput")
+    @StunnerSpecific
+    protected VariableNameTextBox role;
+
+    @Inject
+    @Bound(property = "value")
+    @DataField("cardinalityInput")
+    protected NumericIntegerTextBox cardinality;
+
+    private boolean allowDuplicateNames = false;
+
+    private String previousRole;
+
+    private String previousCardinality;
+
+    @Inject
+    protected Event<NotificationEvent> notification;
+
+    @Inject
+    @DataField
+    protected Button deleteButton;
+
+    /**
+     * Required for implementation of Delete button.
+     */
+    private RolesEditorWidgetView.Presenter parentWidget;
+
+    public void setParentWidget(final RolesEditorWidgetView.Presenter parentWidget) {
+        this.parentWidget = parentWidget;
+    }
+
+    @PostConstruct
+    public void init() {
+        role.setRegExp(StringUtils.ALPHA_NUM_REGEXP, INVALID_CHARACTERS_MESSAGE, INVALID_CHARACTERS_MESSAGE);
+        role.addBlurHandler(getBlurHandler());
+        cardinality.addBlurHandler(getBlurHandler());
+        deleteButton.setIcon(IconType.TRASH);
+    }
+
+    private BlurHandler getBlurHandler() {
+        return new BlurHandler() {
+            @Override
+            public void onBlur(final BlurEvent event) {
+                String value = role.getText();
+                if (!allowDuplicateNames && isDuplicateName(value)) {
+                    notification.fire(new NotificationEvent(DUPLICATE_NAME_ERROR_MESSAGE,
+                                                            NotificationEvent.NotificationType.ERROR));
+                    role.setValue("");
+                    return;
+                }
+                notifyModelChanged();
+            }
+        };
+    }
+
+    @Override
+    public KeyValueRow getModel() {
+        return row.getModel();
+    }
+
+    @Override
+    public void setModel(final KeyValueRow model) {
+        row.setModel(model);
+        previousRole = model.getKey();
+        previousCardinality = model.getValue();
+    }
+
+    @Override
+    public VariableType getVariableType() {
+        return VariableType.PROCESS;
+    }
+
+    @Override
+    public void setReadOnly(final boolean readOnly) {
+        deleteButton.setEnabled(!readOnly);
+        role.setEnabled(!readOnly);
+        cardinality.setEnabled(!readOnly);
+    }
+
+    @Override
+    public boolean isDuplicateName(final String name) {
+        return parentWidget.isDuplicateName(name);
+    }
+
+    @EventHandler("deleteButton")
+    public void handleDeleteButton(final ClickEvent e) {
+        parentWidget.remove(getModel());
+    }
+
+    @Override
+    public void notifyModelChanged() {
+        final String currentRole = row.getModel().getKey();
+        final String currentCardinality = row.getModel().getValue();
+
+        //skip in case not modified values
+        if (Objects.equals(previousRole, currentRole) && Objects.equals(previousCardinality, currentCardinality)) {
+            return;
+        }
+        previousRole = currentRole;
+        previousCardinality = currentCardinality;
+        parentWidget.notifyModelChanged();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/KeyValueRow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/KeyValueRow.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.model;
 import java.util.Objects;
 
 import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.stunner.core.util.UUID;
 
 @Bindable
 public class KeyValueRow {
@@ -27,14 +28,16 @@ public class KeyValueRow {
 
     private String value;
 
-    private String customKey;
+    private String uuid;
 
     public KeyValueRow() {
+        this("", "");
     }
 
     public KeyValueRow(String key, String value) {
-        this.key = key;
-        this.value = value;
+        this.key = Objects.isNull(key) ?"": key;
+        this.value = Objects.isNull(value) ?"": value;
+        this.uuid = UUID.uuid();
     }
 
     public String getKey() {
@@ -53,14 +56,6 @@ public class KeyValueRow {
         this.value = value;
     }
 
-    public String getCustomKey() {
-        return customKey;
-    }
-
-    public void setCustomKey(String customKey) {
-        this.customKey = customKey;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -71,12 +66,13 @@ public class KeyValueRow {
         }
         KeyValueRow that = (KeyValueRow) o;
         return Objects.equals(getKey(), that.getKey()) &&
-                Objects.equals(getValue(), that.getValue());
+                Objects.equals(getValue(), that.getValue()) &&
+                Objects.equals(uuid, that.uuid);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(getKey(), getValue());
+        return Objects.hash(getKey(), getValue(), uuid);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/KeyValueRow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/KeyValueRow.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.model;
+
+import java.util.Objects;
+
+import org.jboss.errai.databinding.client.api.Bindable;
+
+@Bindable
+public class KeyValueRow {
+
+    private String key;
+
+    private String value;
+
+    private String customKey;
+
+    public KeyValueRow() {
+    }
+
+    public KeyValueRow(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getCustomKey() {
+        return customKey;
+    }
+
+    public void setCustomKey(String customKey) {
+        this.customKey = customKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof KeyValueRow)) {
+            return false;
+        }
+        KeyValueRow that = (KeyValueRow) o;
+        return Objects.equals(getKey(), that.getKey()) &&
+                Objects.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(getKey(), getValue());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.bpmn.client.forms.util;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.google.gwt.http.client.URL;
 
@@ -130,5 +131,9 @@ public class StringUtils {
         formattedDataType.append(" [").append(dataType.substring(0,
                                                                  i)).append("]");
         return formattedDataType.toString();
+    }
+
+    public static boolean isBlank(String input) {
+        return Objects.isNull(input) || Objects.equals("", input);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorTest.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.marshalling.client.api.MarshallingSession;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +34,6 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(LienzoMockitoTestRunner.class)
 public class ActivityDataIOEditorTest {
 
     @Captor

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorWidgetViewImplTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.enterprise.event.Event;
 
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.TableCellElement;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -37,7 +38,6 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Assignmen
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
 
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(LienzoMockitoTestRunner.class)
 public class ActivityDataIOEditorWidgetViewImplTest {
 
     @Mock

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
@@ -37,7 +37,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,12 +48,6 @@ public class RolesEditorFieldRendererTest {
 
     @Mock
     private RolesEditorWidgetView view;
-
-    @Mock
-    private RolesListItemWidgetView listView;
-
-    @Mock
-    private KeyValueRow row;
 
     private ManagedInstanceStub<FormGroup> formGroupsInstance;
 
@@ -68,9 +61,6 @@ public class RolesEditorFieldRendererTest {
     public static final KeyValueRow ROLE = new KeyValueRow("role", "1");
 
     private List<KeyValueRow> rows;
-
-    @Mock
-    private RolesListItemWidgetView widget;
 
     @Before
     public void setUp() throws Exception {
@@ -109,18 +99,6 @@ public class RolesEditorFieldRendererTest {
     }
 
     @Test
-    public void doSave() {
-        tested.doSave();
-        verify(view).doSave();
-    }
-
-    @Test
-    public void notifyModelChanged() {
-        tested.notifyModelChanged();
-        verify(tested).doSave();
-    }
-
-    @Test
     public void deserialize() {
         final List<KeyValueRow> deserialized = tested.deserialize(SERIALIZED_ROLE);
         verify(caseRoleSerializer).deserialize(eq(SERIALIZED_ROLE), any());
@@ -132,32 +110,5 @@ public class RolesEditorFieldRendererTest {
         final String serialized = tested.serialize(rows);
         verify(caseRoleSerializer).serialize(eq(Optional.ofNullable(rows)), any(), any());
         assertThat(serialized).isEqualTo(SERIALIZED_ROLE);
-    }
-
-    @Test
-    public void add() {
-        when(view.getWidget(1)).thenReturn(widget);
-        when(view.getRowsCount()).thenReturn(2);
-
-        tested.add();
-        verify(view, never()).setTableDisplayStyle();
-        assertThat(rows.size()).isEqualTo(2);
-        verify(view).getWidget(1);
-        verify(widget).setParentWidget(tested);
-    }
-
-    @Test
-    public void isDuplicateName() {
-        boolean duplicated = tested.isDuplicateName("role");
-        assertThat(duplicated).isFalse();
-        rows.add(ROLE);
-        duplicated = tested.isDuplicateName("role");
-        assertThat(duplicated).isTrue();
-    }
-
-    @Test
-    public void remove() {
-        tested.remove(ROLE);
-        assertThat(rows).isEmpty();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.serializer.cm.CaseRoleSerializer;
+import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RolesEditorFieldRendererTest {
+
+    private RolesEditorFieldRenderer tested;
+
+    @Mock
+    private RolesEditorWidgetView view;
+
+    @Mock
+    private RolesListItemWidgetView listView;
+
+    @Mock
+    private KeyValueRow row;
+
+    private ManagedInstanceStub<FormGroup> formGroupsInstance;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    private CaseRoleSerializer caseRoleSerializer;
+
+    public static final String SERIALIZED_ROLE = "role:1";
+
+    public static final KeyValueRow ROLE = new KeyValueRow("role", "1");
+
+    private List<KeyValueRow> rows;
+
+    @Mock
+    private RolesListItemWidgetView widget;
+
+    @Before
+    public void setUp() throws Exception {
+        rows = new ArrayList<>();
+        rows.add(ROLE);
+        caseRoleSerializer = spy(new CaseRoleSerializer());
+        tested = spy(new RolesEditorFieldRenderer(view, caseRoleSerializer));
+        formGroupsInstance = new ManagedInstanceStub<>(formGroup);
+        Whitebox.setInternalState(tested, "formGroupsInstance", formGroupsInstance);
+        when(view.getRows()).thenReturn(rows);
+    }
+
+    @Test
+    public void getName() {
+        String name = tested.getName();
+        assertThat(name).isEqualTo(RolesEditorFieldDefinition.FIELD_TYPE.getTypeName());
+    }
+
+    @Test
+    public void getSupportedCode() {
+        String code = tested.getSupportedCode();
+        assertThat(code).isEqualTo(RolesEditorFieldDefinition.FIELD_TYPE.getTypeName());
+    }
+
+    @Test
+    public void getFormGroup() {
+        FormGroup formGroup = tested.getFormGroup(RenderMode.EDIT_MODE);
+        verify(view).init(tested);
+        assertThat(formGroup).isInstanceOf(DefaultFormGroup.class);
+    }
+
+    @Test
+    public void setReadOnly() {
+        tested.setReadOnly(true);
+        verify(view).setReadOnly(true);
+    }
+
+    @Test
+    public void doSave() {
+        tested.doSave();
+        verify(view).doSave();
+    }
+
+    @Test
+    public void notifyModelChanged() {
+        tested.notifyModelChanged();
+        verify(tested).doSave();
+    }
+
+    @Test
+    public void deserialize() {
+        final List<KeyValueRow> deserialized = tested.deserialize(SERIALIZED_ROLE);
+        verify(caseRoleSerializer).deserialize(eq(SERIALIZED_ROLE), any());
+        assertThat(deserialized).isEqualTo(rows);
+    }
+
+    @Test
+    public void serialize() {
+        final String serialized = tested.serialize(rows);
+        verify(caseRoleSerializer).serialize(eq(Optional.ofNullable(rows)), any(), any());
+        assertThat(serialized).isEqualTo(SERIALIZED_ROLE);
+    }
+
+    @Test
+    public void add() {
+        when(view.getWidget(1)).thenReturn(widget);
+        when(view.getRowsCount()).thenReturn(2);
+
+        tested.add();
+        verify(view, never()).setTableDisplayStyle();
+        assertThat(rows.size()).isEqualTo(2);
+        verify(view).getWidget(1);
+        verify(widget).setParentWidget(tested);
+    }
+
+    @Test
+    public void isDuplicateName() {
+        boolean duplicated = tested.isDuplicateName("role");
+        assertThat(duplicated).isFalse();
+        rows.add(ROLE);
+        duplicated = tested.isDuplicateName("role");
+        assertThat(duplicated).isTrue();
+    }
+
+    @Test
+    public void remove() {
+        tested.remove(ROLE);
+        assertThat(rows).isEmpty();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -102,7 +103,8 @@ public class RolesEditorFieldRendererTest {
     public void deserialize() {
         final List<KeyValueRow> deserialized = tested.deserialize(SERIALIZED_ROLE);
         verify(caseRoleSerializer).deserialize(eq(SERIALIZED_ROLE), any());
-        assertThat(deserialized).isEqualTo(rows);
+        assertThat(deserialized).usingElementComparator(Comparator.comparing(KeyValueRow::getKey)).isEqualTo(rows);
+        assertThat(deserialized).usingElementComparator(Comparator.comparing(KeyValueRow::getValue)).isEqualTo(rows);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImplTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +72,7 @@ public class RolesEditorWidgetViewImplTest {
         roles = spy(new ArrayList<>());
         roles.add(ROLE);
         when(presenter.deserialize(SERIALIZED_ROLE)).thenReturn(roles);
-        when(presenter.serialize(roles)).thenReturn(SERIALIZED_ROLE);
+        when(presenter.serialize(any())).thenReturn(SERIALIZED_ROLE);
         when(list.getValue()).thenReturn(roles);
         when(list.getComponent(anyInt())).thenReturn(widget);
         when(binder.getModel()).thenReturn(roles);
@@ -91,7 +92,9 @@ public class RolesEditorWidgetViewImplTest {
     @Test
     public void doSave() {
         tested.doSave();
-        verify(presenter).serialize(roles);
+        final ArgumentCaptor<List> rolesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(presenter).serialize(rolesCaptor.capture());
+        assertThat(rolesCaptor.getValue()).isEqualTo(roles);
         verify(tested).setValue(SERIALIZED_ROLE, true);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImplTest.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import com.google.gwt.dom.client.Style;
 import org.gwtbootstrap3.client.ui.Button;
-import org.jboss.errai.ui.client.widget.ListWidget;
+import org.jboss.errai.databinding.client.api.DataBinder;
+import org.jboss.errai.databinding.client.components.ListComponent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,7 +51,7 @@ public class RolesEditorWidgetViewImplTest {
     private Button addButton;
 
     @Mock
-    private ListWidget<KeyValueRow, RolesListItemWidgetView> rows;
+    private ListComponent<KeyValueRow, RolesListItemWidgetView> list;
 
     private List<KeyValueRow> roles;
 
@@ -59,20 +59,22 @@ public class RolesEditorWidgetViewImplTest {
     private RolesListItemWidgetView widget;
 
     @Mock
-    private Style style;
+    private DataBinder<List<KeyValueRow>> binder;
 
     @Before
     public void setUp() throws Exception {
         tested = spy(new RolesEditorWidgetViewImpl());
         tested.addButton = addButton;
-        tested.rows = rows;
+        tested.list = list;
+        tested.binder = binder;
         tested.init(presenter);
         roles = spy(new ArrayList<>());
         roles.add(ROLE);
         when(presenter.deserialize(SERIALIZED_ROLE)).thenReturn(roles);
         when(presenter.serialize(roles)).thenReturn(SERIALIZED_ROLE);
-        when(rows.getValue()).thenReturn(roles);
-        when(rows.getComponent(anyInt())).thenReturn(widget);
+        when(list.getValue()).thenReturn(roles);
+        when(list.getComponent(anyInt())).thenReturn(widget);
+        when(binder.getModel()).thenReturn(roles);
     }
 
     @Test
@@ -82,7 +84,7 @@ public class RolesEditorWidgetViewImplTest {
         tested.setValue(SERIALIZED_ROLE);
         verify(tested).initView();
         verify(presenter).deserialize(SERIALIZED_ROLE);
-        verify(rows).setValue(roles);
+        verify(binder).setModel(roles);
         verify(tested).setReadOnly(false);
     }
 
@@ -97,20 +99,20 @@ public class RolesEditorWidgetViewImplTest {
     public void setReadOnly() {
         tested.setReadOnly(true);
         verify(addButton).setEnabled(false);
-        verify(rows).getComponent(0);
+        verify(list).getComponent(0);
         verify(widget).setReadOnly(true);
     }
 
     @Test
     public void getRowsCount() {
         final int rowsCount = tested.getRowsCount();
-        assertThat(rowsCount).isEqualTo(rows.getValue().size());
+        assertThat(rowsCount).isEqualTo(list.getValue().size());
     }
 
     @Test
     public void setRows() {
         tested.setRows(roles);
-        verify(rows).setValue(roles);
+        verify(binder).setModel(roles);
     }
 
     @Test
@@ -127,7 +129,7 @@ public class RolesEditorWidgetViewImplTest {
     public void handleAddVarButton() {
         reset(roles);
         tested.handleAddVarButton();
-        verify(roles).add(any(KeyValueRow.class));
+        verify(roles).add(anyInt(), any(KeyValueRow.class));
         verify(tested).getWidget(roles.size() - 1);
         verify(widget).setParentWidget(tested);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorWidgetViewImplTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.TableCellElement;
+import com.google.gwt.dom.client.TableElement;
+import org.gwtbootstrap3.client.ui.Button;
+import org.jboss.errai.ui.client.widget.ListWidget;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles.RolesEditorFieldRendererTest.ROLE;
+import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles.RolesEditorFieldRendererTest.SERIALIZED_ROLE;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class RolesEditorWidgetViewImplTest {
+
+    private RolesEditorWidgetViewImpl tested;
+
+    @Mock
+    private RolesEditorWidgetView.Presenter presenter;
+
+    @Mock
+    private Button addButton;
+
+    @Mock
+    private TableCellElement nameCol;
+
+    @Mock
+    private TableCellElement cardinalityCol;
+
+    @Mock
+    private ListWidget<KeyValueRow, RolesListItemWidgetView> rows;
+
+    private List<KeyValueRow> roles;
+
+    @Mock
+    private RolesListItemWidgetView widget;
+
+    @Mock
+    private TableElement table;
+
+    @Mock
+    private Style style;
+
+    @Before
+    public void setUp() throws Exception {
+        tested = spy(new RolesEditorWidgetViewImpl());
+        tested.addButton = addButton;
+        tested.nameCol = nameCol;
+        tested.cardinalityCol = cardinalityCol;
+        tested.rows = rows;
+        tested.table = table;
+        tested.init(presenter);
+        roles = new ArrayList<>();
+        roles.add(ROLE);
+        when(presenter.deserialize(SERIALIZED_ROLE)).thenReturn(roles);
+        when(presenter.serialize(roles)).thenReturn(SERIALIZED_ROLE);
+        when(rows.getValue()).thenReturn(roles);
+        when(rows.getComponent(0)).thenReturn(widget);
+        when(table.getStyle()).thenReturn(style);
+    }
+
+    @Test
+    public void getSetValue() {
+        String value = tested.getValue();
+        assertThat(value).isNull();
+        tested.setValue(SERIALIZED_ROLE);
+        verify(tested).initView();
+        verify(presenter).deserialize(SERIALIZED_ROLE);
+        verify(rows).setValue(roles);
+        verify(tested).setReadOnly(false);
+    }
+
+    @Test
+    public void doSave() {
+        tested.doSave();
+        verify(presenter).serialize(roles);
+        verify(tested).setValue(SERIALIZED_ROLE, true);
+    }
+
+    @Test
+    public void setReadOnly() {
+        tested.setReadOnly(true);
+        verify(addButton).setEnabled(false);
+        verify(rows).getComponent(0);
+        verify(widget).setReadOnly(true);
+    }
+
+    @Test
+    public void getRowsCount() {
+        final int rowsCount = tested.getRowsCount();
+        assertThat(rowsCount).isEqualTo(rows.getValue().size());
+    }
+
+    @Test
+    public void setTableDisplayStyle() {
+        tested.setTableDisplayStyle();
+        verify(style).setDisplay(Style.Display.TABLE);
+    }
+
+    @Test
+    public void setNoneDisplayStyle() {
+        tested.setNoneDisplayStyle();
+        verify(style).setDisplay(Style.Display.NONE);
+    }
+
+    @Test
+    public void setRows() {
+        tested.setRows(roles);
+        verify(rows).setValue(roles);
+    }
+
+    @Test
+    public void getRows() {
+        assertThat(tested.getRows()).isEqualTo(roles);
+    }
+
+    @Test
+    public void getWidget() {
+        assertThat(tested.getWidget(0)).isEqualTo(widget);
+    }
+
+    @Test
+    public void handleAddVarButton() {
+        tested.handleAddVarButton(null);
+        verify(presenter).add();
+    }
+
+    @Test
+    public void remove() {
+        //not empty rows
+        tested.remove(ROLE);
+        verify(presenter).remove(ROLE);
+        verify(tested, never()).setNoneDisplayStyle();
+
+        //empty rows
+        roles.clear();
+        tested.remove(ROLE);
+        verify(presenter, times(2)).remove(ROLE);
+        verify(tested).setNoneDisplayStyle();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetViewImplTest.java
@@ -28,10 +28,10 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueR
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
+import org.kie.workbench.common.stunner.client.widgets.canvas.actions.IntegerTextBox;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.uberfire.ext.widgets.common.client.common.NumericIntegerTextBox;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
 
@@ -57,7 +57,7 @@ public class RolesListItemWidgetViewImplTest {
     private VariableNameTextBox role;
 
     @Mock
-    private NumericIntegerTextBox cardinality;
+    private IntegerTextBox cardinality;
 
     @Mock
     private EventSourceMock<NotificationEvent> notification;
@@ -72,7 +72,7 @@ public class RolesListItemWidgetViewImplTest {
     private DataBinder<KeyValueRow> row;
 
     @Mock
-    private RolesEditorWidgetView.Presenter widget;
+    private RolesEditorWidgetView widget;
 
     @Before
     public void setUp() throws Exception {
@@ -97,7 +97,7 @@ public class RolesListItemWidgetViewImplTest {
         verify(deleteButton).setIcon(IconType.TRASH);
 
         //test blur
-        BlurHandler blur = spy(blurHandlerCaptor.getValue());
+        BlurHandler blur = blurHandlerCaptor.getValue();
         blur.onBlur(null);
         verify(notification, never()).fire(any());
         verify(tested).notifyModelChanged();
@@ -145,7 +145,7 @@ public class RolesListItemWidgetViewImplTest {
 
     @Test
     public void handleDeleteButton() {
-        tested.handleDeleteButton(null);
+        tested.handleDeleteButton();
         verify(widget).remove(ROLE);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesListItemWidgetViewImplTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.event.dom.client.BlurHandler;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.databinding.client.api.DataBinder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.NumericIntegerTextBox;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.cm.roles.RolesEditorFieldRendererTest.ROLE;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class RolesListItemWidgetViewImplTest {
+
+    public static final String ROLE_NAME = "role";
+
+    private RolesListItemWidgetViewImpl tested;
+
+    @Mock
+    private VariableNameTextBox role;
+
+    @Mock
+    private NumericIntegerTextBox cardinality;
+
+    @Mock
+    private EventSourceMock<NotificationEvent> notification;
+
+    @Mock
+    private Button deleteButton;
+
+    @Captor
+    private ArgumentCaptor<BlurHandler> blurHandlerCaptor;
+
+    @Mock
+    private DataBinder<KeyValueRow> row;
+
+    @Mock
+    private RolesEditorWidgetView.Presenter widget;
+
+    @Before
+    public void setUp() throws Exception {
+        tested = spy(new RolesListItemWidgetViewImpl());
+        tested.role = role;
+        tested.cardinality = cardinality;
+        tested.notification = notification;
+        tested.deleteButton = deleteButton;
+        tested.row = row;
+        tested.init();
+        tested.setParentWidget(widget);
+        when(widget.isDuplicateName(ROLE_NAME)).thenReturn(false);
+        when(row.getModel()).thenReturn(ROLE);
+        when(role.getText()).thenReturn(ROLE_NAME);
+    }
+
+    @Test
+    public void init() {
+        verify(role).setRegExp(eq(StringUtils.ALPHA_NUM_REGEXP), anyString(), anyString());
+        verify(role).addBlurHandler(blurHandlerCaptor.capture());
+        verify(cardinality).addBlurHandler(blurHandlerCaptor.capture());
+        verify(deleteButton).setIcon(IconType.TRASH);
+
+        //test blur
+        BlurHandler blur = spy(blurHandlerCaptor.getValue());
+        blur.onBlur(null);
+        verify(notification, never()).fire(any());
+        verify(tested).notifyModelChanged();
+
+        reset(tested);
+        when(widget.isDuplicateName(ROLE_NAME)).thenReturn(true);
+        blur.onBlur(null);
+        verify(notification).fire(any());
+        verify(tested, never()).notifyModelChanged();
+    }
+
+    @Test
+    public void getModel() {
+        tested.getModel();
+        verify(row).getModel();
+    }
+
+    @Test
+    public void setModel() {
+        tested.setModel(ROLE);
+        verify(row).setModel(ROLE);
+    }
+
+    @Test
+    public void getVariableType() {
+        final Variable.VariableType variableType = tested.getVariableType();
+        assertThat(variableType).isEqualByComparingTo(Variable.VariableType.PROCESS);
+    }
+
+    @Test
+    public void setReadOnly() {
+        tested.setReadOnly(true);
+        verify(deleteButton).setEnabled(false);
+        verify(role).setEnabled(false);
+        verify(cardinality).setEnabled(false);
+    }
+
+    @Test
+    public void isDuplicateName() {
+        when(widget.isDuplicateName(ROLE_NAME)).thenReturn(true);
+        final boolean duplicated = tested.isDuplicateName(ROLE_NAME);
+        verify(widget).isDuplicateName(ROLE_NAME);
+        assertThat(duplicated).isTrue();
+    }
+
+    @Test
+    public void handleDeleteButton() {
+        tested.handleDeleteButton(null);
+        verify(widget).remove(ROLE);
+    }
+
+    @Test
+    public void notifyModelChanged() {
+        //without changing the model should not notify
+        tested.setModel(ROLE);
+        tested.notifyModelChanged();
+        verify(widget, never()).notifyModelChanged();
+
+        //with new model set then notify
+        tested.setModel(new KeyValueRow());
+        tested.notifyModelChanged();
+        verify(widget).notifyModelChanged();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImplTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import javax.enterprise.event.Event;
 
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.TableCellElement;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -38,7 +39,6 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.VariableR
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
 
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(LienzoMockitoTestRunner.class)
 public class VariablesEditorWidgetViewImplTest {
 
     protected static final String VARIABLES = "employee:java.lang.String,reason:java.lang.String,performance:java.lang.String";


### PR DESCRIPTION
Hi @romartin @LuboTerifaj here is the PR related to:
Add case roles property related to case management.
The property is at process level to define roles and its cardinality.

- The widget was based on the Process Variables.
- The definition property `CaseRoles` was inserted into a new set, `CaseManagementSet` on the `BPMNDiagramImpl`.
- The marshaling was inserted as an Extension Element using the **new marshallers**, the output is  :
```
.....
<bpmn2:extensionElements>
      <drools:metaData name="customCaseRoles">
        <drools:metaValue><![CDATA[role1:1,role2:2]]></drools:metaValue>
      </drools:metaData>
</bpmn2:extensionElements>
......
```
More details on [JBPM-6840](https://issues.jboss.org/browse/JBPM-6840)

Thanks.