### PR TITLE
DROOLS-2921: [DMN Designer] Stack overflow when a Context has two Relations

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/ClearExpressionTypeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/ClearExpressionTypeCommand.java
@@ -26,10 +26,12 @@ public class ClearExpressionTypeCommand extends BaseClearExpressionCommand {
     public ClearExpressionTypeCommand(final GridCellTuple cellTuple,
                                       final HasExpression hasExpression,
                                       final ContextUIModelMapper uiModelMapper,
-                                      final org.uberfire.mvp.Command canvasOperation) {
+                                      final org.uberfire.mvp.Command executeCanvasOperation,
+                                      final org.uberfire.mvp.Command undoCanvasOperation) {
         super(cellTuple,
               hasExpression,
               uiModelMapper,
-              canvasOperation);
+              executeCanvasOperation,
+              undoCanvasOperation);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommand.java
@@ -49,7 +49,8 @@ public class AddInputClauseCommand extends AbstractCanvasGraphCommand implements
     private final InputClauseColumn uiModelColumn;
     private final int uiColumnIndex;
     private final DecisionTableUIModelMapper uiModelMapper;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
     private final String name;
 
     public AddInputClauseCommand(final DecisionTable dtable,
@@ -58,14 +59,16 @@ public class AddInputClauseCommand extends AbstractCanvasGraphCommand implements
                                  final InputClauseColumn uiModelColumn,
                                  final int uiColumnIndex,
                                  final DecisionTableUIModelMapper uiModelMapper,
-                                 final org.uberfire.mvp.Command canvasOperation) {
+                                 final org.uberfire.mvp.Command executeCanvasOperation,
+                                 final org.uberfire.mvp.Command undoCanvasOperation) {
         this.dtable = dtable;
         this.inputClause = inputClause;
         this.uiModel = uiModel;
         this.uiModelColumn = uiModelColumn;
         this.uiColumnIndex = uiColumnIndex;
         this.uiModelMapper = uiModelMapper;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
         this.name = DecisionTableDefaultValueUtilities.getNewInputClauseName(dtable);
     }
 
@@ -122,7 +125,7 @@ public class AddInputClauseCommand extends AbstractCanvasGraphCommand implements
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -133,7 +136,7 @@ public class AddInputClauseCommand extends AbstractCanvasGraphCommand implements
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommand.java
@@ -48,7 +48,8 @@ public class AddOutputClauseCommand extends AbstractCanvasGraphCommand implement
     private final OutputClauseColumn uiModelColumn;
     private final int uiColumnIndex;
     private final DecisionTableUIModelMapper uiModelMapper;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
     private final String name;
 
     public AddOutputClauseCommand(final DecisionTable dtable,
@@ -57,14 +58,16 @@ public class AddOutputClauseCommand extends AbstractCanvasGraphCommand implement
                                   final OutputClauseColumn uiModelColumn,
                                   final int uiColumnIndex,
                                   final DecisionTableUIModelMapper uiModelMapper,
-                                  final org.uberfire.mvp.Command canvasOperation) {
+                                  final org.uberfire.mvp.Command executeCanvasOperation,
+                                  final org.uberfire.mvp.Command undoCanvasOperation) {
         this.dtable = dtable;
         this.outputClause = outputClause;
         this.uiModel = uiModel;
         this.uiModelColumn = uiModelColumn;
         this.uiColumnIndex = uiColumnIndex;
         this.uiModelMapper = uiModelMapper;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
         this.name = DecisionTableDefaultValueUtilities.getNewOutputClauseName(dtable);
     }
 
@@ -120,7 +123,7 @@ public class AddOutputClauseCommand extends AbstractCanvasGraphCommand implement
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -131,7 +134,7 @@ public class AddOutputClauseCommand extends AbstractCanvasGraphCommand implement
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommand.java
@@ -49,28 +49,29 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
     private final GridData uiModel;
     private final int uiColumnIndex;
     private final DecisionTableUIModelMapper uiModelMapper;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
 
     private final InputClause oldInputClause;
     private final List<UnaryTests> oldColumnData;
     private final GridColumn<?> oldUiModelColumn;
-    private final List<Double> oldColumnWidths;
 
     public DeleteInputClauseCommand(final DecisionTable dtable,
                                     final GridData uiModel,
                                     final int uiColumnIndex,
                                     final DecisionTableUIModelMapper uiModelMapper,
-                                    final org.uberfire.mvp.Command canvasOperation) {
+                                    final org.uberfire.mvp.Command executeCanvasOperation,
+                                    final org.uberfire.mvp.Command undoCanvasOperation) {
         this.dtable = dtable;
         this.uiModel = uiModel;
         this.uiColumnIndex = uiColumnIndex;
         this.uiModelMapper = uiModelMapper;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
 
         this.oldInputClause = dtable.getInput().get(uiColumnIndex - DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
         this.oldColumnData = extractColumnData();
         this.oldUiModelColumn = uiModel.getColumns().get(uiColumnIndex);
-        this.oldColumnWidths = CommandUtils.extractColumnWidths(uiModel);
     }
 
     private List<UnaryTests> extractColumnData() {
@@ -129,7 +130,7 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -145,9 +146,8 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
                 }
 
                 updateParentInformation();
-                restoreColumnWidths();
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -156,9 +156,5 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
 
     public void updateParentInformation() {
         CommandUtils.updateParentInformation(uiModel);
-    }
-
-    public void restoreColumnWidths() {
-        CommandUtils.restoreColumnWidths(uiModel, oldColumnWidths);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommand.java
@@ -49,28 +49,29 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
     private final GridData uiModel;
     private final int uiColumnIndex;
     private final DecisionTableUIModelMapper uiModelMapper;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
 
     private final OutputClause oldOutputClause;
     private final List<LiteralExpression> oldColumnData;
     private final GridColumn<?> oldUiModelColumn;
-    private final List<Double> oldColumnWidths;
 
     public DeleteOutputClauseCommand(final DecisionTable dtable,
                                      final GridData uiModel,
                                      final int uiColumnIndex,
                                      final DecisionTableUIModelMapper uiModelMapper,
-                                     final org.uberfire.mvp.Command canvasOperation) {
+                                     final org.uberfire.mvp.Command executeCanvasOperation,
+                                     final org.uberfire.mvp.Command undoCanvasOperation) {
         this.dtable = dtable;
         this.uiModel = uiModel;
         this.uiColumnIndex = uiColumnIndex;
         this.uiModelMapper = uiModelMapper;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
 
         this.oldOutputClause = dtable.getOutput().get(getOutputClauseIndex());
         this.oldColumnData = extractColumnData();
         this.oldUiModelColumn = uiModel.getColumns().get(uiColumnIndex);
-        this.oldColumnWidths = CommandUtils.extractColumnWidths(uiModel);
     }
 
     private List<LiteralExpression> extractColumnData() {
@@ -129,7 +130,7 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -145,9 +146,8 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
                 }
 
                 updateParentInformation();
-                restoreColumnWidths();
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -156,9 +156,5 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
 
     public void updateParentInformation() {
         CommandUtils.updateParentInformation(uiModel);
-    }
-
-    public void restoreColumnWidths() {
-        CommandUtils.restoreColumnWidths(uiModel, oldColumnWidths);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/ClearExpressionTypeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/ClearExpressionTypeCommand.java
@@ -36,11 +36,13 @@ public class ClearExpressionTypeCommand extends BaseClearExpressionCommand {
     public ClearExpressionTypeCommand(final GridCellTuple cellTuple,
                                       final FunctionDefinition function,
                                       final FunctionUIModelMapper uiModelMapper,
-                                      final org.uberfire.mvp.Command canvasOperation) {
+                                      final org.uberfire.mvp.Command executeCanvasOperation,
+                                      final org.uberfire.mvp.Command undoCanvasOperation) {
         super(cellTuple,
               function,
               uiModelMapper,
-              canvasOperation);
+              executeCanvasOperation,
+              undoCanvasOperation);
         this.oldKind = KindUtilities.getKind(function);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommand.java
@@ -47,7 +47,8 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
     private final FunctionDefinition function;
     private final FunctionDefinition.Kind kind;
     private final Optional<Expression> expression;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
 
     private final FunctionDefinition.Kind oldKind;
     private final Optional<Expression> oldExpression;
@@ -57,12 +58,14 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
                           final FunctionDefinition function,
                           final FunctionDefinition.Kind kind,
                           final Optional<Expression> expression,
-                          final org.uberfire.mvp.Command canvasOperation) {
+                          final org.uberfire.mvp.Command executeCanvasOperation,
+                          final org.uberfire.mvp.Command undoCanvasOperation) {
         this.cellTuple = cellTuple;
         this.function = function;
         this.kind = kind;
         this.expression = expression;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
 
         this.oldKind = KindUtilities.getKind(function);
         this.oldExpression = Optional.ofNullable(function.getExpression());
@@ -105,7 +108,7 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
                                       cellTuple.getColumnIndex(),
                                       cellTuple.getValue());
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -121,7 +124,7 @@ public class SetKindCommand extends AbstractCanvasGraphCommand implements VetoEx
                                                                     cellTuple.getColumnIndex());
                 }
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/ClearExpressionTypeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/ClearExpressionTypeCommand.java
@@ -26,10 +26,12 @@ public class ClearExpressionTypeCommand extends BaseClearExpressionCommand {
     public ClearExpressionTypeCommand(final GridCellTuple cellTuple,
                                       final HasExpression hasExpression,
                                       final InvocationUIModelMapper uiModelMapper,
-                                      final org.uberfire.mvp.Command canvasOperation) {
+                                      final org.uberfire.mvp.Command executeCanvasOperation,
+                                      final org.uberfire.mvp.Command undoCanvasOperation) {
         super(cellTuple,
               hasExpression,
               uiModelMapper,
-              canvasOperation);
+              executeCanvasOperation,
+              undoCanvasOperation);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommand.java
@@ -48,7 +48,8 @@ public class AddRelationColumnCommand extends AbstractCanvasGraphCommand impleme
     private final RelationColumn uiModelColumn;
     private final int uiColumnIndex;
     private final RelationUIModelMapper uiModelMapper;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
     private final String name;
 
     public AddRelationColumnCommand(final Relation relation,
@@ -57,14 +58,16 @@ public class AddRelationColumnCommand extends AbstractCanvasGraphCommand impleme
                                     final RelationColumn uiModelColumn,
                                     final int uiColumnIndex,
                                     final RelationUIModelMapper uiModelMapper,
-                                    final org.uberfire.mvp.Command canvasOperation) {
+                                    final org.uberfire.mvp.Command executeCanvasOperation,
+                                    final org.uberfire.mvp.Command undoCanvasOperation) {
         this.relation = relation;
         this.informationItem = informationItem;
         this.uiModel = uiModel;
         this.uiModelColumn = uiModelColumn;
         this.uiColumnIndex = uiColumnIndex;
         this.uiModelMapper = uiModelMapper;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
         this.name = RelationDefaultValueUtilities.getNewColumnName(relation);
     }
 
@@ -118,7 +121,7 @@ public class AddRelationColumnCommand extends AbstractCanvasGraphCommand impleme
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -130,7 +133,7 @@ public class AddRelationColumnCommand extends AbstractCanvasGraphCommand impleme
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommand.java
@@ -49,28 +49,29 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
     private final GridData uiModel;
     private final int uiColumnIndex;
     private final RelationUIModelMapper uiModelMapper;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
 
     private final InformationItem oldInformationItem;
     private final List<Expression> oldColumnData;
     private final GridColumn<?> oldUiModelColumn;
-    private final List<Double> oldColumnWidths;
 
     public DeleteRelationColumnCommand(final Relation relation,
                                        final GridData uiModel,
                                        final int uiColumnIndex,
                                        final RelationUIModelMapper uiModelMapper,
-                                       final org.uberfire.mvp.Command canvasOperation) {
+                                       final org.uberfire.mvp.Command executeCanvasOperation,
+                                       final org.uberfire.mvp.Command undoCanvasOperation) {
         this.relation = relation;
         this.uiModel = uiModel;
         this.uiColumnIndex = uiColumnIndex;
         this.uiModelMapper = uiModelMapper;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
 
         this.oldInformationItem = relation.getColumn().get(uiColumnIndex - RelationUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
         this.oldColumnData = extractColumnData(uiColumnIndex);
         this.oldUiModelColumn = uiModel.getColumns().get(uiColumnIndex);
-        this.oldColumnWidths = CommandUtils.extractColumnWidths(uiModel);
     }
 
     private List<Expression> extractColumnData(final int uiColumnIndex) {
@@ -125,7 +126,7 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
 
                 updateParentInformation();
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -141,9 +142,8 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
                 }
 
                 updateParentInformation();
-                restoreColumnWidths();
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -152,9 +152,5 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
 
     public void updateParentInformation() {
         CommandUtils.updateParentInformation(uiModel);
-    }
-
-    public void restoreColumnWidths() {
-        CommandUtils.restoreColumnWidths(uiModel, oldColumnWidths);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/undefined/SetCellValueCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/undefined/SetCellValueCommand.java
@@ -48,7 +48,8 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
     private final Optional<String> nodeUUID;
     private final Supplier<UIModelMapper> uiModelMapper;
     private final ExpressionGridCache expressionGridCache;
-    private final org.uberfire.mvp.Command canvasOperation;
+    private final org.uberfire.mvp.Command executeCanvasOperation;
+    private final org.uberfire.mvp.Command undoCanvasOperation;
 
     private final Optional<GridCellValue<?>> oldCellValue;
 
@@ -56,12 +57,14 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
                                final Optional<String> nodeUUID,
                                final Supplier<UIModelMapper> uiModelMapper,
                                final ExpressionGridCache expressionGridCache,
-                               final org.uberfire.mvp.Command canvasOperation) {
+                               final org.uberfire.mvp.Command executeCanvasOperation,
+                               final org.uberfire.mvp.Command undoCanvasOperation) {
         this.cellTuple = cellTuple;
         this.nodeUUID = nodeUUID;
         this.uiModelMapper = uiModelMapper;
         this.expressionGridCache = expressionGridCache;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
 
         this.oldCellValue = extractGridCellValue(cellTuple);
     }
@@ -110,7 +113,7 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
                                       cellTuple.getColumnIndex(),
                                       cellTuple.getValue());
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -128,7 +131,7 @@ public class SetCellValueCommand extends AbstractCanvasGraphCommand implements V
                                                                     cellTuple.getColumnIndex());
                 }
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseClearExpressionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseClearExpressionCommand.java
@@ -45,7 +45,8 @@ public abstract class BaseClearExpressionCommand extends AbstractCanvasGraphComm
     protected final GridCellTuple cellTuple;
     protected final HasExpression hasExpression;
     protected final UIModelMapper uiModelMapper;
-    protected final org.uberfire.mvp.Command canvasOperation;
+    protected final org.uberfire.mvp.Command executeCanvasOperation;
+    protected final org.uberfire.mvp.Command undoCanvasOperation;
 
     protected final Expression oldExpression;
     protected final Optional<GridCellValue<?>> oldCellValue;
@@ -53,11 +54,13 @@ public abstract class BaseClearExpressionCommand extends AbstractCanvasGraphComm
     public BaseClearExpressionCommand(final GridCellTuple cellTuple,
                                       final HasExpression hasExpression,
                                       final UIModelMapper uiModelMapper,
-                                      final org.uberfire.mvp.Command canvasOperation) {
+                                      final org.uberfire.mvp.Command executeCanvasOperation,
+                                      final org.uberfire.mvp.Command undoCanvasOperation) {
         this.cellTuple = cellTuple;
         this.hasExpression = hasExpression;
         this.uiModelMapper = uiModelMapper;
-        this.canvasOperation = canvasOperation;
+        this.executeCanvasOperation = executeCanvasOperation;
+        this.undoCanvasOperation = undoCanvasOperation;
 
         this.oldExpression = hasExpression.getExpression();
         this.oldCellValue = extractGridCellValue(cellTuple);
@@ -96,7 +99,7 @@ public abstract class BaseClearExpressionCommand extends AbstractCanvasGraphComm
                 uiModelMapper.fromDMNModel(cellTuple.getRowIndex(),
                                            cellTuple.getColumnIndex());
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -108,7 +111,7 @@ public abstract class BaseClearExpressionCommand extends AbstractCanvasGraphComm
                                                                                               cellTuple.getColumnIndex(),
                                                                                               v));
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommand.java
@@ -41,11 +41,13 @@ public class ClearExpressionTypeCommand extends BaseClearExpressionCommand {
                                       final HasExpression hasExpression,
                                       final ExpressionContainerUIModelMapper uiModelMapper,
                                       final ExpressionGridCache expressionGridCache,
-                                      final org.uberfire.mvp.Command canvasOperation) {
+                                      final org.uberfire.mvp.Command executeCanvasOperation,
+                                      final org.uberfire.mvp.Command undoCanvasOperation) {
         super(cellTuple,
               hasExpression,
               uiModelMapper,
-              canvasOperation);
+              executeCanvasOperation,
+              undoCanvasOperation);
         this.nodeUUID = nodeUUID;
         this.expressionGridCache = expressionGridCache;
         this.oldExpressionGrid = expressionGridCache.getExpressionGrid(nodeUUID);
