### PR TITLE
DROOLS-3028: [DMN Designer] Consolidate data type select boxes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
@@ -33,6 +33,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HasValue;
+import org.gwtbootstrap3.extras.select.client.ui.OptGroup;
 import org.gwtbootstrap3.extras.select.client.ui.Option;
 import org.gwtbootstrap3.extras.select.client.ui.Select;
 import org.jboss.errai.common.client.dom.Anchor;
@@ -69,6 +70,8 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
     @DataField
     private Select typeSelector;
 
+    private TranslationService translationService;
+
     private QNameConverter qNameConverter;
 
     private DMNGraphUtils dmnGraphUtils;
@@ -95,6 +98,7 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
                                 final ItemDefinitionUtils itemDefinitionUtils) {
         this.typeButton = typeButton;
         this.manageLabel = manageLabel;
+        this.translationService = translationService;
         this.typeSelector = GWT.create(Select.class);
         this.qNameConverter = qNameConverter;
         this.dmnGraphUtils = dmnGraphUtils;
@@ -123,11 +127,16 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
     }
 
     private void addBuiltInTypes() {
+        final OptGroup group = GWT.create(OptGroup.class);
+        group.setLabel(translationService.format(DMNEditorConstants.DataTypeSelectView_DefaultTitle));
+
         Stream.of(BuiltInType.values())
                 .sorted(BUILT_IN_TYPE_COMPARATOR)
                 .map(this::makeTypeSelector)
                 .filter(Optional::isPresent)
-                .forEach(o -> typeSelector.add(o.get()));
+                .forEach(o -> group.add(o.get()));
+
+        typeSelector.add(group);
     }
 
     Optional<Option> makeTypeSelector(final BuiltInType bit) {
@@ -146,22 +155,16 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
         final Definitions definitions = dmnGraphUtils.getDefinitions();
         final List<ItemDefinition> itemDefinitions = definitions != null ? definitions.getItemDefinition() : Collections.emptyList();
 
-        //There will always be BuiltInTypes so it safe to add a divider
-        if (itemDefinitions.size() > 0) {
-            addDivider();
-        }
+        final OptGroup group = GWT.create(OptGroup.class);
+        group.setLabel(translationService.format(DMNEditorConstants.DataTypeSelectView_CustomTitle));
 
         itemDefinitions.stream()
                 .sorted(ITEM_DEFINITION_COMPARATOR)
                 .map(this::makeTypeSelector)
                 .filter(Optional::isPresent)
-                .forEach(o -> typeSelector.add(o.get()));
-    }
+                .forEach(o -> group.add(o.get()));
 
-    void addDivider() {
-        final Option o = GWT.create(Option.class);
-        o.setDivider(true);
-        typeSelector.add(o);
+        typeSelector.add(group);
     }
 
     Optional<Option> makeTypeSelector(final ItemDefinition id) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
@@ -126,9 +126,9 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
         typeSelector.refresh();
     }
 
