### PR TITLE
DROOLS-2804: [DMN Designer] Properties Panel to drill-down to DMN component level

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/DMNDefinitionSet.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/DMNDefinitionSet.java
@@ -19,6 +19,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Association;
 import org.kie.workbench.common.dmn.api.definition.v1_1.AuthorityRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
@@ -28,6 +29,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InformationRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
 import org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
 import org.kie.workbench.common.dmn.api.factory.DMNGraphFactory;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
@@ -52,7 +54,9 @@ import org.kie.workbench.common.stunner.core.rule.annotation.Occurrences;
                 Association.class,
                 InformationRequirement.class,
                 KnowledgeRequirement.class,
-                AuthorityRequirement.class
+                AuthorityRequirement.class,
+                LiteralExpression.class,
+                NOPDomainObject.class
         },
         builder = DMNDefinitionSet.DMNDefinitionSetBuilder.class
 )

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/NOPDomainObject.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/NOPDomainObject.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.api.definition;
+
+import java.util.Set;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.soup.commons.util.Sets;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Categories;
+import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
+
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
+import static org.kie.workbench.common.stunner.core.util.UUID.uuid;
+
+@Portable
+@Bindable
+@Definition(graphFactory = NodeFactory.class)
+@FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
+/**
+ * A "no operation" {@link DomainObject} to allow showing zero Property Form elements. It is possible
+ * to invoke {@link AbstractCanvasHandler#notifyCanvasClear()} to perform the same however that causes the Graph
+ * element to become de-selected (along with other registered {@link CanvasElementListener#clear()} operations
+ * that may have undesirable side-effects.
+ */
+public class NOPDomainObject implements DomainObject {
+
+    @Category
+    public static final transient String stunnerCategory = Categories.DOMAIN_OBJECTS;
+
+    @Labels
+    private final Set<String> stunnerLabels = new Sets.Builder<String>().build();
+
+    private static String UUID = uuid();
+
+    // -----------------------
+    // Stunner core properties
+    // -----------------------
+
+    public String getStunnerCategory() {
+        return stunnerCategory;
+    }
+
+    public Set<String> getStunnerLabels() {
+        return stunnerLabels;
+    }
+
+    // ------------------------------------------------------
+    // DomainObject requirements - to use in Properties Panel
+    // ------------------------------------------------------
+
+    @Override
+    public String getDomainObjectUUID() {
+        return UUID;
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return DMNAPIConstants.NOP_DomainObjectName;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Categories.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Categories.java
@@ -24,4 +24,6 @@ public class Categories {
     public static final String CONNECTORS = "DMNConnectors";
 
     public static final String MISCELLANEOUS = "DMNMiscellaneousObjects";
+
+    public static final String DOMAIN_OBJECTS = "DMNDomainObjects";
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
@@ -15,20 +15,50 @@
  */
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
+import java.util.Set;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
+import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
+
 @Portable
-public class LiteralExpression extends Expression {
+@Bindable
+@Definition(graphFactory = NodeFactory.class)
+@FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
+public class LiteralExpression extends Expression implements DomainObject {
+
+    @Category
+    public static final transient String stunnerCategory = Categories.DOMAIN_OBJECTS;
+
+    @Labels
+    private final Set<String> stunnerLabels = new Sets.Builder<String>().build();
 
     protected String text;
 
     protected ImportedValues importedValues;
 
-    protected String expressionLanguage;
+    @Property
+    @FormField(afterElement = "description")
+    protected ExpressionLanguage expressionLanguage;
 
     public LiteralExpression() {
         this(new Id(),
@@ -36,7 +66,7 @@ public class LiteralExpression extends Expression {
              new QName(),
              null,
              null,
-             null);
+             new ExpressionLanguage());
     }
 
     public LiteralExpression(final Id id,
@@ -44,13 +74,25 @@ public class LiteralExpression extends Expression {
                              final QName typeRef,
                              final String text,
                              final ImportedValues importedValues,
-                             final String expressionLanguage) {
+                             final ExpressionLanguage expressionLanguage) {
         super(id,
               description,
               typeRef);
         this.text = text;
         this.importedValues = importedValues;
         this.expressionLanguage = expressionLanguage;
+    }
+
+    // -----------------------
+    // Stunner core properties
+    // -----------------------
+
+    public String getStunnerCategory() {
+        return stunnerCategory;
+    }
+
+    public Set<String> getStunnerLabels() {
+        return stunnerLabels;
     }
 
     // -----------------------
@@ -73,12 +115,26 @@ public class LiteralExpression extends Expression {
         this.importedValues = importedValues;
     }
 
-    public String getExpressionLanguage() {
+    public ExpressionLanguage getExpressionLanguage() {
         return expressionLanguage;
     }
 
-    public void setExpressionLanguage(final String expressionLanguage) {
+    public void setExpressionLanguage(final ExpressionLanguage expressionLanguage) {
         this.expressionLanguage = expressionLanguage;
+    }
+
+    // ------------------------------------------------------
+    // DomainObject requirements - to use in Properties Panel
+    // ------------------------------------------------------
+
+    @Override
+    public String getDomainObjectUUID() {
+        return getId().getValue();
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return DMNAPIConstants.LiteralExpression_DomainObjectName;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Description.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Description.java
@@ -36,7 +36,7 @@ public class Description implements DMNProperty {
     private String value;
 
     public Description() {
-        this(null);
+        this("");
     }
 
     public Description(final String value) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguage.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguage.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.dmn.api.property.DMNProperty;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldValue;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.I18nMode;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.property.Value;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
+
+@Portable
+@Bindable
+@Property
+@FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
+public class ExpressionLanguage implements DMNProperty {
+
+    @Value
+    @FieldValue
+    private String value;
+
+    public ExpressionLanguage() {
+        this("");
+    }
+
+    public ExpressionLanguage(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ExpressionLanguage)) {
+            return false;
+        }
+
+        final ExpressionLanguage text = (ExpressionLanguage) o;
+
+        return value != null ? value.equals(text.value) : text.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.combineHashCodes(value != null ? value.hashCode() : 0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/resource/i18n/DMNAPIConstants.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/resource/i18n/DMNAPIConstants.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.api.resource.i18n;
+
+import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
+
+public class DMNAPIConstants {
+
+    @TranslationKey(defaultValue = "")
+    public static final String NOP_DomainObjectName = "NOP.DomainObjectName";
+
+    @TranslationKey(defaultValue = "")
+    public static final String LiteralExpression_DomainObjectName = "LiteralExpression.DomainObjectName";
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/DMNAPI.gwt.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/DMNAPI.gwt.xml
@@ -23,6 +23,8 @@
   <inherits name="org.jboss.errai.ui.UI"/>
   <inherits name="org.kie.workbench.common.stunner.core.StunnerClientApi"/>
   <inherits name="org.kie.workbench.common.stunner.shapes.StunnerShapesApi"/>
+  <inherits name="org.kie.workbench.common.forms.adf.AnnotationDrivenFormsBase"/>
+  <inherits name="org.kie.workbench.common.forms.adf.engine.AnnotationDrivenFormsEngineAPI"/>
 
   <source path="api"/>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
@@ -72,6 +72,8 @@ org.kie.workbench.common.dmn.api.property.dmn.AllowedAnswers.label=Allowed Answe
 org.kie.workbench.common.dmn.api.property.dmn.AllowedAnswers.description=The allowed answers
 org.kie.workbench.common.dmn.api.property.dmn.Description.label=Description
 org.kie.workbench.common.dmn.api.property.dmn.Description.description=The shapes description
+org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage.label=Expression Language
+org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage.description=The expression language
 org.kie.workbench.common.dmn.api.property.dmn.Id.label=Id
 org.kie.workbench.common.dmn.api.property.dmn.Id.description=The shapes identifier
 org.kie.workbench.common.dmn.api.property.dmn.KnowledgeSourceType.label=Source Type
@@ -101,3 +103,9 @@ org.kie.workbench.common.dmn.api.property.font.FontFamily.label=Font family
 org.kie.workbench.common.dmn.api.property.font.FontFamily.description=The fonts family
 org.kie.workbench.common.dmn.api.property.font.FontSize.label=Font size
 org.kie.workbench.common.dmn.api.property.font.FontSize.description=The fonts size
+
+#######################
+# DomainObject property
+#######################
+NOP.DomainObjectName=NOP
+LiteralExpression.DomainObjectName=Literal Expression

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguageTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguageTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExpressionLanguageTest {
+
+    private static final String VALUE = "value";
+
+    private ExpressionLanguage expressionLanguage;
+
+    @Test
+    public void testZeroParameterConstructor() {
+        this.expressionLanguage = new ExpressionLanguage();
+
+        assertEquals("", expressionLanguage.getValue());
+    }
+
+    @Test
+    public void testOneParameterConstructor() {
+        this.expressionLanguage = new ExpressionLanguage(VALUE);
+
+        assertEquals(VALUE, expressionLanguage.getValue());
+    }
+
+    @Test
+    public void testSetter() {
+        this.expressionLanguage = new ExpressionLanguage();
+        this.expressionLanguage.setValue(VALUE);
+
+        assertEquals(VALUE, expressionLanguage.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
@@ -26,7 +26,7 @@ public class ContextPropertyConverter {
 
     public static Context wbFromDMN(final org.kie.dmn.model.api.Context dmn) {
         Id id = new Id(dmn.getId());
-        Description description = new Description(dmn.getDescription());
+        Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
         Context result = new Context(id,
                                      description,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
@@ -27,7 +27,7 @@ public class DecisionRulePropertyConverter {
     public static DecisionRule wbFromDMN(final org.kie.dmn.model.api.DecisionRule dmn) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
-        
+
         DecisionRule result = new DecisionRule();
         result.setId(id);
         result.setDescription(description);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DescriptionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DescriptionPropertyConverter.java
@@ -17,24 +17,25 @@
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
 
 public class DescriptionPropertyConverter {
 
-    public static Description wbFromDMN(final String dmn) {
-        if (dmn == null) {
-            return new Description(null);
+    public static Description wbFromDMN(final String description) {
+        if (description == null) {
+            return new Description("");
         } else {
-            return new Description(dmn);
+            return new Description(description);
         }
     }
 
-    public static String dmnFromWB(final Description wb) {
-        if (wb == null) {
+    public static String dmnFromWB(final Description description) {
+        if (description == null) {
             return null;
-        } else if (wb.getValue() == null || wb.getValue().isEmpty()) {
+        } else if (StringUtils.isEmpty(description.getValue())) {
             return null;
         } else {
-            return wb.getValue();
+            return description.getValue();
         }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionLanguagePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionLanguagePropertyConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
+
+public class ExpressionLanguagePropertyConverter {
+
+    public static ExpressionLanguage wbFromDMN(final String language) {
+        if (language == null) {
+            return new ExpressionLanguage("");
+        } else {
+            return new ExpressionLanguage(language);
+        }
+    }
+
+    public static String dmnFromWB(final ExpressionLanguage language) {
+        if (language == null) {
+            return null;
+        } else if (StringUtils.isEmpty(language.getValue())) {
+            return null;
+        } else {
+            return language.getValue();
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
@@ -38,7 +38,7 @@ public class ImportedValuesConverter {
         return wb;
     }
 
-    public static org.kie.dmn.model.api.ImportedValues wbFromDMN(final ImportedValues wb) {
+    public static org.kie.dmn.model.api.ImportedValues dmnFromWB(final ImportedValues wb) {
         if (wb == null) {
             return null;
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
@@ -28,7 +28,7 @@ public class ListPropertyConverter {
 
     public static List wbFromDMN(final org.kie.dmn.model.api.List dmn) {
         Id id = new Id(dmn.getId());
-        Description description = new Description(dmn.getDescription());
+        Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
 
         java.util.List<Expression> expression = new ArrayList<>();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.backend.definition.v1_1;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ImportedValues;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
@@ -32,7 +33,7 @@ public class LiteralExpressionPropertyConverter {
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
         String text = dmn.getText();
-        String expressionLanguage = dmn.getExpressionLanguage();
+        ExpressionLanguage expressionLanguage = ExpressionLanguagePropertyConverter.wbFromDMN(dmn.getExpressionLanguage());
         ImportedValues importedValues = ImportedValuesConverter.wbFromDMN(dmn.getImportedValues());
         LiteralExpression result = new LiteralExpression(id,
                                                          description,
@@ -56,8 +57,8 @@ public class LiteralExpressionPropertyConverter {
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
         result.setText(wb.getText());
-        result.setExpressionLanguage(wb.getExpressionLanguage());
-        result.setImportedValues(ImportedValuesConverter.wbFromDMN(wb.getImportedValues()));
+        result.setExpressionLanguage(ExpressionLanguagePropertyConverter.dmnFromWB(wb.getExpressionLanguage()));
+        result.setImportedValues(ImportedValuesConverter.dmnFromWB(wb.getImportedValues()));
         return result;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
@@ -29,7 +29,7 @@ public class RelationPropertyConverter {
 
     public static Relation wbFromDMN(final org.kie.dmn.model.api.Relation dmn) {
         Id id = new Id(dmn.getId());
-        Description description = new Description(dmn.getDescription());
+        Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef());
 
         List<org.kie.dmn.model.api.InformationItem> column = dmn.getColumn();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
@@ -27,7 +27,7 @@ public class UnaryTestsPropertyConverter {
             return null;
         }
         Id id = new Id(dmn.getId());
-        Description description = new Description(dmn.getDescription());
+        Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
 
         UnaryTests result = new UnaryTests(id, description, dmn.getText(), dmn.getExpressionLanguage());
         return result;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -1203,8 +1203,8 @@ public class DMNMarshallerTest {
     private static void checkDecisionExpression(final Graph<?, Node<View, ?>> unmarshalledGraph,
                                                 final Expression expression) {
         final Node<View, ?> decisionNode = nodeOfDefinition(unmarshalledGraph.nodes().iterator(), Decision.class);
-        assertThat(((Decision) decisionNode.getContent().getDefinition()).getExpression())
-                .isEqualTo(expression);
+        final Expression decisionNodeExpression = ((Decision) decisionNode.getContent().getDefinition()).getExpression();
+        assertThat(decisionNodeExpression).isEqualTo(expression);
     }
 
     private static Node<View, ?> nodeOfDefinition(final Iterator<Node<View, ?>> nodesIterator, final Class aClass) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DescriptionPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DescriptionPropertyConverterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DescriptionPropertyConverterTest {
+
+    private static final String DESCRIPTION = "description";
+
+    @Test
+    public void testWBFromDMNWithNullValue() {
+        assertEquals("", DescriptionPropertyConverter.wbFromDMN(null).getValue());
+    }
+
+    @Test
+    public void testWBFromDMNWithNonNullValue() {
+        assertEquals(DESCRIPTION, DescriptionPropertyConverter.wbFromDMN(DESCRIPTION).getValue());
+    }
+
+    @Test
+    public void testDMNFromWBWithNull() {
+        assertNull(DescriptionPropertyConverter.dmnFromWB(null));
+    }
+
+    @Test
+    public void testDMNFromWBWithNullValue() {
+        assertNull(DescriptionPropertyConverter.dmnFromWB(new Description(null)));
+    }
+
+    @Test
+    public void testDMNFromWBWithEmptyValue() {
+        assertNull(DescriptionPropertyConverter.dmnFromWB(new Description("")));
+    }
+
+    @Test
+    public void testDMNFromWBWithNonNullValue() {
+        assertEquals(DESCRIPTION, DescriptionPropertyConverter.dmnFromWB(new Description(DESCRIPTION)));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionLanguagePropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionLanguagePropertyConverterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ExpressionLanguagePropertyConverterTest {
+
+    private static final String EXPRESSION_LANGUAGE = "feel";
+
+    @Test
+    public void testWBFromDMNWithNullValue() {
+        assertEquals("", ExpressionLanguagePropertyConverter.wbFromDMN(null).getValue());
+    }
+
+    @Test
+    public void testWBFromDMNWithNonNullValue() {
+        assertEquals(EXPRESSION_LANGUAGE, ExpressionLanguagePropertyConverter.wbFromDMN(EXPRESSION_LANGUAGE).getValue());
+    }
+
+    @Test
+    public void testDMNFromWBWithNull() {
+        assertNull(ExpressionLanguagePropertyConverter.dmnFromWB(null));
+    }
+
+    @Test
+    public void testDMNFromWBWithNullValue() {
+        assertNull(ExpressionLanguagePropertyConverter.dmnFromWB(new ExpressionLanguage(null)));
+    }
+
+    @Test
+    public void testDMNFromWBWithEmptyValue() {
+        assertNull(ExpressionLanguagePropertyConverter.dmnFromWB(new ExpressionLanguage()));
+    }
+
+    @Test
+    public void testDMNFromWBWithNonNullValue() {
+        assertEquals(EXPRESSION_LANGUAGE, ExpressionLanguagePropertyConverter.dmnFromWB(new ExpressionLanguage(EXPRESSION_LANGUAGE)));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
@@ -42,7 +42,7 @@ import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecution
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.graph.command.impl.AbstractGraphCommand;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
 public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
@@ -53,7 +53,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
     protected final SessionPresenter<? extends ClientSession, ?, Diagram> presenter;
     protected final SessionManager sessionManager;
     protected final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    protected final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     protected final String nodeUUID;
     protected final HasExpression hasExpression;
@@ -63,7 +63,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
                                final SessionPresenter<? extends ClientSession, ?, Diagram> presenter,
                                final SessionManager sessionManager,
                                final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                               final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                               final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                final String nodeUUID,
                                final HasExpression hasExpression,
                                final Optional<HasName> hasName) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.dmn.client.commands.general;
 
 import java.util.Optional;
 
+import javax.enterprise.event.Event;
+
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.Widget;
@@ -40,6 +42,7 @@ import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecution
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.graph.command.impl.AbstractGraphCommand;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
 public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
@@ -50,6 +53,8 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
     protected final SessionPresenter<? extends ClientSession, ?, Diagram> presenter;
     protected final SessionManager sessionManager;
     protected final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+    protected final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+
     protected final String nodeUUID;
     protected final HasExpression hasExpression;
     protected final Optional<HasName> hasName;
@@ -58,6 +63,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
                                final SessionPresenter<? extends ClientSession, ?, Diagram> presenter,
                                final SessionManager sessionManager,
                                final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                               final Event<RefreshFormProperties> refreshFormPropertiesEvent,
                                final String nodeUUID,
                                final HasExpression hasExpression,
                                final Optional<HasName> hasName) {
@@ -65,6 +71,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
         this.presenter = presenter;
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
+        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
         this.nodeUUID = nodeUUID;
         this.hasExpression = hasExpression;
         this.hasName = hasName;
@@ -77,6 +84,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
                                                                             presenter,
                                                                             sessionManager,
                                                                             sessionCommandManager,
+                                                                            refreshFormPropertiesEvent,
                                                                             nodeUUID,
                                                                             hasExpression,
                                                                             hasName));
@@ -89,6 +97,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
                                                                      presenter,
                                                                      sessionManager,
                                                                      sessionCommandManager,
+                                                                     refreshFormPropertiesEvent,
                                                                      nodeUUID,
                                                                      hasExpression,
                                                                      hasName));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommand.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.dmn.client.commands.general;
 
 import java.util.Optional;
 
+import javax.enterprise.event.Event;
+
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
@@ -35,6 +37,7 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 
 public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements VetoUndoCommand {
 
@@ -42,6 +45,7 @@ public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements V
                                       final SessionPresenter<? extends ClientSession, ?, Diagram> presenter,
                                       final SessionManager sessionManager,
                                       final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                      final Event<RefreshFormProperties> refreshFormPropertiesEvent,
                                       final String nodeUUID,
                                       final HasExpression hasExpression,
                                       final Optional<HasName> hasName) {
@@ -49,6 +53,7 @@ public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements V
               presenter,
               sessionManager,
               sessionCommandManager,
+              refreshFormPropertiesEvent,
               nodeUUID,
               hasExpression,
               hasName);
@@ -67,6 +72,9 @@ public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements V
                 enableHandlers(true);
                 hidePaletteWidget(false);
                 addDRGEditorToCanvasWidget();
+
+                //Ensure Form Properties are updated to reflect the Graph node selection
+                refreshFormPropertiesEvent.fire(new RefreshFormProperties(sessionManager.getCurrentSession(), nodeUUID));
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommand.java
@@ -37,7 +37,7 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements VetoUndoCommand {
 
@@ -45,7 +45,7 @@ public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements V
                                       final SessionPresenter<? extends ClientSession, ?, Diagram> presenter,
                                       final SessionManager sessionManager,
                                       final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                      final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                      final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                       final String nodeUUID,
                                       final HasExpression hasExpression,
                                       final Optional<HasName> hasName) {
@@ -74,7 +74,7 @@ public class NavigateToDRGEditorCommand extends BaseNavigateCommand implements V
                 addDRGEditorToCanvasWidget();
 
                 //Ensure Form Properties are updated to reflect the Graph node selection
-                refreshFormPropertiesEvent.fire(new RefreshFormProperties(sessionManager.getCurrentSession(), nodeUUID));
+                refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(sessionManager.getCurrentSession(), nodeUUID));
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommand.java
@@ -37,7 +37,7 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 public class NavigateToExpressionEditorCommand extends BaseNavigateCommand implements VetoExecutionCommand {
 
@@ -45,7 +45,7 @@ public class NavigateToExpressionEditorCommand extends BaseNavigateCommand imple
                                              final SessionPresenter<? extends ClientSession, ?, Diagram> presenter,
                                              final SessionManager sessionManager,
                                              final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                             final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                             final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                              final String nodeUUID,
                                              final HasExpression hasExpression,
                                              final Optional<HasName> hasName) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommand.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.dmn.client.commands.general;
 
 import java.util.Optional;
 
+import javax.enterprise.event.Event;
+
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
@@ -35,6 +37,7 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 
 public class NavigateToExpressionEditorCommand extends BaseNavigateCommand implements VetoExecutionCommand {
 
@@ -42,6 +45,7 @@ public class NavigateToExpressionEditorCommand extends BaseNavigateCommand imple
                                              final SessionPresenter<? extends ClientSession, ?, Diagram> presenter,
                                              final SessionManager sessionManager,
                                              final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                             final Event<RefreshFormProperties> refreshFormPropertiesEvent,
                                              final String nodeUUID,
                                              final HasExpression hasExpression,
                                              final Optional<HasName> hasName) {
@@ -49,6 +53,7 @@ public class NavigateToExpressionEditorCommand extends BaseNavigateCommand imple
               presenter,
               sessionManager,
               sessionCommandManager,
+              refreshFormPropertiesEvent,
               nodeUUID,
               hasExpression,
               hasName);
@@ -81,6 +86,9 @@ public class NavigateToExpressionEditorCommand extends BaseNavigateCommand imple
                 enableHandlers(true);
                 hidePaletteWidget(false);
                 addDRGEditorToCanvasWidget();
+
+                //Stunner de-selects nodes when a Command is undone; so we need to clear the Form Properties too
+                context.notifyCanvasClear();
 
                 return CanvasCommandResultBuilder.SUCCESS;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/DMNPaletteDefinitionBuilder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/components/palette/DMNPaletteDefinitionBuilder.java
@@ -53,6 +53,7 @@ public class DMNPaletteDefinitionBuilder
             .add(Categories.DIAGRAM)
             .add(Categories.CONNECTORS)
             .add(Categories.MISCELLANEOUS)
+            .add(Categories.DOMAIN_OBJECTS)
             .build();
 
     @PostConstruct

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
@@ -52,7 +52,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -81,7 +81,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
 
     private final ParameterizedCommand<Optional<Expression>> onHasExpressionChanged;
     private final ParameterizedCommand<Optional<HasName>> onHasNameChanged;
-    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    private final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     private ExpressionContainerUIModelMapper uiModelMapper;
 
@@ -95,7 +95,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
                                    final Supplier<ExpressionGridCache> expressionGridCache,
                                    final ParameterizedCommand<Optional<Expression>> onHasExpressionChanged,
                                    final ParameterizedCommand<Optional<HasName>> onHasNameChanged,
-                                   final Event<RefreshFormProperties> refreshFormPropertiesEvent) {
+                                   final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent) {
         super(new DMNGridData(),
               gridLayer,
               gridLayer,
@@ -315,7 +315,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
         if (session != null) {
             final CanvasHandler canvasHandler = session.getCanvasHandler();
             if (canvasHandler != null) {
-                refreshFormPropertiesEvent.fire(new RefreshFormProperties(session, nodeUUID));
+                refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(session, nodeUUID));
             }
         }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGrid.java
@@ -21,7 +21,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import javax.enterprise.event.Event;
+
 import com.ait.lienzo.client.core.event.INodeXYEvent;
+import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -46,18 +49,23 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 import org.uberfire.mvp.ParameterizedCommand;
 
 public class ExpressionContainerGrid extends BaseGridWidget implements HasListSelectorControl {
 
     private static final String COLUMN_GROUP = "ExpressionContainerGrid$Expression0";
 
+    private final GridLayer gridLayer;
     private final CellEditorControlsView.Presenter cellEditorControls;
     private final TranslationService translationService;
 
@@ -73,6 +81,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
 
     private final ParameterizedCommand<Optional<Expression>> onHasExpressionChanged;
     private final ParameterizedCommand<Optional<HasName>> onHasNameChanged;
+    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
 
     private ExpressionContainerUIModelMapper uiModelMapper;
 
@@ -85,11 +94,13 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
                                    final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitions,
                                    final Supplier<ExpressionGridCache> expressionGridCache,
                                    final ParameterizedCommand<Optional<Expression>> onHasExpressionChanged,
-                                   final ParameterizedCommand<Optional<HasName>> onHasNameChanged) {
+                                   final ParameterizedCommand<Optional<HasName>> onHasNameChanged,
+                                   final Event<RefreshFormProperties> refreshFormPropertiesEvent) {
         super(new DMNGridData(),
               gridLayer,
               gridLayer,
               new ExpressionContainerRenderer());
+        this.gridLayer = gridLayer;
         this.cellEditorControls = cellEditorControls;
         this.translationService = translationService;
         this.sessionManager = sessionManager;
@@ -98,6 +109,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
 
         this.onHasExpressionChanged = onHasExpressionChanged;
         this.onHasNameChanged = onHasNameChanged;
+        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
 
         this.uiModelMapper = new ExpressionContainerUIModelMapper(parent,
                                                                   this::getModel,
@@ -144,7 +156,7 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
         uiModelMapper.fromDMNModel(0, 0);
 
         expressionColumn.setWidth(getExistingEditorWidth());
-        selectFirstCell();
+        selectExpressionEditorFirstCell();
     }
 
     double getExistingEditorWidth() {
@@ -256,15 +268,15 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
                                                                      expressionGridCache.get(),
                                                                      () -> {
                                                                          expressionColumn.setWidth(getExistingEditorWidth());
-                                                                         selectFirstCell();
+                                                                         selectExpressionEditorFirstCell();
                                                                      },
                                                                      () -> {
                                                                          expressionColumn.setWidth(getExistingEditorWidth());
-                                                                         selectFirstCell();
+                                                                         selectExpressionEditorFirstCell();
                                                                      }));
     }
 
-    void selectFirstCell() {
+    void selectExpressionEditorFirstCell() {
         final GridCellValue<?> value = model.getCell(0, 0).getValue();
         final Optional<BaseExpressionGrid> grid = ((ExpressionCellValue) value).getValue();
         grid.ifPresent(beg -> {
@@ -272,5 +284,39 @@ public class ExpressionContainerGrid extends BaseGridWidget implements HasListSe
             Optional.ofNullable(getLayer()).ifPresent(layer -> ((DMNGridLayer) layer).select(beg));
             beg.selectFirstCell();
         });
+    }
+
+    @Override
+    public boolean selectCell(final Point2D ap,
+                              final boolean isShiftKeyDown,
+                              final boolean isControlKeyDown) {
+        gridLayer.select(this);
+        fireRefreshFormPropertiesEvent();
+        return super.selectCell(ap,
+                                isShiftKeyDown,
+                                isControlKeyDown);
+    }
+
+    @Override
+    public boolean selectCell(final int uiRowIndex,
+                              final int uiColumnIndex,
+                              final boolean isShiftKeyDown,
+                              final boolean isControlKeyDown) {
+        gridLayer.select(this);
+        fireRefreshFormPropertiesEvent();
+        return super.selectCell(uiRowIndex,
+                                uiColumnIndex,
+                                isShiftKeyDown,
+                                isControlKeyDown);
+    }
+
+    protected void fireRefreshFormPropertiesEvent() {
+        final ClientSession session = sessionManager.getCurrentSession();
+        if (session != null) {
+            final CanvasHandler canvasHandler = session.getCanvasHandler();
+            if (canvasHandler != null) {
+                refreshFormPropertiesEvent.fire(new RefreshFormProperties(session, nodeUUID));
+            }
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -49,7 +49,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 
@@ -75,7 +75,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     private SessionManager sessionManager;
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
-    private Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    private Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     private DMNGridPanel gridPanel;
     private DMNGridLayer gridLayer;
@@ -96,7 +96,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                     final SessionManager sessionManager,
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                     final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
-                                    final Event<RefreshFormProperties> refreshFormPropertiesEvent) {
+                                    final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent) {
         this.returnToDRG = returnToDRG;
         this.expressionType = expressionType;
         this.gridPanelContainer = gridPanelContainer;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -48,6 +49,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 
@@ -73,6 +75,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     private SessionManager sessionManager;
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
+    private Event<RefreshFormProperties> refreshFormPropertiesEvent;
 
     private DMNGridPanel gridPanel;
     private DMNGridLayer gridLayer;
@@ -92,7 +95,8 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                     final ListSelectorView.Presenter listSelector,
                                     final SessionManager sessionManager,
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                    final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
+                                    final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
+                                    final Event<RefreshFormProperties> refreshFormPropertiesEvent) {
         this.returnToDRG = returnToDRG;
         this.expressionType = expressionType;
         this.gridPanelContainer = gridPanelContainer;
@@ -103,6 +107,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
+        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
     }
 
     @Override
@@ -142,7 +147,8 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                                               expressionEditorDefinitionsSupplier,
                                                               getExpressionGridCacheSupplier(),
                                                               this::setExpressionTypeText,
-                                                              this::setReturnToDRGText);
+                                                              this::setReturnToDRGText,
+                                                              refreshFormPropertiesEvent);
         gridLayer.removeAll();
         gridLayer.add(expressionContainerGrid);
         gridLayer.select(expressionContainerGrid);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 public abstract class BaseEditorDefinition<E extends Expression, D extends GridData> implements ExpressionEditorDefinition<E> {
@@ -44,7 +44,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
     protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     protected CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     protected Event<ExpressionEditorChanged> editorSelectedEvent;
-    protected Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     protected Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
     protected ListSelectorView.Presenter listSelector;
     protected TranslationService translationService;
@@ -58,7 +58,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
                                 final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                 final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                 final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                 final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                 final ListSelectorView.Presenter listSelector,
                                 final TranslationService translationService) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -44,6 +45,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
     protected CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     protected Event<ExpressionEditorChanged> editorSelectedEvent;
     protected Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
     protected ListSelectorView.Presenter listSelector;
     protected TranslationService translationService;
 
@@ -57,6 +59,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
                                 final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                 final Event<ExpressionEditorChanged> editorSelectedEvent,
                                 final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                 final ListSelectorView.Presenter listSelector,
                                 final TranslationService translationService) {
         this.definitionUtils = definitionUtils;
@@ -65,6 +68,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
         this.canvasCommandFactory = canvasCommandFactory;
         this.editorSelectedEvent = editorSelectedEvent;
         this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
+        this.domainObjectSelectionEvent = domainObjectSelectionEvent;
         this.listSelector = listSelector;
         this.translationService = translationService;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
@@ -48,7 +48,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class ContextEditorDefinition extends BaseEditorDefinition<Context, ContextGridData> {
@@ -66,7 +66,7 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
                                    final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                   final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                   final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                    final ListSelectorView.Presenter listSelector,
                                    final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -66,6 +67,7 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
                                    final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                   final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                    final ListSelectorView.Presenter listSelector,
                                    final TranslationService translationService,
                                    final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
@@ -76,6 +78,7 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
@@ -142,6 +145,7 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
                                            canvasCommandFactory,
                                            editorSelectedEvent,
                                            refreshFormPropertiesEvent,
+                                           domainObjectSelectionEvent,
                                            getCellEditorControls(),
                                            listSelector,
                                            translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -51,6 +51,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -87,6 +88,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                        final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                        final Event<ExpressionEditorChanged> editorSelectedEvent,
                        final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                       final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                        final CellEditorControlsView.Presenter cellEditorControls,
                        final ListSelectorView.Presenter listSelector,
                        final TranslationService translationService,
@@ -108,6 +110,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,
@@ -307,11 +310,11 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                                                                          uiModelMapper,
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectParentCell();
+                                                                             selectCell(uiRowIndex, ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX, false, false);
                                                                          },
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectFirstCell();
+                                                                             selectExpressionEditorFirstCell(uiRowIndex, ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX);
                                                                          }));
         });
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -58,7 +58,7 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
@@ -87,7 +87,7 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                        final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                        final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                        final Event<ExpressionEditorChanged> editorSelectedEvent,
-                       final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                       final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                        final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                        final CellEditorControlsView.Presenter cellEditorControls,
                        final ListSelectorView.Presenter listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
@@ -43,7 +43,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class DecisionTableEditorDefinition extends BaseEditorDefinition<DecisionTable, DecisionTableGridData> {
@@ -62,7 +62,7 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
                                          final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                          final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                         final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                         final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                          final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                          final ListSelectorView.Presenter listSelector,
                                          final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -62,6 +63,7 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
                                          final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                          final ListSelectorView.Presenter listSelector,
                                          final TranslationService translationService,
                                          final HitPolicyPopoverView.Presenter hitPolicyEditor,
@@ -73,6 +75,7 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.hitPolicyEditor = hitPolicyEditor;
@@ -123,6 +126,7 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
                                                  canvasCommandFactory,
                                                  editorSelectedEvent,
                                                  refreshFormPropertiesEvent,
+                                                 domainObjectSelectionEvent,
                                                  getCellEditorControls(),
                                                  listSelector,
                                                  translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -70,7 +70,7 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.mvp.Command;
@@ -114,7 +114,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                              final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                              final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                              final Event<ExpressionEditorChanged> editorSelectedEvent,
-                             final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                             final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                              final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                              final CellEditorControlsView.Presenter cellEditorControls,
                              final ListSelectorView.Presenter listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -62,6 +62,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -114,6 +115,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                              final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                              final Event<ExpressionEditorChanged> editorSelectedEvent,
                              final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                             final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                              final CellEditorControlsView.Presenter cellEditorControls,
                              final ListSelectorView.Presenter listSelector,
                              final TranslationService translationService,
@@ -135,6 +137,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
@@ -42,6 +42,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -68,6 +69,7 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
                                     final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
                                     final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                     final ListSelectorView.Presenter listSelector,
                                     final TranslationService translationService,
                                     final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
@@ -80,6 +82,7 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
@@ -136,6 +139,7 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
                                             canvasCommandFactory,
                                             editorSelectedEvent,
                                             refreshFormPropertiesEvent,
+                                            domainObjectSelectionEvent,
                                             getCellEditorControls(),
                                             listSelector,
                                             translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefinition, DMNGridData> {
@@ -68,7 +68,7 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                     final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                    final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                    final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                     final ListSelectorView.Presenter listSelector,
                                     final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -63,7 +63,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.mvp.Command;
@@ -90,7 +90,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                         final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                        final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                         final CellEditorControlsView.Presenter cellEditorControls,
                         final ListSelectorView.Presenter listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -59,6 +59,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -90,6 +91,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                         final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                        final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                         final CellEditorControlsView.Presenter cellEditorControls,
                         final ListSelectorView.Presenter listSelector,
                         final TranslationService translationService,
@@ -113,6 +115,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,
@@ -361,11 +364,11 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                                                          uiModelMapper,
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectParentCell();
+                                                                             selectCell(0, 0, false, false);
                                                                          },
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectFirstCell();
+                                                                             selectExpressionEditorFirstCell(0, 0);
                                                                          }));
         });
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -58,6 +59,7 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
                                                      final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
                                                      final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                                      final ListSelectorView.Presenter listSelector,
                                                      final TranslationService translationService,
                                                      final Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
@@ -67,6 +69,7 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
@@ -114,6 +117,7 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
                                                          canvasCommandFactory,
                                                          editorSelectedEvent,
                                                          refreshFormPropertiesEvent,
+                                                         domainObjectSelectionEvent,
                                                          getCellEditorControls(),
                                                          listSelector,
                                                          translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
@@ -43,7 +43,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEditorDefinition<Context, FunctionSupplementaryGridData> {
 
@@ -58,7 +58,7 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
                                                      final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                                      final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                                     final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                                      final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                                      final ListSelectorView.Presenter listSelector,
                                                      final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
@@ -70,7 +70,7 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Funct
                                      final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                      final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                     final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                      final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                      final CellEditorControlsView.Presenter cellEditorControls,
                                      final ListSelectorView.Presenter listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -70,6 +71,7 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Funct
                                      final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
                                      final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                      final CellEditorControlsView.Presenter cellEditorControls,
                                      final ListSelectorView.Presenter listSelector,
                                      final TranslationService translationService,
@@ -90,6 +92,7 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Funct
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
@@ -40,7 +40,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @Dependent
 @FunctionGridSupplementaryEditor
@@ -60,7 +60,7 @@ public class JavaFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
                                         final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                        final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                         final ListSelectorView.Presenter listSelector,
                                         final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelect
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -60,6 +61,7 @@ public class JavaFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
                                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                        final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                         final ListSelectorView.Presenter listSelector,
                                         final TranslationService translationService,
                                         final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
@@ -69,6 +71,7 @@ public class JavaFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService,
               expressionEditorDefinitionsSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
@@ -40,7 +40,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @Dependent
 @FunctionGridSupplementaryEditor
@@ -60,7 +60,7 @@ public class PMMLFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
                                         final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                        final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                         final ListSelectorView.Presenter listSelector,
                                         final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelect
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -60,6 +61,7 @@ public class PMMLFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
                                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                        final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                         final ListSelectorView.Presenter listSelector,
                                         final TranslationService translationService,
                                         final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
@@ -69,6 +71,7 @@ public class PMMLFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService,
               expressionEditorDefinitionsSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
@@ -48,7 +48,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation, InvocationGridData> {
@@ -66,7 +66,7 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
                                       final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                       final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                       final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                      final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                      final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                       final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                       final ListSelectorView.Presenter listSelector,
                                       final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -66,6 +67,7 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
                                       final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                       final Event<ExpressionEditorChanged> editorSelectedEvent,
                                       final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                      final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                       final ListSelectorView.Presenter listSelector,
                                       final TranslationService translationService,
                                       final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
@@ -76,6 +78,7 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
@@ -138,6 +141,7 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
                                               canvasCommandFactory,
                                               editorSelectedEvent,
                                               refreshFormPropertiesEvent,
+                                              domainObjectSelectionEvent,
                                               getCellEditorControls(),
                                               listSelector,
                                               translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -54,6 +54,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -86,6 +87,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                           final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                           final Event<ExpressionEditorChanged> editorSelectedEvent,
                           final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                          final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                           final CellEditorControlsView.Presenter cellEditorControls,
                           final ListSelectorView.Presenter listSelector,
                           final TranslationService translationService,
@@ -107,6 +109,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,
@@ -306,11 +309,11 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                                                                          uiModelMapper,
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectParentCell();
+                                                                             selectCell(uiRowIndex, InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX, false, false);
                                                                          },
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectFirstCell();
+                                                                             selectExpressionEditorFirstCell(uiRowIndex, InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX);
                                                                          }));
         });
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -61,7 +61,7 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
@@ -86,7 +86,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                           final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                           final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                           final Event<ExpressionEditorChanged> editorSelectedEvent,
-                          final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                          final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                           final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                           final CellEditorControlsView.Presenter cellEditorControls,
                           final ListSelectorView.Presenter listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -59,6 +60,7 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
                                              final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                              final Event<ExpressionEditorChanged> editorSelectedEvent,
                                              final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                             final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                              final ListSelectorView.Presenter listSelector,
                                              final TranslationService translationService,
                                              final NameAndDataTypePopoverView.Presenter headerEditor) {
@@ -68,6 +70,7 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.headerEditor = headerEditor;
@@ -109,6 +112,7 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
                                                      canvasCommandFactory,
                                                      editorSelectedEvent,
                                                      refreshFormPropertiesEvent,
+                                                     domainObjectSelectionEvent,
                                                      getCellEditorControls(),
                                                      listSelector,
                                                      translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
@@ -42,7 +42,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<LiteralExpression, DMNGridData> {
@@ -59,7 +59,7 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
                                              final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                              final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                              final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                             final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                             final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                              final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                              final ListSelectorView.Presenter listSelector,
                                              final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 
 import javax.enterprise.event.Event;
 
-import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -43,15 +42,13 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
-import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
 public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression, DMNGridData, LiteralExpressionUIModelMapper> implements HasListSelectorControl {
 
@@ -73,6 +70,7 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
                                  final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                  final Event<ExpressionEditorChanged> editorSelectedEvent,
                                  final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                 final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                  final CellEditorControlsView.Presenter cellEditorControls,
                                  final ListSelectorView.Presenter listSelector,
                                  final TranslationService translationService,
@@ -93,6 +91,7 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,
@@ -105,24 +104,6 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
     }
 
     @Override
-    protected NodeMouseClickHandler getGridMouseClickHandler(final GridSelectionManager selectionManager) {
-        return (event) -> gridLayer.select(parent.getGridWidget());
-    }
-
-    @Override
-    public void selectFirstCell() {
-        final GridCellTuple parent = getParentInformation();
-        final GridWidget parentGridWidget = parent.getGridWidget();
-        final GridData parentUiModel = parentGridWidget.getModel();
-        parentUiModel.clearSelections();
-        parentUiModel.selectCell(parent.getRowIndex(),
-                                 parent.getColumnIndex());
-
-        final DMNGridLayer gridLayer = (DMNGridLayer) getLayer();
-        gridLayer.select(parentGridWidget);
-    }
-
-    @Override
     protected void doInitialisation() {
         // Defer initialisation until after the constructor completes as
         // LiteralExpressionUIModelMapper needs ListSelector to have been set
@@ -132,8 +113,7 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
     public LiteralExpressionUIModelMapper makeUiModelMapper() {
         return new LiteralExpressionUIModelMapper(this::getModel,
                                                   () -> expression,
-                                                  listSelector,
-                                                  parent);
+                                                  listSelector);
     }
 
     @Override
@@ -201,5 +181,12 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
     public void onItemSelected(final ListSelectorItem item) {
         final ListSelectorTextItem li = (ListSelectorTextItem) item;
         li.getCommand().execute();
+    }
+
+    @Override
+    @SuppressWarnings("unused")
+    protected void doAfterSelectionChange(final int uiRowIndex,
+                                          final int uiColumnIndex) {
+        getExpression().ifPresent(this::fireDomainObjectSelectionEvent);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -46,7 +46,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
@@ -69,7 +69,7 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
                                  final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                  final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                  final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                 final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                 final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                  final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                  final CellEditorControlsView.Presenter cellEditorControls,
                                  final ListSelectorView.Presenter listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
@@ -22,7 +22,6 @@ import java.util.function.Supplier;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
@@ -30,16 +29,13 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 public class LiteralExpressionUIModelMapper extends BaseUIModelMapper<LiteralExpression> {
 
     private final ListSelectorView.Presenter listSelector;
-    private final GridCellTuple parent;
 
     public LiteralExpressionUIModelMapper(final Supplier<GridData> uiModel,
                                           final Supplier<Optional<LiteralExpression>> dmnModel,
-                                          final ListSelectorView.Presenter listSelector,
-                                          final GridCellTuple parent) {
+                                          final ListSelectorView.Presenter listSelector) {
         super(uiModel,
               dmnModel);
         this.listSelector = listSelector;
-        this.parent = parent;
     }
 
     @Override
@@ -50,20 +46,6 @@ public class LiteralExpressionUIModelMapper extends BaseUIModelMapper<LiteralExp
                                   columnIndex,
                                   () -> new LiteralExpressionCell<>(new BaseGridCellValue<>(literalExpression.getText()),
                                                                     listSelector));
-            uiModel.get().getCell(rowIndex,
-                                  columnIndex).setSelectionStrategy((final GridData model,
-                                                                     final int uiRowIndex,
-                                                                     final int uiColumnIndex,
-                                                                     final boolean isShiftKeyDown,
-                                                                     final boolean isControlKeyDown) -> {
-                final GridData parentUiModel = parent.getGridWidget().getModel();
-                return parentUiModel.getCell(parent.getRowIndex(),
-                                             parent.getColumnIndex()).getSelectionStrategy().handleSelection(parentUiModel,
-                                                                                                             parent.getRowIndex(),
-                                                                                                             parent.getColumnIndex(),
-                                                                                                             isShiftKeyDown,
-                                                                                                             isControlKeyDown);
-            });
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
@@ -44,7 +44,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class RelationEditorDefinition extends BaseEditorDefinition<Relation, RelationGridData> {
@@ -61,7 +61,7 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                     final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                    final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                    final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                     final ListSelectorView.Presenter listSelector,
                                     final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -61,6 +62,7 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
                                     final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
                                     final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                     final ListSelectorView.Presenter listSelector,
                                     final TranslationService translationService,
                                     final NameAndDataTypePopoverView.Presenter headerEditor) {
@@ -70,6 +72,7 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.headerEditor = headerEditor;
@@ -131,6 +134,7 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
                                             canvasCommandFactory,
                                             editorSelectedEvent,
                                             refreshFormPropertiesEvent,
+                                            domainObjectSelectionEvent,
                                             getCellEditorControls(),
                                             listSelector,
                                             translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -48,6 +48,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -78,6 +79,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                         final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                        final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                         final CellEditorControlsView.Presenter cellEditorControls,
                         final ListSelectorView.Presenter listSelector,
                         final TranslationService translationService,
@@ -98,6 +100,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -55,7 +55,7 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
@@ -78,7 +78,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
                         final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                        final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                         final CellEditorControlsView.Presenter cellEditorControls,
                         final ListSelectorView.Presenter listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
@@ -45,7 +45,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Expression, DMNGridData> {
@@ -62,7 +62,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                                final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                                final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                               final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                               final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                                final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                                final ListSelectorView.Presenter listSelector,
                                                final TranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
@@ -40,6 +40,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -62,6 +63,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                                final Event<ExpressionEditorChanged> editorSelectedEvent,
                                                final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                               final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                                final ListSelectorView.Presenter listSelector,
                                                final TranslationService translationService,
                                                final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
@@ -71,6 +73,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               listSelector,
               translationService);
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
@@ -112,6 +115,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                        canvasCommandFactory,
                                                        editorSelectedEvent,
                                                        refreshFormPropertiesEvent,
+                                                       domainObjectSelectionEvent,
                                                        getCellEditorControls(),
                                                        listSelector,
                                                        translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
@@ -53,7 +53,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
@@ -80,7 +80,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
                                    final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                   final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                   final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                    final CellEditorControlsView.Presenter cellEditorControls,
                                    final ListSelectorView.Presenter listSelector,
@@ -255,7 +255,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
         final ClientSession session = sessionManager.getCurrentSession();
         if (session != null) {
             if (nodeUUID.isPresent()) {
-                refreshFormPropertiesEvent.fire(new RefreshFormProperties(session, nodeUUID.get()));
+                refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(session, nodeUUID.get()));
             } else {
                 super.doAfterSelectionChange(uiRowIndex, uiColumnIndex);
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
@@ -23,7 +23,6 @@ import java.util.function.Supplier;
 
 import javax.enterprise.event.Event;
 
-import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -49,16 +48,15 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
-import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
 public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNGridData, UndefinedExpressionUIModelMapper> implements HasListSelectorControl {
 
@@ -83,6 +81,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
                                    final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                   final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                    final CellEditorControlsView.Presenter cellEditorControls,
                                    final ListSelectorView.Presenter listSelector,
                                    final TranslationService translationService,
@@ -104,6 +103,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
               canvasCommandFactory,
               editorSelectedEvent,
               refreshFormPropertiesEvent,
+              domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
               translationService,
@@ -120,24 +120,6 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
     }
 
     @Override
-    protected NodeMouseClickHandler getGridMouseClickHandler(final GridSelectionManager selectionManager) {
-        return (event) -> gridLayer.select(parent.getGridWidget());
-    }
-
-    @Override
-    public void selectFirstCell() {
-        final GridCellTuple parent = getParentInformation();
-        final GridWidget parentGridWidget = parent.getGridWidget();
-        final GridData parentUiModel = parentGridWidget.getModel();
-        parentUiModel.clearSelections();
-        parentUiModel.selectCell(parent.getRowIndex(),
-                                 parent.getColumnIndex());
-
-        final DMNGridLayer gridLayer = (DMNGridLayer) getLayer();
-        gridLayer.select(parentGridWidget);
-    }
-
-    @Override
     protected void doInitialisation() {
         // Defer initialisation until after the constructor completes as
         // UndefinedExpressionColumn needs expressionEditorDefinitionsSupplier to have been set
@@ -148,8 +130,7 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
         return new UndefinedExpressionUIModelMapper(this::getModel,
                                                     () -> expression,
                                                     listSelector,
-                                                    hasExpression,
-                                                    parent);
+                                                    hasExpression);
     }
 
     @Override
@@ -263,8 +244,21 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
                                                                   },
                                                                   () -> {
                                                                       resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                      selectParentCell();
+                                                                      selectCell(0, 0, false, false);
                                                                   }));
         });
+    }
+
+    @SuppressWarnings("unused")
+    protected void doAfterSelectionChange(final int uiRowIndex,
+                                          final int uiColumnIndex) {
+        final ClientSession session = sessionManager.getCurrentSession();
+        if (session != null) {
+            if (nodeUUID.isPresent()) {
+                refreshFormPropertiesEvent.fire(new RefreshFormProperties(session, nodeUUID.get()));
+            } else {
+                super.doAfterSelectionChange(uiRowIndex, uiColumnIndex);
+            }
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
@@ -24,7 +24,6 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
@@ -32,18 +31,15 @@ public class UndefinedExpressionUIModelMapper extends BaseUIModelMapper<Expressi
 
     private final ListSelectorView.Presenter listSelector;
     private final HasExpression hasExpression;
-    private final GridCellTuple parent;
 
     public UndefinedExpressionUIModelMapper(final Supplier<GridData> uiModel,
                                             final Supplier<Optional<Expression>> dmnModel,
                                             final ListSelectorView.Presenter listSelector,
-                                            final HasExpression hasExpression,
-                                            final GridCellTuple parent) {
+                                            final HasExpression hasExpression) {
         super(uiModel,
               dmnModel);
         this.listSelector = listSelector;
         this.hasExpression = hasExpression;
-        this.parent = parent;
     }
 
     @Override
@@ -52,20 +48,6 @@ public class UndefinedExpressionUIModelMapper extends BaseUIModelMapper<Expressi
         uiModel.get().setCell(rowIndex,
                               columnIndex,
                               () -> new UndefinedExpressionCell(listSelector));
-        uiModel.get().getCell(rowIndex,
-                              columnIndex).setSelectionStrategy((final GridData model,
-                                                                 final int uiRowIndex,
-                                                                 final int uiColumnIndex,
-                                                                 final boolean isShiftKeyDown,
-                                                                 final boolean isControlKeyDown) -> {
-            final GridData parentUiModel = parent.getGridWidget().getModel();
-            return parentUiModel.getCell(parent.getRowIndex(),
-                                         parent.getColumnIndex()).getSelectionStrategy().handleSelection(parentUiModel,
-                                                                                                         parent.getRowIndex(),
-                                                                                                         parent.getColumnIndex(),
-                                                                                                         isShiftKeyDown,
-                                                                                                         isControlKeyDown);
-        });
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -76,7 +76,7 @@ import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -118,7 +118,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
 
     protected final TranslationService translationService;
     protected final Event<ExpressionEditorChanged> editorSelectedEvent;
-    protected final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     protected final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     protected final int nesting;
@@ -138,7 +138,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
                               final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                               final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                               final Event<ExpressionEditorChanged> editorSelectedEvent,
-                              final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                              final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                               final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                               final CellEditorControlsView.Presenter cellEditorControls,
                               final ListSelectorView.Presenter listSelector,
@@ -216,7 +216,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
                                                                                      typeRef,
                                                                                      () -> {
                                                                                          gridLayer.batch();
-                                                                                         getNodeUUID().ifPresent(uuid -> refreshFormPropertiesEvent.fire(new RefreshFormProperties(sessionManager.getCurrentSession(), uuid)));
+                                                                                         getNodeUUID().ifPresent(uuid -> refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(sessionManager.getCurrentSession(), uuid)));
                                                                                      }));
     }
 
@@ -225,7 +225,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
         commandBuilder.addCommand(new DeleteHasNameCommand(hasName,
                                                            () -> {
                                                                gridLayer.batch();
-                                                               getNodeUUID().ifPresent(uuid -> refreshFormPropertiesEvent.fire(new RefreshFormProperties(sessionManager.getCurrentSession(), uuid)));
+                                                               getNodeUUID().ifPresent(uuid -> refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(sessionManager.getCurrentSession(), uuid)));
                                                            }));
         return commandBuilder;
     }
@@ -237,7 +237,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
                                                         name,
                                                         () -> {
                                                             gridLayer.batch();
-                                                            getNodeUUID().ifPresent(uuid -> refreshFormPropertiesEvent.fire(new RefreshFormProperties(sessionManager.getCurrentSession(), uuid)));
+                                                            getNodeUUID().ifPresent(uuid -> refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(sessionManager.getCurrentSession(), uuid)));
                                                         }));
         return commandBuilder;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -32,10 +32,12 @@ import com.ait.lienzo.client.core.event.NodeMouseDoubleClickHandler;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Point2D;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
@@ -46,6 +48,7 @@ import org.kie.workbench.common.dmn.client.commands.general.SetCellValueCommand;
 import org.kie.workbench.common.dmn.client.commands.general.SetHasNameCommand;
 import org.kie.workbench.common.dmn.client.commands.general.SetHeaderValueCommand;
 import org.kie.workbench.common.dmn.client.commands.general.SetTypeRefCommand;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.EditableHeaderGridWidgetMouseDoubleClickHandler;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.EditableHeaderMetaData;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
@@ -60,19 +63,25 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.uberfire.commons.data.Pair;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
@@ -110,6 +119,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
     protected final TranslationService translationService;
     protected final Event<ExpressionEditorChanged> editorSelectedEvent;
     protected final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     protected final int nesting;
     protected M uiModelMapper;
@@ -129,6 +139,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
                               final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                               final Event<ExpressionEditorChanged> editorSelectedEvent,
                               final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                              final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                               final CellEditorControlsView.Presenter cellEditorControls,
                               final ListSelectorView.Presenter listSelector,
                               final TranslationService translationService,
@@ -147,6 +158,7 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
         this.canvasCommandFactory = canvasCommandFactory;
         this.editorSelectedEvent = editorSelectedEvent;
         this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
+        this.domainObjectSelectionEvent = domainObjectSelectionEvent;
         this.cellEditorControls = cellEditorControls;
         this.listSelector = listSelector;
         this.translationService = translationService;
@@ -468,32 +480,74 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
     }
 
     public void selectFirstCell() {
-        final DMNGridLayer gridLayer = (DMNGridLayer) getLayer();
-        gridLayer.select(this);
-
         final GridData uiModel = getModel();
         if (uiModel.getRowCount() == 0 || uiModel.getColumnCount() == 0) {
             return;
         }
+
         uiModel.clearSelections();
         uiModel.getColumns()
                 .stream()
                 .filter(c -> !(c instanceof RowNumberColumn))
                 .map(c -> uiModel.getColumns().indexOf(c))
                 .findFirst()
-                .ifPresent(index -> uiModel.selectCell(0, index));
+                .ifPresent(index -> selectCell(0, index, false, false));
     }
 
-    public void selectParentCell() {
-        final int parentUiRowIndex = parent.getRowIndex();
-        final int parentUiColumnIndex = parent.getColumnIndex();
-        final Optional<GridWidget> parentGridWidget = Optional.ofNullable(parent.getGridWidget());
-        parentGridWidget.ifPresent(pgw -> {
-            ((DMNGridLayer) getLayer()).select(pgw);
-            pgw.selectCell(parentUiRowIndex,
-                           parentUiColumnIndex,
-                           false,
-                           false);
+    @Override
+    public boolean selectCell(final Point2D ap,
+                              final boolean isShiftKeyDown,
+                              final boolean isControlKeyDown) {
+        final Integer uiRowIndex = CoordinateUtilities.getUiRowIndex(this,
+                                                                     ap.getY());
+        final Integer uiColumnIndex = CoordinateUtilities.getUiColumnIndex(this,
+                                                                           ap.getX());
+        if (uiRowIndex == null || uiColumnIndex == null) {
+            return false;
+        }
+
+        gridLayer.select(this);
+
+        final boolean isSelectionChanged = super.selectCell(uiRowIndex,
+                                                            uiColumnIndex,
+                                                            isShiftKeyDown,
+                                                            isControlKeyDown);
+        if (isSelectionChanged) {
+            doAfterSelectionChange(uiRowIndex, uiColumnIndex);
+        }
+
+        return isSelectionChanged;
+    }
+
+    @Override
+    public boolean selectCell(final int uiRowIndex,
+                              final int uiColumnIndex,
+                              final boolean isShiftKeyDown,
+                              final boolean isControlKeyDown) {
+        gridLayer.select(this);
+        final boolean isSelectionChanged = super.selectCell(uiRowIndex,
+                                                            uiColumnIndex,
+                                                            isShiftKeyDown,
+                                                            isControlKeyDown);
+        if (isSelectionChanged) {
+            doAfterSelectionChange(uiRowIndex, uiColumnIndex);
+        }
+
+        return isSelectionChanged;
+    }
+
+    protected void doAfterSelectionChange(final int uiRowIndex,
+                                          final int uiColumnIndex) {
+        fireDomainObjectSelectionEvent(new NOPDomainObject());
+    }
+
+    public void selectExpressionEditorFirstCell(final int uiRowIndex,
+                                                final int uiColumnIndex) {
+        final GridCellValue<?> value = model.getCell(uiRowIndex, uiColumnIndex).getValue();
+        final Optional<BaseExpressionGrid> grid = ((ExpressionCellValue) value).getValue();
+        grid.ifPresent(beg -> {
+            ((DMNGridLayer) getLayer()).select(beg);
+            beg.selectFirstCell();
         });
     }
 
@@ -503,5 +557,15 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
             return Optional.of((BaseExpressionGrid) gridWidget);
         }
         return Optional.empty();
+    }
+
+    protected void fireDomainObjectSelectionEvent(final DomainObject domainObject) {
+        final ClientSession session = sessionManager.getCurrentSession();
+        if (session != null) {
+            final CanvasHandler canvasHandler = session.getCanvasHandler();
+            if (canvasHandler != null) {
+                domainObjectSelectionEvent.fire(new DomainObjectSelectionEvent(canvasHandler, domainObject));
+            }
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelCellSelectionHandlerImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelCellSelectionHandlerImpl.java
@@ -18,9 +18,6 @@ package org.kie.workbench.common.dmn.client.widgets.panel;
 
 import java.util.stream.Stream;
 
-import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
-import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -45,28 +42,14 @@ public class DMNGridPanelCellSelectionHandlerImpl implements DMNGridPanelCellSel
                                      final boolean isShiftKeyDown,
                                      final boolean isControlKeyDown) {
         // If the right-click did not occur in an already selected cell, ensure the cell is selected
-        GridWidget _gridWidget = gridWidget;
-        int _uiRowIndex = uiRowIndex;
-        int _uiColumnIndex = uiColumnIndex;
-
-        // LiteralExpression and UndefinedExpression are not handled as grids in
-        // their own right. In these circumstances use their parent GridWidget.
-        if (_gridWidget instanceof LiteralExpressionGrid || _gridWidget instanceof UndefinedExpressionGrid) {
-            final BaseExpressionGrid grid = (BaseExpressionGrid) _gridWidget;
-            _gridWidget = grid.getParentInformation().getGridWidget();
-            _uiRowIndex = grid.getParentInformation().getRowIndex();
-            _uiColumnIndex = grid.getParentInformation().getColumnIndex();
-        }
-
-        final int rowIndex = _uiRowIndex;
-        final GridData gridData = _gridWidget.getModel();
-        final GridColumn<?> column = gridData.getColumns().get(_uiColumnIndex);
+        final GridData gridData = gridWidget.getModel();
+        final GridColumn<?> column = gridData.getColumns().get(uiColumnIndex);
         final Stream<SelectedCell> modelColumnSelectedCells = gridData.getSelectedCells().stream().filter(sc -> sc.getColumnIndex() == column.getIndex());
-        final boolean isContextMenuCellSelectedCell = modelColumnSelectedCells.map(SelectedCell::getRowIndex).anyMatch(ri -> ri == rowIndex);
+        final boolean isContextMenuCellSelectedCell = modelColumnSelectedCells.map(SelectedCell::getRowIndex).anyMatch(ri -> ri == uiRowIndex);
         if (!isContextMenuCellSelectedCell) {
-            selectCell(_uiRowIndex,
-                       _uiColumnIndex,
-                       _gridWidget,
+            selectCell(uiRowIndex,
+                       uiColumnIndex,
+                       gridWidget,
                        isShiftKeyDown,
                        isControlKeyDown);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigationCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigationCommandTest.java
@@ -33,8 +33,12 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultB
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
+import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
@@ -70,6 +74,9 @@ public abstract class BaseNavigationCommandTest {
     protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
+    protected EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+
+    @Mock
     protected EditorSession session;
 
     @Mock
@@ -89,6 +96,9 @@ public abstract class BaseNavigationCommandTest {
 
     @Mock
     protected Layer layer;
+
+    @Captor
+    protected ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesEventCaptor;
 
     protected BaseNavigateCommand command;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigationCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigationCommandTest.java
@@ -33,7 +33,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultB
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -74,7 +74,7 @@ public abstract class BaseNavigationCommandTest {
     protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    protected EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     protected EditorSession session;
@@ -98,7 +98,7 @@ public abstract class BaseNavigationCommandTest {
     protected Layer layer;
 
     @Captor
-    protected ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesEventCaptor;
+    protected ArgumentCaptor<RefreshFormPropertiesEvent> refreshFormPropertiesEventCaptor;
 
     protected BaseNavigateCommand command;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +43,7 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
                                               sessionPresenter,
                                               sessionManager,
                                               sessionCommandManager,
+                                              refreshFormPropertiesEvent,
                                               NODE_UUID,
                                               hasExpression,
                                               Optional.of(hasName));
@@ -58,6 +60,11 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
         verify(command).addDRGEditorToCanvasWidget();
         verify(sessionPresenterView).setCanvasWidget(view);
         verify(sessionPresenterView).setContentScrollType(eq(SessionPresenter.View.ScrollType.AUTO));
+
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
+
+        final RefreshFormProperties refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertEquals(NODE_UUID, refreshFormPropertiesEvent.getUuid());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +63,7 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
 
         verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
         assertEquals(NODE_UUID, refreshFormPropertiesEvent.getUuid());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommandTest.java
@@ -42,6 +42,7 @@ public class NavigateToExpressionEditorCommandTest extends BaseNavigationCommand
                                                      sessionPresenter,
                                                      sessionManager,
                                                      sessionCommandManager,
+                                                     refreshFormPropertiesEvent,
                                                      NODE_UUID,
                                                      hasExpression,
                                                      Optional.of(hasName));
@@ -74,6 +75,8 @@ public class NavigateToExpressionEditorCommandTest extends BaseNavigationCommand
         verify(command).addDRGEditorToCanvasWidget();
         verify(sessionPresenterView).setCanvasWidget(view);
         verify(sessionPresenterView).setContentScrollType(eq(SessionPresenter.View.ScrollType.AUTO));
+
+        verify(canvasHandler).notifyCanvasClear();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/DMNPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/DMNPaletteDefinitionBuilderTest.java
@@ -90,6 +90,7 @@ public class DMNPaletteDefinitionBuilderTest {
         assertFalse(tested.getPaletteDefinitionBuilder().getCategoryFilter().test(Categories.DIAGRAM));
         assertFalse(tested.getPaletteDefinitionBuilder().getCategoryFilter().test(Categories.CONNECTORS));
         assertFalse(tested.getPaletteDefinitionBuilder().getCategoryFilter().test(Categories.MISCELLANEOUS));
+        assertFalse(tested.getPaletteDefinitionBuilder().getCategoryFilter().test(Categories.DOMAIN_OBJECTS));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.ait.lienzo.client.core.event.INodeXYEvent;
+import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
@@ -55,6 +56,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -62,6 +64,8 @@ import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionManager;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 
@@ -137,16 +141,25 @@ public class ExpressionContainerGridTest {
     private HasExpression hasExpression;
 
     @Mock
+    private ParameterizedCommand<Optional<Expression>> onHasExpressionChanged;
+
+    @Mock
     private ParameterizedCommand<Optional<HasName>> onHasNameChanged;
 
     @Mock
-    private ParameterizedCommand<Optional<Expression>> onHasExpressionChanged;
+    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+
+    @Mock
+    private CellSelectionManager cellSelectionManager;
 
     @Captor
     private ArgumentCaptor<Optional<HasName>> hasNameCaptor;
 
     @Captor
     private ArgumentCaptor<ClearExpressionTypeCommand> clearExpressionTypeCommandCaptor;
+
+    @Captor
+    private ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesCaptor;
 
     private HasName hasName = new HasName() {
 
@@ -185,7 +198,13 @@ public class ExpressionContainerGridTest {
                                                 expressionEditorDefinitionsSupplier,
                                                 () -> expressionGridCache,
                                                 onHasExpressionChanged,
-                                                onHasNameChanged);
+                                                onHasNameChanged,
+                                                refreshFormPropertiesEvent) {
+            @Override
+            protected CellSelectionManager getCellSelectionManager() {
+                return cellSelectionManager;
+            }
+        };
 
         this.gridLayer.add(grid);
 
@@ -565,5 +584,46 @@ public class ExpressionContainerGridTest {
         final HasExpression spy = grid.spyHasExpression(hasExpression);
 
         assertThat(spy.asDMNModelInstrumentedBase()).isEqualTo(literalExpression);
+    }
+
+    @Test
+    public void testSelectCellWithPoint() {
+        final Point2D point = mock(Point2D.class);
+
+        grid.setExpression(NODE_UUID,
+                           hasExpression,
+                           Optional.of(hasName));
+
+        grid.selectCell(point, false, true);
+
+        verify(gridLayer).select(eq(grid));
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+
+        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
+        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
+
+        verify(cellSelectionManager).selectCell(eq(point), eq(false), eq(true));
+    }
+
+    @Test
+    public void testSelectCellWithCoordinates() {
+        final int uiRowIndex = 0;
+        final int uiColumnIndex = 1;
+
+        grid.setExpression(NODE_UUID,
+                           hasExpression,
+                           Optional.of(hasName));
+
+        grid.selectCell(uiRowIndex, uiColumnIndex, false, true);
+
+        verify(gridLayer).select(eq(grid));
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+
+        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
+        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
+
+        verify(cellSelectionManager).selectCell(eq(uiRowIndex), eq(uiColumnIndex), eq(false), eq(true));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
@@ -56,7 +56,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -147,7 +147,7 @@ public class ExpressionContainerGridTest {
     private ParameterizedCommand<Optional<HasName>> onHasNameChanged;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private CellSelectionManager cellSelectionManager;
@@ -159,7 +159,7 @@ public class ExpressionContainerGridTest {
     private ArgumentCaptor<ClearExpressionTypeCommand> clearExpressionTypeCommandCaptor;
 
     @Captor
-    private ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesCaptor;
+    private ArgumentCaptor<RefreshFormPropertiesEvent> refreshFormPropertiesEventCaptor;
 
     private HasName hasName = new HasName() {
 
@@ -597,11 +597,11 @@ public class ExpressionContainerGridTest {
         grid.selectCell(point, false, true);
 
         verify(gridLayer).select(eq(grid));
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(NODE_UUID);
 
         verify(cellSelectionManager).selectCell(eq(point), eq(false), eq(true));
     }
@@ -618,11 +618,11 @@ public class ExpressionContainerGridTest {
         grid.selectCell(uiRowIndex, uiColumnIndex, false, true);
 
         verify(gridLayer).select(eq(grid));
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(NODE_UUID);
 
         verify(cellSelectionManager).selectCell(eq(uiRowIndex), eq(uiColumnIndex), eq(false), eq(true));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -52,7 +52,7 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanelContainer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -121,7 +121,7 @@ public class ExpressionEditorViewImplTest {
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private ExpressionEditorDefinition undefinedExpressionEditorDefinition;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -52,6 +52,7 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanelContainer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -59,6 +60,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
+import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -117,6 +119,9 @@ public class ExpressionEditorViewImplTest {
 
     @Mock
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
+
+    @Mock
+    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
     private ExpressionEditorDefinition undefinedExpressionEditorDefinition;
@@ -193,7 +198,8 @@ public class ExpressionEditorViewImplTest {
                                                      listSelector,
                                                      sessionManager,
                                                      sessionCommandManager,
-                                                     expressionEditorDefinitionsSupplier));
+                                                     expressionEditorDefinitionsSupplier,
+                                                     refreshFormPropertiesEvent));
         view.init(presenter);
         view.bind(session);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -111,6 +112,9 @@ public class ContextEditorDefinitionTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     private Optional<HasName> hasName = Optional.empty();
 
     private ContextEditorDefinition definition;
@@ -129,6 +133,7 @@ public class ContextEditorDefinitionTest {
                                                       canvasCommandFactory,
                                                       editorSelectedEvent,
                                                       refreshFormPropertiesEvent,
+                                                      domainObjectSelectionEvent,
                                                       listSelector,
                                                       translationService,
                                                       expressionEditorDefinitionsSupplier,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -110,7 +110,7 @@ public class ContextEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
@@ -78,7 +78,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
@@ -220,7 +220,7 @@ public class ContextGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
@@ -70,6 +70,7 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -221,6 +222,9 @@ public class ContextGridTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     @Captor
     private ArgumentCaptor<AddContextEntryCommand> addContextEntryCommandCaptor;
 
@@ -265,6 +269,7 @@ public class ContextGridTest {
                                                  canvasCommandFactory,
                                                  editorSelectedEvent,
                                                  refreshFormPropertiesEvent,
+                                                 domainObjectSelectionEvent,
                                                  listSelector,
                                                  translationService,
                                                  expressionEditorDefinitionsSupplier,
@@ -705,11 +710,11 @@ public class ContextGridTest {
         clearExpressionTypeCommand.execute(canvasHandler);
 
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(gridWidget);
-        verify(gridWidget).selectCell(eq(0),
-                                      eq(2),
-                                      eq(false),
-                                      eq(false));
+        verify(gridLayer).select(grid);
+        verify(grid).selectCell(eq(0),
+                                eq(ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX),
+                                eq(false),
+                                eq(false));
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         redrawCommandCaptor.getValue().execute();
         verify(gridLayer).draw();
@@ -721,8 +726,10 @@ public class ContextGridTest {
         //Verify Expression has been restored and UndefinedExpressionEditor resized
         assertThat(grid.getModel().getColumns().get(2).getWidth()).isEqualTo(DMNGridColumn.DEFAULT_WIDTH);
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(grid);
-        verify(grid).selectFirstCell();
+
+        verify(grid).selectExpressionEditorFirstCell(eq(0), eq(ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX));
+        verify(gridLayer).select(undefinedExpressionEditor);
+        verify(undefinedExpressionEditor).selectFirstCell();
 
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         assertThat(redrawCommandCaptor.getAllValues()).hasSize(2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
@@ -41,6 +41,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -99,6 +100,9 @@ public class ExpressionEditorColumnTest {
 
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -403,6 +407,7 @@ public class ExpressionEditorColumnTest {
                                       canvasCommandFactory,
                                       editorSelectedEvent,
                                       refreshFormPropertiesEvent,
+                                      domainObjectSelectionEvent,
                                       cellEditorControls,
                                       listSelector,
                                       translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
@@ -45,7 +45,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
@@ -99,7 +99,7 @@ public class ExpressionEditorColumnTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -109,6 +110,9 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
     private NameAndDataTypePopoverView.Presenter headerEditor;
 
     @Mock
@@ -138,6 +142,7 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
                                                             canvasCommandFactory,
                                                             editorSelectedEvent,
                                                             refreshFormPropertiesEvent,
+                                                            domainObjectSelectionEvent,
                                                             listSelector,
                                                             translationService,
                                                             hitPolicyEditor,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
@@ -53,7 +53,7 @@ import org.kie.workbench.common.stunner.core.graph.impl.GraphImpl;
 import org.kie.workbench.common.stunner.core.graph.store.GraphNodeStoreImpl;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -107,7 +107,7 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
@@ -92,7 +92,7 @@ import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecution
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -237,7 +237,7 @@ public class DecisionTableGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
@@ -82,6 +82,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -238,6 +239,9 @@ public class DecisionTableGridTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     @Captor
     private ArgumentCaptor<AddInputClauseCommand> addInputClauseCommandCaptor;
 
@@ -295,6 +299,7 @@ public class DecisionTableGridTest {
                                                             canvasCommandFactory,
                                                             editorSelectedEvent,
                                                             refreshFormPropertiesEvent,
+                                                            domainObjectSelectionEvent,
                                                             listSelector,
                                                             translationService,
                                                             hitPolicyEditor,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
@@ -49,7 +49,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -116,7 +116,7 @@ public class FunctionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -117,6 +118,9 @@ public class FunctionEditorDefinitionTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     private Optional<HasName> hasName = Optional.empty();
 
     private FunctionEditorDefinition definition;
@@ -135,6 +139,7 @@ public class FunctionEditorDefinitionTest {
                                                        canvasCommandFactory,
                                                        editorSelectedEvent,
                                                        refreshFormPropertiesEvent,
+                                                       domainObjectSelectionEvent,
                                                        listSelector,
                                                        translationService,
                                                        expressionEditorDefinitionsSupplier,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
@@ -71,6 +71,7 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -190,6 +191,9 @@ public class FunctionGridTest {
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
     private LiteralExpressionGrid literalExpressionEditor;
 
     @Mock
@@ -270,6 +274,7 @@ public class FunctionGridTest {
                                                   canvasCommandFactory,
                                                   editorSelectedEvent,
                                                   refreshFormPropertiesEvent,
+                                                  domainObjectSelectionEvent,
                                                   listSelector,
                                                   translationService,
                                                   expressionEditorDefinitionsSupplier,
@@ -282,6 +287,7 @@ public class FunctionGridTest {
                                                                                       canvasCommandFactory,
                                                                                       editorSelectedEvent,
                                                                                       refreshFormPropertiesEvent,
+                                                                                      domainObjectSelectionEvent,
                                                                                       listSelector,
                                                                                       translationService,
                                                                                       headerEditor));
@@ -589,6 +595,7 @@ public class FunctionGridTest {
         when(literalExpressionEditor.getLayer()).thenReturn(gridLayer);
         when(literalExpressionEditor.getParentInformation()).thenReturn(parent);
         when(literalExpressionEditor.getModel()).thenReturn(new BaseGridData(false));
+        when(literalExpressionEditor.getExpression()).thenReturn(Optional.empty());
         doCallRealMethod().when(literalExpressionEditor).selectFirstCell();
 
         grid.setKind(FunctionDefinition.Kind.FEEL);
@@ -713,7 +720,15 @@ public class FunctionGridTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testClearExpressionType() {
+        doReturn(Optional.of(literalExpressionEditor)).when(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
+                                                                                                         any(Optional.class),
+                                                                                                         any(HasExpression.class),
+                                                                                                         any(Optional.class),
+                                                                                                         any(Optional.class),
+                                                                                                         anyInt());
+
         setupGrid(0);
 
         grid.clearExpressionType();
@@ -725,11 +740,11 @@ public class FunctionGridTest {
         clearExpressionTypeCommand.execute(canvasHandler);
 
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(gridWidget);
-        verify(gridWidget).selectCell(eq(0),
-                                      eq(0),
-                                      eq(false),
-                                      eq(false));
+        verify(gridLayer).select(grid);
+        verify(grid).selectCell(eq(0),
+                                eq(0),
+                                eq(false),
+                                eq(false));
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         redrawCommandCaptor.getValue().execute();
         verify(gridLayer).draw();
@@ -741,8 +756,10 @@ public class FunctionGridTest {
         //Verify Expression has been restored and UndefinedExpressionEditor resized
         assertThat(grid.getModel().getColumns().get(0).getWidth()).isEqualTo(DMNGridColumn.DEFAULT_WIDTH);
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(grid);
-        verify(grid).selectFirstCell();
+
+        verify(grid).selectExpressionEditorFirstCell(eq(0), eq(0));
+        verify(gridLayer).select(literalExpressionEditor);
+        verify(literalExpressionEditor).selectFirstCell();
 
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         assertThat(redrawCommandCaptor.getAllValues()).hasSize(2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
@@ -79,7 +79,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -188,7 +188,7 @@ public class FunctionGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
@@ -100,7 +100,7 @@ public abstract class BaseFunctionSupplementaryGridTest<D extends ExpressionEdit
     protected EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    protected EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     protected EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -100,6 +101,9 @@ public abstract class BaseFunctionSupplementaryGridTest<D extends ExpressionEdit
 
     @Mock
     protected EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+
+    @Mock
+    protected EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
     private GridCellTuple parent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/JavaFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/JavaFunctionSupplementaryGridTest.java
@@ -30,6 +30,7 @@ public class JavaFunctionSupplementaryGridTest extends BaseFunctionSupplementary
                                                 canvasCommandFactory,
                                                 editorSelectedEvent,
                                                 refreshFormPropertiesEvent,
+                                                domainObjectSelectionEvent,
                                                 listSelector,
                                                 translationService,
                                                 expressionEditorDefinitionsSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/PMMLFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/PMMLFunctionSupplementaryGridTest.java
@@ -30,6 +30,7 @@ public class PMMLFunctionSupplementaryGridTest extends BaseFunctionSupplementary
                                                 canvasCommandFactory,
                                                 editorSelectedEvent,
                                                 refreshFormPropertiesEvent,
+                                                domainObjectSelectionEvent,
                                                 listSelector,
                                                 translationService,
                                                 expressionEditorDefinitionsSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -105,7 +105,7 @@ public class JavaFunctionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -106,6 +107,9 @@ public class JavaFunctionEditorDefinitionTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     private Optional<HasName> hasName = Optional.empty();
 
     private JavaFunctionEditorDefinition definition;
@@ -124,6 +128,7 @@ public class JavaFunctionEditorDefinitionTest {
                                                            canvasCommandFactory,
                                                            editorSelectedEvent,
                                                            refreshFormPropertiesEvent,
+                                                           domainObjectSelectionEvent,
                                                            listSelector,
                                                            translationService,
                                                            expressionEditorDefinitionsSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -106,6 +107,9 @@ public class PMMLFunctionEditorDefinitionTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     private Optional<HasName> hasName = Optional.empty();
 
     private PMMLFunctionEditorDefinition definition;
@@ -124,6 +128,7 @@ public class PMMLFunctionEditorDefinitionTest {
                                                            canvasCommandFactory,
                                                            editorSelectedEvent,
                                                            refreshFormPropertiesEvent,
+                                                           domainObjectSelectionEvent,
                                                            listSelector,
                                                            translationService,
                                                            expressionEditorDefinitionsSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -105,7 +105,7 @@ public class PMMLFunctionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -110,7 +110,7 @@ public class InvocationEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -111,6 +112,9 @@ public class InvocationEditorDefinitionTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     private Optional<HasName> hasName = Optional.empty();
 
     private InvocationEditorDefinition definition;
@@ -129,6 +133,7 @@ public class InvocationEditorDefinitionTest {
                                                          canvasCommandFactory,
                                                          editorSelectedEvent,
                                                          refreshFormPropertiesEvent,
+                                                         domainObjectSelectionEvent,
                                                          listSelector,
                                                          translationService,
                                                          expressionEditorDefinitionsSupplier,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
@@ -81,7 +81,7 @@ import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecution
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -223,7 +223,7 @@ public class InvocationGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
@@ -72,6 +72,7 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -224,6 +225,9 @@ public class InvocationGridTest {
     @Mock
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
     @Captor
     private ArgumentCaptor<AddParameterBindingCommand> addParameterBindingCommandCaptor;
 
@@ -268,6 +272,7 @@ public class InvocationGridTest {
                                                     canvasCommandFactory,
                                                     editorSelectedEvent,
                                                     refreshFormPropertiesEvent,
+                                                    domainObjectSelectionEvent,
                                                     listSelector,
                                                     translationService,
                                                     expressionEditorDefinitionsSupplier,
@@ -689,11 +694,11 @@ public class InvocationGridTest {
         clearExpressionTypeCommand.execute(canvasHandler);
 
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(gridWidget);
-        verify(gridWidget).selectCell(eq(0),
-                                      eq(2),
-                                      eq(false),
-                                      eq(false));
+        verify(gridLayer).select(grid);
+        verify(grid).selectCell(eq(0),
+                                eq(InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX),
+                                eq(false),
+                                eq(false));
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         redrawCommandCaptor.getValue().execute();
         verify(gridLayer).draw();
@@ -705,8 +710,10 @@ public class InvocationGridTest {
         //Verify Expression has been restored and UndefinedExpressionEditor resized
         assertThat(grid.getModel().getColumns().get(2).getWidth()).isEqualTo(DMNGridColumn.DEFAULT_WIDTH);
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(grid);
-        verify(grid).selectFirstCell();
+
+        verify(grid).selectExpressionEditorFirstCell(eq(0), eq(InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX));
+        verify(gridLayer).select(undefinedExpressionEditor);
+        verify(undefinedExpressionEditor).selectFirstCell();
 
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         assertThat(redrawCommandCaptor.getAllValues()).hasSize(2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
@@ -43,7 +43,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -96,7 +96,7 @@ public class LiteralExpressionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -98,6 +99,9 @@ public class LiteralExpressionEditorDefinitionTest {
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
     private NameAndDataTypePopoverView.Presenter headerEditor;
 
     private Optional<HasName> hasName = Optional.of(HasName.NOP);
@@ -118,6 +122,7 @@ public class LiteralExpressionEditorDefinitionTest {
                                                                 canvasCommandFactory,
                                                                 editorSelectedEvent,
                                                                 refreshFormPropertiesEvent,
+                                                                domainObjectSelectionEvent,
                                                                 listSelector,
                                                                 translationService,
                                                                 headerEditor);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -64,7 +64,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -171,7 +171,7 @@ public class LiteralExpressionGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import com.ait.lienzo.client.core.event.NodeMouseClickEvent;
-import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
@@ -57,6 +56,7 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -70,6 +70,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.GridData.SelectedCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
@@ -173,10 +174,16 @@ public class LiteralExpressionGridTest {
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
     private NameAndDataTypePopoverView.Presenter headerEditor;
 
     @Captor
     private ArgumentCaptor<CompositeCommand> compositeCommandCaptor;
+
+    @Captor
+    private ArgumentCaptor<DomainObjectSelectionEvent> domainObjectSelectionEventCaptor;
 
     private Decision hasExpression = new Decision();
 
@@ -204,6 +211,7 @@ public class LiteralExpressionGridTest {
                                                            canvasCommandFactory,
                                                            editorSelectedEvent,
                                                            refreshFormPropertiesEvent,
+                                                           domainObjectSelectionEvent,
                                                            listSelector,
                                                            translationService,
                                                            headerEditor);
@@ -243,25 +251,21 @@ public class LiteralExpressionGridTest {
     }
 
     @Test
-    public void testGridMouseClickHandler() {
-        setupGrid(0);
-
-        final NodeMouseClickHandler handler = grid.getGridMouseClickHandler(selectionManager);
-
-        handler.onNodeMouseClick(mouseClickEvent);
-
-        verify(gridLayer).select(parentGridWidget);
-    }
-
-    @Test
     public void testSelectFirstCell() {
         setupGrid(0);
 
         grid.selectFirstCell();
 
-        verify(parentGridUiModel).clearSelections();
-        verify(parentGridUiModel).selectCell(eq(0), eq(1));
-        verify(gridLayer).select(parentGridWidget);
+        final List<SelectedCell> selectedCells = grid.getModel().getSelectedCells();
+        assertThat(selectedCells.size()).isEqualTo(1);
+        assertThat(selectedCells.get(0).getRowIndex()).isEqualTo(0);
+        assertThat(selectedCells.get(0).getColumnIndex()).isEqualTo(0);
+
+        verify(gridLayer).select(grid);
+
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isEqualTo(expression.get());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
@@ -23,30 +23,18 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.ext.wires.core.grids.client.model.GridCell;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LiteralExpressionUIModelMapperTest {
-
-    private static final int PARENT_ROW_INDEX = 0;
-
-    private static final int PARENT_COLUMN_INDEX = 1;
 
     @Mock
     private LiteralExpressionColumn uiLiteralExpressionColumn;
@@ -56,18 +44,6 @@ public class LiteralExpressionUIModelMapperTest {
 
     @Mock
     private ListSelectorView.Presenter listSelector;
-
-    @Mock
-    private GridWidget parentGridWidget;
-
-    @Mock
-    private GridData parentGridUiModel;
-
-    @Mock
-    private GridCell parentGridUiCell;
-
-    @Mock
-    private CellSelectionStrategy parentGridUiCellCellSelectionStrategy;
 
     private BaseGridData uiModel;
 
@@ -82,18 +58,12 @@ public class LiteralExpressionUIModelMapperTest {
         uiModel.appendRow(new DMNGridRow());
         uiModel.appendColumn(uiLiteralExpressionColumn);
         doReturn(0).when(uiLiteralExpressionColumn).getIndex();
-        when(parentGridWidget.getModel()).thenReturn(parentGridUiModel);
-        when(parentGridUiModel.getCell(eq(PARENT_ROW_INDEX), eq(PARENT_COLUMN_INDEX))).thenReturn(parentGridUiCell);
-        when(parentGridUiCell.getSelectionStrategy()).thenReturn(parentGridUiCellCellSelectionStrategy);
 
         literalExpression = new LiteralExpression();
 
         mapper = new LiteralExpressionUIModelMapper(() -> uiModel,
                                                     () -> Optional.of(literalExpression),
-                                                    listSelector,
-                                                    new GridCellTuple(PARENT_ROW_INDEX,
-                                                                      PARENT_COLUMN_INDEX,
-                                                                      parentGridWidget));
+                                                    listSelector);
     }
 
     @Test
@@ -116,21 +86,6 @@ public class LiteralExpressionUIModelMapperTest {
         mapper.fromDMNModel(0, 0);
 
         assertTrue(uiModel.getCell(0, 0) instanceof LiteralExpressionCell);
-    }
-
-    @Test
-    public void testFromDmn_CellSelectionStrategy() {
-        mapper.fromDMNModel(0, 0);
-
-        final CellSelectionStrategy strategy = uiModel.getCell(0, 0).getSelectionStrategy();
-
-        strategy.handleSelection(uiModel, 0, 0, true, false);
-
-        verify(parentGridUiCellCellSelectionStrategy).handleSelection(eq(parentGridUiModel),
-                                                                      eq(PARENT_ROW_INDEX),
-                                                                      eq(PARENT_COLUMN_INDEX),
-                                                                      eq(true),
-                                                                      eq(false));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
@@ -40,6 +40,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -102,6 +103,9 @@ public class RelationEditorDefinitionTest {
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
     private NameAndDataTypePopoverView.Presenter headerEditor;
 
     private Optional<HasName> hasName = Optional.empty();
@@ -122,6 +126,7 @@ public class RelationEditorDefinitionTest {
                                                        canvasCommandFactory,
                                                        editorSelectedEvent,
                                                        refreshFormPropertiesEvent,
+                                                       domainObjectSelectionEvent,
                                                        listSelector,
                                                        translationService,
                                                        headerEditor);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
@@ -44,7 +44,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -100,7 +100,7 @@ public class RelationEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
@@ -65,6 +65,7 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -190,6 +191,9 @@ public class RelationGridTest {
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
     private NameAndDataTypePopoverView.Presenter headerEditor;
 
     @Captor
@@ -241,6 +245,7 @@ public class RelationGridTest {
                                                   canvasCommandFactory,
                                                   editorSelectedEvent,
                                                   refreshFormPropertiesEvent,
+                                                  domainObjectSelectionEvent,
                                                   listSelector,
                                                   translationService,
                                                   headerEditor);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
@@ -70,7 +70,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -188,7 +188,7 @@ public class RelationGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
@@ -23,7 +23,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.ait.lienzo.client.core.event.NodeMouseClickEvent;
-import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
@@ -31,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.undefined.SetCellValueCommand;
@@ -55,6 +55,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
@@ -63,8 +64,11 @@ import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager;
@@ -163,13 +167,22 @@ public class UndefinedExpressionGridTest {
     private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
     private ManagedSession managedSession;
 
     @Captor
     private ArgumentCaptor<SetCellValueCommand> setCellValueCommandArgumentCaptor;
 
     @Captor
+    private ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesArgumentCaptor;
+
+    @Captor
     private ArgumentCaptor<GridLayerRedrawManager.PrioritizedCommand> redrawCommandArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<DomainObjectSelectionEvent> domainObjectSelectionArgumentEventCaptor;
 
     private LiteralExpression literalExpression = new LiteralExpression();
 
@@ -201,6 +214,7 @@ public class UndefinedExpressionGridTest {
                                                              canvasCommandFactory,
                                                              editorSelectedEvent,
                                                              refreshFormPropertiesEvent,
+                                                             domainObjectSelectionEvent,
                                                              listSelector,
                                                              translationService,
                                                              expressionEditorDefinitionsSupplier);
@@ -216,7 +230,12 @@ public class UndefinedExpressionGridTest {
         doReturn(LiteralExpression.class.getSimpleName()).when(literalExpressionEditorDefinition).getName();
         doCallRealMethod().when(literalExpressionEditor).selectFirstCell();
         doReturn(gridLayer).when(literalExpressionEditor).getLayer();
-        doReturn(mock(GridData.class)).when(literalExpressionEditor).getModel();
+
+        final GridData literalExpressionUiModel = new BaseGridData();
+        literalExpressionUiModel.appendColumn(mock(GridColumn.class));
+        literalExpressionUiModel.appendRow(mock(GridRow.class));
+        doReturn(literalExpressionUiModel).when(literalExpressionEditor).getModel();
+
         doReturn(Optional.of(literalExpression)).when(literalExpressionEditorDefinition).getModelClass();
         doReturn(Optional.of(literalExpressionEditor)).when(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
                                                                                                          any(Optional.class),
@@ -247,25 +266,23 @@ public class UndefinedExpressionGridTest {
     }
 
     @Test
-    public void testGridMouseClickHandler() {
-        setupGrid(0);
-
-        final NodeMouseClickHandler handler = grid.getGridMouseClickHandler(selectionManager);
-
-        handler.onNodeMouseClick(mouseClickEvent);
-
-        verify(gridLayer).select(parentGridWidget);
-    }
-
-    @Test
     public void testSelectFirstCell() {
         setupGrid(0);
 
         grid.selectFirstCell();
 
-        verify(parentGridUiModel).clearSelections();
-        verify(parentGridUiModel).selectCell(eq(0), eq(1));
-        verify(gridLayer).select(parentGridWidget);
+        final List<GridData.SelectedCell> selectedCells = grid.getModel().getSelectedCells();
+        assertThat(selectedCells.size()).isEqualTo(1);
+        assertThat(selectedCells.get(0).getRowIndex()).isEqualTo(0);
+        assertThat(selectedCells.get(0).getColumnIndex()).isEqualTo(0);
+
+        verify(gridLayer).select(grid);
+
+        verify(domainObjectSelectionEvent, never()).fire(any(DomainObjectSelectionEvent.class));
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesArgumentCaptor.capture());
+        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesArgumentCaptor.getValue();
+        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
     }
 
     @Test
@@ -447,6 +464,11 @@ public class UndefinedExpressionGridTest {
         assertOnExpressionTypeChanged(1);
 
         verify(expressionGridCache, never()).getExpressionGrid(anyString());
+
+        verify(refreshFormPropertiesEvent, never()).fire(any(RefreshFormProperties.class));
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionArgumentEventCaptor.capture());
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionArgumentEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isInstanceOf(NOPDomainObject.class);
     }
 
     @Test
@@ -455,6 +477,12 @@ public class UndefinedExpressionGridTest {
         assertOnExpressionTypeChanged(0);
 
         verify(expressionGridCache).getExpressionGrid(eq(NODE_UUID));
+
+        verify(domainObjectSelectionEvent, never()).fire(any(DomainObjectSelectionEvent.class));
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesArgumentCaptor.capture());
+        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesArgumentCaptor.getValue();
+        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
     }
 
     private void assertResize(final Function<BaseExpressionGrid, Double> expectedResizer) {
@@ -490,7 +518,10 @@ public class UndefinedExpressionGridTest {
         setCellValueCommand.execute(handler);
 
         assertResize(BaseExpressionGrid.RESIZE_EXISTING);
-        verify(gridLayer).select(eq(literalExpressionEditor));
+        verify(literalExpressionEditor).selectCell(eq(0),
+                                                   eq(0),
+                                                   eq(false),
+                                                   eq(false));
         verify(literalExpressionEditor).selectFirstCell();
 
         reset(gridPanel, gridLayer, parent);
@@ -499,10 +530,10 @@ public class UndefinedExpressionGridTest {
         setCellValueCommand.undo(handler);
 
         assertResize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(parentGridWidget);
-        verify(parentGridWidget).selectCell(eq(PARENT_ROW_INDEX),
-                                            eq(PARENT_COLUMN_INDEX),
-                                            eq(false),
-                                            eq(false));
+        verify(gridLayer).select(grid);
+        verify(grid).selectCell(eq(0),
+                                eq(0),
+                                eq(false),
+                                eq(false));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGridTest.java
@@ -60,7 +60,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -164,7 +164,7 @@ public class UndefinedExpressionGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
@@ -176,7 +176,7 @@ public class UndefinedExpressionGridTest {
     private ArgumentCaptor<SetCellValueCommand> setCellValueCommandArgumentCaptor;
 
     @Captor
-    private ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesArgumentCaptor;
+    private ArgumentCaptor<RefreshFormPropertiesEvent> refreshFormPropertiesArgumentCaptor;
 
     @Captor
     private ArgumentCaptor<GridLayerRedrawManager.PrioritizedCommand> redrawCommandArgumentCaptor;
@@ -280,9 +280,9 @@ public class UndefinedExpressionGridTest {
 
         verify(domainObjectSelectionEvent, never()).fire(any(DomainObjectSelectionEvent.class));
         verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesArgumentCaptor.capture());
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesArgumentCaptor.getValue();
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesArgumentCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(NODE_UUID);
     }
 
     @Test
@@ -465,7 +465,7 @@ public class UndefinedExpressionGridTest {
 
         verify(expressionGridCache, never()).getExpressionGrid(anyString());
 
-        verify(refreshFormPropertiesEvent, never()).fire(any(RefreshFormProperties.class));
+        verify(refreshFormPropertiesEvent, never()).fire(any(RefreshFormPropertiesEvent.class));
         verify(domainObjectSelectionEvent).fire(domainObjectSelectionArgumentEventCaptor.capture());
         final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionArgumentEventCaptor.getValue();
         assertThat(domainObjectSelectionEvent.getDomainObject()).isInstanceOf(NOPDomainObject.class);
@@ -480,9 +480,9 @@ public class UndefinedExpressionGridTest {
 
         verify(domainObjectSelectionEvent, never()).fire(any(DomainObjectSelectionEvent.class));
         verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesArgumentCaptor.capture());
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesArgumentCaptor.getValue();
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(NODE_UUID);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesArgumentCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(NODE_UUID);
     }
 
     private void assertResize(final Function<BaseExpressionGrid, Double> expectedResizer) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
@@ -29,15 +29,11 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.context.Exp
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridRow;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Matchers.eq;
@@ -47,10 +43,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UndefinedExpressionUIModelMapperTest {
-
-    private static final int PARENT_ROW_INDEX = 0;
-
-    private static final int PARENT_COLUMN_INDEX = 1;
 
     @Mock
     private Expression expression;
@@ -70,18 +62,6 @@ public class UndefinedExpressionUIModelMapperTest {
     @Mock
     private UndefinedExpressionColumn uiColumn;
 
-    @Mock
-    private GridWidget parentGridWidget;
-
-    @Mock
-    private GridData parentGridUiModel;
-
-    @Mock
-    private GridCell parentGridUiCell;
-
-    @Mock
-    private CellSelectionStrategy parentGridUiCellCellSelectionStrategy;
-
     private GridData uiModel;
 
     private Supplier<Optional<GridCellValue<?>>> cellValueSupplier;
@@ -97,15 +77,9 @@ public class UndefinedExpressionUIModelMapperTest {
         this.mapper = new UndefinedExpressionUIModelMapper(() -> uiModel,
                                                            () -> Optional.ofNullable(expression),
                                                            listSelector,
-                                                           hasExpression,
-                                                           new GridCellTuple(PARENT_ROW_INDEX,
-                                                                             PARENT_COLUMN_INDEX,
-                                                                             parentGridWidget));
+                                                           hasExpression);
         this.cellValueSupplier = () -> Optional.of(new ExpressionCellValue(Optional.of(editor)));
 
-        when(parentGridWidget.getModel()).thenReturn(parentGridUiModel);
-        when(parentGridUiModel.getCell(eq(PARENT_ROW_INDEX), eq(PARENT_COLUMN_INDEX))).thenReturn(parentGridUiCell);
-        when(parentGridUiCell.getSelectionStrategy()).thenReturn(parentGridUiCellCellSelectionStrategy);
         when(hasExpression.asDMNModelInstrumentedBase()).thenReturn(hasExpressionDMNModelInstrumentedBase);
     }
 
@@ -114,21 +88,6 @@ public class UndefinedExpressionUIModelMapperTest {
         mapper.fromDMNModel(0, 0);
 
         assertThat(mapper.getUiModel().get().getCell(0, 0)).isInstanceOf(UndefinedExpressionCell.class);
-    }
-
-    @Test
-    public void testFromDMNCellSelectionStrategy() {
-        mapper.fromDMNModel(0, 0);
-
-        final CellSelectionStrategy strategy = uiModel.getCell(0, 0).getSelectionStrategy();
-
-        strategy.handleSelection(uiModel, 0, 0, true, false);
-
-        verify(parentGridUiCellCellSelectionStrategy).handleSelection(eq(parentGridUiModel),
-                                                                      eq(PARENT_ROW_INDEX),
-                                                                      eq(PARENT_COLUMN_INDEX),
-                                                                      eq(true),
-                                                                      eq(false));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
@@ -61,7 +61,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.UUID;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -126,7 +126,7 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     private ArgumentCaptor<Command> commandCaptor;
 
     @Captor
-    private ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesCaptor;
+    private ArgumentCaptor<RefreshFormPropertiesEvent> refreshFormPropertiesEventCaptor;
 
     @Captor
     private ArgumentCaptor<DomainObjectSelectionEvent> domainObjectSelectionEventCaptor;
@@ -491,11 +491,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
                                        DeleteHasNameCommand.class);
 
         verify(gridLayer).batch();
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
     }
 
     @Test
@@ -519,11 +519,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
 
         verify(gridLayer).batch();
         verify(updateElementPropertyCommand).execute(eq(canvasHandler));
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
     }
 
     @SuppressWarnings("unchecked")
@@ -558,11 +558,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
                                      SetHasNameCommand.class);
 
         verify(gridLayer).batch();
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
     }
 
     @Test
@@ -586,11 +586,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
 
         verify(gridLayer).batch();
         verify(updateElementPropertyCommand).execute(eq(canvasHandler));
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
     }
 
     @SuppressWarnings("unchecked")
@@ -623,11 +623,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
         doTestSetTypeRefConsumer();
 
         verify(gridLayer).batch();
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesCaptor.capture());
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
-        final RefreshFormProperties refreshFormProperties = refreshFormPropertiesCaptor.getValue();
-        assertThat(refreshFormProperties.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormProperties.getSession()).isEqualTo(session);
+        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
+        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
+        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
@@ -23,12 +23,14 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
@@ -39,6 +41,7 @@ import org.kie.workbench.common.dmn.client.commands.general.SetHasNameCommand;
 import org.kie.workbench.common.dmn.client.commands.general.SetHeaderValueCommand;
 import org.kie.workbench.common.dmn.client.commands.general.SetTypeRefCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.GridFactoryCommandUtils;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.EditableHeaderMetaData;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
@@ -50,6 +53,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -124,6 +128,9 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     @Captor
     private ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesCaptor;
 
+    @Captor
+    private ArgumentCaptor<DomainObjectSelectionEvent> domainObjectSelectionEventCaptor;
+
     private Decision decision = new Decision();
 
     @Override
@@ -165,6 +172,7 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
                                       canvasCommandFactory,
                                       editorSelectedEvent,
                                       refreshFormPropertiesEvent,
+                                      domainObjectSelectionEvent,
                                       cellEditorControls,
                                       listSelector,
                                       translationService,
@@ -299,6 +307,10 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
 
         assertThat(grid.getModel().getSelectedCells()).isNotEmpty();
         assertThat(grid.getModel().getSelectedCells()).contains(new GridData.SelectedCell(0, 0));
+
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isInstanceOf(NOPDomainObject.class);
     }
 
     @Test
@@ -320,29 +332,47 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
 
         assertThat(grid.getModel().getSelectedCells()).isNotEmpty();
         assertThat(grid.getModel().getSelectedCells()).contains(new GridData.SelectedCell(0, 1));
+
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isInstanceOf(NOPDomainObject.class);
     }
 
     @Test
-    public void testSelectParentCellWithNullParent() {
-        grid.selectParentCell();
+    public void testSelectCellWithPoint() {
+        grid.getModel().appendRow(new DMNGridRow());
+        appendColumns(RowNumberColumn.class, GridColumn.class);
 
-        verify(gridLayer, never()).select(any(GridWidget.class));
+        final Point2D point = mock(Point2D.class);
+        final double columnOffset = grid.getModel().getColumns().get(0).getWidth();
+        final double columnWidth = grid.getModel().getColumns().get(1).getWidth() / 2;
+        when(point.getX()).thenReturn(columnOffset + columnWidth);
+
+        grid.selectCell(point, false, true);
+
+        assertThat(grid.getModel().getSelectedCells()).isNotEmpty();
+        assertThat(grid.getModel().getSelectedCells()).contains(new GridData.SelectedCell(0, 1));
+
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isInstanceOf(NOPDomainObject.class);
     }
 
     @Test
-    public void testSelectParentCellWithNonNullParent() {
-        final GridWidget parentGrid = mock(BaseExpressionGrid.class);
-        when(parentCell.getGridWidget()).thenReturn(parentGrid);
-        when(parentCell.getRowIndex()).thenReturn(0);
-        when(parentCell.getColumnIndex()).thenReturn(1);
+    public void testSelectExpressionEditorFirstCell() {
+        grid.getModel().appendRow(new DMNGridRow());
+        appendColumns(GridColumn.class);
 
-        grid.selectParentCell();
+        final ExpressionCellValue cellValue = mock(ExpressionCellValue.class);
+        final BaseExpressionGrid cellGrid = mock(BaseExpressionGrid.class);
+        when(cellValue.getValue()).thenReturn(Optional.of(cellGrid));
 
-        verify(gridLayer).select(parentGrid);
-        verify(parentGrid).selectCell(eq(0),
-                                      eq(1),
-                                      eq(false),
-                                      eq(false));
+        grid.getModel().setCellValue(0, 0, cellValue);
+
+        grid.selectExpressionEditorFirstCell(0, 0);
+
+        verify(gridLayer).select(cellGrid);
+        verify(cellGrid).selectFirstCell();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
@@ -169,6 +169,7 @@ public class BaseExpressionGridRenderingTest extends BaseExpressionGridTest {
                                       canvasCommandFactory,
                                       editorSelectedEvent,
                                       refreshFormPropertiesEvent,
+                                      domainObjectSelectionEvent,
                                       cellEditorControls,
                                       listSelector,
                                       translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -93,6 +94,9 @@ public abstract class BaseExpressionGridTest {
 
     @Mock
     protected EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+
+    @Mock
+    protected EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     protected BaseExpressionGrid grid;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
@@ -93,7 +93,7 @@ public abstract class BaseExpressionGridTest {
     protected EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    protected EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    protected EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     protected EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelCellSelectionHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelCellSelectionHandlerTest.java
@@ -22,11 +22,8 @@ import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
@@ -106,37 +103,6 @@ public class DMNGridPanelCellSelectionHandlerTest {
                                                                anyBoolean(),
                                                                anyBoolean());
         verify(gridLayer, never()).batch();
-    }
-
-    @Test
-    public void testSelectCellIfRequiredWhenLiteralExpressionGrid() {
-        assertSelectCellIfRequiredForParentGridWidget(mockGridWidget(LiteralExpressionGrid.class));
-    }
-
-    @Test
-    public void testSelectCellIfRequiredWhenUndefinedExpressionGrid() {
-        assertSelectCellIfRequiredForParentGridWidget(mockGridWidget(UndefinedExpressionGrid.class));
-    }
-
-    private void assertSelectCellIfRequiredForParentGridWidget(final BaseExpressionGrid gridWidget) {
-        final GridData gridData = gridWidget.getModel();
-        gridData.setCell(0, 1, () -> gridCell);
-
-        final GridWidget parentGridWidget = mockGridWidget(BaseExpressionGrid.class);
-        final GridCellTuple parentInformation = new GridCellTuple(2, 3, parentGridWidget);
-        when(gridWidget.getParentInformation()).thenReturn(parentInformation);
-        final GridData parentGridData = parentGridWidget.getModel();
-        parentGridData.setCell(2, 3, () -> gridCell);
-
-        cellSelectionHandler.selectCellIfRequired(0, 1, gridWidget, true, false);
-
-        verify(gridLayer).select(eq(parentGridWidget));
-        verify(cellSelectionStrategy).handleSelection(eq(parentGridData),
-                                                      eq(2),
-                                                      eq(3),
-                                                      eq(true),
-                                                      eq(false));
-        verify(gridLayer).batch();
     }
 
     private <G extends BaseExpressionGrid> G mockGridWidget(final Class<G> gridClass) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
@@ -83,6 +83,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.workbench.stunner</groupId>
+      <artifactId>kie-wb-common-stunner-forms-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- DMN Editor -->
     <dependency>
       <groupId>org.kie.workbench</groupId>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -44,7 +44,7 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramFocusEvent;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramLoseFocusEvent;
@@ -81,7 +81,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    private final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     private final DecisionNavigatorDock decisionNavigatorDock;
 
     @Inject
@@ -97,7 +97,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final DMNProjectEditorMenuSessionItems menuSessionItems,
                             final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                             final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
-                            final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                            final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                             final ProjectMessagesListener projectMessagesListener,
                             final DiagramClientErrorHandler diagramClientErrorHandler,
                             final ClientTranslationService translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramFocusEvent;
 import org.kie.workbench.common.stunner.project.client.editor.event.OnDiagramLoseFocusEvent;
@@ -80,6 +81,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
     private final DecisionNavigatorDock decisionNavigatorDock;
 
     @Inject
@@ -95,6 +97,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final DMNProjectEditorMenuSessionItems menuSessionItems,
                             final Event<OnDiagramFocusEvent> onDiagramFocusEvent,
                             final Event<OnDiagramLoseFocusEvent> onDiagramLostFocusEvent,
+                            final Event<RefreshFormProperties> refreshFormPropertiesEvent,
                             final ProjectMessagesListener projectMessagesListener,
                             final DiagramClientErrorHandler diagramClientErrorHandler,
                             final ClientTranslationService translationService,
@@ -122,6 +125,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
               projectDiagramResourceServiceCaller);
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
+        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
         this.decisionNavigatorDock = decisionNavigatorDock;
     }
 
@@ -220,6 +224,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                                                                                 getSessionPresenter(),
                                                                                 sessionManager,
                                                                                 sessionCommandManager,
+                                                                                refreshFormPropertiesEvent,
                                                                                 event.getNodeUUID(),
                                                                                 event.getHasExpression(),
                                                                                 event.getHasName()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -29,11 +29,13 @@ import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorTest;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
 import org.kie.workbench.common.workbench.client.PerspectiveIds;
 import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 
@@ -64,6 +66,9 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
 
     @Mock
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
 
     @Mock
     private ExpressionEditorView.Presenter expressionEditor;
@@ -110,6 +115,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                  (DMNProjectEditorMenuSessionItems) getMenuSessionItems(),
                                                  onDiagramFocusEvent,
                                                  onDiagramLostFocusEvent,
+                                                 refreshFormPropertiesEvent,
                                                  projectMessagesListener,
                                                  diagramClientErrorHandler,
                                                  translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -29,7 +29,7 @@ import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorTest;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
@@ -68,7 +68,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private ExpressionEditorView.Presenter expressionEditor;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/pom.xml
@@ -801,6 +801,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -66,7 +66,7 @@ import org.kie.workbench.common.stunner.core.util.UUID;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
 import org.kie.workbench.common.stunner.core.validation.Violation;
 import org.kie.workbench.common.stunner.core.validation.impl.ValidationUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.client.annotations.WorkbenchContextId;
 import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
@@ -99,7 +99,7 @@ public class SessionDiagramEditorScreen {
     private final SessionEditorPresenter<EditorSession> presenter;
     private final Event<ChangeTitleWidgetEvent> changeTitleNotificationEvent;
     private final Event<SessionFocusedEvent> sessionFocusedEvent;
-    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    private final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     private final MenuDevCommandsBuilder menuDevCommandsBuilder;
     private final ScreenPanelView screenPanelView;
     private final ScreenErrorView screenErrorView;
@@ -117,7 +117,7 @@ public class SessionDiagramEditorScreen {
                                       final SessionEditorPresenter<EditorSession> presenter,
                                       final Event<ChangeTitleWidgetEvent> changeTitleNotificationEvent,
                                       final Event<SessionFocusedEvent> sessionFocusedEvent,
-                                      final Event<RefreshFormProperties> refreshFormPropertiesEvent,
+                                      final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                       final MenuDevCommandsBuilder menuDevCommandsBuilder,
                                       final ScreenPanelView screenPanelView,
                                       final ScreenErrorView screenErrorView,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -66,6 +66,7 @@ import org.kie.workbench.common.stunner.core.util.UUID;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
 import org.kie.workbench.common.stunner.core.validation.Violation;
 import org.kie.workbench.common.stunner.core.validation.impl.ValidationUtils;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.uberfire.client.annotations.WorkbenchContextId;
 import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
@@ -98,6 +99,7 @@ public class SessionDiagramEditorScreen {
     private final SessionEditorPresenter<EditorSession> presenter;
     private final Event<ChangeTitleWidgetEvent> changeTitleNotificationEvent;
     private final Event<SessionFocusedEvent> sessionFocusedEvent;
+    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
     private final MenuDevCommandsBuilder menuDevCommandsBuilder;
     private final ScreenPanelView screenPanelView;
     private final ScreenErrorView screenErrorView;
@@ -115,6 +117,7 @@ public class SessionDiagramEditorScreen {
                                       final SessionEditorPresenter<EditorSession> presenter,
                                       final Event<ChangeTitleWidgetEvent> changeTitleNotificationEvent,
                                       final Event<SessionFocusedEvent> sessionFocusedEvent,
+                                      final Event<RefreshFormProperties> refreshFormPropertiesEvent,
                                       final MenuDevCommandsBuilder menuDevCommandsBuilder,
                                       final ScreenPanelView screenPanelView,
                                       final ScreenErrorView screenErrorView,
@@ -127,6 +130,7 @@ public class SessionDiagramEditorScreen {
         this.presenter = presenter;
         this.changeTitleNotificationEvent = changeTitleNotificationEvent;
         this.sessionFocusedEvent = sessionFocusedEvent;
+        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
         this.menuDevCommandsBuilder = menuDevCommandsBuilder;
         this.screenPanelView = screenPanelView;
         this.screenErrorView = screenErrorView;
@@ -430,6 +434,7 @@ public class SessionDiagramEditorScreen {
                                                                                 presenter,
                                                                                 sessionManager,
                                                                                 sessionCommandManager,
+                                                                                refreshFormPropertiesEvent,
                                                                                 event.getNodeUUID(),
                                                                                 event.getHasExpression(),
                                                                                 event.getHasName()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -75,7 +75,7 @@ public class SessionDiagramEditorScreenTest {
     private DMNEditorSession session;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Captor
     private ArgumentCaptor<Consumer<EditorSession>> clientFullSessionConsumer;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
@@ -34,11 +34,13 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 
 import static org.mockito.Matchers.any;
@@ -72,12 +74,16 @@ public class SessionDiagramEditorScreenTest {
     @Mock
     private DMNEditorSession session;
 
+    @Mock
+    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+
     @Captor
     private ArgumentCaptor<Consumer<EditorSession>> clientFullSessionConsumer;
 
     private SessionDiagramEditorScreen editor;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() {
         doReturn(presenter).when(presenter).withToolbar(anyBoolean());
         doReturn(presenter).when(presenter).withPalette(anyBoolean());
@@ -107,6 +113,7 @@ public class SessionDiagramEditorScreenTest {
                                                     presenter,
                                                     null,
                                                     null,
+                                                    refreshFormPropertiesEvent,
                                                     null,
                                                     screenPanelView,
                                                     null,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/selection/DomainObjectSelectionEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/selection/DomainObjectSelectionEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.event.selection;
+
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.AbstractCanvasHandlerEvent;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+
+public final class DomainObjectSelectionEvent
+        extends AbstractCanvasHandlerEvent<CanvasHandler> {
+
+    private final DomainObject domainObject;
+
+    public DomainObjectSelectionEvent(final CanvasHandler canvasHandler,
+                                      final DomainObject domainObject) {
+        super(canvasHandler);
+        this.domainObject = domainObject;
+    }
+
+    public DomainObject getDomainObject() {
+        return domainObject;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/CanvasDomainObjectListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/CanvasDomainObjectListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.canvas.listener;
+
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+
+public interface CanvasDomainObjectListener {
+
+    /**
+     * A DomainObject has been updated on the canvas.
+     */
+    void update(final DomainObject domainObject);
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
@@ -20,7 +20,9 @@ import java.util.Collection;
 import java.util.function.Consumer;
 
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -98,6 +100,11 @@ public interface CanvasCommandFactory<H extends CanvasHandler> {
     CanvasCommand<H> updatePropertyValue(final Element element,
                                          final String propertyId,
                                          final Object value);
+
+    CanvasCommand<H> updateDomainObjectPropertyValue(final CanvasDomainObjectListener domainObjectCanvasListener,
+                                                     final DomainObject domainObject,
+                                                     final String propertyId,
+                                                     final Object value);
 
     CanvasCommand<H> clearCanvas();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/domainobject/DefaultDomainObject.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/domainobject/DefaultDomainObject.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.domainobject;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.stunner.core.util.UUID;
+
+/**
+ * A NOP implementation of {@link DomainObject} required by Errai.
+ */
+@Portable
+public class DefaultDomainObject implements DomainObject {
+
+    private final String uuid = UUID.uuid();
+
+    @Override
+    public String getDomainObjectUUID() {
+        return uuid;
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return "";
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/domainobject/DomainObject.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/domainobject/DomainObject.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.domainobject;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.definition.annotation.DefinitionSet;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+
+/**
+ * A DomainObject belongs to the underlying model represented by the Graph but is not represented by a Node.
+ * It is ordinarily itself a property of a Node Content that can have its properties displayed by the Properties Panel.
+ * A DomainObject must adhere to the same requirements as Nodes bound to the Properties Panel; namely:
+ * 1) It must be {@link Portable}
+ * 2) It must be {@link Bindable}
+ * 3) It must be a {@link Definition}
+ * 4) It must have a {@link FormDefinition}
+ * 5) It must have a {@link Category} property and associated public getter.
+ * 6) It must have a {@link Labels} property and associated public getter.
+ * 7) It must be included in a {@link DefinitionSet} declaration.
+ * 8) It can have one or more {@link PropertySet} or {@link Property}
+ * 9) All {@link PropertySet} or {@link Property} must be non-null instances.
+ */
+public interface DomainObject {
+
+    String getDomainObjectUUID();
+
+    String getDomainObjectNameTranslationKey();
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/resources/org/kie/workbench/common/stunner/core/StunnerCoreApi.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/resources/org/kie/workbench/common/stunner/core/StunnerCoreApi.gwt.xml
@@ -29,6 +29,7 @@
   <source path="command"/>
   <source path="definition"/>
   <source path="diagram"/>
+  <source path="domainobject"/>
   <source path="graph"/>
   <source path="factory"/>
   <source path="lookup"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
@@ -24,9 +24,11 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -206,6 +208,17 @@ public class DefaultCanvasCommandFactory implements CanvasCommandFactory<Abstrac
         return new UpdateElementPropertyCommand(element,
                                                 propertyId,
                                                 value);
+    }
+
+    @Override
+    public CanvasCommand<AbstractCanvasHandler> updateDomainObjectPropertyValue(final CanvasDomainObjectListener domainObjectCanvasListener,
+                                                                                final DomainObject domainObject,
+                                                                                final String propertyId,
+                                                                                final Object value) {
+        return new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
+                                                     domainObject,
+                                                     propertyId,
+                                                     value);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommand.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.canvas.command;
+
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.impl.UpdateDomainObjectPropertyValueCommand;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+public class UpdateDomainObjectPropertyCommand extends AbstractCanvasGraphCommand {
+
+    private final CanvasDomainObjectListener domainObjectCanvasListener;
+    private final DomainObject domainObject;
+    private final String propertyId;
+    private final Object value;
+
+    public class RefreshPropertiesPanelCommand extends AbstractCanvasCommand {
+
+        @Override
+        public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
+            domainObjectCanvasListener.update(domainObject);
+            return CanvasCommandResultBuilder.SUCCESS;
+        }
+
+        @Override
+        public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
+            domainObjectCanvasListener.update(domainObject);
+            return CanvasCommandResultBuilder.SUCCESS;
+        }
+    }
+
+    public UpdateDomainObjectPropertyCommand(final CanvasDomainObjectListener domainObjectCanvasListener,
+                                             final DomainObject domainObject,
+                                             final String propertyId,
+                                             final Object value) {
+        this.domainObjectCanvasListener = domainObjectCanvasListener;
+        this.domainObject = domainObject;
+        this.propertyId = propertyId;
+        this.value = value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
+        return new UpdateDomainObjectPropertyValueCommand(domainObject,
+                                                          propertyId,
+                                                          value);
+    }
+
+    @Override
+    protected AbstractCanvasCommand newCanvasCommand(final AbstractCanvasHandler context) {
+        return new RefreshPropertiesPanelCommand();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommandTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.command;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.impl.UpdateDomainObjectPropertyValueCommand;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateDomainObjectPropertyCommandTest {
+
+    private static final String PROPERTY_ID = "property.id";
+
+    private static final Object VALUE = new Object();
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private CanvasDomainObjectListener domainObjectCanvasListener;
+
+    @Mock
+    private DomainObject domainObject;
+
+    @Test
+    public void testNewGraphCommand() {
+        final Command<GraphCommandExecutionContext, RuleViolation> command = new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
+                                                                                                                   domainObject,
+                                                                                                                   PROPERTY_ID,
+                                                                                                                   VALUE).newGraphCommand(canvasHandler);
+
+        assertThat(command).isInstanceOf(UpdateDomainObjectPropertyValueCommand.class);
+    }
+
+    @Test
+    public void testNewCanvasCommandExecute() {
+        final CanvasCommand<AbstractCanvasHandler> command = new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
+                                                                                                   domainObject,
+                                                                                                   PROPERTY_ID,
+                                                                                                   VALUE).newCanvasCommand(canvasHandler);
+
+        assertThat(command).isInstanceOf(UpdateDomainObjectPropertyCommand.RefreshPropertiesPanelCommand.class);
+
+        assertThat(command.execute(canvasHandler)).isEqualTo(CanvasCommandResultBuilder.SUCCESS);
+
+        verify(domainObjectCanvasListener).update(eq(domainObject));
+    }
+
+    @Test
+    public void testNewCanvasCommandUndo() {
+        final CanvasCommand<AbstractCanvasHandler> command = new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
+                                                                                                   domainObject,
+                                                                                                   PROPERTY_ID,
+                                                                                                   VALUE).newCanvasCommand(canvasHandler);
+
+        assertThat(command).isInstanceOf(UpdateDomainObjectPropertyCommand.RefreshPropertiesPanelCommand.class);
+
+        assertThat(command.undo(canvasHandler)).isEqualTo(CanvasCommandResultBuilder.SUCCESS);
+
+        verify(domainObjectCanvasListener).update(eq(domainObject));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommand.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.graph.command.impl;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+/**
+ * A Command to update a DomainObject's property.
+ */
+@Portable
+public final class UpdateDomainObjectPropertyValueCommand extends AbstractGraphCommand {
+
+    private final DomainObject domainObject;
+    private final String propertyId;
+    private final Object value;
+
+    private Object oldValue;
+
+    public UpdateDomainObjectPropertyValueCommand(final @MapsTo("domainObject") DomainObject domainObject,
+                                                  final @MapsTo("propertyId") String propertyId,
+                                                  final @MapsTo("value") Object value) {
+        this.domainObject = PortablePreconditions.checkNotNull("domainObject",
+                                                               domainObject);
+        this.propertyId = PortablePreconditions.checkNotNull("propertyId",
+                                                             propertyId);
+        this.value = value;
+    }
+
+    @Override
+    protected CommandResult<RuleViolation> check(final GraphCommandExecutionContext context) {
+        return GraphCommandResultBuilder.SUCCESS;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
+        final DefinitionManager definitionManager = context.getDefinitionManager();
+        final Object p = GraphUtils.getProperty(definitionManager,
+                                                domainObject,
+                                                propertyId);
+        final AdapterManager adapterManager = definitionManager.adapters();
+        final AdapterRegistry adapterRegistry = adapterManager.registry();
+        final PropertyAdapter<Object, Object> adapter = (PropertyAdapter<Object, Object>) adapterRegistry.getPropertyAdapter(p.getClass());
+        oldValue = adapter.getValue(p);
+        adapter.setValue(p,
+                         value);
+        return GraphCommandResultBuilder.SUCCESS;
+    }
+
+    @Override
+    public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
+        final UpdateDomainObjectPropertyValueCommand undoCommand = new UpdateDomainObjectPropertyValueCommand(domainObject,
+                                                                                                              propertyId,
+                                                                                                              oldValue);
+        return undoCommand.execute(context);
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateDomainObjectPropertyValueCommand [domainObject=" + domainObject + ", property=" + propertyId + ", value=" + value + "]";
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
@@ -52,6 +53,18 @@ public class GraphUtils {
         if (null != element) {
             final Object def = element.getContent().getDefinition();
             final Set<?> properties = definitionManager.adapters().forDefinition().getProperties(def);
+            return getProperty(definitionManager,
+                               properties,
+                               id);
+        }
+        return null;
+    }
+
+    public static Object getProperty(final DefinitionManager definitionManager,
+                                     final DomainObject domainObject,
+                                     final String id) {
+        if (null != domainObject) {
+            final Set<?> properties = definitionManager.adapters().forDefinition().getProperties(domainObject);
             return getProperty(definitionManager,
                                properties,
                                id);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/StunnerCoreCommon.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/StunnerCoreCommon.gwt.xml
@@ -23,6 +23,7 @@
   <inherits name="org.kie.workbench.common.stunner.core.StunnerCoreApi"/>
   <inherits name="org.hibernate.validator.HibernateValidator" />
   <inherits name="org.jboss.errai.validation.Validation" />
+  <inherits name="org.kie.soup.commons.KIESoupCommons"/>
 
   <source path="api"/>
   <source path="command"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommandTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.graph.command.impl;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Sets;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateDomainObjectPropertyValueCommandTest extends AbstractGraphCommandTest {
+
+    private static final String PROPERTY = "property";
+
+    private static final String PROPERTY_ID = "property.id";
+
+    private static final String PROPERTY_VALUE = "value";
+
+    private static final String PROPERTY_OLD_VALUE = "oldValue";
+
+    @Mock
+    private DomainObject domainObject;
+
+    private UpdateDomainObjectPropertyValueCommand command;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        super.init(500, 500);
+
+        final Set<Object> properties = new Sets.Builder<>().add(PROPERTY).build();
+        when(definitionAdapter.getProperties(eq(domainObject))).thenReturn(properties);
+        when(propertyAdapter.getId(eq(PROPERTY))).thenReturn(PROPERTY_ID);
+        when(propertyAdapter.getValue(eq(PROPERTY))).thenReturn(PROPERTY_OLD_VALUE);
+
+        this.command = new UpdateDomainObjectPropertyValueCommand(domainObject,
+                                                                  PROPERTY_ID,
+                                                                  PROPERTY_VALUE);
+    }
+
+    @Test
+    public void testAllow() {
+        assertEquals(CommandResult.Type.INFO,
+                     command.allow(graphCommandExecutionContext).getType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testExecute() {
+        assertEquals(CommandResult.Type.INFO,
+                     command.execute(graphCommandExecutionContext).getType());
+
+        verify(propertyAdapter).getValue(eq(PROPERTY));
+        verify(propertyAdapter).setValue(eq(PROPERTY), eq(PROPERTY_VALUE));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUndo() {
+        command.execute(graphCommandExecutionContext);
+
+        verify(propertyAdapter).getValue(eq(PROPERTY));
+        verify(propertyAdapter).setValue(eq(PROPERTY),
+                                         eq(PROPERTY_VALUE));
+
+        assertEquals(CommandResult.Type.INFO,
+                     command.undo(graphCommandExecutionContext).getType());
+
+        //One read for the execute, one read for the undo. Resetting the mock would require it to be setup again.
+        verify(propertyAdapter, times(2)).getValue(eq(PROPERTY));
+        verify(propertyAdapter).setValue(eq(PROPERTY),
+                                         eq(PROPERTY_OLD_VALUE));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
@@ -21,20 +21,56 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundImpl;
 import org.kie.workbench.common.stunner.core.graph.content.view.BoundsImpl;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GraphUtilsTest {
+
+    private static final String PROPERTY = "property";
+
+    private static final String PROPERTY_ID = "property.id";
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private DefinitionAdapter definitionAdapter;
+
+    @Mock
+    private PropertyAdapter propertyAdapter;
+
+    @Mock
+    private Element<? extends Definition> element;
+
+    @Mock
+    private DomainObject domainObject;
 
     private TestingGraphMockHandler graphTestHandler;
     private TestingGraphInstanceBuilder.TestGraph4 graphInstance;
@@ -122,5 +158,46 @@ public class GraphUtilsTest {
         assertEquals(dockedNodes.get(1), graphInstance.intermNode);
         assertEquals(dockedNodes.get(2), graphInstance.endNode);
         assertEquals(dockedNodes.get(3), graphInstance.dockedNode);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetPropertyForNullElement() {
+        assertNull(GraphUtils.getProperty(definitionManager, (Element) null, PROPERTY_ID));
+    }
+
+    @Test
+    public void testGetPropertyForNonNullElement() {
+        setupDefinitionManager();
+
+        assertEquals(PROPERTY, GraphUtils.getProperty(definitionManager, element, PROPERTY_ID));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetPropertyForNullDomainObject() {
+        assertNull(GraphUtils.getProperty(definitionManager, (DomainObject) null, PROPERTY_ID));
+    }
+
+    @Test
+    public void testGetPropertyForNonNullDomainObject() {
+        setupDefinitionManager();
+
+        assertEquals(PROPERTY, GraphUtils.getProperty(definitionManager, domainObject, PROPERTY_ID));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupDefinitionManager() {
+        final Definition<String> definition = mock(Definition.class);
+        final String content = "content";
+        when(element.getContent()).thenReturn(definition);
+        when(definition.getDefinition()).thenReturn(content);
+
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
+        when(definitionAdapter.getProperties(eq(content))).thenReturn(new Sets.Builder<String>().add(PROPERTY).build());
+        when(definitionAdapter.getProperties(any(DomainObject.class))).thenReturn(new Sets.Builder<String>().add(PROPERTY).build());
+        when(adapterManager.forProperty()).thenReturn(propertyAdapter);
+        when(propertyAdapter.getId(PROPERTY)).thenReturn(PROPERTY_ID);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/event/RefreshFormPropertiesEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/event/RefreshFormPropertiesEvent.java
@@ -18,13 +18,13 @@ package org.kie.workbench.common.stunner.forms.client.event;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.uberfire.workbench.events.UberFireEvent;
 
-public final class RefreshFormProperties implements UberFireEvent {
+public final class RefreshFormPropertiesEvent implements UberFireEvent {
 
     private final ClientSession session;
     private final String uuid;
 
-    public RefreshFormProperties(final ClientSession session,
-                                 final String uuid) {
+    public RefreshFormPropertiesEvent(final ClientSession session,
+                                      final String uuid) {
         this.session = session;
         this.uuid = uuid;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/formFilters/FormFiltersProviderFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/formFilters/FormFiltersProviderFactory.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.forms.adf.engine.shared.FormElementFilter;
-import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 
 public class FormFiltersProviderFactory {
 
@@ -36,11 +34,11 @@ public class FormFiltersProviderFactory {
         providers.put(provider.getDefinitionType(), provider);
     }
 
-    public static Collection<FormElementFilter> getFilterForDefinition(String elementUUID, Element<? extends Definition<?>> element, Object definition) {
+    public static Collection<FormElementFilter> getFilterForDefinition(String elementUUID, Object definition) {
         StunnerFormElementFilterProvider provider = providers.get(definition.getClass());
 
         if (provider != null) {
-            return provider.provideFilters(elementUUID, element, definition);
+            return provider.provideFilters(elementUUID, definition);
         }
 
         return Collections.emptyList();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/formFilters/StunnerFormElementFilterProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/formFilters/StunnerFormElementFilterProvider.java
@@ -19,12 +19,10 @@ package org.kie.workbench.common.stunner.forms.client.formFilters;
 import java.util.Collection;
 
 import org.kie.workbench.common.forms.adf.engine.shared.FormElementFilter;
-import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 
 public interface StunnerFormElementFilterProvider {
 
     Class<?> getDefinitionType();
 
-    Collection<FormElementFilter> provideFilters (String elementUUID, Element<? extends Definition<?>> element, Object definition);
+    Collection<FormElementFilter> provideFilters(String elementUUID, Object definition);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidget.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.forms.client.widgets;
 
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,6 +34,7 @@ import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
@@ -154,8 +156,19 @@ public class FormPropertiesWidget implements IsElement,
                       final Command callback) {
         final String uuid = element.getUUID();
         final Diagram<?, ?> diagram = formSessionHandler.getDiagram();
-        final Object definition = element.getContent().getDefinition();
-        final Path diagramPath = diagram.getMetadata().getPath();
+        if (Objects.isNull(diagram)) {
+            return;
+        }
+        final Metadata metadata = diagram.getMetadata();
+        if (Objects.isNull(metadata)) {
+            return;
+        }
+        final Path diagramPath = metadata.getPath();
+        final Definition content = element.getContent();
+        if (Objects.isNull(content)) {
+            return;
+        }
+        final Object definition = content.getDefinition();
         final RenderMode renderMode = formSessionHandler.getSession() instanceof EditorSession ? RenderMode.EDIT_MODE : RenderMode.READ_ONLY_MODE;
 
         formsContainer.render(graphUuid,
@@ -184,7 +197,14 @@ public class FormPropertiesWidget implements IsElement,
         final String domainObjectUUID = domainObject.getDomainObjectUUID();
         final String domainObjectName = translationService.getTranslation(domainObject.getDomainObjectNameTranslationKey());
         final Diagram<?, ?> diagram = formSessionHandler.getDiagram();
-        final Path diagramPath = diagram.getMetadata().getPath();
+        if (Objects.isNull(diagram)) {
+            return;
+        }
+        final Metadata metadata = diagram.getMetadata();
+        if (Objects.isNull(metadata)) {
+            return;
+        }
+        final Path diagramPath = metadata.getPath();
         final RenderMode renderMode = formSessionHandler.getSession() instanceof EditorSession ? RenderMode.EDIT_MODE : RenderMode.READ_ONLY_MODE;
 
         formsContainer.render(graphUuid,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidget.java
@@ -28,15 +28,18 @@ import javax.inject.Inject;
 import com.google.gwt.logging.client.LogConfiguration;
 import org.jboss.errai.common.client.api.IsElement;
 import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.FormPropertiesOpened;
 import org.kie.workbench.common.stunner.forms.client.widgets.container.FormsContainer;
+import org.uberfire.backend.vfs.Path;
 import org.uberfire.mvp.Command;
 
 @Dependent
@@ -50,9 +53,10 @@ public class FormPropertiesWidget implements IsElement,
     private final Event<FormPropertiesOpened> propertiesOpenedEvent;
     private final FormsCanvasSessionHandler formSessionHandler;
     private final FormsContainer formsContainer;
+    private final TranslationService translationService;
 
     protected FormPropertiesWidget() {
-        this(null, null, null, null, null);
+        this(null, null, null, null, null, null);
     }
 
     @Inject
@@ -60,21 +64,29 @@ public class FormPropertiesWidget implements IsElement,
                                 final DefinitionUtils definitionUtils,
                                 final FormsCanvasSessionHandler formSessionHandler,
                                 final Event<FormPropertiesOpened> propertiesOpenedEvent,
-                                final FormsContainer formsContainer) {
+                                final FormsContainer formsContainer,
+                                final TranslationService translationService) {
         this.view = view;
         this.definitionUtils = definitionUtils;
         this.formSessionHandler = formSessionHandler;
         this.propertiesOpenedEvent = propertiesOpenedEvent;
         this.formsContainer = formsContainer;
+        this.translationService = translationService;
     }
 
     @PostConstruct
+    @SuppressWarnings("unchecked")
     public void init() {
         log(Level.INFO, "FormPropertiesWidget instance build.");
         formSessionHandler.setRenderer(new FormsCanvasSessionHandler.FormRenderer() {
             @Override
             public void render(String graphUuid, Element element, Command callback) {
                 show(graphUuid, element, callback);
+            }
+
+            @Override
+            public void render(String graphUuid, DomainObject domainObject) {
+                show(graphUuid, domainObject);
             }
 
             @Override
@@ -143,26 +155,58 @@ public class FormPropertiesWidget implements IsElement,
         final String uuid = element.getUUID();
         final Diagram<?, ?> diagram = formSessionHandler.getDiagram();
         final Object definition = element.getContent().getDefinition();
+        final Path diagramPath = diagram.getMetadata().getPath();
         final RenderMode renderMode = formSessionHandler.getSession() instanceof EditorSession ? RenderMode.EDIT_MODE : RenderMode.READ_ONLY_MODE;
 
-        formsContainer.render(graphUuid, element, diagram.getMetadata().getPath(), (fieldName, newValue) -> {
-            try {
-                formSessionHandler.executeUpdateProperty(element, fieldName, newValue);
-            } catch (final Exception ex) {
-                log(Level.SEVERE,
-                    "Something wrong happened refreshing the canvas for " +
-                            "field '" + fieldName + "': " + ex.getCause());
-            } finally {
-                if (null != callback) {
-                    callback.execute();
-                }
-            }
-        }, renderMode);
+        formsContainer.render(graphUuid,
+                              uuid,
+                              definition,
+                              diagramPath,
+                              (fieldName, newValue) -> {
+                                  try {
+                                      formSessionHandler.executeUpdateProperty(element, fieldName, newValue);
+                                  } catch (final Exception ex) {
+                                      log(Level.SEVERE,
+                                          "Something wrong happened refreshing the canvas for " +
+                                                  "field '" + fieldName + "': " + ex.getCause());
+                                  } finally {
+                                      if (null != callback) {
+                                          callback.execute();
+                                      }
+                                  }
+                              }, renderMode);
         final String name = definitionUtils.getName(definition);
         propertiesOpenedEvent.fire(new FormPropertiesOpened(formSessionHandler.getSession(), uuid, name));
     }
 
-    private static void log(final Level level, final String message) {
+    private void show(final String graphUuid,
+                      final DomainObject domainObject) {
+        final String domainObjectUUID = domainObject.getDomainObjectUUID();
+        final String domainObjectName = translationService.getTranslation(domainObject.getDomainObjectNameTranslationKey());
+        final Diagram<?, ?> diagram = formSessionHandler.getDiagram();
+        final Path diagramPath = diagram.getMetadata().getPath();
+        final RenderMode renderMode = formSessionHandler.getSession() instanceof EditorSession ? RenderMode.EDIT_MODE : RenderMode.READ_ONLY_MODE;
+
+        formsContainer.render(graphUuid,
+                              domainObjectUUID,
+                              domainObject,
+                              diagramPath,
+                              (fieldName, newValue) -> {
+                                  try {
+                                      formSessionHandler.executeUpdateDomainObjectProperty(domainObject,
+                                                                                           fieldName,
+                                                                                           newValue);
+                                  } catch (final Exception ex) {
+                                      log(Level.SEVERE,
+                                          "Something wrong happened refreshing the DomainObject '"
+                                                  + domainObject + "' for field '"
+                                                  + fieldName + "': " + ex.getCause());
+                                  }
+                              }, renderMode);
+        propertiesOpenedEvent.fire(new FormPropertiesOpened(formSessionHandler.getSession(), domainObjectUUID, domainObjectName));
+    }
+
+    protected void log(final Level level, final String message) {
         if (LogConfiguration.loggingIsEnabled()) {
             LOGGER.log(level, message);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.forms.client.widgets;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,7 +49,7 @@ import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.mvp.Command;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
@@ -203,7 +204,7 @@ public class FormsCanvasSessionHandler {
         return definitionManager.adapters().forProperty().getId(property);
     }
 
-    void onRefreshFormPropertiesEvent(@Observes RefreshFormProperties event) {
+    void onRefreshFormPropertiesEvent(@Observes RefreshFormPropertiesEvent event) {
         checkNotNull("event", event);
 
         if (null != getCanvasHandler()) {
@@ -261,7 +262,15 @@ public class FormsCanvasSessionHandler {
     private void render(final String uuid,
                         final Command callback) {
         if (null != renderer) {
-            renderer.render(getDiagram().getGraph().getUUID(), getElement(uuid), callback);
+            final Diagram diagram = getDiagram();
+            if (Objects.isNull(diagram)) {
+                return;
+            }
+            final Graph graph = diagram.getGraph();
+            if (Objects.isNull(graph)) {
+                return;
+            }
+            renderer.render(graph.getUUID(), getElement(uuid), callback);
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
@@ -32,8 +32,6 @@ import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandler;
-import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.forms.client.widgets.container.displayer.FormDisplayer;
 import org.uberfire.backend.vfs.Path;
 
@@ -56,11 +54,16 @@ public class FormsContainer implements IsElement {
         this.formDisplayers = new HashMap<>();
     }
 
-    public void render(final String graphUuid, final Element<? extends Definition<?>> element, final Path diagramPath, final FieldChangeHandler changeHandler, final RenderMode renderMode) {
+    public void render(final String graphUuid,
+                       final String domainObjectUUID,
+                       final Object domainObject,
+                       final Path diagramPath,
+                       final FieldChangeHandler changeHandler,
+                       final RenderMode renderMode) {
 
-        FormDisplayer displayer = getDisplayer(graphUuid, element);
+        FormDisplayer displayer = getDisplayer(graphUuid, domainObjectUUID);
 
-        displayer.render(element, diagramPath, changeHandler, renderMode);
+        displayer.render(domainObjectUUID, domainObject, diagramPath, changeHandler, renderMode);
 
         if (null != currentDisplayer && !displayer.equals(currentDisplayer)) {
             currentDisplayer.hide();
@@ -70,8 +73,9 @@ public class FormsContainer implements IsElement {
         currentDisplayer = displayer;
     }
 
-    private FormDisplayer getDisplayer(String graphUuid, Element<? extends Definition<?>> element) {
-        FormDisplayerKey key = new FormDisplayerKey(graphUuid, element.getUUID());
+    private FormDisplayer getDisplayer(final String graphUuid,
+                                       final String elementUuid) {
+        FormDisplayerKey key = new FormDisplayerKey(graphUuid, elementUuid);
         FormDisplayer displayer = formDisplayers.get(key);
 
         LOGGER.fine("Getting form displayer for : " + key);
@@ -86,12 +90,12 @@ public class FormsContainer implements IsElement {
         displayer.hide();
         view.addDisplayer(displayer);
 
-        formDisplayers.put(new FormDisplayerKey(graphUuid, element.getUUID()), displayer);
+        formDisplayers.put(new FormDisplayerKey(graphUuid, elementUuid), displayer);
 
         return displayer;
     }
 
-    public void clearDiagramDisplayers(String graphUuid) {
+    public void clearDiagramDisplayers(final String graphUuid) {
         LOGGER.fine("Clearing properties forms for graph: " + graphUuid);
         List<FormDisplayerKey> keys = formDisplayers.keySet()
                 .stream()
@@ -101,7 +105,8 @@ public class FormsContainer implements IsElement {
         LOGGER.fine("Cleared properties forms for graph: " + graphUuid);
     }
 
-    public void clearFormDisplayer(String graphUuid, String elementUid) {
+    public void clearFormDisplayer(final String graphUuid,
+                                   final String elementUid) {
         formDisplayers.keySet()
                 .stream()
                 .filter(key -> key.getGraphUuid().equals(graphUuid) && key.getElementUid().equals(elementUid))
@@ -109,7 +114,7 @@ public class FormsContainer implements IsElement {
                 .ifPresent(this::clearDisplayer);
     }
 
-    private void clearDisplayer(FormDisplayerKey key) {
+    private void clearDisplayer(final FormDisplayerKey key) {
         FormDisplayer displayer = formDisplayers.remove(key);
         LOGGER.fine("Clearing form displayer for element: " + key.getElementUid());
         view.removeDisplayer(displayer);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/displayer/FormDisplayer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/displayer/FormDisplayer.java
@@ -41,8 +41,6 @@ import org.kie.workbench.common.forms.dynamic.service.shared.adf.DynamicFormMode
 import org.kie.workbench.common.forms.dynamic.service.shared.impl.StaticModelFormRenderingContext;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandler;
 import org.kie.workbench.common.forms.processing.engine.handling.FormField;
-import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.forms.client.formFilters.FormFiltersProviderFactory;
 import org.kie.workbench.common.stunner.forms.context.PathAwareFormContext;
 import org.uberfire.backend.vfs.Path;
@@ -71,18 +69,24 @@ public class FormDisplayer implements FormDisplayerView.Presenter,
         view.init(this);
     }
 
-    public void render(final Element<? extends Definition<?>> element, final Path diagramPath, final FieldChangeHandler changeHandler, final RenderMode renderMode) {
+    public void render(final String domainObjectUUID,
+                       final Object domainObject,
+                       final Path diagramPath,
+                       final FieldChangeHandler changeHandler,
+                       final RenderMode renderMode) {
 
-        final Object definition = element.getContent().getDefinition();
+        LOGGER.fine("Rendering form for element: " + domainObjectUUID);
 
-        LOGGER.fine("Rendering form for element: " + element.getUUID());
-
-        doRender(element, definition, diagramPath, changeHandler, renderMode);
+        doRender(domainObjectUUID, domainObject, diagramPath, changeHandler, renderMode);
 
         show();
     }
 
-    private void doRender(Element<? extends Definition<?>> element, Object definition, Path diagramPath, FieldChangeHandler changeHandler, RenderMode renderMode) {
+    private void doRender(final String domainObjectUUID,
+                          final Object domainObject,
+                          final Path diagramPath,
+                          final FieldChangeHandler changeHandler,
+                          final RenderMode renderMode) {
 
         final List<String> previousExpandedCollapses = new ArrayList<>();
 
@@ -101,9 +105,9 @@ public class FormDisplayer implements FormDisplayerView.Presenter,
 
         LOGGER.fine("Rendering a new form for element");
 
-        Collection<FormElementFilter> filters = FormFiltersProviderFactory.getFilterForDefinition(element.getUUID(), element, definition);
+        Collection<FormElementFilter> filters = FormFiltersProviderFactory.getFilterForDefinition(domainObjectUUID, domainObject);
 
-        final BindableProxy<?> proxy = (BindableProxy<?>) BindableProxyFactory.getBindableProxy(definition);
+        final BindableProxy<?> proxy = (BindableProxy<?>) BindableProxyFactory.getBindableProxy(domainObject);
         final StaticModelFormRenderingContext generatedCtx = modelGenerator.getContextForModel(proxy.deepUnwrap(), filters.stream().toArray(FormElementFilter[]::new));
         final FormRenderingContext<?> pathAwareCtx = new PathAwareFormContext<>(generatedCtx, diagramPath);
         pathAwareCtx.setRenderMode(renderMode);
@@ -133,11 +137,11 @@ public class FormDisplayer implements FormDisplayerView.Presenter,
         }
     }
 
-    private boolean checkCollapsibleGroup(FormField formField) {
+    private boolean checkCollapsibleGroup(final FormField formField) {
         return formField.getContainer() instanceof CollapsibleFormGroup;
     }
 
-    private CollapsibleFormGroup toFormGroup(FormField formField) {
+    private CollapsibleFormGroup toFormGroup(final FormField formField) {
         return (CollapsibleFormGroup) formField.getContainer();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/resources/org/kie/workbench/common/stunner/forms/StunnerFormsClient.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/resources/org/kie/workbench/common/stunner/forms/StunnerFormsClient.gwt.xml
@@ -24,6 +24,9 @@
   <inherits name="org.kie.workbench.common.stunner.forms.StunnerFormsAPI"/>
   <inherits name="org.uberfire.ext.widgets.common.UberfireWidgetsCommons"/>
   <inherits name="org.gwtbootstrap3.extras.slider.Slider"/>
+  <inherits name="org.kie.workbench.common.forms.dynamic.service.DynamicFormsAPIServices"/>
+  <inherits name="org.kie.workbench.common.forms.processing.FormProcessingEngine"/>
+  <inherits name="org.kie.workbench.common.forms.dynamic.DynamicFormsClient"/>
 
   <source path="client"/>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/event/RefreshFormPropertiesEventTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/event/RefreshFormPropertiesEventTest.java
@@ -25,18 +25,18 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RefreshFormPropertiesTest {
+public class RefreshFormPropertiesEventTest {
 
     private static final String UUID = "uuid";
 
     @Mock
     private ClientSession session;
 
-    private RefreshFormProperties event;
+    private RefreshFormPropertiesEvent event;
 
     @Before
     public void setup() {
-        this.event = new RefreshFormProperties(session, UUID);
+        this.event = new RefreshFormPropertiesEvent(session, UUID);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
@@ -23,9 +23,11 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
@@ -76,9 +78,14 @@ public class FormsCanvasSessionHandlerTest {
     @Mock
     private Element<? extends Definition<?>> element;
 
+    @Mock
+    private DomainObject domainObject;
+
     private RefreshFormProperties refreshFormPropertiesEvent;
 
     private CanvasSelectionEvent canvasSelectionEvent;
+
+    private DomainObjectSelectionEvent domainObjectSelectionEvent;
 
     private FormsCanvasSessionHandler handler;
 
@@ -142,6 +149,28 @@ public class FormsCanvasSessionHandlerTest {
         canvasSelectionEvent = new CanvasSelectionEvent(abstractCanvasHandler, UUID);
 
         handler.onCanvasSelectionEvent(canvasSelectionEvent);
+
+        verify(formRenderer, never()).render(anyString(), any(DomainObject.class));
+    }
+
+    @Test
+    public void testOnDomainObjectSelectionEventSameSession() {
+        handler.bind(session);
+
+        domainObjectSelectionEvent = new DomainObjectSelectionEvent(abstractCanvasHandler, domainObject);
+
+        handler.onDomainObjectSelectionEvent(domainObjectSelectionEvent);
+
+        verify(formRenderer).render(anyString(), eq(domainObject));
+    }
+
+    @Test
+    public void testOnDomainObjectSelectionEventDifferentSession() {
+        handler.bind(mock(EditorSession.class));
+
+        domainObjectSelectionEvent = new DomainObjectSelectionEvent(abstractCanvasHandler, domainObject);
+
+        handler.onDomainObjectSelectionEvent(domainObjectSelectionEvent);
 
         verify(formRenderer, never()).render(anyString(), any(Element.class), any(Command.class));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
@@ -32,7 +32,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mvp.Command;
@@ -81,7 +81,7 @@ public class FormsCanvasSessionHandlerTest {
     @Mock
     private DomainObject domainObject;
 
-    private RefreshFormProperties refreshFormPropertiesEvent;
+    private RefreshFormPropertiesEvent refreshFormPropertiesEvent;
 
     private CanvasSelectionEvent canvasSelectionEvent;
 
@@ -91,7 +91,7 @@ public class FormsCanvasSessionHandlerTest {
 
     @Before
     public void setup() {
-        this.refreshFormPropertiesEvent = new RefreshFormProperties(session, UUID);
+        this.refreshFormPropertiesEvent = new RefreshFormPropertiesEvent(session, UUID);
         this.handler = spy(new FormsCanvasSessionHandler(definitionManager, commandFactory));
         this.handler.setRenderer(formRenderer);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandler;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
 import org.kie.workbench.common.stunner.forms.client.widgets.container.displayer.FormDisplayer;
 import org.mockito.Mock;
@@ -94,7 +95,7 @@ public class FormsContainerTest {
     public void testRenderExistingNode() {
         //arbitrary render mode
         RenderMode renderMode = RenderMode.EDIT_MODE;
-        NodeImpl firstNode = getNode(FIRST_ELEMENT_UID);
+        NodeImpl<Definition<?>> firstNode = getNode(FIRST_ELEMENT_UID);
 
         FormDisplayer firstDisplayer = testRender(firstNode, 1, 1, renderMode);
 
@@ -102,14 +103,14 @@ public class FormsContainerTest {
 
         FormDisplayer secondDisplayer = testRender(secondNode, 2, 1, renderMode);
 
-        formsContainer.render(GRAPH_UID, firstNode, path, fieldChangeHandler, renderMode);
+        formsContainer.render(GRAPH_UID, firstNode.getUUID(), firstNode.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
 
         verify(displayersInstance, times(2)).get();
 
         verify(secondDisplayer, times(2)).hide();
 
         verify(firstDisplayer, times(2)).show();
-        verify(firstDisplayer, times(2)).render(firstNode, path, fieldChangeHandler, renderMode);
+        verify(firstDisplayer, times(2)).render(firstNode.getUUID(), firstNode.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
     }
 
     @Test
@@ -174,9 +175,9 @@ public class FormsContainerTest {
         verify(displayersInstance, times(1)).destroyAll();
     }
 
-    private FormDisplayer testRender(NodeImpl node, int expectedDisplayers, int currentDisplayerRender, RenderMode renderMode) {
+    private FormDisplayer testRender(NodeImpl<Definition<?>> node, int expectedDisplayers, int currentDisplayerRender, RenderMode renderMode) {
 
-        formsContainer.render(GRAPH_UID, node, path, fieldChangeHandler, renderMode);
+        formsContainer.render(GRAPH_UID, node.getUUID(), node.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
 
         verify(displayersInstance, times(expectedDisplayers)).get();
 
@@ -184,7 +185,7 @@ public class FormsContainerTest {
 
         FormDisplayer displayer = activeDisplayers.get(expectedDisplayers - 1);
 
-        verify(displayer, times(currentDisplayerRender)).render(node, path, fieldChangeHandler, renderMode);
+        verify(displayer, times(currentDisplayerRender)).render(node.getUUID(), node.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
 
         verify(displayer, times(currentDisplayerRender)).hide();
         verify(view, times(currentDisplayerRender)).addDisplayer(displayer);
@@ -193,10 +194,12 @@ public class FormsContainerTest {
         return displayer;
     }
 
-    protected NodeImpl getNode(final String uuid) {
-        NodeImpl node = mock(NodeImpl.class);
+    @SuppressWarnings("unchecked")
+    protected NodeImpl<Definition<?>> getNode(final String uuid) {
+        NodeImpl<Definition<?>> node = mock(NodeImpl.class);
 
         when(node.getUUID()).thenReturn(uuid);
+        when(node.getContent()).thenReturn(mock(Definition.class));
 
         return node;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/container/displayer/FormDisplayerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/container/displayer/FormDisplayerTest.java
@@ -57,7 +57,7 @@ public class FormDisplayerTest {
     private static final String FIELD2 = "field2";
 
     @Mock
-    private NodeImpl node;
+    private NodeImpl<Definition> node;
 
     @Mock
     private Definition nodeContent;
@@ -246,7 +246,7 @@ public class FormDisplayerTest {
     }
 
     private void testRender(int renderingTimes, int initializedTimes, int newContextTimes, int boundTimes, int viewTimes, RenderMode renderMode) {
-        displayer.render(node, path, fieldChangeHandler, renderMode);
+        displayer.render(node.getUUID(), node.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
 
         verify(formRenderer, times(initializedTimes)).isInitialized();
         verify(formRenderer, times(boundTimes)).unBind();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/CatchingIntermediateEventFilterProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/CatchingIntermediateEventFilterProvider.java
@@ -16,17 +16,15 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.filters;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.kie.workbench.common.forms.adf.engine.shared.FormElementFilter;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 import org.kie.workbench.common.stunner.forms.client.formFilters.StunnerFormElementFilterProvider;
 
@@ -47,15 +45,16 @@ public class CatchingIntermediateEventFilterProvider implements StunnerFormEleme
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Collection<FormElementFilter> provideFilters(final String uuid,
-                                                        final Element<? extends Definition<?>> element,
                                                         final Object definition) {
         final Predicate predicate = o -> isBoundaryEvent(uuid);
         final FormElementFilter isInterruptingFilter = new FormElementFilter("executionSet.cancelActivity",
                                                                              predicate);
-        return Arrays.asList(isInterruptingFilter);
+        return Collections.singletonList(isInterruptingFilter);
     }
 
+    @SuppressWarnings("unchecked")
     private boolean isBoundaryEvent(final String uuid) {
         final AbstractCanvasHandler canvasHandler = (AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler();
         final Node node = canvasHandler.getGraphIndex().getNode(uuid);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/StartEventFilterProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/StartEventFilterProvider.java
@@ -15,8 +15,8 @@
  */
 package org.kie.workbench.common.stunner.bpmn.client.forms.filters;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -27,7 +27,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 import org.kie.workbench.common.stunner.forms.client.formFilters.StunnerFormElementFilterProvider;
@@ -49,13 +48,15 @@ public class StartEventFilterProvider implements StunnerFormElementFilterProvide
     }
 
     @Override
-    public Collection<FormElementFilter> provideFilters(String elementUUID, Element<? extends Definition<?>> element, Object definition) {
+    @SuppressWarnings("unchecked")
+    public Collection<FormElementFilter> provideFilters(String elementUUID, Object definition) {
         Predicate predicate = o -> isParentAnEventSubProcess(elementUUID);
         FormElementFilter isInterruptingFilter = new FormElementFilter("executionSet.isInterrupting",
                                                                        predicate);
-        return Arrays.asList(isInterruptingFilter);
+        return Collections.singletonList(isInterruptingFilter);
     }
 
+    @SuppressWarnings("unchecked")
     private boolean isParentAnEventSubProcess(final String uuid) {
         AbstractCanvasHandler canvasHandler = (AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler();
         Node node = canvasHandler.getGraphIndex().getNode(uuid);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/CatchingIntermediateEventFilterProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/CatchingIntermediateEventFilterProviderTest.java
@@ -115,9 +115,7 @@ public class CatchingIntermediateEventFilterProviderTest {
         assertEquals(filterClass,
                      filterProvider.getDefinitionType());
 
-        Collection<FormElementFilter> formElementFilters = filterProvider.provideFilters(UUID,
-                                                                                         element,
-                                                                                         definition);
+        Collection<FormElementFilter> formElementFilters = filterProvider.provideFilters(UUID, definition);
         assertEquals(1,
                      formElementFilters.size());
 
@@ -134,9 +132,7 @@ public class CatchingIntermediateEventFilterProviderTest {
         assertEquals(filterClass,
                      filterProvider.getDefinitionType());
 
-        Collection<FormElementFilter> formElementFilters = filterProvider.provideFilters(UUID,
-                                                                                         element,
-                                                                                         definition);
+        Collection<FormElementFilter> formElementFilters = filterProvider.provideFilters(UUID, definition);
         assertEquals(1,
                      formElementFilters.size());
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/StartEventFilterProviderFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/StartEventFilterProviderFactoryTest.java
@@ -161,7 +161,7 @@ public class StartEventFilterProviderFactoryTest {
         assertEquals(filterClass,
                      startEventFilterProvider.getDefinitionType());
 
-        Collection<FormElementFilter> formElementFilters = startEventFilterProvider.provideFilters(ELEMENT_UUID, element, definition);
+        Collection<FormElementFilter> formElementFilters = startEventFilterProvider.provideFilters(ELEMENT_UUID, definition);
 
         FormElementFilter formElementFilter = formElementFilters.iterator().next();
 
@@ -180,7 +180,7 @@ public class StartEventFilterProviderFactoryTest {
         assertEquals(filterClass,
                      startEventFilterProvider.getDefinitionType());
 
-        Collection<FormElementFilter> formElementFilters = startEventFilterProvider.provideFilters(ELEMENT_UUID, element, definition);
+        Collection<FormElementFilter> formElementFilters = startEventFilterProvider.provideFilters(ELEMENT_UUID, definition);
 
         FormElementFilter formElementFilter = formElementFilters.iterator().next();
 
@@ -199,7 +199,7 @@ public class StartEventFilterProviderFactoryTest {
         assertEquals(filterClass,
                      startEventFilterProvider.getDefinitionType());
 
-        Collection<FormElementFilter> formElementFilters = startEventFilterProvider.provideFilters(ELEMENT_UUID, element, definition);
+        Collection<FormElementFilter> formElementFilters = startEventFilterProvider.provideFilters(ELEMENT_UUID,  definition);
 
         FormElementFilter formElementFilter = formElementFilters.iterator().next();
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2804

This PR brings support for "drill down" and support for `LiteralExpression` "Expression Language". For example, create a `Decision` and set the `Expression` to a `LiteralExpression` . The Properties Panel shows `ID`, `Description` and `ExpressionLanguage`. This works for any `LiteralExpression` (whether in a `ContextEntry` or `Function` etc).

Support for the other properties @tarilabs has kindly added to the JIRA will probably move to a new JIRA (since this sprint is almost complete and this PR brings the generic mechanism, if not all properties that can be drilled into).

This PR currently stands at 116 files (yikes.. but a lot are simple changes to parameter lists).. another reason to add the additional properties that can be drilled into as a new JIRA/PR.