### PR TITLE
Drools 2762: [DMN Editor] Custom data-types - "Add row" component - this component creates new lines (in the treegrid-table)

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypeModal.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypeModal.java
@@ -22,9 +22,13 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.Node;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManagerStackStore;
 import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeList;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.DataTypeStore;
@@ -33,8 +37,6 @@ import org.uberfire.ext.editor.commons.client.file.popups.elemental2.Elemental2M
 
 @ApplicationScoped
 public class DataTypeModal extends Elemental2Modal<DataTypeModal.View> {
-
-    private static final String MODAL_WIDTH = "800px";
 
     private final DataTypeList treeList;
 
@@ -46,13 +48,16 @@ public class DataTypeModal extends Elemental2Modal<DataTypeModal.View> {
 
     private final DataTypeManager dataTypeManager;
 
+    private final DataTypeManagerStackStore stackIndex;
+
     @Inject
     public DataTypeModal(final View view,
                          final DataTypeList treeList,
                          final ItemDefinitionUtils itemDefinitionUtils,
                          final ItemDefinitionStore definitionStore,
                          final DataTypeStore dataTypeStore,
-                         final DataTypeManager dataTypeManager) {
+                         final DataTypeManager dataTypeManager,
+                         final DataTypeManagerStackStore stackIndex) {
         super(view);
 
         this.treeList = treeList;
@@ -60,12 +65,13 @@ public class DataTypeModal extends Elemental2Modal<DataTypeModal.View> {
         this.definitionStore = definitionStore;
         this.dataTypeStore = dataTypeStore;
         this.dataTypeManager = dataTypeManager;
+        this.stackIndex = stackIndex;
     }
 
     @PostConstruct
     public void setup() {
         super.setup();
-        setWidth(MODAL_WIDTH);
+        setDataTypeModalCSSClasses();
         getView().setup(treeList);
     }
 
@@ -78,6 +84,7 @@ public class DataTypeModal extends Elemental2Modal<DataTypeModal.View> {
     void cleanDataTypeStore() {
         definitionStore.clear();
         dataTypeStore.clear();
+        stackIndex.clear();
     }
 
     void loadDataTypes() {
@@ -94,6 +101,20 @@ public class DataTypeModal extends Elemental2Modal<DataTypeModal.View> {
 
     void superShow() {
         super.show();
+    }
+
+    void setDataTypeModalCSSClasses() {
+        final Element modalDialogElement = getModalDialogElement();
+        modalDialogElement.classList.add("kie-data-types-modal");
+    }
+
+    Element getModalDialogElement() {
+        final HTMLElement body = getView().getBody();
+        final Node modalBodyNode = body.parentNode;
+        final Node modalContentNode = modalBodyNode.parentNode;
+        final Node modalDialogNode = modalContentNode.parentNode;
+        final Node modalParentNode = modalDialogNode.parentNode;
+        return modalParentNode.querySelector(".modal-dialog");
     }
 
     public interface View extends Elemental2Modal.View<DataTypeModal> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypeModalView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypeModalView.less
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,32 +14,31 @@
  * limitations under the License.
  */
 
-[data-i18n-prefix="DataTypeListView."] {
-  h3 {
-    font-weight: 600;
-    font-size: 14px;
-    margin: 5px 0 10px;
-  }
+.kie-data-types-modal {
 
-  .description-buttons {
-    text-align: right;
-    margin-bottom: 15px;
+  &.modal-dialog {
+    width: 800px;
+    height: ~"calc(100% - 60px)";
 
-    a {
-      float: left;
-    }
+    .modal-content {
+      height: ~"calc(100% - 60px)";
 
-    .btn {
-      padding-right: 15px;
-      padding-left: 15px;
+      .modal-body {
+        height: ~"calc(100% - 40px)";
 
-      i {
-        padding-right: 3px;
+        [data-field="body"] {
+          height: 100%;
+
+          [data-i18n-prefix="DataTypeListView."] {
+            height: 100%;
+
+            [data-field="list-items"] {
+              height: ~"calc(100% - 120px)";
+              overflow-y: scroll;
+            }
+          }
+        }
       }
     }
-  }
-
-  ul {
-    padding: 0 15px;
   }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtils.java
@@ -14,32 +14,18 @@
  * limitations under the License.
  */
 
-[data-i18n-prefix="DataTypeListView."] {
-  h3 {
-    font-weight: 600;
-    font-size: 14px;
-    margin: 5px 0 10px;
-  }
+package org.kie.workbench.common.dmn.client.editors.types.common;
 
-  .description-buttons {
-    text-align: right;
-    margin-bottom: 15px;
+import java.util.Objects;
+import java.util.stream.Stream;
 
-    a {
-      float: left;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+
+public class BuiltInTypeUtils {
+
+    public static boolean isDefault(final String type) {
+        return Stream
+                .of(BuiltInType.values())
+                .anyMatch(dataType -> Objects.equals(dataType.getName(), type));
     }
-
-    .btn {
-      padding-right: 15px;
-      padding-left: 15px;
-
-      i {
-        padding-right: 3px;
-      }
-    }
-  }
-
-  ul {
-    padding: 0 15px;
-  }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataType.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataType.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.editors.types.common;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.kie.workbench.common.dmn.client.editors.types.persistence.ActiveRecord;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.ItemDefinitionRecordEngine;
@@ -91,6 +92,6 @@ public class DataType extends ActiveRecord<DataType> {
     }
 
     public boolean isTopLevel() {
-        return getParentUUID().equals(TOP_LEVEL_PARENT_UUID);
+        return Objects.equals(getParentUUID(), TOP_LEVEL_PARENT_UUID);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerStackStore.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerStackStore.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Stores the stack hierarchy for each Data Type, indexed by UUID.
+ * <p>
+ * e.g.
+ * * - tPerson
+ * *    - name (Text)
+ * *    - age (Number)
+ * *    - city (tCity)
+ * *        - name (Text)
+ * *        - mayor (tPerson) <-- The "tPerson" type is already represented at this point.
+ */
+@ApplicationScoped
+public class DataTypeManagerStackStore {
+
+    private final Map<String, List<String>> typeStack = new HashMap<>();
+
+    public List<String> get(final String uuid) {
+        return Optional.ofNullable(typeStack.get(uuid)).orElse(new ArrayList<>());
+    }
+
+    public void put(final String uuid,
+                    final List<String> types) {
+        typeStack.put(uuid, types);
+    }
+
+    public void clear() {
+        typeStack.clear();
+    }
+
+    int size() {
+        return typeStack.size();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.html
@@ -19,21 +19,23 @@
         <button data-field="edit-button" class="btn btn-sm btn-default" data-i18n-key="Edit"></button>
         <button data-field="save-button" class="btn btn-sm btn-default" data-i18n-key="Save"></button>
         <button data-field="close-button" class="btn btn-sm btn-default close-button">✖</button>
-        <div class="dropdown pull-right dropdown-kebab-pf">
-            <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span class="fa fa-ellipsis-v"></span>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-right">
-                <li><a data-field="remove-button" href="#" data-i18n-key="Remove"></a></li>
-                <li role="separator" class="divider"></li>
-                <li><a href="#" data-i18n-key="InsertFieldAbove"></a></li>
-                <li><a href="#" data-i18n-key="InsertFieldBelow"></a></li>
-                <li role="separator" class="divider"></li>
-                <li><a href="#" data-i18n-key="InsertNestedField"></a></li>
-                <li role="separator" class="divider"></li>
-                <li><a href="#" data-i18n-key="MoveUp"></a></li>
-                <li><a href="#" data-i18n-key="MoveDown"></a></li>
-            </ul>
+        <div data-field="kebab-menu" class="dropdown-kebab-container">
+            <div class="dropdown pull-right dropdown-kebab-pf">
+                <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                    <span class="fa fa-ellipsis-v"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                    <li><a data-field="remove-button" href="#" data-i18n-key="Remove"></a></li>
+                    <li role="separator" class="divider"></li>
+                    <li><a href="#" data-i18n-key="InsertFieldAbove"></a></li>
+                    <li><a href="#" data-i18n-key="InsertFieldBelow"></a></li>
+                    <li role="separator" class="divider"></li>
+                    <li><a href="#" data-i18n-key="InsertNestedField"></a></li>
+                    <li role="separator" class="divider"></li>
+                    <li><a href="#" data-i18n-key="MoveUp"></a></li>
+                    <li><a href="#" data-i18n-key="MoveDown"></a></li>
+                </ul>
+            </div>
         </div>
     </div>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.types.listview;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -37,6 +38,7 @@ import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.HiddenHelper;
+import org.kie.workbench.common.dmn.client.editors.types.listview.common.KebabMenuInitializer;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.ListItemViewCssHelper;
 
 import static org.kie.workbench.common.dmn.client.editors.types.listview.common.HiddenHelper.hide;
@@ -89,6 +91,9 @@ public class DataTypeListItemView implements DataTypeListItem.View {
     @DataField("remove-button")
     private final HTMLAnchorElement removeButton;
 
+    @DataField("kebab-menu")
+    private HTMLDivElement kebabMenu;
+
     private DataTypeListItem presenter;
 
     @Inject
@@ -101,7 +106,8 @@ public class DataTypeListItemView implements DataTypeListItem.View {
                                 final HTMLButtonElement editButton,
                                 final HTMLButtonElement saveButton,
                                 final HTMLButtonElement closeButton,
-                                final HTMLAnchorElement removeButton) {
+                                final HTMLAnchorElement removeButton,
+                                final HTMLDivElement kebabMenu) {
         this.view = view;
         this.level = level;
         this.arrow = arrow;
@@ -112,6 +118,12 @@ public class DataTypeListItemView implements DataTypeListItem.View {
         this.saveButton = saveButton;
         this.closeButton = closeButton;
         this.removeButton = removeButton;
+        this.kebabMenu = kebabMenu;
+    }
+
+    @PostConstruct
+    public void setupKebabElement() {
+        new KebabMenuInitializer(kebabMenu).init();
     }
 
     @Override
@@ -144,12 +156,6 @@ public class DataTypeListItemView implements DataTypeListItem.View {
     void setupNameComponent(final DataType dataType) {
         hide(nameInput);
         setName(dataType.getName());
-    }
-
-    @Override
-    public void setName(final String name) {
-        nameText.textContent = name;
-        nameInput.value = name;
     }
 
     void setupActionButtons() {
@@ -244,6 +250,12 @@ public class DataTypeListItemView implements DataTypeListItem.View {
     @Override
     public String getName() {
         return nameInput.value;
+    }
+
+    @Override
+    public void setName(final String name) {
+        nameText.textContent = name;
+        nameInput.value = name;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
@@ -23,7 +23,7 @@
   &.list-group-item {
     border-color: #e2e4e3;
     height: 50px;
-    padding: 0;
+    padding: 0 5px 0 0;
   }
 
   &.focused-data-type {
@@ -97,5 +97,11 @@
 
   ul.dropdown-menu {
     padding: 3px 0;
+  }
+
+  .dropdown-kebab-container {
+    float: right;
+    margin: 0;
+    width: 20px;
   }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.html
@@ -18,7 +18,6 @@
     <h3 data-i18n-key="Title"></h3>
     <div class="description" data-field="collapsed-description">
         <p data-i18n-key="CollapsedText"></p>
-        <a data-field="view-more" href="#"><span data-i18n-key="ViewMore"></span> »</a>
     </div>
     <div class="description" data-field="expanded-description">
         <p data-i18n-key="ExpandedText1"></p>
@@ -34,7 +33,14 @@
                 <span data-i18n-key="ExpandedText4"></span>
             </li>
         </ul>
+    </div>
+    <div class="description-buttons">
+        <a data-field="view-more" href="#"><span data-i18n-key="ViewMore"></span> »</a>
         <a data-field="view-less" href="#">« <span data-i18n-key="ViewLess"></span></a>
+        <button data-field="add-button" class="btn btn-sm btn-primary">
+            <i class="fa fa-plus-circle"></i>
+            <span data-i18n-key="Add"></span>
+        </button>
     </div>
     <div data-field="list-items" class="pf-list-compound-expansion">
     </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/JQuery.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/JQuery.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.listview.common;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import elemental2.dom.Element;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
@@ -24,22 +25,26 @@ import jsinterop.annotations.JsType;
 import static jsinterop.annotations.JsPackage.GLOBAL;
 
 @JsType(isNative = true)
-public abstract class JQuerySelectPicker {
+public abstract class JQuery {
 
     @JsMethod(namespace = GLOBAL, name = "jQuery")
-    public native static JQuerySelectPicker $(final Element selector);
+    public native static JQuery $(final Element selector);
 
-    public native JQuerySelectPicker selectpicker(final String method);
+    public native JQuery animate(final JavaScriptObject properties,
+                                 final int duration);
 
-    public native JQuerySelectPicker selectpicker(final String method,
-                                                  final String value);
+    public native JQuery on(final String event,
+                            final CallbackFunction callbackFunction);
 
-    public native JQuerySelectPicker on(final String event,
-                                        final CallbackFunction callbackFunction);
+    public native JQuery append(final JQuery jQueryElement);
+
+    public native JQuery css(final JavaScriptObject properties);
+
+    public native JQuery detach();
 
     @JsFunction
     public interface CallbackFunction {
 
-        void call(final JQuerySelectPickerEvent event);
+        void call(final JQueryEvent event);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/JQueryEvent.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/JQueryEvent.java
@@ -14,32 +14,13 @@
  * limitations under the License.
  */
 
-[data-i18n-prefix="DataTypeListView."] {
-  h3 {
-    font-weight: 600;
-    font-size: 14px;
-    margin: 5px 0 10px;
-  }
+package org.kie.workbench.common.dmn.client.editors.types.listview.common;
 
-  .description-buttons {
-    text-align: right;
-    margin-bottom: 15px;
+import elemental2.dom.Element;
+import jsinterop.annotations.JsType;
 
-    a {
-      float: left;
-    }
+@JsType(isNative = true)
+public abstract class JQueryEvent {
 
-    .btn {
-      padding-right: 15px;
-      padding-left: 15px;
-
-      i {
-        padding-right: 3px;
-      }
-    }
-  }
-
-  ul {
-    padding: 0 15px;
-  }
+    public Element target;
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/KebabMenuInitializer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/KebabMenuInitializer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.common;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLDivElement;
+
+import static org.kie.workbench.common.dmn.client.editors.types.listview.common.JQuery.$;
+
+/**
+ * This class implements a workaround for the kebab menu.
+ * <p>
+ * The kebab menu cannot be affected by the "overflow: hidden" CSS property from the dialog content.
+ * Thus, this workaround moves the dropdown element to the ".modal.in" element when the menu is opened, and it
+ * moves the dropdown element back to the "kebabMenu" when the menu closed.
+ */
+public class KebabMenuInitializer {
+
+    private final HTMLDivElement kebabMenu;
+
+    public KebabMenuInitializer(final HTMLDivElement kebabMenu) {
+        this.kebabMenu = kebabMenu;
+    }
+
+    public void init() {
+        final Element dropdown = dropdown();
+
+        $(dropdown).on("show.bs.dropdown", moveDropDownToBody());
+        $(dropdown).on("hidden.bs.dropdown", moveDropDownToKebabContainer());
+    }
+
+    JQuery.CallbackFunction moveDropDownToBody() {
+        return (event) -> {
+            final JavaScriptObject properties = bodyDropdownProperties(event).getJavaScriptObject();
+            JQuery $ = $(modalInElement());
+            JQuery css = $(event.target).css(properties);
+            JQuery detach = css.detach();
+            $.append(detach);
+        };
+    }
+
+    JQuery.CallbackFunction moveDropDownToKebabContainer() {
+        return (event) -> {
+            final JavaScriptObject properties = emptyProperties().getJavaScriptObject();
+            $(kebabMenu).append($(event.target).css(properties).detach());
+        };
+    }
+
+    JSONObject bodyDropdownProperties(final JQueryEvent e) {
+        final JSONObject jsonObject = makeJsonObject();
+        jsonObject.put("position", new JSONString("absolute"));
+        jsonObject.put("zIndex", new JSONNumber(1051)); // Bootstrap modal z-index value is 1050
+        jsonObject.put("left", new JSONNumber(offsetLeft(e.target)));
+        jsonObject.put("top", new JSONNumber(offsetTop(e.target)));
+        return jsonObject;
+    }
+
+    JSONObject emptyProperties() {
+        final JSONObject jsonObject = makeJsonObject();
+        jsonObject.put("position", new JSONString(""));
+        jsonObject.put("zIndex", new JSONString(""));
+        jsonObject.put("left", new JSONString(""));
+        jsonObject.put("top", new JSONString(""));
+        return jsonObject;
+    }
+
+    JSONObject makeJsonObject() {
+        return new JSONObject();
+    }
+
+    Element modalInElement() {
+        return DomGlobal.document.querySelector(".modal.in");
+    }
+
+    Element dropdown() {
+        return kebabMenu.querySelector(".dropdown");
+    }
+
+    double offsetLeft(final Element target) {
+        return target.getBoundingClientRect().left + modalInElement().scrollLeft;
+    }
+
+    double offsetTop(final Element target) {
+        return target.getBoundingClientRect().top + modalInElement().scrollTop;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ActiveRecord.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ActiveRecord.java
@@ -38,8 +38,8 @@ public abstract class ActiveRecord<T> {
         return getRecordEngine().destroy(getRecord());
     }
 
-    public void create() {
-        getRecordEngine().create(getRecord());
+    public T create() {
+        return getRecordEngine().create(getRecord());
     }
 
     public RecordEngine<T> getRecordEngine() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.DataTypeDestroyHandler;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.DataTypeUpdateHandler;
+import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.ItemDefinitionCreateHandler;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.ItemDefinitionDestroyHandler;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.ItemDefinitionUpdateHandler;
 
@@ -41,6 +42,8 @@ public class ItemDefinitionRecordEngine implements RecordEngine<DataType> {
 
     private final ItemDefinitionUpdateHandler itemDefinitionUpdateHandler;
 
+    private final ItemDefinitionCreateHandler itemDefinitionCreateHandler;
+
     private final DataTypeDestroyHandler dataTypeDestroyHandler;
 
     private final DataTypeUpdateHandler dataTypeUpdateHandler;
@@ -49,11 +52,13 @@ public class ItemDefinitionRecordEngine implements RecordEngine<DataType> {
     public ItemDefinitionRecordEngine(final ItemDefinitionStore itemDefinitionStore,
                                       final ItemDefinitionDestroyHandler itemDefinitionDestroyHandler,
                                       final ItemDefinitionUpdateHandler itemDefinitionUpdateHandler,
+                                      final ItemDefinitionCreateHandler itemDefinitionCreateHandler,
                                       final DataTypeDestroyHandler dataTypeDestroyHandler,
                                       final DataTypeUpdateHandler dataTypeUpdateHandler) {
         this.itemDefinitionStore = itemDefinitionStore;
         this.itemDefinitionDestroyHandler = itemDefinitionDestroyHandler;
         this.itemDefinitionUpdateHandler = itemDefinitionUpdateHandler;
+        this.itemDefinitionCreateHandler = itemDefinitionCreateHandler;
         this.dataTypeDestroyHandler = dataTypeDestroyHandler;
         this.dataTypeUpdateHandler = dataTypeUpdateHandler;
     }
@@ -84,8 +89,8 @@ public class ItemDefinitionRecordEngine implements RecordEngine<DataType> {
     }
 
     @Override
-    public void create(final DataType record) {
-        // TODO: https://issues.jboss.org/browse/DROOLS-2762
+    public DataType create(final DataType dataType) {
+        return itemDefinitionCreateHandler.create(dataType);
     }
 
     public void doUpdate(final DataType dataType,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/RecordEngine.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/RecordEngine.java
@@ -41,5 +41,5 @@ public interface RecordEngine<T> {
      * Create a record
      * @param record
      */
-    void create(final T record);
+    T create(final T record);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.persistence.handlers;
+
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
+
+@Dependent
+public class ItemDefinitionCreateHandler {
+
+    private final DataTypeManager dataTypeManager;
+
+    private final ItemDefinitionUtils itemDefinitionUtils;
+
+    @Inject
+    public ItemDefinitionCreateHandler(final DataTypeManager dataTypeManager,
+                                       final ItemDefinitionUtils itemDefinitionUtils) {
+        this.dataTypeManager = dataTypeManager;
+        this.itemDefinitionUtils = itemDefinitionUtils;
+    }
+
+    public DataType create(final DataType dataType) {
+
+        final ItemDefinition itemDefinition = createItemDefinition();
+
+        return dataTypeManager
+                .withDataType(dataType)
+                .withItemDefinition(itemDefinition)
+                .withIndexedItemDefinition()
+                .get();
+    }
+
+    ItemDefinition createItemDefinition() {
+        final ItemDefinition itemDefinition = new ItemDefinition();
+        itemDefinitions().add(itemDefinition);
+        return itemDefinition;
+    }
+
+    private List<ItemDefinition> itemDefinitions() {
+        return itemDefinitionUtils.all();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandler.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.dmn.client.editors.types.persistence.handlers;
 
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -25,13 +24,13 @@ import javax.inject.Inject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
-import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
 import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 
 import static org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace.FEEL;
 import static org.kie.workbench.common.dmn.api.property.dmn.QName.NULL_NS_URI;
+import static org.kie.workbench.common.dmn.client.editors.types.common.BuiltInTypeUtils.isDefault;
 
 @Dependent
 public class ItemDefinitionUpdateHandler {
@@ -74,12 +73,6 @@ public class ItemDefinitionUpdateHandler {
 
     QName normaliseTypeRef(final QName typeRef) {
         return itemDefinitionUtils.normaliseTypeRef(typeRef);
-    }
-
-    boolean isDefault(final String type) {
-        return Stream
-                .of(BuiltInType.values())
-                .anyMatch(dataType -> Objects.equals(dataType.getName(), type));
     }
 
     private boolean isStructure(final DataType dataType) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
@@ -78,6 +78,7 @@ DataTypeListView.Title=Custom Data Types
 DataTypeListView.CollapsedText=Data types determine the structure of the data used in DMN decision tables. You can use basic data types (example, Boolean) or you can use this dialog to create custom data types.
 DataTypeListView.ViewMore=View more
 DataTypeListView.ViewLess=View less
+DataTypeListView.Add=Add
 DataTypeListView.ExpandedText1=Data types determine the structure of the data used in DMN decision tables. You can use basic data types (example, Boolean) or you can use this dialog to create custom data types.
 DataTypeListView.ExpandedText2=Custom data types that you create in this dialog can be Simple or Structured data types:
 DataTypeListView.ExpandedText3=data types have only a name and a type assignment. Example: "Age (Number)"

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtilsTest.java
@@ -14,32 +14,22 @@
  * limitations under the License.
  */
 
-[data-i18n-prefix="DataTypeListView."] {
-  h3 {
-    font-weight: 600;
-    font-size: 14px;
-    margin: 5px 0 10px;
-  }
+package org.kie.workbench.common.dmn.client.editors.types.common;
 
-  .description-buttons {
-    text-align: right;
-    margin-bottom: 15px;
+import org.junit.Test;
 
-    a {
-      float: left;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BuiltInTypeUtilsTest {
+
+    @Test
+    public void testIsDefaultWhenItIsDefault() {
+        assertTrue(BuiltInTypeUtils.isDefault("string"));
     }
 
-    .btn {
-      padding-right: 15px;
-      padding-left: 15px;
-
-      i {
-        padding-right: 3px;
-      }
+    @Test
+    public void testIsDefaultWhenItIsNotDefault() {
+        assertFalse(BuiltInTypeUtils.isDefault("tAddress"));
     }
-  }
-
-  ul {
-    padding: 0 15px;
-  }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerStackStoreTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerStackStoreTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.common;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+
+public class DataTypeManagerStackStoreTest {
+
+    private DataTypeManagerStackStore typeStack;
+
+    private String uuid = "123";
+
+    private List<String> types = asList("tCity", "tPerson");
+
+    @Before
+    public void setup() {
+        this.typeStack = new DataTypeManagerStackStore();
+
+        typeStack.put(uuid, types);
+    }
+
+    @Test
+    public void testGetWhenTypeStackHasTheUUID() {
+        assertEquals(types, typeStack.get(uuid));
+    }
+
+    @Test
+    public void testGetWhenTypeStackDoesNotHaveTheUUID() {
+
+        final List<Object> expectedTypes = emptyList();
+        final List<String> actualTypes = typeStack.get("otherUUID");
+
+        assertEquals(expectedTypes, actualTypes);
+    }
+
+    @Test
+    public void testPut() {
+
+        final String uuid = "456";
+        final List<String> expectedTypes = asList("tCompany", "tPerson");
+
+        typeStack.put(uuid, expectedTypes);
+
+        final List<String> actualTypes = typeStack.get(uuid);
+
+        assertEquals(expectedTypes, actualTypes);
+    }
+
+    @Test
+    public void testClear() {
+        typeStack.clear();
+
+        assertEquals(0, typeStack.size());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtilsTest.java
@@ -56,13 +56,16 @@ public class DataTypeUtilsTest {
     @Mock
     private ManagedInstance<DataTypeManager> dataTypeManagers;
 
+    @Mock
+    private DataTypeManagerStackStore typeStack;
+
     private DataTypeManager dataTypeManager;
 
     private DataTypeUtils utils;
 
     @Before
     public void setup() {
-        dataTypeManager = spy(new DataTypeManager(translationService, recordEngine, itemDefinitionStore, dataTypeStore, itemDefinitionUtils, dataTypeManagers));
+        dataTypeManager = spy(new DataTypeManager(translationService, recordEngine, itemDefinitionStore, dataTypeStore, itemDefinitionUtils, dataTypeManagers, typeStack));
         utils = spy(new DataTypeUtils(dataTypeStore, dataTypeManager));
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
@@ -22,6 +22,7 @@ import elemental2.dom.CSSProperties.MarginLeftUnionType;
 import elemental2.dom.CSSStyleDeclaration;
 import elemental2.dom.DOMTokenList;
 import elemental2.dom.Element;
+import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
@@ -93,11 +94,17 @@ public class DataTypeListItemViewTest {
     @Mock
     private HTMLElement dataTypeListElement;
 
+    @Mock
+    private HTMLAnchorElement removeButton;
+
+    @Mock
+    private HTMLDivElement kebabMenu;
+
     private DataTypeListItemView view;
 
     @Before
     public void setup() {
-        view = spy(new DataTypeListItemView(row, level, arrow, nameText, nameInput, type, editButton, saveButton, closeButton, null));
+        view = spy(new DataTypeListItemView(row, level, arrow, nameText, nameInput, type, editButton, saveButton, closeButton, removeButton, kebabMenu));
         view.init(presenter);
 
         doReturn(dataTypeListElement).when(view).dataTypeListElement();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
@@ -23,6 +23,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import elemental2.dom.DOMTokenList;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
+import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.Node;
@@ -44,6 +45,7 @@ import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTyp
 import static org.kie.workbench.common.dmn.client.editors.types.listview.common.HiddenHelper.HIDDEN_CSS_CLASS;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.common.ListItemViewCssHelper.RIGHT_ARROW_CSS_CLASS;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -78,11 +80,18 @@ public class DataTypeListViewTest {
     @Mock
     private HTMLElement element;
 
+    @Mock
+    private HTMLButtonElement addButton;
+
+    @Mock
+    private DataTypeList presenter;
+
     private DataTypeListView view;
 
     @Before
     public void setup() {
-        view = spy(new DataTypeListView(listItems, collapsedDescription, expandedDescription, viewMore, viewLess));
+        view = spy(new DataTypeListView(listItems, collapsedDescription, expandedDescription, viewMore, viewLess, addButton));
+        view.init(presenter);
         doReturn(element).when(view).getElement();
     }
 
@@ -164,6 +173,34 @@ public class DataTypeListViewTest {
         verifyStatic();
         ElementHelper.insertAfter(listItemElement1, dataTypeRow);
         ElementHelper.insertAfter(listItemElement2, listItemElement1);
+    }
+
+    @Test
+    public void testAddSubItem() {
+
+        final DataTypeListItem listItem = mock(DataTypeListItem.class);
+        final HTMLElement element = mock(HTMLElement.class);
+
+        when(listItem.getElement()).thenReturn(element);
+
+        view.addSubItem(listItem);
+
+        verify(listItems).appendChild(element);
+    }
+
+    @Test
+    public void testOnAddClick() {
+
+        final ClickEvent event = mock(ClickEvent.class);
+        final double expectedScrollTop = 200d;
+
+        doNothing().when(view).scrollTo(any(), anyDouble());
+        listItems.scrollHeight = expectedScrollTop;
+
+        view.onAddClick(event);
+
+        verify(view).scrollTo(listItems, expectedScrollTop);
+        verify(presenter).addDataType();
     }
 
     @Test
@@ -308,6 +345,8 @@ public class DataTypeListViewTest {
 
         assertTrue(collapsedDescription.hidden);
         assertFalse(expandedDescription.hidden);
+        assertFalse(viewLess.hidden);
+        assertTrue(viewMore.hidden);
     }
 
     @Test
@@ -316,6 +355,8 @@ public class DataTypeListViewTest {
 
         assertFalse(collapsedDescription.hidden);
         assertTrue(expandedDescription.hidden);
+        assertTrue(viewLess.hidden);
+        assertFalse(viewMore.hidden);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/KebabMenuInitializerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/KebabMenuInitializerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.common;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@PrepareForTest({JQuery.class})
+@RunWith(PowerMockRunner.class)
+public class KebabMenuInitializerTest {
+
+    @Mock
+    private HTMLDivElement kebabMenu;
+
+    private KebabMenuInitializer initializer;
+
+    @Before
+    public void setup() {
+        this.initializer = spy(new KebabMenuInitializer(kebabMenu));
+    }
+
+    @Test
+    public void testInit() {
+
+        final JQuery jQuery = mock(JQuery.class);
+        final JQuery.CallbackFunction moveDropDownToBody = mock(JQuery.CallbackFunction.class);
+        final JQuery.CallbackFunction moveDropDownToKebabContainer = mock(JQuery.CallbackFunction.class);
+        final Element dropdown = mock(Element.class);
+
+        doReturn(dropdown).when(initializer).dropdown();
+        doReturn(moveDropDownToBody).when(initializer).moveDropDownToBody();
+        doReturn(moveDropDownToKebabContainer).when(initializer).moveDropDownToKebabContainer();
+
+        mockStatic(JQuery.class);
+        PowerMockito.when(JQuery.$(dropdown)).thenReturn(jQuery);
+
+        initializer.init();
+
+        verify(jQuery).on("show.bs.dropdown", moveDropDownToBody);
+        verify(jQuery).on("hidden.bs.dropdown", moveDropDownToKebabContainer);
+    }
+
+    @Test
+    public void testMoveDropDownToBody() {
+
+        final HTMLElement modalInElement = mock(HTMLElement.class);
+        final HTMLElement target = mock(HTMLElement.class);
+        final JQuery jQueryModalIn = mock(JQuery.class);
+        final JQuery jQueryTarget = mock(JQuery.class);
+        final JQuery jQueryCSS = mock(JQuery.class);
+        final JQuery jQueryDetach = mock(JQuery.class);
+        final JQueryEvent event = mock(JQueryEvent.class);
+        final JSONObject jsonObjectProperties = mock(JSONObject.class);
+        final JavaScriptObject javaScriptObjectProperties = mock(JavaScriptObject.class);
+
+        event.target = target;
+        doReturn(jsonObjectProperties).when(initializer).bodyDropdownProperties(event);
+        doReturn(modalInElement).when(initializer).modalInElement();
+        when(jsonObjectProperties.getJavaScriptObject()).thenReturn(javaScriptObjectProperties);
+        when(jQueryTarget.css(javaScriptObjectProperties)).thenReturn(jQueryCSS);
+        when(jQueryCSS.detach()).thenReturn(jQueryDetach);
+
+        mockStatic(JQuery.class);
+        PowerMockito.when(JQuery.$(modalInElement)).thenReturn(jQueryModalIn);
+        PowerMockito.when(JQuery.$(target)).thenReturn(jQueryTarget);
+
+        initializer.moveDropDownToBody().call(event);
+
+        verify(jQueryModalIn).append(jQueryDetach);
+    }
+
+    @Test
+    public void testMoveDropDownToKebabContainer() {
+
+        final HTMLElement modalInElement = mock(HTMLElement.class);
+        final HTMLElement target = mock(HTMLElement.class);
+        final JQuery jQueryModalIn = mock(JQuery.class);
+        final JQuery jQueryTarget = mock(JQuery.class);
+        final JQuery jQueryCSS = mock(JQuery.class);
+        final JQuery jQueryDetach = mock(JQuery.class);
+        final JQueryEvent event = mock(JQueryEvent.class);
+        final JSONObject jsonObjectProperties = mock(JSONObject.class);
+        final JavaScriptObject javaScriptObjectProperties = mock(JavaScriptObject.class);
+
+        event.target = target;
+        doReturn(jsonObjectProperties).when(initializer).emptyProperties();
+        doReturn(modalInElement).when(initializer).modalInElement();
+        when(jsonObjectProperties.getJavaScriptObject()).thenReturn(javaScriptObjectProperties);
+        when(jQueryTarget.css(javaScriptObjectProperties)).thenReturn(jQueryCSS);
+        when(jQueryCSS.detach()).thenReturn(jQueryDetach);
+
+        mockStatic(JQuery.class);
+        PowerMockito.when(JQuery.$(kebabMenu)).thenReturn(jQueryModalIn);
+        PowerMockito.when(JQuery.$(target)).thenReturn(jQueryTarget);
+
+        initializer.moveDropDownToKebabContainer().call(event);
+
+        verify(jQueryModalIn).append(jQueryDetach);
+    }
+
+    @Test
+    public void testBodyDropdownProperties() {
+
+        final JQueryEvent event = mock(JQueryEvent.class);
+        final HTMLElement target = mock(HTMLElement.class);
+        final double left = 1d;
+        final double top = 1d;
+        final JSONObject expectedJSONObject = mock(JSONObject.class);
+
+        // Mock "JSONObject" since it relies on a native implementation.
+        doReturn(expectedJSONObject).when(initializer).makeJsonObject();
+
+        event.target = target;
+        doReturn(left).when(initializer).offsetLeft(target);
+        doReturn(top).when(initializer).offsetTop(target);
+
+        final JSONObject actualJSONObject = initializer.bodyDropdownProperties(event);
+
+        verify(expectedJSONObject).put("position", new JSONString("absolute"));
+        verify(expectedJSONObject).put("zIndex", new JSONNumber(1051));
+        verify(expectedJSONObject).put("left", new JSONNumber(left));
+        verify(expectedJSONObject).put("top", new JSONNumber(top));
+        assertEquals(expectedJSONObject, actualJSONObject);
+    }
+
+    @Test
+    public void testEmptyProperties() {
+
+        final JSONObject expectedJSONObject = mock(JSONObject.class);
+
+        // Mock "JSONObject" since it relies on a native implementation.
+        doReturn(expectedJSONObject).when(initializer).makeJsonObject();
+
+        final JSONObject actualJSONObject = initializer.emptyProperties();
+
+        verify(expectedJSONObject).put("position", new JSONString(""));
+        verify(expectedJSONObject).put("zIndex", new JSONString(""));
+        verify(expectedJSONObject).put("left", new JSONString(""));
+        verify(expectedJSONObject).put("top", new JSONString(""));
+        assertEquals(expectedJSONObject, actualJSONObject);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ActiveRecordTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ActiveRecordTest.java
@@ -107,6 +107,7 @@ public class ActiveRecordTest {
 
     private RecordEngine<Data> makeRecordEngine() {
         return spy(new RecordEngine<Data>() {
+
             @Override
             public List<Data> update(final Data record) {
                 return null;
@@ -118,8 +119,8 @@ public class ActiveRecordTest {
             }
 
             @Override
-            public void create(final Data record) {
-
+            public Data create(final Data record) {
+                return null;
             }
         });
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.DataTypeDestroyHandler;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.DataTypeUpdateHandler;
+import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.ItemDefinitionCreateHandler;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.ItemDefinitionDestroyHandler;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.ItemDefinitionUpdateHandler;
 import org.mockito.Mock;
@@ -51,6 +52,9 @@ public class ItemDefinitionRecordEngineTest {
     private ItemDefinitionUpdateHandler itemDefinitionUpdateHandler;
 
     @Mock
+    private ItemDefinitionCreateHandler itemDefinitionCreateHandler;
+
+    @Mock
     private DataTypeDestroyHandler dataTypeDestroyHandler;
 
     @Mock
@@ -60,7 +64,7 @@ public class ItemDefinitionRecordEngineTest {
 
     @Before
     public void setup() {
-        recordEngine = spy(new ItemDefinitionRecordEngine(itemDefinitionStore, itemDefinitionDestroyHandler, itemDefinitionUpdateHandler, dataTypeDestroyHandler, dataTypeUpdateHandler));
+        recordEngine = spy(new ItemDefinitionRecordEngine(itemDefinitionStore, itemDefinitionDestroyHandler, itemDefinitionUpdateHandler, itemDefinitionCreateHandler, dataTypeDestroyHandler, dataTypeUpdateHandler));
     }
 
     @Test
@@ -117,6 +121,19 @@ public class ItemDefinitionRecordEngineTest {
 
         verify(recordEngine).doDestroy(dataType);
         assertEquals(expectedDependentDataTypes, actualDependentDataTypes);
+    }
+
+    @Test
+    public void testCreate() {
+
+        final DataType dataType = mock(DataType.class);
+        final DataType expectedDataType = mock(DataType.class);
+
+        when(itemDefinitionCreateHandler.create(dataType)).thenReturn(expectedDataType);
+
+        final DataType actualDataType = recordEngine.create(dataType);
+
+        assertEquals(expectedDataType, actualDataType);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.persistence.handlers;
+
+import java.util.ArrayList;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ItemDefinitionCreateHandlerTest {
+
+    @Mock
+    private DataTypeManager dataTypeManager;
+
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
+
+    private ItemDefinitionCreateHandler handler;
+
+    @Before
+    public void setup() {
+        handler = spy(new ItemDefinitionCreateHandler(dataTypeManager, itemDefinitionUtils));
+    }
+
+    @Test
+    public void testCreate() {
+
+        final DataType expectedDataType = mock(DataType.class);
+        final ItemDefinition itemDefinition = mock(ItemDefinition.class);
+
+        doReturn(itemDefinition).when(handler).createItemDefinition();
+        when(dataTypeManager.withDataType(any())).thenReturn(dataTypeManager);
+        when(dataTypeManager.withItemDefinition(any())).thenReturn(dataTypeManager);
+        when(dataTypeManager.withIndexedItemDefinition()).thenReturn(dataTypeManager);
+        when(dataTypeManager.get()).thenReturn(expectedDataType);
+
+        final DataType actualDataType = handler.create(expectedDataType);
+        final InOrder inOrder = Mockito.inOrder(dataTypeManager);
+
+        inOrder.verify(dataTypeManager).withDataType(expectedDataType);
+        inOrder.verify(dataTypeManager).withItemDefinition(itemDefinition);
+        inOrder.verify(dataTypeManager).withIndexedItemDefinition();
+        inOrder.verify(dataTypeManager).get();
+
+        assertEquals(expectedDataType, actualDataType);
+    }
+
+    @Test
+    public void testCreateItemDefinition() {
+
+        when(itemDefinitionUtils.all()).thenReturn(new ArrayList<>());
+
+        final ItemDefinition itemDefinition = handler.createItemDefinition();
+
+        assertTrue(itemDefinitionUtils.all().contains(itemDefinition));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandlerTest.java
@@ -33,7 +33,6 @@ import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -108,16 +107,6 @@ public class ItemDefinitionUpdateHandlerTest {
     }
 
     @Test
-    public void testIsDefaultWhenItIsDefault() {
-        assertTrue(handler.isDefault("string"));
-    }
-
-    @Test
-    public void testIsDefaultWhenItIsNotDefault() {
-        assertFalse(handler.isDefault("tAddress"));
-    }
-
-    @Test
     public void testMakeName() {
 
         final DataType dataType = mock(DataType.class);
@@ -136,7 +125,6 @@ public class ItemDefinitionUpdateHandlerTest {
         final DataType dataType = mock(DataType.class);
         final String expectedName = "string";
 
-        doReturn(true).when(handler).isDefault(expectedName);
         when(dataType.getType()).thenReturn(expectedName);
 
         final QName name = handler.makeQName(dataType);
@@ -151,7 +139,6 @@ public class ItemDefinitionUpdateHandlerTest {
         final DataType dataType = mock(DataType.class);
         final String expectedName = "tAddress";
 
-        doReturn(false).when(handler).isDefault(expectedName);
         when(dataType.getType()).thenReturn(expectedName);
 
         final QName name = handler.makeQName(dataType);


### PR DESCRIPTION
See:
- [DROOLS-2762](https://issues.jboss.org/browse/DROOLS-2762): [DMN Editor] Custom data-types - "Add row" component - this component creates new lines (in the treegrid-table)
- [DROOLS-2842](https://issues.jboss.org/browse/DROOLS-2842): [DMN Designer] Recursive item definitions

![drools 2762](https://user-images.githubusercontent.com/1079279/45838311-cd24ac00-bce7-11e8-96da-f04b447f28b3.gif)

---

PS.: I'm planing to handle scenarios related to nested data types in the next Sprints/JIRAs, because they will involve code related to ordering/sorting features. Thus, the following buttons still don't have any action:
<img width="186" alt="add-nested" src="https://user-images.githubusercontent.com/1079279/45838439-196fec00-bce8-11e8-9e81-2a3977cf519f.png">