@@ -63,7 +65,7 @@ public class ClearExpressionTypeCommand extends BaseClearExpressionCommand {
                 uiModelMapper.fromDMNModel(cellTuple.getRowIndex(),
                                            cellTuple.getColumnIndex());
 
-                canvasOperation.execute();
+                executeCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }
@@ -77,7 +79,7 @@ public class ClearExpressionTypeCommand extends BaseClearExpressionCommand {
                                                                                               cellTuple.getColumnIndex(),
                                                                                               v));
 
-                canvasOperation.execute();
+                undoCanvasOperation.execute();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.client.commands.util;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
@@ -100,21 +99,5 @@ public class CommandUtils {
         final GridCell<?> cell = cellTuple.getGridWidget().getModel().getCell(cellTuple.getRowIndex(),
                                                                               cellTuple.getColumnIndex());
         return Optional.ofNullable(cell == null ? null : cell.getValue());
-    }
-
-    public static List<Double> extractColumnWidths(final GridData uiModel) {
-        return uiModel.getColumns()
-                .stream()
-                .map(GridColumn::getWidth)
-                .collect(Collectors.toList());
-    }
-
-    public static void restoreColumnWidths(final GridData uiModel,
-                                           final List<Double> oldColumnWidths) {
-        IntStream.range(0, oldColumnWidths.size())
-                .forEach(index -> uiModel
-                        .getColumns()
-                        .get(index)
-                        .setWidth(oldColumnWidths.get(index)));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/tree/DecisionNavigatorTreeView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/tree/DecisionNavigatorTreeView.java
@@ -126,7 +126,7 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
     @Override
     public void remove(final DecisionNavigatorItem item) {
         ofNullable(findItem(item)).ifPresent(element -> {
-            if (element.parentNode != null){
+            if (element.parentNode != null) {
                 element.parentNode.removeChild(element);
             }
         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -274,7 +274,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                                                                                                                    new DMNGridRow(),
                                                                                                                    index,
                                                                                                                    uiModelMapper,
-                                                                                                                   this::resize));
+                                                                                                                   () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
 
             if (!CommandUtils.isError(result)) {
                 selectCell(index, ContextUIModelMapperHelper.NAME_COLUMN_INDEX, false, false);
@@ -289,7 +289,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                                           new DeleteContextEntryCommand(c,
                                                                         model,
                                                                         index,
-                                                                        this::resize));
+                                                                        () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 
@@ -302,7 +302,13 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                                       new ClearExpressionTypeCommand(gc,
                                                                      hasExpression,
                                                                      uiModelMapper,
-                                                                     () -> resizeBasedOnCellExpressionEditor(uiRowIndex,
-                                                                                                             ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX)));
+                                                                     () -> {
+                                                                         resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                                         selectParentCell();
+                                                                     },
+                                                                     () -> {
+                                                                         resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                                         selectFirstCell();
+                                                                     }));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -399,7 +399,8 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                                                                                                   inputClauseColumn,
                                                                                                                   index,
                                                                                                                   uiModelMapper,
