### PR TITLE
DROOLS-2954: [DMN Designer] [IE11] Custom data type select box not rendered correctly after change

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypeModalView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypeModalView.less
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.modal-dialog {
+  left: 50%;
+  margin-left: -400px;
+  position: fixed;
+  width: 800px;
+}


### PR DESCRIPTION
It fixes [DROOLS-2954](https://issues.jboss.org/browse/DROOLS-2954) and [DROOLS-2953](https://issues.jboss.org/browse/DROOLS-2953).

The issue is in the way that IE11 handles z-index. Setting the modal-dialog with a fixed position prevents IE11 to reorder z-index of children elements in a wrong way, with no side-effects in others browsers.