### PR TITLE
JBPM-7601 (Stunner) - Case Files

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
@@ -127,10 +127,8 @@ public class AdHocSubprocess
         if (o instanceof AdHocSubprocess) {
             AdHocSubprocess other = (AdHocSubprocess) o;
             return super.equals(other) &&
-                    Objects.equals(executionSet,
-                                   other.executionSet) &&
-                    Objects.equals(processData,
-                                   other.processData);
+                    Objects.equals(executionSet, other.executionSet) &&
+                    Objects.equals(processData, other.processData);
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.kie.workbench.common.stunner.bpmn.definition;
 
 import java.util.Set;
@@ -59,6 +58,7 @@ public class BPMNDiagramImpl implements BPMNDiagram {
     @Category
     public static final transient String category = BPMNCategories.CONTAINERS;
     public static final String DIAGRAM_SET = "diagramSet";
+    public static final String PROCESS_DATA = "processData";
     public static final String CASE_MANAGEMENT_SET = "caseManagementSet";
 
     @PropertySet
@@ -75,7 +75,7 @@ public class BPMNDiagramImpl implements BPMNDiagram {
 
     @PropertySet
     @FormField(
-            afterElement = DIAGRAM_SET
+            afterElement = PROCESS_DATA
     )
     protected CaseManagementSet caseManagementSet;
 
@@ -108,17 +108,17 @@ public class BPMNDiagramImpl implements BPMNDiagram {
     }
 
     public BPMNDiagramImpl(final @MapsTo(DIAGRAM_SET) DiagramSet diagramSet,
-                           final @MapsTo("processData") ProcessData processData,
+                           final @MapsTo(PROCESS_DATA) ProcessData processData,
                            final @MapsTo(CASE_MANAGEMENT_SET) CaseManagementSet caseManagementSet,
                            final @MapsTo("backgroundSet") BackgroundSet backgroundSet,
                            final @MapsTo("fontSet") FontSet fontSet,
                            final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet) {
         this.diagramSet = diagramSet;
         this.processData = processData;
+        this.caseManagementSet = caseManagementSet;
         this.backgroundSet = backgroundSet;
         this.fontSet = fontSet;
         this.dimensionsSet = dimensionsSet;
-        this.caseManagementSet = caseManagementSet;
     }
 
     public String getCategory() {
@@ -133,24 +133,12 @@ public class BPMNDiagramImpl implements BPMNDiagram {
         return diagramSet;
     }
 
-    public RectangleDimensionsSet getDimensionsSet() {
-        return dimensionsSet;
-    }
-
-    public void setDimensionsSet(final RectangleDimensionsSet dimensionsSet) {
-        this.dimensionsSet = dimensionsSet;
-    }
-
     public ProcessData getProcessData() {
         return processData;
     }
 
     public CaseManagementSet getCaseManagementSet() {
         return caseManagementSet;
-    }
-
-    public void setCaseManagementSet(CaseManagementSet caseManagementSet) {
-        this.caseManagementSet = caseManagementSet;
     }
 
     public BackgroundSet getBackgroundSet() {
@@ -161,6 +149,10 @@ public class BPMNDiagramImpl implements BPMNDiagram {
         return fontSet;
     }
 
+    public RectangleDimensionsSet getDimensionsSet() {
+        return dimensionsSet;
+    }
+
     public void setDiagramSet(final DiagramSet diagramSet) {
         this.diagramSet = diagramSet;
     }
@@ -169,12 +161,20 @@ public class BPMNDiagramImpl implements BPMNDiagram {
         this.processData = processData;
     }
 
+    public void setCaseManagementSet(final CaseManagementSet caseManagementSet) {
+        this.caseManagementSet = caseManagementSet;
+    }
+
     public void setBackgroundSet(final BackgroundSet backgroundSet) {
         this.backgroundSet = backgroundSet;
     }
 
     public void setFontSet(final FontSet fontSet) {
         this.fontSet = fontSet;
+    }
+
+    public void setDimensionsSet(final RectangleDimensionsSet dimensionsSet) {
+        this.dimensionsSet = dimensionsSet;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/EmbeddedSubprocess.java
@@ -144,10 +144,8 @@ public class EmbeddedSubprocess extends BaseSubprocess implements DataIOModel {
         if (o instanceof EmbeddedSubprocess) {
             EmbeddedSubprocess other = (EmbeddedSubprocess) o;
             return super.equals(other) &&
-                    Objects.equals(executionSet,
-                                   other.executionSet) &&
-                    Objects.equals(processData,
-                                   other.processData);
+                    Objects.equals(executionSet, other.executionSet) &&
+                    Objects.equals(processData, other.processData);
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseFileVariables.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseFileVariables.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition.property.cm;
+
+import java.util.Objects;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldValue;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.I18nMode;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNProperty;
+import org.kie.workbench.common.stunner.bpmn.definition.property.type.VariablesType;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.property.Type;
+import org.kie.workbench.common.stunner.core.definition.annotation.property.Value;
+import org.kie.workbench.common.stunner.core.definition.property.PropertyType;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
+
+@Portable
+@Bindable
+@Property
+@FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
+public class CaseFileVariables implements BPMNProperty {
+
+    public static final String CASE_FILE_PREFIX = "caseFile_";
+
+    @Type
+    public static final PropertyType type = new VariablesType();
+
+    @Value
+    @FieldValue
+    private String value;
+
+    public CaseFileVariables() {
+        this("");
+    }
+
+    public CaseFileVariables(final String value) {
+        this.value = value;
+    }
+
+    public PropertyType getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+
+    public String getRawValue() {
+        String rawValue = "";
+        String[] variables = value.split(",");
+        for (String variable : variables) {
+            if (!variable.isEmpty()) {
+                if (!rawValue.isEmpty()) {
+                    rawValue += ",";
+                }
+                rawValue += CASE_FILE_PREFIX + variable;
+            }
+        }
+        return rawValue;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.combineHashCodes(Objects.hashCode(value));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof CaseFileVariables) {
+            CaseFileVariables other = (CaseFileVariables) o;
+            return Objects.equals(value, other.value);
+        }
+        return false;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.definition.property.cm;
 
+import java.util.Objects;
+
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
@@ -25,6 +27,7 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNPropertySet;
+import org.kie.workbench.common.stunner.bpmn.forms.model.VariablesEditorFieldType;
 import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldType;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
@@ -46,12 +49,21 @@ public class CaseManagementSet implements BPMNPropertySet {
     @Valid
     private CaseRoles caseRoles;
 
+    @Property
+    @FormField(
+            type = VariablesEditorFieldType.class
+    )
+    @Valid
+    private CaseFileVariables caseFileVariables;
+
     public CaseManagementSet() {
-        this(new CaseRoles());
+        this(new CaseRoles(), new CaseFileVariables());
     }
 
-    public CaseManagementSet(final @MapsTo("caseRoles") CaseRoles caseRoles) {
+    public CaseManagementSet(final @MapsTo("caseRoles") CaseRoles caseRoles,
+                             final @MapsTo("caseFileVariables") CaseFileVariables caseFileVariables) {
         this.caseRoles = caseRoles;
+        this.caseFileVariables = caseFileVariables;
     }
 
     public CaseRoles getCaseRoles() {
@@ -62,16 +74,27 @@ public class CaseManagementSet implements BPMNPropertySet {
         this.caseRoles = caseRoles;
     }
 
+    public CaseFileVariables getCaseFileVariables() {
+        return caseFileVariables;
+    }
+
+    public void setCaseFileVariables(CaseFileVariables caseFileVariables) {
+        this.caseFileVariables = caseFileVariables;
+    }
+
     @Override
     public int hashCode() {
-        return HashUtil.combineHashCodes(caseRoles.hashCode());
+        return HashUtil.combineHashCodes(caseRoles.hashCode(),
+                                         caseFileVariables.hashCode());
     }
 
     @Override
     public boolean equals(Object o) {
         if (o instanceof CaseManagementSet) {
             CaseManagementSet other = (CaseManagementSet) o;
-            return caseRoles.equals(other.caseRoles);
+            return Objects.equals(caseRoles, other.caseRoles) &&
+                    Objects.equals(caseFileVariables, other.caseFileVariables);
+
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/MultipleInstanceSubprocessTaskExecutionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/MultipleInstanceSubprocessTaskExecutionSet.java
@@ -47,7 +47,7 @@ public class MultipleInstanceSubprocessTaskExecutionSet implements BPMNPropertyS
     @FormField(type = ListBoxFieldType.class)
     @SelectorDataProvider(
             type = SelectorDataProvider.ProviderType.CLIENT,
-            className = "org.kie.workbench.common.stunner.bpmn.client.dataproviders.ProcessVariablesProvider"
+            className = "org.kie.workbench.common.stunner.bpmn.client.dataproviders.VariablesProvider"
     )
     @Valid
     private MultipleInstanceCollectionInput multipleInstanceCollectionInput;
@@ -66,7 +66,7 @@ public class MultipleInstanceSubprocessTaskExecutionSet implements BPMNPropertyS
     )
     @SelectorDataProvider(
             type = SelectorDataProvider.ProviderType.CLIENT,
-            className = "org.kie.workbench.common.stunner.bpmn.client.dataproviders.ProcessVariablesProvider"
+            className = "org.kie.workbench.common.stunner.bpmn.client.dataproviders.VariablesProvider"
     )
     @Valid
     private MultipleInstanceCollectionOutput multipleInstanceCollectionOutput;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -403,6 +403,8 @@ org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVaria
 #######################
 org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet.label=Case Management
 org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles.label=Case Roles
+org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables.label=Case File Variables
+org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables.description=File Variables for the Case
 
 #######################
 # SignalScopeProvider

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/HashCodeAndEqualityTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/HashCodeAndEqualityTest.java
@@ -102,11 +102,9 @@ public class HashCodeAndEqualityTest {
     @Test
     public void testAdHocSubprocessEquals() {
         AdHocSubprocess a = new AdHocSubprocess();
-        AdHocSubprocess b = new AdHocSubprocess();;
-        assertEquals(a,
-                     b);
-        assertEquals(new AdHocSubprocess(),
-                     new AdHocSubprocess());
+        AdHocSubprocess b = new AdHocSubprocess();
+        assertEquals(a, b);
+        assertEquals(new AdHocSubprocess(), new AdHocSubprocess());
         assertFalse(a.equals(19));
         assertFalse(a.equals(null));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseFileVariablesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseFileVariablesTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition.property.cm;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.bpmn.definition.property.type.VariablesType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+public class CaseFileVariablesTest {
+
+    private String _value;
+    private String _rawValue;
+
+    @Before
+    public void setup() {
+        _value = "CFV1:Boolean,CFV2:Boolean,CFV3:Boolean";
+        _rawValue = CaseFileVariables.CASE_FILE_PREFIX + "CFV1:Boolean," +
+                CaseFileVariables.CASE_FILE_PREFIX + "CFV2:Boolean," +
+                CaseFileVariables.CASE_FILE_PREFIX + "CFV3:Boolean";
+    }
+
+    @Test
+    public void testGetType() {
+        CaseFileVariables tested = new CaseFileVariables(_value);
+        assertEquals(new VariablesType(), tested.getType());
+    }
+
+    @Test
+    public void testGetValue() {
+        CaseFileVariables tested = new CaseFileVariables(_value);
+        assertEquals(_value, tested.getValue());
+    }
+
+    @Test
+    public void testGetRawValue() {
+        CaseFileVariables testedWithValue = new CaseFileVariables(_value);
+        assertEquals(testedWithValue.getRawValue(), _rawValue);
+
+        CaseFileVariables testedNoValue = new CaseFileVariables();
+        assertEquals(testedNoValue.getRawValue(), "");
+    }
+
+    @Test
+    public void testHashCode() {
+        CaseFileVariables testedWithValue = new CaseFileVariables(_value);
+        assertEquals(testedWithValue.hashCode(), -1359743347);
+    }
+
+    @Test
+    public void testEquals() {
+        CaseFileVariables testedWithValue = new CaseFileVariables(_value);
+        CaseFileVariables otherEqual = new CaseFileVariables(_value);
+
+        assertFalse(testedWithValue.equals(null));
+        assertEquals(testedWithValue, testedWithValue);
+        assertEquals(otherEqual, testedWithValue);
+        assertEquals(testedWithValue, otherEqual);
+
+        CaseFileVariables otherNotEqual = new CaseFileVariables();
+        assertNotEquals(new Object(), testedWithValue);
+        assertNotEquals(testedWithValue, new Object());
+        assertNotEquals(otherNotEqual, testedWithValue);
+        assertNotEquals(testedWithValue, otherNotEqual);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
@@ -22,6 +22,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Defi
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;
@@ -75,6 +76,9 @@ public class RootProcessConverter {
         //Case Management
         final CaseRoles caseRoles = definition.getCaseManagementSet().getCaseRoles();
         p.setCaseRoles(caseRoles);
+
+        final CaseFileVariables caseFileVariables = definition.getCaseManagementSet().getCaseFileVariables();
+        p.setCaseFileVariables(caseFileVariables);
 
         return p;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.DeclarationList;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.ElementContainer;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables;
 
@@ -173,6 +174,21 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
                     variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType());
+            properties.add(variable.getTypedIdentifier());
+            this.itemDefinitions.add(variable.getTypeDeclaration());
+        });
+    }
+
+    public void setCaseFileVariables(CaseFileVariables caseFileVariables) {
+        String value = caseFileVariables.getValue();
+        DeclarationList declarationList = DeclarationList.fromString(value);
+
+        List<Property> properties = process.getProperties();
+        declarationList.getDeclarations().forEach(decl -> {
+            VariableScope.Variable variable =
+                    variableScope.declare(this.process.getId(),
+                                          CaseFileVariables.CASE_FILE_PREFIX + decl.getIdentifier(),
+                                          decl.getType());
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());
         });

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.Defini
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.ProcessPropertyReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.PropertyReaderFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.AdHoc;
@@ -104,8 +105,9 @@ public class RootProcessConverter {
         );
 
         definition.setCaseManagementSet(new CaseManagementSet(
-                new CaseRoles(e.getCaseRoles())
-        ));
+                new CaseRoles(e.getCaseRoles()),
+                new CaseFileVariables(e.getCaseFileVariables()))
+        );
 
         definition.setProcessData(new ProcessData(
                 new ProcessVariables(e.getProcessVariables())

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CaseFileVariableReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CaseFileVariableReader.java
@@ -22,32 +22,36 @@ import java.util.stream.Collectors;
 
 import org.eclipse.bpmn2.ItemDefinition;
 import org.eclipse.bpmn2.Property;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 
-class ProcessVariableReader {
+class CaseFileVariableReader {
 
-    static String getProcessVariables(List<Property> properties) {
+    static String getCaseFileVariables(List<Property> properties) {
         return properties
                 .stream()
-                .filter(ProcessVariableReader::isProcessVariable)
-                .map(ProcessVariableReader::toProcessVariableString)
+                .filter(CaseFileVariableReader::isCaseFileVariable)
+                .map(CaseFileVariableReader::toCaseFileVariableString)
                 .collect(Collectors.joining(","));
     }
 
-    private static String toProcessVariableString(Property p) {
-        String processVariableName = getProcessVariableName(p);
+    private static String toCaseFileVariableString(Property p) {
+        String variableName = getCaseFileVariableName(p);
+        String caseFileVariableName = variableName.substring(CaseFileVariables.CASE_FILE_PREFIX.length());
+
         return Optional.ofNullable(p.getItemSubjectRef())
                 .map(ItemDefinition::getStructureRef)
-                .map(type -> processVariableName + ":" + type)
-                .orElse(processVariableName);
+                .map(type -> caseFileVariableName + ":" + type)
+                .orElse(caseFileVariableName);
     }
 
-    public static String getProcessVariableName(Property p) {
+    private static String getCaseFileVariableName(Property p) {
         String name = p.getName();
         // legacy uses ID instead of name
-        return name == null? p.getId() : name;
+        return name == null ? p.getId() : name;
     }
 
-    public static boolean isProcessVariable(Property p) {
-        return !CaseFileVariableReader.isCaseFileVariable(p);
+    public static boolean isCaseFileVariable(Property p) {
+        String name = getCaseFileVariableName(p);
+        return name.startsWith(CaseFileVariables.CASE_FILE_PREFIX);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/MultipleInstanceSubProcessPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/MultipleInstanceSubProcessPropertyReader.java
@@ -38,7 +38,7 @@ public class MultipleInstanceSubProcessPropertyReader extends SubProcessProperty
                 .orElse(null);
         return process.getDataInputAssociations().stream()
                 .filter(dia -> dia.getTargetRef().getId().equals(ieDataInput.getId()))
-                .map(dia -> ProcessVariableReader.getProcessVariableName((Property) dia.getSourceRef().get(0)))
+                .map(dia -> getVariableName((Property) dia.getSourceRef().get(0)))
                 .findFirst()
                 .orElse(null);
     }
@@ -49,7 +49,7 @@ public class MultipleInstanceSubProcessPropertyReader extends SubProcessProperty
                 .orElse(null);
         return process.getDataOutputAssociations().stream()
                 .filter(doa -> doa.getSourceRef().get(0).getId().equals(ieDataOutput.getId()))
-                .map(doa -> ProcessVariableReader.getProcessVariableName((Property) doa.getTargetRef()))
+                .map(doa -> getVariableName((Property) doa.getTargetRef()))
                 .findFirst()
                 .orElse(null);
     }
@@ -76,5 +76,9 @@ public class MultipleInstanceSubProcessPropertyReader extends SubProcessProperty
 
     private Optional<MultiInstanceLoopCharacteristics> getMultiInstanceLoopCharacteristics() {
         return Optional.ofNullable((MultiInstanceLoopCharacteristics) process.getLoopCharacteristics());
+    }
+
+    private static String getVariableName(Property property) {
+        return ProcessVariableReader.getProcessVariableName(property);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessPropertyReader.java
@@ -66,6 +66,10 @@ public class ProcessPropertyReader extends BasePropertyReader {
         return ProcessVariableReader.getProcessVariables(process.getProperties());
     }
 
+    public String getCaseFileVariables() {
+        return CaseFileVariableReader.getCaseFileVariables(process.getProperties());
+    }
+
     public String getCaseRoles() {
         return CustomElement.caseRole.of(process).get();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.lane
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
@@ -71,6 +72,9 @@ public class RootProcessConverterTest {
     private CaseRoles caseRoles;
 
     @Mock
+    private CaseFileVariables caseFileVariables;
+
+    @Mock
     private ProcessPropertyWriter processPropertyWriter;
 
     @Mock
@@ -94,6 +98,7 @@ public class RootProcessConverterTest {
         when(node.getContent()).thenReturn(content);
         when(content.getDefinition()).thenReturn(diagram);
         when(caseManagementSet.getCaseRoles()).thenReturn(caseRoles);
+        when(caseManagementSet.getCaseFileVariables()).thenReturn(caseFileVariables);
         when(converterFactory.subProcessConverter()).thenReturn(subProcessConverter);
         when(converterFactory.viewDefinitionConverter()).thenReturn(viewDefinitionConverter);
         when(converterFactory.laneConverter()).thenReturn(laneConverter);
@@ -103,5 +108,6 @@ public class RootProcessConverterTest {
     public void convertProcessWithCaseRoles() {
         final ProcessPropertyWriter propertyWriter = converter.convertProcess();
         verify(propertyWriter).setCaseRoles(caseRoles);
+        verify(propertyWriter).setCaseFileVariables(caseFileVariables);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -97,6 +98,13 @@ public class ProcessPropertyWriterTest {
         p.setCaseRoles(caseRole);
         String cdata = CustomElement.caseRole.of(p.getProcess()).get();
         assertThat("role").isEqualTo(CustomElement.caseRole.stripCData(cdata));
+    }
+
+    @Test
+    public void caseFileVariables() {
+        CaseFileVariables caseFileVariables = new CaseFileVariables("CFV1:Boolean,CFV2:Boolean,CFV3:Boolean");
+        p.setCaseFileVariables(caseFileVariables);
+        assertThat(p.itemDefinitions.size() == 3);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CaseFileVariableReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/CaseFileVariableReaderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.bpmn2.ItemDefinition;
+import org.eclipse.bpmn2.Property;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseFileVariableReaderTest {
+
+    private List<Property> properties;
+
+    @Mock
+    protected Property property1;
+    @Mock
+    protected Property property2;
+    @Mock
+    protected Property property3;
+    @Mock
+    protected Property property4;
+
+    @Mock
+    protected ItemDefinition definition;
+
+    @Before
+    public void setup() {
+        properties = new ArrayList<>();
+        properties.add(property1);
+        properties.add(property2);
+        properties.add(property3);
+        properties.add(property4);
+
+        when(property1.getName()).thenReturn(CaseFileVariables.CASE_FILE_PREFIX + "CFV1");
+        when(property1.getId()).thenReturn(CaseFileVariables.CASE_FILE_PREFIX + "CFV1");
+        when(property1.getItemSubjectRef()).thenReturn(definition);
+
+        when(property2.getName()).thenReturn(null);
+        when(property2.getId()).thenReturn(CaseFileVariables.CASE_FILE_PREFIX + "CFV2");
+        when(property2.getItemSubjectRef()).thenReturn(definition);
+
+        when(definition.getStructureRef()).thenReturn("Boolean");
+
+        when(property3.getName()).thenReturn("PV1");
+        when(property3.getId()).thenReturn("PV1");
+
+        when(property4.getName()).thenReturn(null);
+        when(property4.getId()).thenReturn("PV2");
+    }
+
+    @Test
+    public void getCaseFileVariables() {
+        String caseFileVariables = CaseFileVariableReader.getCaseFileVariables(properties);
+        assertEquals(caseFileVariables, "CFV1:Boolean,CFV2:Boolean");
+    }
+
+    @Test
+    public void isCaseFileVariable() {
+        boolean isCaseFile1 = CaseFileVariableReader.isCaseFileVariable(property1);
+        assertTrue(isCaseFile1);
+
+        boolean isCaseFile2 = CaseFileVariableReader.isCaseFileVariable(property2);
+        assertTrue(isCaseFile2);
+
+        boolean isCaseFile3 = CaseFileVariableReader.isCaseFileVariable(property3);
+        assertFalse(isCaseFile3);
+
+        boolean isCaseFile4 = CaseFileVariableReader.isCaseFileVariable(property4);
+        assertFalse(isCaseFile4);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariablesProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariablesProvider.java
@@ -26,17 +26,18 @@ import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.uberfire.commons.data.Pair;
 
-public class ProcessVariablesProvider
+public class VariablesProvider
         extends AbstractProcessFilteredNodeProvider {
 
     @Inject
-    public ProcessVariablesProvider(final SessionManager sessionManager) {
+    public VariablesProvider(final SessionManager sessionManager) {
         super(sessionManager);
     }
 
@@ -68,16 +69,34 @@ public class ProcessVariablesProvider
             Object oDefinition = ((View) node.getContent()).getDefinition();
             if (oDefinition instanceof BPMNDiagram) {
                 BPMNDiagramImpl bpmnDiagram = (BPMNDiagramImpl) oDefinition;
+
                 ProcessVariables processVars = bpmnDiagram.getProcessData().getProcessVariables();
-                if (processVars.getValue().length() > 0) {
-                    List<String> list = Arrays.asList(processVars.getValue().split(","));
-                    list.forEach(s1 -> {
-                        String value = s1.split(":")[0];
-                        result.add(new Pair<>(value, value));
-                    });
-                }
+                addPropertyVariableToResult(result, processVars.getValue());
+
+                CaseFileVariables caseVars = bpmnDiagram.getCaseManagementSet().getCaseFileVariables();
+                addCaseFileVariableToResult(result, caseVars.getValue());
             }
         }
         return result;
+    }
+
+    private void addPropertyVariableToResult(Collection<Pair<Object, String>> result, String element) {
+        if (element.length() > 0) {
+            List<String> list = Arrays.asList(element.split(","));
+            list.forEach(s1 -> {
+                String value = s1.split(":")[0];
+                result.add(new Pair<>(value, value));
+            });
+        }
+    }
+
+    private void addCaseFileVariableToResult(Collection<Pair<Object, String>> result, String element) {
+        if (element.length() > 0) {
+            List<String> list = Arrays.asList(element.split(","));
+            list.forEach(s1 -> {
+                String value = CaseFileVariables.CASE_FILE_PREFIX + s1.split(":")[0];
+                result.add(new Pair<>(value, value));
+            });
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidget.java
@@ -56,6 +56,8 @@ import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.EventSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.MultipleInstanceSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOModel;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables;
 import org.kie.workbench.common.stunner.bpmn.service.DataTypesService;
@@ -321,6 +323,16 @@ public class AssignmentsEditorWidget extends Composite implements HasValue<Strin
                             variables.append(",");
                         }
                         variables.append(processVariables.getValue());
+                    }
+                    CaseManagementSet caseManagementSet = bpmnDiagram.getCaseManagementSet();
+                    if (caseManagementSet != null) {
+                        CaseFileVariables caseFileVariables = caseManagementSet.getCaseFileVariables();
+                        if (caseFileVariables != null) {
+                            if (variables.length() > 0) {
+                                variables.append(",");
+                            }
+                            variables.append(caseFileVariables.getRawValue());
+                        }
                     }
                 }
                 if (parent != null) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableDeleteHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableDeleteHandler.java
@@ -26,7 +26,7 @@ import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 
-public class BPMNProcessVariableDeleteHandler {
+public class VariableDeleteHandler {
 
     private final String PROPERTY_IN_PREFIX = "[din]";
     private final String PROPERTY_OUT_PREFIX = "[dout]";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
@@ -45,7 +45,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
         implements VariablesEditorWidgetView.Presenter {
 
     private final SessionManager sessionManager;
-    private final BPMNProcessVariableDeleteHandler deleteHandler;
+    private final VariableDeleteHandler deleteHandler;
     Map<String, String> mapDataTypeNamesToDisplayNames = null;
     Map<String, String> mapDataTypeDisplayNamesToNames = null;
     ListBoxValues dataTypeListBoxValues;
@@ -62,7 +62,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
     @Inject
     public VariablesEditorFieldRenderer(final VariablesEditorWidgetView variablesEditor,
                                         final SessionManager sessionManager,
-                                        final BPMNProcessVariableDeleteHandler deleteHandler) {
+                                        final VariableDeleteHandler deleteHandler) {
         this.view = variablesEditor;
         this.sessionManager = sessionManager;
         this.deleteHandler = deleteHandler;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariableProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariableProviderTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorDataProvider;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
@@ -39,12 +42,14 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
-public class ProcessVariableProviderTest
+public class VariableProviderTest
         extends AbstractProcessFilteredNodeProviderBaseTest {
 
     private static final String ROOT_NODE_UUID = "UUID";
 
     private static final String PROCESS_VARIABLES = "var1:String,var2:String";
+
+    private static final String CASE_FILE_VARIABLES = "var1:String,var2:String";
 
     @Mock
     private View view;
@@ -66,7 +71,7 @@ public class ProcessVariableProviderTest
     @Override
     protected List<Element> mockModes() {
         List<Element> nodes = new ArrayList<>();
-        nodes.add(mockRootNode(PROCESS_VARIABLES));
+        nodes.add(mockRootNode(PROCESS_VARIABLES, CASE_FILE_VARIABLES));
         return nodes;
     }
 
@@ -83,7 +88,7 @@ public class ProcessVariableProviderTest
     @Override
     public void testGetSelectorDataWithNoValues() {
         List<Element> nodes = new ArrayList<>();
-        nodes.add(mockRootNodeWithoutProcessVariables());
+        nodes.add(mockRootNodeWithoutVariables());
         when(graph.nodes()).thenReturn(nodes);
         when(graph.getNode(eq(ROOT_NODE_UUID))).thenReturn((Node) nodes.get(0));
         SelectorData selectorData = provider.getSelectorData(renderingContext);
@@ -93,26 +98,34 @@ public class ProcessVariableProviderTest
 
     @Override
     protected SelectorDataProvider createProvider() {
-        return new ProcessVariablesProvider(sessionManager);
+        return new VariablesProvider(sessionManager);
     }
 
     @Override
     protected void verifyValues(Map values) {
-        assertEquals(2,
+        assertEquals(4,
                      values.size());
+
         assertEquals("var1",
                      values.get("var1"));
         assertEquals("var2",
                      values.get("var2"));
+        assertEquals(CaseFileVariables.CASE_FILE_PREFIX + "var1",
+                     values.get(CaseFileVariables.CASE_FILE_PREFIX + "var1"));
+        assertEquals(CaseFileVariables.CASE_FILE_PREFIX + "var2",
+                     values.get(CaseFileVariables.CASE_FILE_PREFIX + "var2"));
     }
 
-    private Element mockRootNode(String processVariables) {
+    private Element mockRootNode(String processVariables, String caseFileVariables) {
         BPMNDiagramImpl rootNode = new BPMNDiagramImpl();
         rootNode.setProcessData(new ProcessData(new ProcessVariables(processVariables)));
+        rootNode.setCaseManagementSet((new CaseManagementSet(
+                new CaseRoles(""),
+                new CaseFileVariables(caseFileVariables))));
         return mockNode(rootNode);
     }
 
-    private Element mockRootNodeWithoutProcessVariables() {
+    private Element mockRootNodeWithoutVariables() {
         BPMNDiagramImpl rootNode = new BPMNDiagramImpl();
         rootNode.setProcessData(new ProcessData(new ProcessVariables("")));
         return mockNode(rootNode);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableDeleteHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableDeleteHandlerTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class BPMNProcessVariableDeleteHandlerTest {
+public class VariableDeleteHandlerTest {
 
     private final String PROPERTY_ID_INPUT = "[din]test_input_task->test_input_process";
     private final String PROPERTY_ID_OUTPUT = "[dout]test_output_task->test_output_process";
@@ -66,12 +66,12 @@ public class BPMNProcessVariableDeleteHandlerTest {
     @Mock
     private Definition definition;
 
-    private BPMNProcessVariableDeleteHandler bpmnProcessVariableDeleteHandler;
+    private VariableDeleteHandler variableDeleteHandler;
 
     @Before
     public void setUp() throws Exception {
         assignmentsInfoString = PROPERTY_ID_INPUT + "," + PROPERTY_ID_OUTPUT;
-        bpmnProcessVariableDeleteHandler = new BPMNProcessVariableDeleteHandler();
+        variableDeleteHandler = new VariableDeleteHandler();
         this.graphTestHandler = new TestingGraphMockHandler();
         graphInstance = TestingGraphInstanceBuilder.newGraph2(graphTestHandler);
         when(userTask.getExecutionSet()).thenReturn(userTaskExecutionSet);
@@ -86,64 +86,64 @@ public class BPMNProcessVariableDeleteHandlerTest {
     @Test
     public void testGetVariableListInputUserTask() {
         when(definition.getDefinition()).thenReturn(userTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_INPUT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_INPUT);
         assertTrue(isVariableBound);
     }
 
     @Test
     public void testGetVariableListOutputUserTask() {
         when(definition.getDefinition()).thenReturn(userTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_OUTPUT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_OUTPUT);
         assertTrue(isVariableBound);
     }
 
     @Test
     public void testGetVariableListInputBusinessRuleTask() {
         when(definition.getDefinition()).thenReturn(businessRuleTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_INPUT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_INPUT);
         assertTrue(isVariableBound);
     }
 
     @Test
     public void testGetVariableListOutputBusinessRule() {
         when(definition.getDefinition()).thenReturn(businessRuleTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_OUTPUT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_OUTPUT);
         assertTrue(isVariableBound);
     }
 
     @Test
     public void testGetVariableListInputUserTaskNoResult() {
         when(definition.getDefinition()).thenReturn(userTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_INPUT_NO_RESULT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_INPUT_NO_RESULT);
         assertFalse(isVariableBound);
     }
 
     @Test
     public void testGetVariableListOutputUserTaskNoResult() {
         when(definition.getDefinition()).thenReturn(userTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_OUTPUT_NO_RESULT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_OUTPUT_NO_RESULT);
         assertFalse(isVariableBound);
     }
 
     @Test
     public void testGetVariableListInputBusinessRuleTaskNoResult() {
         when(definition.getDefinition()).thenReturn(businessRuleTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_INPUT_NO_RESULT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_INPUT_NO_RESULT);
         assertFalse(isVariableBound);
     }
 
     @Test
     public void testGetVariableListOutputBusinessRuleNoResult() {
         when(definition.getDefinition()).thenReturn(businessRuleTask);
-        boolean isVariableBound = bpmnProcessVariableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
-                                                                                          VARIABLE_ID_OUTPUT_NO_RESULT);
+        boolean isVariableBound = variableDeleteHandler.isVariableBoundToNodes(graphInstance.graph,
+                                                                               VARIABLE_ID_OUTPUT_NO_RESULT);
         assertFalse(isVariableBound);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
@@ -60,7 +60,7 @@ public class VariablesEditorFieldRendererTest {
     private SessionManager abstractClientSessionManager;
 
     @Mock
-    private BPMNProcessVariableDeleteHandler deleteHandler;
+    private VariableDeleteHandler deleteHandler;
 
     @Mock
     private Graph graph;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/CaseManagementDiagram.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/CaseManagementDiagram.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.BPMNBaseInfo;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNCategories;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
 import org.kie.workbench.common.stunner.bpmn.definition.property.background.BackgroundSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dimensions.RectangleDimensionsSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.font.FontSet;
@@ -63,6 +64,9 @@ public class CaseManagementDiagram implements BPMNDiagram {
 
     @Category
     public static final transient String category = BPMNCategories.CONTAINERS;
+    public static final String DIAGRAM_SET = "diagramSet";
+    public static final String PROCESS_DATA = "processData";
+    public static final String CASE_MANAGEMENT_SET = "caseManagementSet";
 
     @PropertySet
     @FormField
@@ -71,10 +75,16 @@ public class CaseManagementDiagram implements BPMNDiagram {
 
     @PropertySet
     @FormField(
-            afterElement = "diagramSet"
+            afterElement = DIAGRAM_SET
     )
     @Valid
     protected ProcessData processData;
+
+    @PropertySet
+    @FormField(
+            afterElement = PROCESS_DATA
+    )
+    protected CaseManagementSet caseManagementSet;
 
     @PropertySet
     private BackgroundSet backgroundSet;
@@ -97,18 +107,21 @@ public class CaseManagementDiagram implements BPMNDiagram {
     public CaseManagementDiagram() {
         this(new DiagramSet(""),
              new ProcessData(),
+             new CaseManagementSet(),
              new BackgroundSet(),
              new FontSet(),
              new RectangleDimensionsSet(WIDTH, HEIGHT));
     }
 
-    public CaseManagementDiagram(final @MapsTo("diagramSet") DiagramSet diagramSet,
-                                 final @MapsTo("processData") ProcessData processData,
+    public CaseManagementDiagram(final @MapsTo(DIAGRAM_SET) DiagramSet diagramSet,
+                                 final @MapsTo(PROCESS_DATA) ProcessData processData,
+                                 final @MapsTo(CASE_MANAGEMENT_SET) CaseManagementSet caseManagementSet,
                                  final @MapsTo("backgroundSet") BackgroundSet backgroundSet,
                                  final @MapsTo("fontSet") FontSet fontSet,
                                  final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet) {
         this.diagramSet = diagramSet;
         this.processData = processData;
+        this.caseManagementSet = caseManagementSet;
         this.backgroundSet = backgroundSet;
         this.fontSet = fontSet;
         this.dimensionsSet = dimensionsSet;
@@ -126,16 +139,12 @@ public class CaseManagementDiagram implements BPMNDiagram {
         return diagramSet;
     }
 
-    public RectangleDimensionsSet getDimensionsSet() {
-        return dimensionsSet;
-    }
-
-    public void setDimensionsSet(final RectangleDimensionsSet dimensionsSet) {
-        this.dimensionsSet = dimensionsSet;
-    }
-
     public ProcessData getProcessData() {
         return processData;
+    }
+
+    public CaseManagementSet getCaseManagementSet() {
+        return caseManagementSet;
     }
 
     public BackgroundSet getBackgroundSet() {
@@ -146,6 +155,10 @@ public class CaseManagementDiagram implements BPMNDiagram {
         return fontSet;
     }
 
+    public RectangleDimensionsSet getDimensionsSet() {
+        return dimensionsSet;
+    }
+
     public void setDiagramSet(final DiagramSet diagramSet) {
         this.diagramSet = diagramSet;
     }
@@ -154,12 +167,20 @@ public class CaseManagementDiagram implements BPMNDiagram {
         this.processData = processData;
     }
 
+    public void setCaseManagementSet(final CaseManagementSet caseManagementSet) {
+        this.caseManagementSet = caseManagementSet;
+    }
+
     public void setBackgroundSet(final BackgroundSet backgroundSet) {
         this.backgroundSet = backgroundSet;
     }
 
     public void setFontSet(final FontSet fontSet) {
         this.fontSet = fontSet;
+    }
+
+    public void setDimensionsSet(final RectangleDimensionsSet dimensionsSet) {
+        this.dimensionsSet = dimensionsSet;
     }
 
     @Override
@@ -171,6 +192,7 @@ public class CaseManagementDiagram implements BPMNDiagram {
     public int hashCode() {
         return HashUtil.combineHashCodes(diagramSet.hashCode(),
                                          processData.hashCode(),
+                                         caseManagementSet.hashCode(),
                                          backgroundSet.hashCode(),
                                          fontSet.hashCode(),
                                          dimensionsSet.hashCode());
@@ -182,6 +204,7 @@ public class CaseManagementDiagram implements BPMNDiagram {
             CaseManagementDiagram other = (CaseManagementDiagram) o;
             return diagramSet.equals(other.diagramSet) &&
                     processData.equals(other.processData) &&
+                    caseManagementSet.equals(other.caseManagementSet) &&
                     backgroundSet.equals(other.backgroundSet) &&
                     fontSet.equals(other.fontSet) &&
                     dimensionsSet.equals(other.dimensionsSet);


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-7601

This adds case file variables to the new Designer. They idea is to
replicate the same functionality of the old Designer. Other than minimal
UI differences they both will work identically.

The variables will be displayed in a different section called Case Data,
under the Process Data section, where available. Case File Variables can
be used on the MI Collection Input/Output in Multiple Instance Processes
as well.