-                                                                                                                  this::resize));
+                                                                                                                  () -> resize(BaseExpressionGrid.RESIZE_EXISTING),
+                                                                                                                  () -> resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM)));
 
             if (!CommandUtils.isError(result)) {
                 inputClauseColumn.startEditingHeaderCell(0);
@@ -414,7 +415,8 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                                                        model,
                                                                        index,
                                                                        uiModelMapper,
-                                                                       this::resize));
+                                                                       () -> resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM),
+                                                                       () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 
@@ -430,7 +432,8 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                                                                                                    outputClauseColumn,
                                                                                                                    index,
                                                                                                                    uiModelMapper,
-                                                                                                                   this::resize));
+                                                                                                                   () -> resize(BaseExpressionGrid.RESIZE_EXISTING),
+                                                                                                                   () -> resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM)));
 
             if (!CommandUtils.isError(result)) {
                 outputClauseColumn.startEditingHeaderCell(1);
@@ -445,7 +448,8 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                                                         model,
                                                                         index,
                                                                         uiModelMapper,
-                                                                        this::resize));
+                                                                        () -> resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM),
+                                                                        () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 
@@ -458,7 +462,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                                                      new DMNGridRow(),
                                                                      index,
                                                                      uiModelMapper,
-                                                                     this::resize));
+                                                                     () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 
@@ -468,7 +472,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                           new DeleteDecisionRuleCommand(dtable,
                                                                         model,
                                                                         index,
-                                                                        this::resize));
+                                                                        () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -338,7 +338,14 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                                          function,
                                                          kind,
                                                          expression,
