### PR TITLE
Use <target> instead of deprecated <tasks> in antrun plugin config

### DIFF
--- a/kie-wb-common-cli/kie-wb-common-cli-migration-tool/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-migration-tool/pom.xml
@@ -114,9 +114,9 @@
             <id>unzip-niogit</id>
             <phase>process-test-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <unzip src="${basedir}/src/test/resources/org.kie.workbench.common.migration/test_64x_niogit.zip" dest="${project.build.directory}" />
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
@@ -166,7 +166,7 @@
               <execution>
                 <phase>generate-sources</phase>
                 <configuration>
-                  <tasks>
+                  <target>
                     <condition property="antlr.debugParser" value="-Xconversiontimeout 32000 -debug" else="">
                       <isset property="debugParser"/>
                     </condition>
@@ -187,7 +187,7 @@
                         <include name="*.tokens"/>
                       </fileset>
                     </delete>
-                  </tasks>
+                  </target>
                 </configuration>
                 <goals>
                   <goal>run</goal>


### PR DESCRIPTION
Fixes the warning
"[WARNING] Parameter tasks is deprecated, use target instead"

See maven-antrun-plugin [docs](http://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html#tasks)