### PR TITLE
 JBPM-7726: Stunner - (Un)Marshaller tests for Rest Service Tasks are failing

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ServiceTaskPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ServiceTaskPropertyWriter.java
@@ -19,14 +19,18 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.pro
 import org.eclipse.bpmn2.Task;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomAttribute;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomInput;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.Scripts;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnEntryAction;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnExitAction;
 
 public class ServiceTaskPropertyWriter extends ActivityPropertyWriter {
 
+    private final Task task;
+
     public ServiceTaskPropertyWriter(Task task, VariableScope variableScope) {
         super(task, variableScope);
+        this.task = task;
     }
 
     public void setAsync(Boolean value) {
@@ -47,5 +51,9 @@ public class ServiceTaskPropertyWriter extends ActivityPropertyWriter {
 
     public void setServiceTaskName(String name) {
         CustomAttribute.serviceTaskName.of(flowElement).set(name);
+    }
+
+    public void setTaskName(String value) {
+        CustomInput.taskName.of(task).set(value);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/tasks/TaskConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/tasks/TaskConverter.java
@@ -62,6 +62,7 @@ public class TaskConverter {
     private PropertyWriter serviceTask(Node<View<ServiceTask>, ?> n) {
         org.eclipse.bpmn2.Task task = bpmn2.createTask();
         task.setId(n.getUUID());
+
         ServiceTask definition = n.getContent().getDefinition();
         ServiceTaskPropertyWriter p = propertyWriterFactory.of(task);
 
@@ -71,15 +72,17 @@ public class TaskConverter {
         p.setName(general.getName().getValue());
         p.setDocumentation(general.getDocumentation().getValue());
 
+        p.setAssignmentsInfo(
+                definition.getDataIOSet().getAssignmentsinfo());
+
         ServiceTaskExecutionSet executionSet =
                 definition.getExecutionSet();
 
+        p.setTaskName(executionSet.getTaskName().getValue());
         p.setAsync(executionSet.getIsAsync().getValue());
         p.setOnEntryAction(executionSet.getOnEntryAction());
         p.setOnExitAction(executionSet.getOnExitAction());
         p.setAdHocAutostart(executionSet.getAdHocAutostart().getValue());
-
-        p.setAssignmentsInfo(definition.getDataIOSet().getAssignmentsinfo());
 
         p.setSimulationSet(definition.getSimulationSet());
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ServiceTaskPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ServiceTaskPropertyReader.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.prope
 import java.util.Collections;
 import java.util.Optional;
 
+import org.drools.core.util.StringUtils;
 import org.eclipse.bpmn2.InputOutputSpecification;
 import org.eclipse.bpmn2.Task;
 import org.eclipse.bpmn2.di.BPMNPlane;
@@ -41,7 +42,7 @@ public class ServiceTaskPropertyReader extends TaskPropertyReader {
     @Override
     public String getName() {
         String name = super.getName();
-        if (name == null || name.isEmpty()) {
+        if (StringUtils.isEmpty(name)) {
             return "";
         } else {
             return name;
@@ -51,7 +52,7 @@ public class ServiceTaskPropertyReader extends TaskPropertyReader {
     @Override
     public String getDocumentation() {
         String documentation = super.getDocumentation();
-        if (documentation == null || documentation.isEmpty()) {
+        if (StringUtils.isEmpty(documentation)) {
             return "";
         } else {
             return documentation;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ServiceTaskPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ServiceTaskPropertyReader.java
@@ -53,7 +53,8 @@ public class ServiceTaskPropertyReader extends TaskPropertyReader {
     public String getDocumentation() {
         String documentation = super.getDocumentation();
         if (StringUtils.isEmpty(documentation)) {
-            return "";
+            String defaultDocumentation = workItemDefinition.getDocumentation();
+            return defaultDocumentation == null ? "" : defaultDocumentation;
         } else {
             return documentation;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ServiceTaskPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ServiceTaskPropertyReader.java
@@ -42,7 +42,7 @@ public class ServiceTaskPropertyReader extends TaskPropertyReader {
     public String getName() {
         String name = super.getName();
         if (name == null || name.isEmpty()) {
-            return workItemDefinition.getName();
+            return "";
         } else {
             return name;
         }
@@ -52,7 +52,7 @@ public class ServiceTaskPropertyReader extends TaskPropertyReader {
     public String getDocumentation() {
         String documentation = super.getDocumentation();
         if (documentation == null || documentation.isEmpty()) {
-            return workItemDefinition.getDocumentation();
+            return "";
         } else {
             return documentation;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
@@ -139,10 +139,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         assertDataIOSet(filledTopLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after these issues will be resolved:\n" +
-            "https://issues.jboss.org/browse/JBPM-7072\n" +
-            "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
     public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
@@ -231,10 +227,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         assertDataIOSet(filledSubprocessLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after these issues will be resolved:\n" +
-            "https://issues.jboss.org/browse/JBPM-7072\n" +
-            "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
     public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
@@ -322,10 +314,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         assertDataIOSet(filledTopLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after these issues will be resolved:\n" +
-            "https://issues.jboss.org/browse/JBPM-7072\n" +
-            "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
     public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
@@ -347,10 +335,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         assertDataIOSet(emptyTopLevelTask.getDataIOSet(), EMPTY_TASK_DATA_INPUT_OUTPUT);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after these issues will be resolved:\n" +
-            "https://issues.jboss.org/browse/JBPM-7072\n" +
-            "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
     public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
@@ -504,10 +488,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         assertDataIOSet(filledTopLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after these issues will be resolved:\n" +
-            "https://issues.jboss.org/browse/JBPM-7072\n" +
-            "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
     public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
@@ -529,10 +509,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         assertDataIOSet(emptyTopLevelTask.getDataIOSet(), EMPTY_TASK_DATA_INPUT_OUTPUT);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after these issues will be resolved:\n" +
-            "https://issues.jboss.org/browse/JBPM-7072\n" +
-            "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
     public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
@@ -620,8 +596,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         assertDataIOSet(filledSubprocessLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     @Test
     @Override
     public void testMarshallTopLevelTaskFilledProperties() throws Exception {
@@ -630,8 +604,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     @Test
     @Override
     public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
@@ -640,8 +612,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     @Test
     @Override
     public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
@@ -650,8 +620,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     @Test
     @Override
     public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
@@ -660,8 +628,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     @Test
     @Override
     public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
@@ -670,8 +636,6 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "It should be enabled after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     @Test
     @Override
     public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
@@ -91,8 +91,6 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
         assertEquals(value, dataIOSet.getAssignmentsinfo().getValue());
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "Delete this test from this class after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     // The test is already defined in parent Task test class.
     @Test
     @Override
@@ -100,8 +98,6 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
         checkTaskMarshalling(getEmptyTopLevelTaskId(), ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "Delete this test from this class after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     // The test is already defined in parent Task test class.
     @Test
     @Override
@@ -109,8 +105,6 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
         checkTaskMarshalling(getEmptySubprocessLevelTaskOneIncomeId(), ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "Delete this test from this class after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     // The test is already defined in parent Task test class.
     @Test
     @Override
@@ -118,8 +112,6 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
         checkTaskMarshalling(getEmptySubprocessLevelTaskTwoIncomesId(), TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "Delete this test from this class after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     // The test is already defined in parent Task test class.
     @Test
     @Override
@@ -127,8 +119,6 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
         checkTaskMarshalling(getEmptyTopLevelTaskOneIncomeId(), ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "Delete this test from this class after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     // The test is already defined in parent Task test class.
     @Test
     @Override
@@ -136,8 +126,6 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
         checkTaskMarshalling(getEmptyTopLevelTaskTwoIncomesId(), TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
     }
 
-    @Ignore("The test is ignored because there is a bug in new Marshaller.\n" +
-            "Delete this test from this class after https://issues.jboss.org/browse/JBPM-7726 will be resolved.")
     // The test is already defined in parent Task test class.
     @Test
     @Override


### PR DESCRIPTION
As discussed, this fixes all of the tests except [this](https://github.com/kiegroup/kie-wb-common/blob/8ba0a5c6b8764030dc27ec27644e0737363bb0cb/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java#L2965-L2966)

```java
        assertEquals(WorkItemDefinitionMockRegistry.EMAIL.getDocumentation(),
email.getGeneral().getDocumentation().getValue());
```

because the expected value there is "index.html", while now it is an empty string.

The failure in this test is to be expected, because the tests we're fixing **expect** this value to be **the empty string**. 

So I suppose either **this** test is wrong, or the others. Which is which?

@LuboTerifaj @hasys 