-                                                         () -> resizeBasedOnCellExpressionEditor(0, 0)));
+                                                         () -> {
+                                                             resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                             editor.ifPresent(BaseExpressionGrid::selectFirstCell);
+                                                         },
+                                                         () -> {
+                                                             resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                             selectFirstCell();
+                                                         }));
     }
 
     void clearExpressionType() {
@@ -350,7 +357,14 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                           new ClearExpressionTypeCommand(gc,
                                                                          function,
                                                                          uiModelMapper,
-                                                                         () -> resizeBasedOnCellExpressionEditor(0, 0)));
+                                                                         () -> {
+                                                                             resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                                             selectParentCell();
+                                                                         },
+                                                                         () -> {
+                                                                             resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                                             selectFirstCell();
+                                                                         }));
         });
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -271,7 +271,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                                                                                                                        new DMNGridRow(),
                                                                                                                        index,
                                                                                                                        uiModelMapper,
-                                                                                                                       this::resize));
+                                                                                                                       () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
 
             if (!CommandUtils.isError(result)) {
                 selectCell(index, InvocationUIModelMapper.BINDING_PARAMETER_COLUMN_INDEX, false, false);
@@ -286,7 +286,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                                           new DeleteParameterBindingCommand(invocation,
                                                                             model,
                                                                             index,
-                                                                            this::resize));
+                                                                            () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 
@@ -299,7 +299,13 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                                       new ClearExpressionTypeCommand(gc,
                                                                      hasExpression,
                                                                      uiModelMapper,
-                                                                     () -> resizeBasedOnCellExpressionEditor(uiRowIndex,
-                                                                                                             InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX)));
+                                                                     () -> {
+                                                                         resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                                         selectParentCell();
+                                                                     },
+                                                                     () -> {
+                                                                         resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+                                                                         selectFirstCell();
+                                                                     }));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -49,6 +49,7 @@ import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
 public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression, DMNGridData, LiteralExpressionUIModelMapper> implements HasListSelectorControl {
@@ -109,10 +110,15 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
 
     @Override
     public void selectFirstCell() {
-        final GridData uiModel = parent.getGridWidget().getModel();
-        uiModel.clearSelections();
-        uiModel.selectCell(parent.getRowIndex(),
-                           parent.getColumnIndex());
+        final GridCellTuple parent = getParentInformation();
+        final GridWidget parentGridWidget = parent.getGridWidget();
+        final GridData parentUiModel = parentGridWidget.getModel();
+        parentUiModel.clearSelections();
+        parentUiModel.selectCell(parent.getRowIndex(),
+                                 parent.getColumnIndex());
+
+        final DMNGridLayer gridLayer = (DMNGridLayer) getLayer();
+        gridLayer.select(parentGridWidget);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumn.java
@@ -16,20 +16,14 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.relation;
 
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.kie.soup.commons.validation.PortablePreconditions;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
-import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.NameAndDataTypeDOMElementColumnRenderer;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNSimpleGridColumn;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
-import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.HasDOMElementResources;
@@ -49,45 +43,6 @@ public class RelationColumn extends DMNSimpleGridColumn<RelationGrid, String> im
                                                           factory);
         setMovable(true);
         setResizable(false);
-    }
-
-    @Override
-    public Double getMinimumWidth() {
-        final double minimumWidth = super.getMinimumWidth();
-        final double minimumWidthOfPeers = getMinimumWidthOfPeers();
-        final double widthOfThisEditor = gridWidget.getWidth();
-        final double widthOfThisColumn = getWidth();
-
-        return Math.max(minimumWidth,
-                        minimumWidthOfPeers - (widthOfThisEditor - widthOfThisColumn));
-    }
-
-    private double getMinimumWidthOfPeers() {
-        final GridCellTuple parent = gridWidget.getParentInformation();
-        final GridData parentUiModel = parent.getGridWidget().getModel();
-        final int parentUiRowIndex = parent.getRowIndex();
-        final int parentUiColumnIndex = parent.getColumnIndex();
-
-        double minimumWidth = super.getMinimumWidth();
-
-        for (int uiRowIndex = 0; uiRowIndex < parentUiModel.getRowCount(); uiRowIndex++) {
-            if (uiRowIndex != parentUiRowIndex) {
-                final GridRow row = parentUiModel.getRow(uiRowIndex);
-                final GridCell<?> cell = row.getCells().get(parentUiColumnIndex);
-                if (cell != null) {
-                    final GridCellValue<?> value = cell.getValue();
-                    if (value instanceof ExpressionCellValue) {
-                        final ExpressionCellValue ecv = (ExpressionCellValue) value;
-                        final Optional<BaseExpressionGrid> editor = ecv.getValue();
-                        final double padding = editor.map(BaseExpressionGrid::getPadding).get();
-                        minimumWidth = Math.max(minimumWidth,
-                                                ecv.getMinimumWidth().orElse(0.0) + padding * 2);
-                    }
-                }
-            }
-        }
-
-        return minimumWidth;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -235,7 +235,8 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
                                                                                                                      relationColumn,
                                                                                                                      index,
                                                                                                                      uiModelMapper,
-                                                                                                                     this::resize));
+                                                                                                                     () -> resize(BaseExpressionGrid.RESIZE_EXISTING),
+                                                                                                                     () -> resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM)));
 
             if (!CommandUtils.isError(result)) {
                 relationColumn.startEditingHeaderCell(0);
@@ -250,7 +251,8 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
                                                                           model,
                                                                           index,
                                                                           uiModelMapper,
-                                                                          this::resize));
+                                                                          () -> resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM),
+                                                                          () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 
@@ -263,7 +265,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
                                                                     new DMNGridRow(),
                                                                     index,
                                                                     uiModelMapper,
