### PR TITLE
DROOLS-2941: [DMN Designer] - Save external DMN model

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
@@ -85,7 +85,7 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
              new org.kie.workbench.common.dmn.api.property.dmn.Description(),
              new Name(),
              new InformationItem(),
-             new FunctionDefinition(),
+             null,
              new BackgroundSet(),
              new FontSet(),
              new RectangleDimensionsSet());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
@@ -65,15 +65,15 @@ public class DMNDiagram extends DMNModelInstrumentedBase implements DMNDefinitio
         add("dmn_diagram");
     }};
 
-    @PropertySet
-    @FormField
-    @Valid
-    protected Definitions definitions;
-
     @Property
     @FormField(readonly = true)
     @Valid
     protected Id id;
+
+    @PropertySet
+    @FormField
+    @Valid
+    protected Definitions definitions;
 
     public DMNDiagram() {
         this(new Id(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTable.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTable.java
@@ -45,7 +45,7 @@ public class DecisionTable extends Expression {
              HitPolicy.ANY,
              null,
              DecisionTableOrientation.RULE_AS_ROW,
-             "");
+             null);
     }
 
     public DecisionTable(final Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Definitions.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Definitions.java
@@ -73,11 +73,11 @@ public class Definitions extends DMNElement implements HasName,
              new ArrayList<>(),
              new ArrayList<>(),
              new ArrayList<>(),
-             "",
-             "",
-             "",
-             "",
-             "");
+             null,
+             null,
+             null,
+             null,
+             null);
     }
 
     public Definitions(final Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Import.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Import.java
@@ -29,9 +29,9 @@ public class Import extends DMNModelInstrumentedBase {
     protected String importType;
 
     public Import() {
-        this("",
+        this(null,
              new LocationURI(),
-             "");
+             null);
     }
 
     public Import(final String namespace,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ImportedValues.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ImportedValues.java
@@ -28,11 +28,11 @@ public class ImportedValues extends Import implements DMNPropertySet {
     protected String expressionLanguage;
 
     public ImportedValues() {
-        this("",
+        this(null,
              new LocationURI(),
-             "",
-             "",
-             "");
+             null,
+             null,
+             null);
     }
 
     public ImportedValues(final String namespace,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClause.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClause.java
@@ -29,8 +29,8 @@ public class InputClause extends DMNElement {
     public InputClause() {
         this(new Id(),
              new Description(),
-             new LiteralExpression(),
-             new UnaryTests());
+             null,
+             null);
     }
 
     public InputClause(final Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ItemDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ItemDefinition.java
@@ -39,10 +39,10 @@ public class ItemDefinition extends NamedElement implements HasTypeRef {
         this(new Id(),
              new Description(),
              new Name(),
-             new QName(),
-             new UnaryTests(),
              null,
-             "",
+             null,
+             null,
+             null,
              false);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
@@ -34,9 +34,9 @@ public class LiteralExpression extends Expression {
         this(new Id(),
              new Description(),
              new QName(),
-             "",
-             new ImportedValues(),
-             "");
+             null,
+             null,
+             null);
     }
 
     public LiteralExpression(final Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/OrganizationalUnit.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/OrganizationalUnit.java
@@ -34,7 +34,7 @@ public class OrganizationalUnit extends BusinessContextElement {
         this(new Id(),
              new Description(),
              new Name(),
-             "",
+             null,
              null,
              null);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClause.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClause.java
@@ -33,9 +33,9 @@ public class OutputClause extends DMNElement implements HasTypeRef {
     public OutputClause() {
         this(new Id(),
              new Description(),
-             new UnaryTests(),
-             new LiteralExpression(),
-             "",
+             null,
+             null,
+             null,
              new QName());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/PerformanceIndicator.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/PerformanceIndicator.java
@@ -33,7 +33,7 @@ public class PerformanceIndicator extends BusinessContextElement {
         this(new Id(),
              new Description(),
              new Name(),
-             "",
+             null,
              null);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/UnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/UnaryTests.java
@@ -29,8 +29,8 @@ public class UnaryTests extends DMNElement {
     public UnaryTests() {
         this(new Id(),
              new Description(),
-             "",
-             "");
+             null,
+             null);
     }
 
     public UnaryTests(final Id id,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Description.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Description.java
@@ -36,7 +36,7 @@ public class Description implements DMNProperty {
     private String value;
 
     public Description() {
-        this("");
+        this(null);
     }
 
     public Description(final String value) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
@@ -149,6 +149,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Graph unmarshall(final Metadata metadata,
                             final InputStream input) throws IOException {
         org.kie.dmn.model.api.Definitions dmnXml = marshaller.unmarshal(new InputStreamReader(input));
@@ -302,14 +303,13 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         Graph graph = factoryManager.newDiagram("prova",
                                                 BindableAdapterUtils.getDefinitionSetId(DMNDefinitionSet.class),
                                                 metadata).getGraph();
-        elems.values().stream().map(kv -> kv.getValue()).forEach(graph::addNode);
+        elems.values().stream().map(Map.Entry::getValue).forEach(graph::addNode);
         textAnnotations.values().forEach(graph::addNode);
 
-        @SuppressWarnings("unchecked")
-        Node<View<DMNDiagram>, ?> dmnDiagramRoot = findDMNDiagramRoot(graph);
+        Node<?, ?> dmnDiagramRoot = findDMNDiagramRoot(graph);
         Definitions definitionsStunnerPojo = DefinitionsConverter.wbFromDMN(dmnXml);
-        dmnDiagramRoot.getContent().getDefinition().setDefinitions(definitionsStunnerPojo);
-        elems.values().stream().map(kv -> kv.getValue()).forEach(node -> connectRootWithChild(dmnDiagramRoot,
+        ((View<DMNDiagram>) dmnDiagramRoot.getContent()).getDefinition().setDefinitions(definitionsStunnerPojo);
+        elems.values().stream().map(Map.Entry::getValue).forEach(node -> connectRootWithChild(dmnDiagramRoot,
                                                                                               node));
         textAnnotations.values().stream().forEach(node -> connectRootWithChild(dmnDiagramRoot,
                                                                                node));
@@ -381,13 +381,13 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public String marshall(final Diagram<Graph, Metadata> diagram) throws IOException {
         Graph<?, Node<View, ?>> g = diagram.getGraph();
 
         Map<String, org.kie.dmn.model.api.DRGElement> nodes = new HashMap<>();
         Map<String, org.kie.dmn.model.api.TextAnnotation> textAnnotations = new HashMap<>();
 
-        @SuppressWarnings("unchecked")
         Node<View<DMNDiagram>, ?> dmnDiagramRoot = (Node<View<DMNDiagram>, ?>) findDMNDiagramRoot(g);
         Definitions definitionsStunnerPojo = dmnDiagramRoot.getContent().getDefinition().getDefinitions();
         org.kie.dmn.model.api.Definitions definitions = DefinitionsConverter.dmnFromWB(definitionsStunnerPojo);
@@ -426,9 +426,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         nodes.values().forEach(definitions.getDrgElement()::add);
         textAnnotations.values().forEach(definitions.getArtifact()::add);
 
-        String marshalled = marshaller.marshal(definitions);
-
-        return marshalled;
+        return marshaller.marshal(definitions);
     }
 
     private void ddExtAugmentStunner(Optional<org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDiagram> dmnDDDiagram, Node currentNode) {
@@ -550,6 +548,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
         }
     }
 
+    @SuppressWarnings("unchecked")
     private org.kie.dmn.model.api.DRGElement stunnerToDMN(final Node<?, ?> node) {
         if (node.getContent() instanceof View<?>) {
             View<?> view = (View<?>) node.getContent();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
@@ -47,7 +47,7 @@ public class AssociationConverter {
 
                     org.kie.dmn.model.api.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
                     adding.setId(((View<Association>) e.getContent()).getDefinition().getId().getValue());
-                    adding.setDescription(((View<Association>) e.getContent()).getDefinition().getDescription().getValue());
+                    adding.setDescription(DescriptionPropertyConverter.dmnFromWB(((View<Association>) e.getContent()).getDefinition().getDescription()));
                     adding.setSourceRef(sourceRef);
                     adding.setTargetRef(ta_elementReference);
                     result.add(adding);
@@ -66,7 +66,7 @@ public class AssociationConverter {
 
                     org.kie.dmn.model.api.Association adding = new org.kie.dmn.model.v1_1.TAssociation();
                     adding.setId(((View<Association>) e.getContent()).getDefinition().getId().getValue());
-                    adding.setDescription(((View<Association>) e.getContent()).getDefinition().getDescription().getValue());
+                    adding.setDescription(DescriptionPropertyConverter.dmnFromWB(((View<Association>) e.getContent()).getDefinition().getDescription()));
                     adding.setSourceRef(ta_elementReference);
                     adding.setTargetRef(targetRef);
                     result.add(adding);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
@@ -44,7 +44,7 @@ public class ContextPropertyConverter {
     public static org.kie.dmn.model.api.Context dmnFromWB(final Context wb) {
         org.kie.dmn.model.api.Context result = new org.kie.dmn.model.v1_1.TContext();
         result.setId(wb.getId().getValue());
-        result.setDescription(wb.getDescription().getValue());
+        result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
         for (ContextEntry ce : wb.getContextEntry()) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DescriptionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DescriptionPropertyConverter.java
@@ -22,7 +22,7 @@ public class DescriptionPropertyConverter {
 
     public static Description wbFromDMN(final String dmn) {
         if (dmn == null) {
-            return new Description("");
+            return new Description(null);
         } else {
             return new Description(dmn);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
@@ -24,27 +24,27 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public final class ImportConverter {
 
-  public static Import nodeFromDMN(org.kie.dmn.model.api.Import source) {
-    LocationURI locationURI = new LocationURI(source.getLocationURI());
-    Import result = new Import(source.getNamespace(), locationURI, source.getImportType());
-    Map<QName, String> additionalAttributes = new HashMap<>();
-    for (Map.Entry<javax.xml.namespace.QName, String> entry : source.getAdditionalAttributes().entrySet()) {
-      additionalAttributes.put(QNamePropertyConverter.wbFromDMN(entry.getKey()), entry.getValue());
+    public static Import nodeFromDMN(org.kie.dmn.model.api.Import source) {
+        LocationURI locationURI = new LocationURI(source.getLocationURI());
+        Import result = new Import(source.getNamespace(), locationURI, source.getImportType());
+        Map<QName, String> additionalAttributes = new HashMap<>();
+        for (Map.Entry<javax.xml.namespace.QName, String> entry : source.getAdditionalAttributes().entrySet()) {
+            additionalAttributes.put(QNamePropertyConverter.wbFromDMN(entry.getKey()), entry.getValue());
+        }
+        result.setAdditionalAttributes(additionalAttributes);
+        return result;
     }
-    result.setAdditionalAttributes(additionalAttributes);
-    return result;
-  }
 
-  public static org.kie.dmn.model.api.Import dmnFromNode(Import source) {
-    org.kie.dmn.model.api.Import result = new org.kie.dmn.model.v1_1.TImport();
-    result.setImportType(source.getImportType());
-    result.setLocationURI(source.getLocationURI().getValue());
-    result.setNamespace(source.getNamespace());
-    Map<javax.xml.namespace.QName, String> additionalAttributes = new HashMap<>();
-    for (Map.Entry<QName, String> entry : source.getAdditionalAttributes().entrySet()) {
-      additionalAttributes.put(QNamePropertyConverter.dmnFromWB(entry.getKey()).get(), entry.getValue());
+    public static org.kie.dmn.model.api.Import dmnFromNode(Import source) {
+        org.kie.dmn.model.api.Import result = new org.kie.dmn.model.v1_1.TImport();
+        result.setImportType(source.getImportType());
+        result.setLocationURI(source.getLocationURI().getValue());
+        result.setNamespace(source.getNamespace());
+        Map<javax.xml.namespace.QName, String> additionalAttributes = new HashMap<>();
+        for (Map.Entry<QName, String> entry : source.getAdditionalAttributes().entrySet()) {
+            additionalAttributes.put(QNamePropertyConverter.dmnFromWB(entry.getKey()).get(), entry.getValue());
+        }
+        result.setAdditionalAttributes(additionalAttributes);
+        return result;
     }
-    result.setAdditionalAttributes(additionalAttributes);
-    return result;
-  }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
@@ -29,7 +29,7 @@ public class InputClausePropertyConverter {
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         LiteralExpression inputExpression = LiteralExpressionPropertyConverter.wbFromDMN(dmn.getInputExpression());
         UnaryTests inputValues = UnaryTestsPropertyConverter.wbFromDMN(dmn.getInputValues());
-        
+
         InputClause result = new InputClause(id, description, inputExpression, inputValues);
 
         if (inputExpression != null) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
@@ -49,7 +49,7 @@ public class ListPropertyConverter {
     public static org.kie.dmn.model.api.List dmnFromWB(final List wb) {
         org.kie.dmn.model.api.List result = new org.kie.dmn.model.v1_1.TList();
         result.setId(wb.getId().getValue());
-        result.setDescription(wb.getDescription().getValue());
+        result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -52,7 +52,7 @@ public class LiteralExpressionPropertyConverter {
         }
         org.kie.dmn.model.api.LiteralExpression result = new org.kie.dmn.model.v1_1.TLiteralExpression();
         result.setId(wb.getId().getValue());
-        result.setDescription(wb.getDescription().getValue());
+        result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
         result.setText(wb.getText());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
@@ -31,7 +31,7 @@ public class OutputClausePropertyConverter {
         UnaryTests outputValues = UnaryTestsPropertyConverter.wbFromDMN(dmn.getOutputValues());
         LiteralExpression defaultOutputEntry = LiteralExpressionPropertyConverter.wbFromDMN(dmn.getDefaultOutputEntry());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
-        
+
         OutputClause result = new OutputClause();
         result.setId(id);
         result.setName(dmn.getName());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
@@ -55,7 +55,7 @@ public class RelationPropertyConverter {
     public static org.kie.dmn.model.api.Relation dmnFromWB(final Relation wb) {
         org.kie.dmn.model.api.Relation result = new org.kie.dmn.model.v1_1.TRelation();
         result.setId(wb.getId().getValue());
-        result.setDescription(wb.getDescription().getValue());
+        result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
@@ -39,7 +39,7 @@ public class UnaryTestsPropertyConverter {
         }
         org.kie.dmn.model.api.UnaryTests result = new org.kie.dmn.model.v1_1.TUnaryTests();
         result.setId(wb.getId().getValue());
-        result.setDescription(wb.getDescription().getValue());
+        result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setText(wb.getText());
         result.setExpressionLanguage(wb.getExpressionLanguage());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -1168,6 +1168,13 @@ public class DMNMarshallerTest {
         final DMNRuntime dmnRuntime = roundTripUnmarshalMarshalThenUnmarshalDMN(this.getClass().getResourceAsStream("/DROOLS-2941.dmn"));
         final List<DMNMessage> dmn_messages = dmnRuntime.getModels().get(0).getMessages();
         assertThat(dmn_messages).isEmpty();
+
+        assertThat(dmnRuntime.getModels()).hasSize(1);
+        final DMNModel dmnModel = dmnRuntime.getModels().get(0);
+        final DMNContext context = dmnRuntime.newContext();
+        context.set("A Vowel", "b");
+        final DMNResult result = dmnRuntime.evaluateAll(dmnModel, context);
+        assertThat(result.getDecisionResultByName("A Vowel").getResult()).isEqualTo("a");
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -175,6 +176,7 @@ public class DMNMarshallerTest {
     TestScopeModelFactory testScopeModelFactory;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         // Graph utils.
         when(definitionManager.adapters()).thenReturn(adapterManager);
@@ -306,7 +308,7 @@ public class DMNMarshallerTest {
     public void test_diamond() throws IOException {
         // round trip test
         roundTripUnmarshalThenMarshalUnmarshal(this.getClass().getResourceAsStream("/diamond.dmn"),
-                                               this::checkDiamongGraph);
+                                               this::checkDiamondGraph);
 
         // additionally, check the marshalled is still DMN executable as expected
 
@@ -342,7 +344,7 @@ public class DMNMarshallerTest {
 
         // additionally, check DMN DD/DI for version 1.1
 
-        org.kie.dmn.api.marshalling.v1_1.DMNMarshaller dmnMarshaller = new XStreamMarshaller(Arrays.asList(new DDExtensionsRegister()));
+        org.kie.dmn.api.marshalling.v1_1.DMNMarshaller dmnMarshaller = new XStreamMarshaller(Collections.singletonList(new DDExtensionsRegister()));
         Definitions definitions = dmnMarshaller.unmarshal(mString);
 
         assertNotNull(definitions.getExtensionElements());
@@ -406,7 +408,7 @@ public class DMNMarshallerTest {
     @Test
     public void test_potpourri_drawing() throws IOException {
         roundTripUnmarshalThenMarshalUnmarshal(this.getClass().getResourceAsStream("/potpourri_drawing.dmn"),
-                                               this::checkPotpourryGraph);
+                                               this::checkPotpourriGraph);
     }
 
     @Test
@@ -433,6 +435,7 @@ public class DMNMarshallerTest {
                                                this::checkDecisionWithContext);
     }
 
+    @SuppressWarnings("unchecked")
     private void checkTextAnnotationGraph(Graph<?, Node<?, ?>> graph) {
         Node<?, ?> textAnnotation = graph.getNode("60915990-9E1D-42DF-B7F6-0D28383BE9D1");
         assertNodeContentDefinitionIs(textAnnotation,
@@ -531,6 +534,7 @@ public class DMNMarshallerTest {
                           AuthorityRequirement.class);
     }
 
+    @SuppressWarnings("unchecked")
     private void checkDecisionWithContext(Graph<?, Node<?, ?>> g) {
         Node<?, ?> decisionNode = g.getNode("_30810b88-8416-4c02-8ed1-8c19b7606243");
         assertNodeContentDefinitionIs(decisionNode,
@@ -562,7 +566,8 @@ public class DMNMarshallerTest {
                              .getParent()).getId().getValue());
     }
 
-    private void checkDiamongGraph(Graph<?, Node<?, ?>> g) {
+    @SuppressWarnings("unchecked")
+    private void checkDiamondGraph(Graph<?, Node<?, ?>> g) {
         Node<?, ?> idNode = g.getNode("_4cd17e52-6253-41d6-820d-5824bf5197f3");
         assertNodeContentDefinitionIs(idNode,
                                       InputData.class);
@@ -606,6 +611,7 @@ public class DMNMarshallerTest {
                                   myDecisionNode);
     }
 
+    @SuppressWarnings("unchecked")
     private void checkAssociationsGraph(Graph<?, Node<?, ?>> g) {
         Node<?, ?> inputData = g.getNode("BD168F8B-4398-4478-8BEA-E67AA5F90FAF");
         assertNodeContentDefinitionIs(inputData,
@@ -652,7 +658,8 @@ public class DMNMarshallerTest {
                      ((View<Association>) fromKnowledgeSource.getContent()).getDefinition().getDescription().getValue());
     }
 
-    private void checkPotpourryGraph(Graph<?, Node<?, ?>> g) {
+    @SuppressWarnings("unchecked")
+    private void checkPotpourriGraph(Graph<?, Node<?, ?>> g) {
         Node<?, ?> _My_Input_Data = g.getNode("_My_Input_Data");
         assertNodeContentDefinitionIs(_My_Input_Data,
                                       InputData.class);
@@ -1031,6 +1038,7 @@ public class DMNMarshallerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void test_wrong_context() throws IOException {
         // DROOLS-2217
         // SPECIAL CASE: to represent a partially edited DMN file.
@@ -1055,10 +1063,8 @@ public class DMNMarshallerTest {
         assertEquals(null, ((org.kie.dmn.model.api.LiteralExpression) contextEntryValue).getText());
 
         // -- Stunner side.
-
         DMNMarshaller m = new DMNMarshaller(new XMLEncoderDiagramMetadataMarshaller(), applicationFactoryManager);
         Graph<?, ?> g = m.unmarshall(null, this.getClass().getResourceAsStream("/wrong_context.dmn"));
-        DiagramImpl diagram = new DiagramImpl("", null);
 
         Node<?, ?> decisionNode = g.getNode("_653b3426-933a-4050-9568-ab2a66b43c36");
         assertNodeContentDefinitionIs(decisionNode, Decision.class);
@@ -1131,6 +1137,7 @@ public class DMNMarshallerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testContextEntryDataType() throws Exception {
         final DMNMarshaller marshaller = new DMNMarshaller(new XMLEncoderDiagramMetadataMarshaller(),
                                                            applicationFactoryManager);
@@ -1141,6 +1148,7 @@ public class DMNMarshallerTest {
         final ContextEntry contextEntry = new ContextEntry();
         final LiteralExpression literalExpression = new LiteralExpression();
         literalExpression.setTypeRef(BuiltInType.BOOLEAN.asQName());
+        literalExpression.setText("feel");
         contextEntry.setExpression(literalExpression);
         context.getContextEntry().add(contextEntry);
 
@@ -1155,6 +1163,14 @@ public class DMNMarshallerTest {
         checkDecisionExpression(unmarshalledGraph, context);
     }
 
+    @Test
+    public void testDefaultObjectsAreNotCreated() throws IOException {
+        final DMNRuntime dmnRuntime = roundTripUnmarshalMarshalThenUnmarshalDMN(this.getClass().getResourceAsStream("/DROOLS-2941.dmn"));
+        final List<DMNMessage> dmn_messages = dmnRuntime.getModels().get(0).getMessages();
+        assertThat(dmn_messages).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
     private static Diagram<Graph, Metadata> newDiagramDecisionWithExpression(final Expression expression) {
         final Diagram<Graph, Metadata> diagram = new DiagramImpl("dmn graph", null);
         final Graph<DefinitionSet, Node> graph = mock(Graph.class);
@@ -1191,7 +1207,8 @@ public class DMNMarshallerTest {
                 .findFirst().get();
     }
 
-    private XPath namespaceAwareXPath(Map.Entry<String, String>... pfxAndURI) {
+    @SafeVarargs
+    private final XPath namespaceAwareXPath(Map.Entry<String, String>... pfxAndURI) {
         XPath result = XPathFactory.newInstance().newXPath();
         result.setNamespaceContext(new NamespaceContext() {
             final Map<String, String> pfxToURI = new HashMap<String, String>() {{

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -1172,7 +1172,6 @@ public class DMNMarshallerTest {
         assertThat(dmnRuntime.getModels()).hasSize(1);
         final DMNModel dmnModel = dmnRuntime.getModels().get(0);
         final DMNContext context = dmnRuntime.newContext();
-        context.set("A Vowel", "b");
         final DMNResult result = dmnRuntime.evaluateAll(dmnModel, context);
         assertThat(result.getDecisionResultByName("A Vowel").getResult()).isEqualTo("a");
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DROOLS-2941.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DROOLS-2941.dmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dmn11:definitions xmlns="http://www.trisotech.com/dmn/definitions/_cbbece1a-e91f-4610-a2bf-ee334bdd574b" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="6.1.6.1" id="_cbbece1a-e91f-4610-a2bf-ee334bdd574b" name="Drawing 1" namespace="http://www.trisotech.com/dmn/definitions/_cbbece1a-e91f-4610-a2bf-ee334bdd574b" triso:logoChoice="Default" xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd">
+  <dmn11:extensionElements/>
+  <dmn11:itemDefinition label="tVowel" name="tVowel">
+    <dmn11:typeRef>feel:string</dmn11:typeRef>
+    <dmn11:allowedValues triso:constraintsType="enumeration">
+      <dmn11:text>"a","e","i","o","u"</dmn11:text>
+    </dmn11:allowedValues>
+  </dmn11:itemDefinition>
+  <dmn11:itemDefinition label="tText" name="tText">
+    <dmn11:typeRef>feel:string</dmn11:typeRef>
+  </dmn11:itemDefinition>
+  <dmn11:decision id="_d3370226-84bc-4a93-838e-409afd9b3d84" name="A Vowel">
+    <dmn11:variable id="_5774b0ea-6eef-46be-bbde-fc1a729888cd" name="A Vowel" typeRef="tVowel"/>
+    <dmn11:literalExpression id="_a6976ac8-7e5b-415b-8131-3d4ef8073ae9" typeRef="tVowel">
+      <dmn11:text>"a"</dmn11:text>
+    </dmn11:literalExpression>
+  </dmn11:decision>
+</dmn11:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommand.java
@@ -81,7 +81,8 @@ public class AddInputClauseCommand extends AbstractCanvasGraphCommand implements
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
                 final int clauseIndex = uiColumnIndex - DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT;
                 dtable.getInput().add(clauseIndex, inputClause);
-                final LiteralExpression le = inputClause.getInputExpression();
+                final LiteralExpression le = new LiteralExpression();
+                inputClause.setInputExpression(le);
                 le.setText(name);
 
                 dtable.getRule().forEach(rule -> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/RegisterNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/RegisterNodeCommand.java
@@ -44,9 +44,10 @@ public class RegisterNodeCommand extends org.kie.workbench.common.stunner.core.g
             if (candidate.getContent() instanceof View) {
                 final DMNModelInstrumentedBase dmnModel = (DMNModelInstrumentedBase) ((View) candidate.getContent()).getDefinition();
                 if (dmnModel instanceof BusinessKnowledgeModel) {
-                    final FunctionDefinition function = ((BusinessKnowledgeModel) dmnModel).getEncapsulatedLogic();
-                    KindUtilities.setKind(function,
-                                          FunctionDefinition.Kind.FEEL);
+                    final FunctionDefinition function = new FunctionDefinition();
+                    KindUtilities.setKind(function, FunctionDefinition.Kind.FEEL);
+                    ((BusinessKnowledgeModel) dmnModel).setEncapsulatedLogic(function);
+
                     final LiteralExpression le = new LiteralExpression();
                     function.setExpression(le);
                     le.setParent(function);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
@@ -71,6 +71,6 @@ public class LiteralExpressionUIModelMapper extends BaseUIModelMapper<LiteralExp
     public void toDMNModel(final int rowIndex,
                            final int columnIndex,
                            final Supplier<Optional<GridCellValue<?>>> cell) {
-        dmnModel.get().ifPresent(literalExpression -> literalExpression.setText(cell.get().orElse(new BaseGridCellValue<>("")).getValue().toString()));
+        dmnModel.get().ifPresent(literalExpression -> literalExpression.setText((String) cell.get().orElse(new BaseGridCellValue<>("")).getValue()));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapper.java
@@ -95,7 +95,7 @@ public class RelationUIModelMapper extends BaseUIModelMapper<Relation> {
                         // to limit ourselves to LiteralExpressions. Our Grid-system supports ANY (nested) expression too; however
                         // the simplification has been made for the benefit of USERS.
                         final LiteralExpression le = (LiteralExpression) ex;
-                        le.setText(cell.get().orElse(new BaseGridCellValue<>("")).getValue().toString());
+                        le.setText((String) cell.get().orElse(new BaseGridCellValue<>("")).getValue());
                     });
             }
         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectView.less
@@ -28,7 +28,7 @@
       color: #0c8fd1;
 
       .text {
-        font-family: "Open Sans",Helvetica,Arial,sans-serif;
+        font-family: "Open Sans", Helvetica, Arial, sans-serif;
         padding-left: 8px;
         font-weight: 600;
       }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
@@ -47,6 +47,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -173,8 +174,7 @@ public class AddInputClauseCommandTest {
         assertEquals(2, dtable.getInput().size());
         assertEquals(DecisionTableDefaultValueUtilities.INPUT_CLAUSE_PREFIX + "1",
                      dtable.getInput().get(0).getInputExpression().getText());
-        assertEquals("",
-                     dtable.getInput().get(1).getInputExpression().getText());
+        assertNull(dtable.getInput().get(1).getInputExpression());
 
         // first rule
         final List<UnaryTests> inputEntriesRuleOne = dtable.getRule().get(0).getInputEntry();
@@ -214,12 +214,10 @@ public class AddInputClauseCommandTest {
                      graphCommand.execute(graphCommandExecutionContext));
 
         assertEquals(3, dtable.getInput().size());
-        assertEquals("",
-                     dtable.getInput().get(0).getInputExpression().getText());
+        assertNull(dtable.getInput().get(0).getInputExpression());
         assertEquals(DecisionTableDefaultValueUtilities.INPUT_CLAUSE_PREFIX + "1",
                      dtable.getInput().get(1).getInputExpression().getText());
-        assertEquals("",
-                     dtable.getInput().get(2).getInputExpression().getText());
+        assertNull(dtable.getInput().get(2).getInputExpression());
 
         final List<UnaryTests> ruleInputs = dtable.getRule().get(0).getInputEntry();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -50,6 +50,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -189,8 +190,7 @@ public class AddOutputClauseCommandTest {
         assertEquals(2, dtable.getOutput().size());
         assertEquals(DecisionTableDefaultValueUtilities.OUTPUT_CLAUSE_PREFIX + "1",
                      dtable.getOutput().get(0).getName());
-        assertEquals("",
-                     dtable.getOutput().get(1).getName());
+        assertNull(dtable.getOutput().get(1).getName());
 
         // first rule
         final List<LiteralExpression> outputEntriesRuleOne = dtable.getRule().get(0).getOutputEntry();
@@ -230,12 +230,10 @@ public class AddOutputClauseCommandTest {
                      graphCommand.execute(graphCommandExecutionContext));
 
         assertEquals(3, dtable.getOutput().size());
-        assertEquals("",
-                     dtable.getOutput().get(0).getName());
+        assertNull(dtable.getOutput().get(0).getName());
         assertEquals(DecisionTableDefaultValueUtilities.OUTPUT_CLAUSE_PREFIX + "1",
                      dtable.getOutput().get(1).getName());
-        assertEquals("",
-                     dtable.getOutput().get(2).getName());
+        assertNull(dtable.getOutput().get(2).getName());
 
         final List<LiteralExpression> ruleOutputs = dtable.getRule().get(0).getOutputEntry();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
@@ -45,6 +45,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -318,8 +319,7 @@ public class AddRelationColumnCommandTest {
                      uiModel.getRows().get(0).getCells().size());
         assertEquals(1,
                      uiModel.getCell(0, 0).getValue().getValue());
-        assertEquals("",
-                     uiModel.getCell(0, 1).getValue().getValue());
+        assertNull(uiModel.getCell(0, 1).getValue().getValue());
 
         verify(command).updateParentInformation();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
@@ -44,6 +44,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
@@ -265,8 +266,7 @@ public class AddRelationRowCommandTest {
                      uiModel.getRows().get(1).getCells().size());
         assertEquals(2,
                      uiModel.getCell(1, 0).getValue().getValue());
-        assertEquals("",
-                     uiModel.getCell(1, 1).getValue().getValue());
+        assertNull(uiModel.getCell(1, 1).getValue().getValue());
 
         verify(command).updateRowNumbers();
         verify(command).updateParentInformation();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
@@ -34,6 +34,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -99,7 +100,7 @@ public class LiteralExpressionUIModelMapperTest {
     public void testFromDmn_Empty() throws Exception {
         mapper.fromDMNModel(0, 0);
 
-        assertEquals("", ((BaseGridCellValue) uiModel.getCell(0, 0).getValue()).getValue());
+        assertNull(((BaseGridCellValue) uiModel.getCell(0, 0).getValue()).getValue());
     }
 
     @Test
@@ -130,6 +131,13 @@ public class LiteralExpressionUIModelMapperTest {
                                                                       eq(PARENT_COLUMN_INDEX),
                                                                       eq(true),
                                                                       eq(false));
+    }
+
+    @Test
+    public void testToDmn_Null() throws Exception {
+        mapper.toDMNModel(0, 0, () -> Optional.of(new BaseGridCellValue<>(null)));
+
+        assertNull(literalExpression.getText());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
@@ -344,7 +344,7 @@ public class RelationGridTest {
         assertThat(uiModel.getRowCount()).isEqualTo(1);
 
         assertThat(uiModel.getCell(0, 0).getValue().getValue()).isEqualTo(1);
-        assertThat(uiModel.getCell(0, 1).getValue().getValue()).isEqualTo("");
+        assertThat(uiModel.getCell(0, 1).getValue().getValue()).isNull();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
@@ -39,6 +39,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowS
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -150,6 +151,25 @@ public class RelationUIModelMapperTest {
         assertThat(uiModel.getCell(1, 0)).isInstanceOf(RelationGridCell.class);
         assertThat(uiModel.getCell(1, 1)).isInstanceOf(RelationGridCell.class);
         assertThat(uiModel.getCell(1, 2)).isInstanceOf(RelationGridCell.class);
+    }
+
+    @Test
+    public void testToDMNModelLiteralExpressionsNullValue() {
+        cellValueSupplier = () -> Optional.of(new BaseGridCellValue<>(null));
+        for (int uiRowIndex = 0; uiRowIndex < uiModel.getRowCount(); uiRowIndex++) {
+            for (int uiColumnIndex = 1; uiColumnIndex < uiModel.getColumnCount(); uiColumnIndex++) {
+                mapper.toDMNModel(uiRowIndex,
+                                  uiColumnIndex,
+                                  cellValueSupplier);
+                final LiteralExpression le = (LiteralExpression) relation
+                        .getRow()
+                        .get(uiRowIndex)
+                        .getExpression()
+                        .get(uiColumnIndex - RelationUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
+
+                assertNull(le.getText());
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2941

@tarilabs Can you approve the use of ```DescriptionPropertyConverter.dmnFromWB(..)``` for **ALL** ```Description``` instances (I found a few that simply copied the value from DMN to WB).

@jomarko @tarilabs This PR removes all default _empty_ instances of properties on ```DMNElement``` objects that were being created by the WB model. There were a few related changes in the client code but nothing too serious.

I tested with the @tarilabs  minimal reproducer DMN file that highlights the issue. Tests now succeed and doing a file comparison between the original and "round-tripped" files are now very much more comparable.