-    private void addBuiltInTypes() {
+    void addBuiltInTypes() {
         final OptGroup group = GWT.create(OptGroup.class);
-        group.setLabel(translationService.format(DMNEditorConstants.DataTypeSelectView_DefaultTitle));
+        group.setLabel(translationService.getTranslation(DMNEditorConstants.DataTypeSelectView_DefaultTitle));
 
         Stream.of(BuiltInType.values())
                 .sorted(BUILT_IN_TYPE_COMPARATOR)
@@ -151,12 +151,12 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
         return itemDefinitionUtils.normaliseTypeRef(typeRef);
     }
 
-    private void addItemDefinitions() {
+    void addItemDefinitions() {
         final Definitions definitions = dmnGraphUtils.getDefinitions();
         final List<ItemDefinition> itemDefinitions = definitions != null ? definitions.getItemDefinition() : Collections.emptyList();
 
         final OptGroup group = GWT.create(OptGroup.class);
-        group.setLabel(translationService.format(DMNEditorConstants.DataTypeSelectView_CustomTitle));
+        group.setLabel(translationService.getTranslation(DMNEditorConstants.DataTypeSelectView_CustomTitle));
 
         itemDefinitions.stream()
                 .sorted(ITEM_DEFINITION_COMPARATOR)

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtils.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.editors.types.common;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.enterprise.context.Dependent;
@@ -51,6 +52,10 @@ public class DataTypeUtils {
     }
 
     public List<DataType> customDataTypes() {
-        return dataTypeStore.getTopLevelDataTypes();
+        return dataTypeStore
+                .getTopLevelDataTypes()
+                .stream()
+                .sorted(Comparator.comparing(DataType::getName))
+                .collect(Collectors.toList());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectView.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.listview;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -43,6 +44,8 @@ import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConsta
 @Dependent
 @Templated
 public class DataTypeSelectView implements DataTypeSelect.View {
+
+    static final Comparator<DataType> DATA_TYPE_COMPARATOR = Comparator.comparing(DataType::getName);
 
     @DataField("type-text")
     private final HTMLDivElement typeText;
@@ -117,11 +120,12 @@ public class DataTypeSelectView implements DataTypeSelect.View {
 
         optionGroup.label = groupTitle;
 
-        dataTypes.forEach(dataType -> {
-            final String optionValue = dataTypeConsumer.apply(dataType);
-            final HTMLOptionElement option = makeOption(optionValue);
-            optionGroup.appendChild(option);
-        });
+        dataTypes.stream()
+                .sorted(DATA_TYPE_COMPARATOR)
+                .forEach(dataType -> {
+                    final HTMLOptionElement option = makeOption(dataType, dataTypeConsumer);
+                    optionGroup.appendChild(option);
+                });
 
         return optionGroup;
     }
@@ -130,10 +134,13 @@ public class DataTypeSelectView implements DataTypeSelect.View {
         return typeSelectStructureOptGroup;
     }
 
-    HTMLOptionElement makeOption(final String value) {
+    HTMLOptionElement makeOption(final DataType dataType,
+                                 final Function<DataType, String> dataTypeConsumer) {
+        final String optionValue = dataTypeConsumer.apply(dataType);
+
         final HTMLOptionElement option = makeHTMLOptionElement();
-        option.text = value;
-        option.value = value;
+        option.text = optionValue;
+        option.value = optionValue;
         return option;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectView.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.listview;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -44,8 +43,6 @@ import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConsta
 @Dependent
 @Templated
 public class DataTypeSelectView implements DataTypeSelect.View {
-
-    static final Comparator<DataType> DATA_TYPE_COMPARATOR = Comparator.comparing(DataType::getName);
 
     @DataField("type-text")
     private final HTMLDivElement typeText;
@@ -121,7 +118,6 @@ public class DataTypeSelectView implements DataTypeSelect.View {
         optionGroup.label = groupTitle;
 
         dataTypes.stream()
-                .sorted(DATA_TYPE_COMPARATOR)
                 .forEach(dataType -> {
                     final HTMLOptionElement option = makeOption(dataType, dataTypeConsumer);
                     optionGroup.appendChild(option);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
@@ -45,7 +45,6 @@ import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,9 +54,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -167,15 +164,20 @@ public class DataTypePickerWidgetTest {
 
         verify(qNameConverter).setDMNModel(eq(dmnModel));
         verify(typeSelector).clear();
+        verify(picker).addBuiltInTypes();
+        verify(picker).addItemDefinitions();
         verify(typeSelector).refresh();
     }
 
     @Test
     public void testSetDMNModel_BuiltInTypes() {
-        picker.setDMNModel(dmnModel);
+        picker.addBuiltInTypes();
 
         final BuiltInType[] bits = BuiltInType.values();
         verify(picker, times(bits.length)).makeTypeSelector(builtInTypeCaptor.capture());
+        verify(group).setLabel(DMNEditorConstants.DataTypeSelectView_DefaultTitle);
+        verify(group, times(bits.length)).add(eq(option));
+        verify(typeSelector).add(group);
 
         //Checks all BuiltInTypes were handled by makeTypeSelector(BuiltInType)
         final List<BuiltInType> builtInTypes = Arrays.asList(bits);
@@ -194,10 +196,13 @@ public class DataTypePickerWidgetTest {
             setName(new Name("user_defined_data_type"));
         }});
 
-        picker.setDMNModel(dmnModel);
+        picker.addItemDefinitions();
 
         final List<ItemDefinition> itemDefinitions = definitions.getItemDefinition();
         verify(picker, times(itemDefinitions.size())).makeTypeSelector(itemDefinitionCaptor.capture());
+        verify(group).setLabel(DMNEditorConstants.DataTypeSelectView_CustomTitle);
+        verify(group, times(itemDefinitions.size())).add(eq(option));
+        verify(typeSelector).add(group);
 
         //Checks all ItemDefinitions were handled by makeTypeSelector(ItemDefinition)
         assertFalse(itemDefinitions.isEmpty());
@@ -216,16 +221,6 @@ public class DataTypePickerWidgetTest {
         picker.setDMNModel(dmnModel);
 
         verify(picker, never()).makeTypeSelector(any(ItemDefinition.class));
-    }
-
-    @Test
-    public void testSetDMNModel_Divider() {
-        final InOrder order = inOrder(picker);
-
-        picker.setDMNModel(dmnModel);
-
-        order.verify(picker, atLeastOnce()).makeTypeSelector(any(BuiltInType.class));
-        order.verify(picker, atLeastOnce()).makeTypeSelector(any(ItemDefinition.class));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
@@ -24,6 +24,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.thirdparty.guava.common.collect.Ordering;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.extras.select.client.ui.OptGroup;
 import org.gwtbootstrap3.extras.select.client.ui.Option;
 import org.gwtbootstrap3.extras.select.client.ui.Select;
 import org.jboss.errai.common.client.dom.Anchor;
@@ -97,6 +98,10 @@ public class DataTypePickerWidgetTest {
     @GwtMock
     @SuppressWarnings("unused")
     private Option option;
+
+    @GwtMock
+    @SuppressWarnings("unused")
+    private OptGroup group;
 
     @Mock
     private com.google.gwt.user.client.Element optionElement;
@@ -210,7 +215,6 @@ public class DataTypePickerWidgetTest {
 
         picker.setDMNModel(dmnModel);
 
-        verify(picker, never()).addDivider();
         verify(picker, never()).makeTypeSelector(any(ItemDefinition.class));
     }
 
@@ -221,7 +225,6 @@ public class DataTypePickerWidgetTest {
         picker.setDMNModel(dmnModel);
 
         order.verify(picker, atLeastOnce()).makeTypeSelector(any(BuiltInType.class));
-        order.verify(picker).addDivider();
         order.verify(picker, atLeastOnce()).makeTypeSelector(any(ItemDefinition.class));
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtilsTest.java
@@ -92,12 +92,15 @@ public class DataTypeUtilsTest {
 
         final DataType dataType1 = mock(DataType.class);
         final DataType dataType2 = mock(DataType.class);
-        final List<DataType> expectedDataType = asList(dataType1, dataType2);
+        final List<DataType> unorderedDataTypes = asList(dataType1, dataType2);
+        final List<DataType> expectedDataTypes = asList(dataType2, dataType1);
 
-        when(dataTypeStore.getTopLevelDataTypes()).thenReturn(expectedDataType);
+        when(dataTypeStore.getTopLevelDataTypes()).thenReturn(unorderedDataTypes);
+        when(dataType1.getName()).thenReturn("z");
+        when(dataType2.getName()).thenReturn("a");
 
         final List<DataType> actualDataTypes = utils.customDataTypes();
 
-        assertEquals(expectedDataType, actualDataTypes);
+        assertEquals(expectedDataTypes, actualDataTypes);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectViewTest.java
@@ -19,7 +19,9 @@ package org.kie.workbench.common.dmn.client.editors.types.listview;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
+import com.google.gwt.thirdparty.guava.common.collect.Ordering;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.DOMTokenList;
 import elemental2.dom.Element;
@@ -35,10 +37,14 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.JQuerySelectPickerEvent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.JQuerySelectPickerTarget;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.common.HiddenHelper.HIDDEN_CSS_CLASS;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DataTypeSelectView_CustomTitle;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DataTypeSelectView_DefaultTitle;
@@ -51,6 +57,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -74,6 +81,9 @@ public class DataTypeSelectViewTest {
 
     @Mock
     private TranslationService translationService;
+
+    @Captor
+    private ArgumentCaptor<DataType> dataTypeCaptor;
 
     private DataTypeSelectView view;
 
@@ -128,8 +138,8 @@ public class DataTypeSelectViewTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testMakeOptionGroup() {
-
         final String dataTypeName = "name";
         final String groupTitle = "Title";
         final DataType dataType = makeDataType(dataTypeName);
@@ -138,7 +148,7 @@ public class DataTypeSelectViewTest {
         final HTMLOptionElement optionElement = mock(HTMLOptionElement.class);
 
         doReturn(expectedGroupElement).when(view).makeHTMLOptGroupElement();
-        doReturn(optionElement).when(view).makeOption(dataTypeName);
+        doReturn(optionElement).when(view).makeOption(eq(dataType), any(Function.class));
 
         final HTMLOptGroupElement actualGroupElement = view.makeOptionGroup(groupTitle, dataTypes, DataType::getName);
 
@@ -148,14 +158,40 @@ public class DataTypeSelectViewTest {
     }
 
     @Test
-    public void testMakeOption() {
+    @SuppressWarnings("unchecked")
+    public void testOptionGroupSorting() {
+        final HTMLOptGroupElement groupElement = mock(HTMLOptGroupElement.class);
+        final HTMLOptionElement optionElement = mock(HTMLOptionElement.class);
 
+        doReturn(groupElement).when(view).makeHTMLOptGroupElement();
+        doReturn(optionElement).when(view).makeHTMLOptionElement();
+
+        final List<DataType> dataTypes = new ArrayList<>();
+        final DataType dataType1 = makeDataType("z");
+        final DataType dataType2 = makeDataType("a");
+        dataTypes.add(dataType1);
+        dataTypes.add(dataType2);
+
+        view.makeOptionGroup("title", dataTypes, DataType::getName);
+
+        //Check all items were added to the group
+        verify(view, times(dataTypes.size())).makeOption(dataTypeCaptor.capture(), any(Function.class));
+        final List<DataType> dataTypesAddedToWidget = dataTypeCaptor.getAllValues();
+        assertThat(dataTypes).hasSameElementsAs(dataTypesAddedToWidget);
+
+        //Check the items were sorted correctly
+        assertTrue(Ordering.from(DataTypeSelectView.DATA_TYPE_COMPARATOR).isOrdered(dataTypesAddedToWidget));
+    }
+
+    @Test
+    public void testMakeOption() {
         final String value = "value";
+        final DataType dataType = makeDataType(value);
         final HTMLOptionElement htmlOptionElement = mock(HTMLOptionElement.class);
 
         doReturn(htmlOptionElement).when(view).makeHTMLOptionElement();
 
-        final HTMLOptionElement option = view.makeOption(value);
+        final HTMLOptionElement option = view.makeOption(dataType, DataType::getName);
 
         assertEquals(value, option.text);
         assertEquals(value, option.value);


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3028

This PR:
- Adds the `OptionGroup` to the Properties Panel data-type selector
- Sorts data-types added to the data-type selector in the Data Types dialog

This ensures the content of both is consistent.  