-                                                                    this::resize));
+                                                                    () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 
@@ -273,7 +275,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
                                           new DeleteRelationRowCommand(relation,
                                                                        model,
                                                                        index,
-                                                                       this::resize));
+                                                                       () -> resize(BaseExpressionGrid.RESIZE_EXISTING)));
         });
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridColumn.java
@@ -65,8 +65,10 @@ public abstract class DMNGridColumn<G extends GridWidget, T> extends BaseGridCol
             final int parentColumnIndex = beg.getParentInformation().getColumnIndex();
             final GridData parentGridData = beg.getParentInformation().getGridWidget().getModel();
             if (parentGridData != null) {
-                final GridColumn<?> parentColumn = parentGridData.getColumns().get(parentColumnIndex);
-                parentColumn.setWidth(beg.getWidth() + beg.getPadding() * 2);
+                if (parentColumnIndex < parentGridData.getColumnCount()) {
+                    final GridColumn<?> parentColumn = parentGridData.getColumns().get(parentColumnIndex);
+                    parentColumn.setWidth(beg.getWidth() + beg.getPadding() * 2);
+                }
             }
         }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import com.google.gwt.user.client.ui.RequiresResize;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
@@ -62,14 +63,16 @@ public class GridCellTuple implements RequiresResize {
         return gridWidget;
     }
 
-    public void proposeContainingColumnWidth(final double proposedWidth) {
+    public void proposeContainingColumnWidth(final double proposedWidth,
+                                             final Function<BaseExpressionGrid, Double> requiredWidthSupplier) {
         final GridColumn<?> parentColumn = gridWidget.getModel().getColumns().get(columnIndex);
-        final double requiredWidth = Math.max(proposedWidth, getMinimumParentColumnWidth(proposedWidth));
+        final double requiredWidth = Math.max(proposedWidth, getRequiredParentColumnWidth(proposedWidth, requiredWidthSupplier));
         parentColumn.setWidth(requiredWidth);
     }
 
-    private double getMinimumParentColumnWidth(final double proposedWidth) {
-        double minimumWidth = proposedWidth;
+    private double getRequiredParentColumnWidth(final double proposedWidth,
+                                                final Function<BaseExpressionGrid, Double> requiredWidthSupplier) {
+        double width = proposedWidth;
         final GridData uiModel = gridWidget.getModel();
         for (GridRow row : uiModel.getRows()) {
             final GridCell<?> cell = row.getCells().get(columnIndex);
@@ -80,12 +83,12 @@ public class GridCellTuple implements RequiresResize {
                     final Optional<BaseExpressionGrid> editor = ecv.getValue();
                     if (editor.isPresent()) {
                         final BaseExpressionGrid beg = editor.get();
-                        minimumWidth = Math.max(minimumWidth, beg.getMinimumWidth());
+                        width = Math.max(width, requiredWidthSupplier.apply(beg));
                     }
                 }
             }
         }
-        return minimumWidth;
+        return width;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/DMNClient.gwt.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/DMNClient.gwt.xml
@@ -24,6 +24,7 @@
   <inherits name="org.kie.workbench.common.stunner.svg.StunnerSvgClient"/>
   <inherits name="org.kie.workbench.common.stunner.shapes.StunnerShapesClient"/>
   <inherits name="org.kie.workbench.common.stunner.client.StunnerWidgets"/>
+  <inherits name="org.kie.workbench.common.stunner.forms.StunnerFormsClient"/>
 
   <inherits name="org.uberfire.ext.wires.core.grids.WiresCoreGrids"/>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/ClearExpressionTypeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/ClearExpressionTypeCommandTest.java
@@ -42,7 +42,8 @@ public class ClearExpressionTypeCommandTest extends BaseClearExpressionCommandTe
                                                                 gridWidget),
                                               hasExpression,
                                               uiModelMapper,
-                                              gridLayer::batch);
+                                              executeCanvasOperation,
+                                              undoCanvasOperation);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
@@ -70,6 +70,12 @@ public class AddInputClauseCommandTest {
     @Mock
     private GraphCommandExecutionContext graphCommandExecutionContext;
 
+    @Mock
+    private org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    private org.uberfire.mvp.Command undoCanvasOperation;
+
     private DecisionTable dtable;
 
     private InputClause inputClause;
@@ -79,9 +85,6 @@ public class AddInputClauseCommandTest {
     private DecisionTableUIModelMapper uiModelMapper;
 
     private AddInputClauseCommand command;
-
-    @Mock
-    private org.uberfire.mvp.Command canvasOperation;
 
     @Before
     public void setUp() throws Exception {
@@ -104,7 +107,8 @@ public class AddInputClauseCommandTest {
                                                      uiInputClauseColumn,
                                                      index,
                                                      uiModelMapper,
-                                                     canvasOperation));
+                                                     executeCanvasOperation,
+                                                     undoCanvasOperation));
     }
 
     @Test
@@ -322,8 +326,8 @@ public class AddInputClauseCommandTest {
                      canvasAddInputClauseCommand.undo(canvasHandler));
         assertEquals(1, uiModel.getColumnCount());
 
-        // one time in execute(), one time in undo()
-        verify(canvasOperation, times(2)).execute();
+        verify(executeCanvasOperation).execute();
+        verify(undoCanvasOperation).execute();
         verify(command, times(2)).updateParentInformation();
     }
 
