### PR TITLE
DROOLS-3010: [DMN Designer] Regression - Unable to add InputClause columns

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -181,7 +181,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
 
     private InputClauseColumn makeInputClauseColumn(final InputClause ic) {
         final InputClauseColumn column = new InputClauseColumn(new InputClauseColumnHeaderMetaData(wrapInputClauseIntoHasName(ic),
-                                                                                                   ic.getInputExpression(),
+                                                                                                   ic::getInputExpression,
                                                                                                    clearDisplayNameConsumer(false),
                                                                                                    setDisplayNameConsumer(false),
                                                                                                    setTypeRefConsumer(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/InputClauseColumnHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/InputClauseColumnHeaderMetaData.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
@@ -34,7 +35,7 @@ public class InputClauseColumnHeaderMetaData extends NameAndDataTypeHeaderMetaDa
     private static final String NAME_DATA_TYPE_COLUMN_GROUP = "InputClauseColumnHeaderMetaData$NameAndDataTypeColumn";
 
     public InputClauseColumnHeaderMetaData(final HasName hasName,
-                                           final LiteralExpression hasTypeRef,
+                                           final Supplier<LiteralExpression> hasTypeRef,
                                            final Consumer<HasName> clearDisplayNameConsumer,
                                            final BiConsumer<HasName, Name> setDisplayNameConsumer,
                                            final BiConsumer<HasTypeRef, QName> setTypeRefConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumnHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumnHeaderMetaData.java
@@ -41,7 +41,7 @@ public class OutputClauseColumnHeaderMetaData extends NameAndDataTypeHeaderMetaD
                                             final CellEditorControlsView.Presenter cellEditorControls,
                                             final NameAndDataTypeEditorView.Presenter headerEditor) {
         super(Optional.of(hasName),
-              hasTypeRef,
+              () -> hasTypeRef,
               clearDisplayNameConsumer,
               setDisplayNameConsumer,
               setTypeRefConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumnHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumnHeaderMetaData.java
@@ -41,7 +41,7 @@ public class RelationColumnHeaderMetaData extends NameAndDataTypeHeaderMetaData<
                                         final CellEditorControlsView.Presenter cellEditorControls,
                                         final NameAndDataTypeEditorView.Presenter headerEditor) {
         super(Optional.ofNullable(variable),
-              variable,
+              () -> variable,
               clearDisplayNameConsumer,
               setDisplayNameConsumer,
               setTypeRefConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaData.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
@@ -36,7 +37,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellE
 public abstract class NameAndDataTypeHeaderMetaData<E extends Expression> extends EditablePopupHeaderMetaData<HasNameAndTypeRef, NameAndDataTypeEditorView.Presenter> implements HasNameAndTypeRef {
 
     private final Optional<HasName> hasName;
-    private final HasTypeRef hasTypeRef;
+    private final Supplier<HasTypeRef> hasTypeRef;
     private final Consumer<HasName> clearDisplayNameConsumer;
     private final BiConsumer<HasName, Name> setDisplayNameConsumer;
     private final BiConsumer<HasTypeRef, QName> setTypeRefConsumer;
@@ -50,7 +51,7 @@ public abstract class NameAndDataTypeHeaderMetaData<E extends Expression> extend
                                          final CellEditorControlsView.Presenter cellEditorControls,
                                          final NameAndDataTypeEditorView.Presenter headerEditor) {
         this(hasName,
-             getTypeRefOfExpression(expression, hasExpression),
+             () -> getTypeRefOfExpression(expression, hasExpression),
              clearDisplayNameConsumer,
              setDisplayNameConsumer,
              setTypeRefConsumer,
@@ -59,7 +60,7 @@ public abstract class NameAndDataTypeHeaderMetaData<E extends Expression> extend
     }
 
     public NameAndDataTypeHeaderMetaData(final Optional<HasName> hasName,
-                                         final HasTypeRef hasTypeRef,
+                                         final Supplier<HasTypeRef> hasTypeRef,
                                          final Consumer<HasName> clearDisplayNameConsumer,
                                          final BiConsumer<HasName, Name> setDisplayNameConsumer,
                                          final BiConsumer<HasTypeRef, QName> setTypeRefConsumer,
@@ -119,7 +120,7 @@ public abstract class NameAndDataTypeHeaderMetaData<E extends Expression> extend
 
     @Override
     public QName getTypeRef() {
-        return hasTypeRef.getTypeRef();
+        return hasTypeRef.get().getTypeRef();
     }
 
     @Override
@@ -128,11 +129,11 @@ public abstract class NameAndDataTypeHeaderMetaData<E extends Expression> extend
             return;
         }
 
-        setTypeRefConsumer.accept(hasTypeRef, typeRef);
+        setTypeRefConsumer.accept(hasTypeRef.get(), typeRef);
     }
 
     @Override
     public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
-        return hasTypeRef.asDMNModelInstrumentedBase();
+        return hasTypeRef.get().asDMNModelInstrumentedBase();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaDataTest.java
@@ -27,7 +27,7 @@ public class NameAndDataTypeHeaderMetaDataTest extends BaseNameAndDataTypeHeader
 
     public void setup(final Optional<HasName> hasName) {
         this.metaData = new NameAndDataTypeHeaderMetaData(hasName,
-                                                          hasTypeRef,
+                                                          () -> hasTypeRef,
                                                           clearDisplayNameConsumer,
                                                           setDisplayNameConsumer,
                                                           setTypeRefConsumer,


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3010

This PR defers retrieval of the ```HasTypeRef``` in ```NameAndDataTypeHeaderMetaData``` to _when it is needed_ vs when ```NameAndDataTypeHeaderMetaData``` was instantiated.