@@ -337,7 +341,7 @@ public class AddInputClauseCommandTest {
         // just row number column
         assertEquals(1, uiModel.getColumnCount());
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -76,6 +76,12 @@ public class AddOutputClauseCommandTest {
     @Mock
     private GraphCommandExecutionContext graphCommandExecutionContext;
 
+    @Mock
+    private org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    private org.uberfire.mvp.Command undoCanvasOperation;
+
     private DecisionTable dtable;
 
     private OutputClause outputClause;
@@ -85,9 +91,6 @@ public class AddOutputClauseCommandTest {
     private DecisionTableUIModelMapper uiModelMapper;
 
     private AddOutputClauseCommand command;
-
-    @Mock
-    private org.uberfire.mvp.Command canvasOperation;
 
     @Before
     public void setUp() throws Exception {
@@ -110,7 +113,8 @@ public class AddOutputClauseCommandTest {
                                                       uiOutputClauseColumn,
                                                       index,
                                                       uiModelMapper,
-                                                      canvasOperation));
+                                                      executeCanvasOperation,
+                                                      undoCanvasOperation));
     }
 
     @Test
@@ -346,8 +350,8 @@ public class AddOutputClauseCommandTest {
                      canvasAddOutputClauseCommand.undo(canvasHandler));
         assertEquals(2, uiModel.getColumnCount());
 
-        // one time in execute(), one time in undo()
-        verify(canvasOperation, times(2)).execute();
+        verify(executeCanvasOperation).execute();
+        verify(undoCanvasOperation).execute();
         verify(command, times(2)).updateParentInformation();
     }
 
@@ -383,8 +387,8 @@ public class AddOutputClauseCommandTest {
                      canvasAddOutputClauseCommand.undo(canvasHandler));
         assertEquals(1, uiModel.getColumnCount());
 
-        // one time in execute(), one time in undo()
-        verify(canvasOperation, times(2)).execute();
+        verify(executeCanvasOperation).execute();
+        verify(undoCanvasOperation).execute();
         verify(command, times(2)).updateParentInformation();
     }
 
@@ -398,7 +402,7 @@ public class AddOutputClauseCommandTest {
         // just row number column
         assertEquals(1, uiModel.getColumnCount());
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
@@ -73,7 +73,10 @@ public class DeleteInputClauseCommandTest {
     private GraphCommandExecutionContext graphCommandExecutionContext;
 
     @Mock
-    private org.uberfire.mvp.Command canvasOperation;
+    private org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    private org.uberfire.mvp.Command undoCanvasOperation;
 
     private DecisionTable dtable;
 
@@ -112,7 +115,8 @@ public class DeleteInputClauseCommandTest {
                                                         uiModel,
                                                         uiColumnIndex,
                                                         uiModelMapper,
-                                                        canvasOperation));
+                                                        executeCanvasOperation,
+                                                        undoCanvasOperation));
     }
 
     @Test
@@ -213,7 +217,7 @@ public class DeleteInputClauseCommandTest {
         assertThat(uiModel.getColumns()).containsOnly(uiRowNumberColumn,
                                                       uiDescriptionColumn);
 
-        verify(canvasOperation).execute();
+        verify(executeCanvasOperation).execute();
         verify(command).updateParentInformation();
     }
 
@@ -226,7 +230,7 @@ public class DeleteInputClauseCommandTest {
         assertThat(uiModel.getColumns()).containsOnly(uiRowNumberColumn,
                                                       uiDescriptionColumn);
 
-        reset(canvasOperation, command);
+        reset(command);
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      canvasAddRuleCommand.undo(canvasHandler));
 
@@ -234,8 +238,7 @@ public class DeleteInputClauseCommandTest {
                                                       uiInputClauseColumn,
                                                       uiDescriptionColumn);
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
-        verify(command).restoreColumnWidths();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
@@ -73,7 +73,10 @@ public class DeleteOutputClauseCommandTest {
     private GraphCommandExecutionContext graphCommandExecutionContext;
 
     @Mock
-    private org.uberfire.mvp.Command canvasOperation;
+    private org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    private org.uberfire.mvp.Command undoCanvasOperation;
 
     private DecisionTable dtable;
 
@@ -112,7 +115,8 @@ public class DeleteOutputClauseCommandTest {
                                                          uiModel,
                                                          uiColumnIndex,
                                                          uiModelMapper,
-                                                         canvasOperation));
+                                                         executeCanvasOperation,
+                                                         undoCanvasOperation));
     }
 
     @Test
@@ -213,7 +217,7 @@ public class DeleteOutputClauseCommandTest {
         assertThat(uiModel.getColumns()).containsOnly(uiRowNumberColumn,
                                                       uiDescriptionColumn);
 
-        verify(canvasOperation).execute();
+        verify(executeCanvasOperation).execute();
         verify(command).updateParentInformation();
     }
 
@@ -226,7 +230,7 @@ public class DeleteOutputClauseCommandTest {
         assertThat(uiModel.getColumns()).containsOnly(uiRowNumberColumn,
                                                       uiDescriptionColumn);
 
-        reset(canvasOperation, command);
+        reset(command);
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      canvasAddRuleCommand.undo(canvasHandler));
 
@@ -234,8 +238,7 @@ public class DeleteOutputClauseCommandTest {
                                                       uiOutputClauseColumn,
                                                       uiDescriptionColumn);
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
-        verify(command).restoreColumnWidths();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/ClearExpressionTypeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/ClearExpressionTypeCommandTest.java
@@ -50,7 +50,8 @@ public class ClearExpressionTypeCommandTest extends BaseClearExpressionCommandTe
                                                                 gridWidget),
                                               expression,
                                               uiModelMapper,
-                                              gridLayer::batch);
+                                              executeCanvasOperation,
+                                              undoCanvasOperation);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommandTest.java
@@ -45,7 +45,6 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -58,7 +57,10 @@ public class SetKindCommandTest {
     private GridColumn mockColumn;
 
     @Mock
-    private org.uberfire.mvp.Command canvasOperation;
+    private org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    private org.uberfire.mvp.Command undoCanvasOperation;
 
     @Mock
     private AbstractCanvasHandler handler;
@@ -116,7 +118,8 @@ public class SetKindCommandTest {
                                           function,
                                           newKind,
                                           Optional.of(newExpression),
-                                          canvasOperation);
+                                          executeCanvasOperation,
+                                          undoCanvasOperation);
     }
 
     @Test
@@ -202,7 +205,7 @@ public class SetKindCommandTest {
         assertEquals(newEditor,
                      ((ExpressionCellValue) uiModel.getCell(0, 0).getValue()).getValue().get());
 
-        verify(canvasOperation).execute();
+        verify(executeCanvasOperation).execute();
     }
 
     @Test
@@ -220,7 +223,6 @@ public class SetKindCommandTest {
         assertEquals(originalEditor,
                      ((ExpressionCellValue) uiModel.getCell(0, 0).getValue()).getValue().get());
 
-        //Once for execute, once for undo
-        verify(canvasOperation, times(2)).execute();
+        verify(undoCanvasOperation).execute();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/ClearExpressionTypeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/invocation/ClearExpressionTypeCommandTest.java
@@ -42,7 +42,8 @@ public class ClearExpressionTypeCommandTest extends BaseClearExpressionCommandTe
                                                                 gridWidget),
                                               hasExpression,
                                               uiModelMapper,
-                                              gridLayer::batch);
+                                              executeCanvasOperation,
+                                              undoCanvasOperation);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
@@ -65,7 +65,10 @@ public class AddRelationColumnCommandTest {
     private ListSelectorView.Presenter listSelector;
 
     @Mock
-    private org.uberfire.mvp.Command canvasOperation;
+    private org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    private org.uberfire.mvp.Command undoCanvasOperation;
 
     @Mock
     private AbstractCanvasHandler handler;
@@ -110,7 +113,8 @@ public class AddRelationColumnCommandTest {
                                                    uiModelColumn,
                                                    uiColumnIndex,
                                                    uiModelMapper,
-                                                   canvasOperation));
+                                                   executeCanvasOperation,
+                                                   undoCanvasOperation));
     }
 
     @Test
@@ -323,7 +327,7 @@ public class AddRelationColumnCommandTest {
 
         verify(command).updateParentInformation();
 
-        verify(canvasOperation).execute();
+        verify(executeCanvasOperation).execute();
     }
 
     @Test
@@ -373,7 +377,7 @@ public class AddRelationColumnCommandTest {
 
         verify(command).updateParentInformation();
 
-        verify(canvasOperation).execute();
+        verify(executeCanvasOperation).execute();
     }
 
     @Test
@@ -391,7 +395,7 @@ public class AddRelationColumnCommandTest {
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.execute(handler));
 
-        reset(command, canvasOperation);
+        reset(command);
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.undo(handler));
 
@@ -408,7 +412,7 @@ public class AddRelationColumnCommandTest {
 
         verify(command).updateParentInformation();
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
     }
 
     @Test
@@ -422,7 +426,7 @@ public class AddRelationColumnCommandTest {
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.execute(handler));
 
-        reset(command, canvasOperation);
+        reset(command);
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.undo(handler));
 
@@ -435,6 +439,6 @@ public class AddRelationColumnCommandTest {
 
         verify(command).updateParentInformation();
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
@@ -65,7 +65,10 @@ public class DeleteRelationColumnCommandTest {
     private ListSelectorView.Presenter listSelector;
 
     @Mock
-    private org.uberfire.mvp.Command canvasOperation;
+    private org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    private org.uberfire.mvp.Command undoCanvasOperation;
 
     @Mock
     private AbstractCanvasHandler handler;
@@ -109,7 +112,8 @@ public class DeleteRelationColumnCommandTest {
                                                            uiModel,
                                                            uiColumnIndex,
                                                            uiModelMapper,
-                                                           canvasOperation));
+                                                           executeCanvasOperation,
+                                                           undoCanvasOperation));
     }
 
     private void makeCommand() {
@@ -270,7 +274,7 @@ public class DeleteRelationColumnCommandTest {
 
         verify(command).updateParentInformation();
 
-        verify(canvasOperation).execute();
+        verify(executeCanvasOperation).execute();
     }
 
     @Test
@@ -290,7 +294,7 @@ public class DeleteRelationColumnCommandTest {
 
         verify(command).updateParentInformation();
 
-        verify(canvasOperation).execute();
+        verify(executeCanvasOperation).execute();
     }
 
     @Test
@@ -310,7 +314,7 @@ public class DeleteRelationColumnCommandTest {
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.execute(handler));
 
-        reset(command, canvasOperation);
+        reset(command);
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.undo(handler));
 
@@ -328,9 +332,8 @@ public class DeleteRelationColumnCommandTest {
                      uiModel.getCell(0, 1).getValue().getValue());
 
         verify(command).updateParentInformation();
-        verify(command).restoreColumnWidths();
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
     }
 
     @Test
@@ -343,7 +346,7 @@ public class DeleteRelationColumnCommandTest {
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.execute(handler));
 
-        reset(command, canvasOperation);
+        reset(command);
         assertEquals(CanvasCommandResultBuilder.SUCCESS,
                      cc.undo(handler));
 
@@ -357,8 +360,7 @@ public class DeleteRelationColumnCommandTest {
                      uiModel.getRowCount());
 
         verify(command).updateParentInformation();
-        verify(command).restoreColumnWidths();
 
-        verify(canvasOperation).execute();
+        verify(undoCanvasOperation).execute();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseClearExpressionCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseClearExpressionCommandTest.java
@@ -23,7 +23,6 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
 import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
-import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
@@ -49,9 +48,6 @@ public abstract class BaseClearExpressionCommandTest<C extends BaseClearExpressi
     protected static final int COLUMN_INDEX = 1;
 
     @Mock
-    protected DMNGridLayer gridLayer;
-
-    @Mock
     protected GridWidget gridWidget;
 
     @Mock
@@ -74,6 +70,12 @@ public abstract class BaseClearExpressionCommandTest<C extends BaseClearExpressi
 
     @Mock
     protected HasExpression hasExpression;
+
+    @Mock
+    protected org.uberfire.mvp.Command executeCanvasOperation;
+
+    @Mock
+    protected org.uberfire.mvp.Command undoCanvasOperation;
 
     protected E expression;
 
@@ -163,7 +165,7 @@ public abstract class BaseClearExpressionCommandTest<C extends BaseClearExpressi
         verify(uiModelMapper).fromDMNModel(eq(ROW_INDEX),
                                            eq(COLUMN_INDEX));
 
-        verify(gridLayer).batch();
+        verify(executeCanvasOperation).execute();
     }
 
     @Test
@@ -177,7 +179,7 @@ public abstract class BaseClearExpressionCommandTest<C extends BaseClearExpressi
                                       eq(COLUMN_INDEX),
                                       eq(gridCellValue));
 
-        verify(gridLayer).batch();
+        verify(undoCanvasOperation).execute();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommandTest.java
@@ -69,7 +69,8 @@ public class ClearExpressionTypeCommandTest extends BaseClearExpressionCommandTe
                                               hasExpression,
                                               uiModelMapper,
                                               expressionGridCache,
-                                              gridLayer::batch);
+                                              executeCanvasOperation,
+                                              undoCanvasOperation);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtilsTest.java
@@ -259,39 +259,6 @@ public class CommandUtilsTest {
         Assertions.assertThat(CommandUtils.extractGridCellValue(cellTuple)).hasValue(gridCellValue);
     }
 
-    @Test
-    public void testExtractColumnWidths() {
-        final GridColumn uiColumn1 = new RowNumberColumn();
-        final GridColumn uiColumn2 = new RowNumberColumn();
-        uiColumn1.setWidth(100.0);
-        uiColumn2.setWidth(200.0);
-        uiModel.appendColumn(uiColumn1);
-        uiModel.appendColumn(uiColumn2);
-
-        final List<Double> columnWidths = CommandUtils.extractColumnWidths(uiModel);
-
-        Assertions.assertThat(columnWidths).containsExactly(100.0, 200.0);
-    }
-
-    @Test
-    public void testRestoreColumnWidths() {
-        final GridColumn uiColumn1 = new RowNumberColumn();
-        final GridColumn uiColumn2 = new RowNumberColumn();
-        uiColumn1.setWidth(100.0);
-        uiColumn2.setWidth(200.0);
-        uiModel.appendColumn(uiColumn1);
-        uiModel.appendColumn(uiColumn2);
-
-        final List<Double> columnWidths = CommandUtils.extractColumnWidths(uiModel);
-
-        uiColumn1.setWidth(300.0);
-        uiColumn2.setWidth(500.0);
-
-        CommandUtils.restoreColumnWidths(uiModel, columnWidths);
-
-        Assertions.assertThat(columnWidths).containsExactly(100.0, 200.0);
-    }
-
     private void assertParentInformationValues(final int expressionColumnIndex) {
         IntStream.range(0, ROW_COUNT)
                 .forEach(rowIndex -> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
@@ -61,6 +61,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextBoxS
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
@@ -326,6 +327,10 @@ public class ContextGridTest {
                                                            expression,
                                                            hasName,
                                                            nesting).get());
+
+        when(parent.getGridWidget()).thenReturn(gridWidget);
+        when(parent.getRowIndex()).thenReturn(0);
+        when(parent.getColumnIndex()).thenReturn(2);
     }
 
     @Test
@@ -617,7 +622,7 @@ public class ContextGridTest {
 
         addContextEntry(0);
 
-        verify(parent).proposeContainingColumnWidth(eq(grid.getWidth() + grid.getPadding() * 2));
+        verify(parent).proposeContainingColumnWidth(eq(grid.getWidth() + grid.getPadding() * 2), eq(BaseExpressionGrid.RESIZE_EXISTING));
 
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         verify(gridPanel).refreshScrollPosition();
@@ -638,6 +643,7 @@ public class ContextGridTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testAddContextEntryAutoEditContextEntryName() {
         setupGrid(0);
         final InOrder inOrder = Mockito.inOrder(grid);
@@ -696,7 +702,30 @@ public class ContextGridTest {
         final ClearExpressionTypeCommand clearExpressionTypeCommand = clearExpressionTypeCommandCaptor.getValue();
         clearExpressionTypeCommand.execute(canvasHandler);
 
-        verify(undefinedExpressionEditor).resizeWhenExpressionEditorChanged();
+        verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+        verify(gridLayer).select(gridWidget);
+        verify(gridWidget).selectCell(eq(0),
+                                      eq(2),
+                                      eq(false),
+                                      eq(false));
+        verify(gridLayer).batch(redrawCommandCaptor.capture());
+        redrawCommandCaptor.getValue().execute();
+        verify(gridLayer).draw();
+
+        //Check undo operation
+        reset(grid, gridLayer);
+        clearExpressionTypeCommand.undo(canvasHandler);
+
+        //Verify Expression has been restored and UndefinedExpressionEditor resized
+        assertThat(grid.getModel().getColumns().get(2).getWidth()).isEqualTo(DMNGridColumn.DEFAULT_WIDTH);
+        verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
+        verify(gridLayer).select(grid);
+        verify(grid).selectFirstCell();
+
+        verify(gridLayer).batch(redrawCommandCaptor.capture());
+        assertThat(redrawCommandCaptor.getAllValues()).hasSize(2);
+        redrawCommandCaptor.getAllValues().get(1).execute();
+        verify(gridLayer).draw();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -258,6 +258,7 @@ public class LiteralExpressionGridTest {
 
         verify(parentGridUiModel).clearSelections();
         verify(parentGridUiModel).selectCell(eq(0), eq(1));
+        verify(gridLayer).select(parentGridWidget);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTupleTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTupleTest.java
@@ -63,7 +63,7 @@ public class GridCellTupleTest {
     public void testProposeContainingColumnWidthWhenLargerThanExisting() {
         when(gridColumn.getWidth()).thenReturn(100.0);
 
-        tuple.proposeContainingColumnWidth(200.0);
+        tuple.proposeContainingColumnWidth(200.0, BaseExpressionGrid.RESIZE_EXISTING);
 
         verify(gridColumn).setWidth(200.0);
     }
@@ -72,7 +72,7 @@ public class GridCellTupleTest {
     public void testProposeContainingColumnWidthWhenSmallerThanExisting() {
         when(gridColumn.getWidth()).thenReturn(100.0);
 
-        tuple.proposeContainingColumnWidth(50.0);
+        tuple.proposeContainingColumnWidth(50.0, BaseExpressionGrid.RESIZE_EXISTING);
 
         verify(gridColumn).setWidth(50.0);
     }
@@ -84,9 +84,9 @@ public class GridCellTupleTest {
         when(existingEditor.getMinimumWidth()).thenReturn(200.0);
         when(gridColumn.getWidth()).thenReturn(100.0);
 
-        tuple.proposeContainingColumnWidth(50.0);
+        tuple.proposeContainingColumnWidth(50.0, BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
 
-        verify(gridColumn).setWidth(200.0);
+        verify(gridColumn).setWidth(220.0);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class GridCellTupleTest {
         when(existingEditor.getMinimumWidth()).thenReturn(200.0);
         when(gridColumn.getWidth()).thenReturn(100.0);
 
-        tuple.proposeContainingColumnWidth(300.0);
+        tuple.proposeContainingColumnWidth(300.0, BaseExpressionGrid.RESIZE_EXISTING);
 
         verify(gridColumn).setWidth(300.0);
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2921

This PR fixes the reported issue and also tidies up the code relating to nested grid resizing and cell selection (of "new" nested Expression editors when chosen from the "Undefined" Expression editor selector). Behaviour seems vastly improved on this front and in association with undo/redo operations too.