### PR TITLE
JBPM-7604 Stunner - Showing case management properties for cases only

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -195,6 +195,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/event/FormFieldChanged.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/event/FormFieldChanged.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.forms.client.event;
+
+import org.uberfire.workbench.events.UberFireEvent;
+
+public class FormFieldChanged implements UberFireEvent {
+
+    private final String name;
+    private final Object value;
+    private final String uuid;
+
+    public FormFieldChanged(final String name,
+                            final Object value,
+                            final String uuid) {
+        this.name = name;
+        this.value = value;
+        this.uuid = uuid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
@@ -33,8 +33,6 @@ import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandler;
-import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.forms.client.event.FormFieldChanged;
 import org.kie.workbench.common.stunner.forms.client.widgets.container.displayer.FormDisplayer;
 import org.uberfire.backend.vfs.Path;
@@ -80,7 +78,7 @@ public class FormsContainer implements IsElement {
         currentDisplayer = displayer;
 
         currentDisplayer.getRenderer().addFieldChangeHandler((name, value)-> {
-            formFieldChangedEvent.fire(new FormFieldChanged(name, value, element.getUUID()));
+            formFieldChangedEvent.fire(new FormFieldChanged(name, value, domainObjectUUID));
         });
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/BPMNDiagramImpl.java
@@ -58,6 +58,8 @@ public class BPMNDiagramImpl implements BPMNDiagram {
 
     @Category
     public static final transient String category = BPMNCategories.CONTAINERS;
+    public static final String DIAGRAM_SET = "diagramSet";
+    public static final String CASE_MANAGEMENT_SET = "caseManagementSet";
 
     @PropertySet
     @FormField
@@ -66,14 +68,14 @@ public class BPMNDiagramImpl implements BPMNDiagram {
 
     @PropertySet
     @FormField(
-            afterElement = "diagramSet"
+            afterElement = DIAGRAM_SET
     )
     @Valid
     protected ProcessData processData;
 
     @PropertySet
     @FormField(
-            afterElement = "diagramSet"
+            afterElement = DIAGRAM_SET
     )
     protected CaseManagementSet caseManagementSet;
 
@@ -105,9 +107,9 @@ public class BPMNDiagramImpl implements BPMNDiagram {
                                         HEIGHT));
     }
 
-    public BPMNDiagramImpl(final @MapsTo("diagramSet") DiagramSet diagramSet,
+    public BPMNDiagramImpl(final @MapsTo(DIAGRAM_SET) DiagramSet diagramSet,
                            final @MapsTo("processData") ProcessData processData,
-                           final @MapsTo("caseManagementSet") CaseManagementSet caseManagementSet,
+                           final @MapsTo(CASE_MANAGEMENT_SET) CaseManagementSet caseManagementSet,
                            final @MapsTo("backgroundSet") BackgroundSet backgroundSet,
                            final @MapsTo("fontSet") FontSet fontSet,
                            final @MapsTo("dimensionsSet") RectangleDimensionsSet dimensionsSet) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/DiagramSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/DiagramSet.java
@@ -43,6 +43,8 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
 public class DiagramSet implements BPMNPropertySet,
                                    BPMNBaseInfo {
 
+    public static final String ADHOC = "adHoc";
+
     @Property
     @FormField
     @Valid
@@ -86,7 +88,7 @@ public class DiagramSet implements BPMNPropertySet,
 
     @Property
     @FormField(
-            afterElement = "adHoc"
+            afterElement = ADHOC
     )
     @Valid
     private ProcessInstanceDescription processInstanceDescription;
@@ -110,7 +112,7 @@ public class DiagramSet implements BPMNPropertySet,
                       final @MapsTo("id") Id id,
                       final @MapsTo("packageProperty") Package packageProperty,
                       final @MapsTo("version") Version version,
-                      final @MapsTo("adHoc") AdHoc adHoc,
+                      final @MapsTo(ADHOC) AdHoc adHoc,
                       final @MapsTo("processInstanceDescription") ProcessInstanceDescription processInstanceDescription,
                       final @MapsTo("executable") Executable executable) {
         this.name = name;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/service/BPMNDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/service/BPMNDiagramService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.bpmn.definition;
+package org.kie.workbench.common.stunner.bpmn.service;
 
-import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.uberfire.backend.vfs.Path;
 
-public interface BPMNDiagram extends BPMNViewDefinition {
+@Remote
+public interface BPMNDiagramService {
 
-    DiagramSet getDiagramSet();
+    ProjectType getProjectType(Path projectRootPath);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/service/ProjectType.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/service/ProjectType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.service;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public enum ProjectType {
+
+    BPMN(null),
+    CASE(".caseproject");
+
+    ProjectType(String fileName) {
+        this.fileName = fileName;
+    }
+
+    private String fileName;
+
+    public static Optional<ProjectType> fromFileName(Optional<String> fileName) {
+        return fileName.map(name -> Stream.of(ProjectType.values())
+                .filter(v -> Objects.equals(v.fileName, name))
+                .findFirst().orElse(null));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/service/BPMNDiagramServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/service/BPMNDiagramServiceImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.service;
+
+import java.util.stream.StreamSupport;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.workbench.common.stunner.bpmn.service.BPMNDiagramService;
+import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+
+@Service
+public class BPMNDiagramServiceImpl implements BPMNDiagramService {
+
+    private IOService ioService;
+
+    @Inject
+    public BPMNDiagramServiceImpl(final @Named("ioStrategy") IOService ioService) {
+        this.ioService = ioService;
+    }
+
+    public BPMNDiagramServiceImpl() {
+    }
+
+    @Override
+    public ProjectType getProjectType(Path projectRootPath) {
+        org.uberfire.java.nio.file.DirectoryStream<org.uberfire.java.nio.file.Path> paths =
+                ioService.newDirectoryStream(Paths.convert(projectRootPath), f -> f.getFileName().toString().startsWith("."));
+        return ProjectType.fromFileName(StreamSupport.stream(paths.spliterator(), false)
+                                                .map(Paths::convert)
+                                                .map(Path::getFileName)
+                                                .findFirst()
+        ).orElse(null);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/BPMNDiagramServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/BPMNDiagramServiceImplTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.service;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.DirectoryStream;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BPMNDiagramServiceImplTest {
+
+    public static final String DIR_URI = "default://master@diagrams/root";
+
+    private static final String FILE_NAME = ".caseproject";
+
+    public static final String FILE_URI = DIR_URI + "/" + FILE_NAME;
+
+    private BPMNDiagramServiceImpl tested;
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private DirectoryStream<org.uberfire.java.nio.file.Path> directoryStream;
+
+    @Mock
+    private org.uberfire.backend.vfs.Path projectPath;
+
+    @Mock
+    private Path fsPath;
+
+    @Mock
+    private Path fileName;
+
+    @Mock
+    private FileSystem fs;
+
+    @Before
+    public void setUp() throws Exception {
+
+        ArgumentCaptor<DirectoryStream.Filter> filter = ArgumentCaptor.forClass(DirectoryStream.Filter.class);
+        when(ioService.newDirectoryStream(any(), filter.capture())).thenReturn(directoryStream);
+        when(directoryStream.spliterator()).thenReturn(Arrays.asList(fsPath).spliterator());
+        when(projectPath.toURI()).thenReturn(DIR_URI);
+        when(fsPath.getFileName()).thenReturn(fileName);
+        when(fsPath.toUri()).thenReturn(new URI(FILE_URI));
+        when(fsPath.getFileSystem()).thenReturn(fs);
+        when(fileName.toString()).thenReturn(FILE_NAME);
+
+        tested = new BPMNDiagramServiceImpl(ioService);
+    }
+
+    @Test
+    public void getProjectTypeCase() {
+        final ProjectType projectType = tested.getProjectType(projectPath);
+        assertEquals(projectType, ProjectType.CASE);
+    }
+
+    @Test
+    public void getProjectTypeNull() {
+        when(directoryStream.spliterator()).thenReturn(Collections.<Path>emptyList().spliterator());
+        final ProjectType projectType = tested.getProjectType(projectPath);
+        assertEquals(projectType, null);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPoint.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPoint.java
@@ -20,6 +20,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
 import org.kie.workbench.common.stunner.bpmn.client.forms.filters.CatchingIntermediateEventFilterProvider;
 import org.kie.workbench.common.stunner.bpmn.client.forms.filters.StartEventFilterProvider;
@@ -36,6 +37,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.StartSignalEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.StartTimerEvent;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.forms.client.formFilters.FormFiltersProviderFactory;
+import org.kie.workbench.common.stunner.forms.client.formFilters.StunnerFormElementFilterProvider;
 
 @EntryPoint
 @Bundle("resources/i18n/StunnerBPMNConstants.properties")
@@ -43,9 +45,12 @@ public class StunnerBPMNEntryPoint {
 
     private SessionManager sessionManager;
 
+    private ManagedInstance<StunnerFormElementFilterProvider> managedFilters;
+
     @Inject
-    public StunnerBPMNEntryPoint(SessionManager sessionManager) {
+    public StunnerBPMNEntryPoint(SessionManager sessionManager, ManagedInstance<StunnerFormElementFilterProvider> managedFilters) {
         this.sessionManager = sessionManager;
+        this.managedFilters = managedFilters;
     }
 
     @PostConstruct
@@ -61,5 +66,8 @@ public class StunnerBPMNEntryPoint {
         FormFiltersProviderFactory.registerProvider(new CatchingIntermediateEventFilterProvider(sessionManager, IntermediateConditionalEvent.class));
         FormFiltersProviderFactory.registerProvider(new CatchingIntermediateEventFilterProvider(sessionManager, IntermediateMessageEventCatching.class));
         FormFiltersProviderFactory.registerProvider(new CatchingIntermediateEventFilterProvider(sessionManager, IntermediateEscalationEvent.class));
+
+        //registering managed filters instances
+        managedFilters.forEach(FormFiltersProviderFactory::registerProvider);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/diagram/DiagramTypeService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/diagram/DiagramTypeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.bpmn.definition;
+package org.kie.workbench.common.stunner.bpmn.client.diagram;
 
-import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
+import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
 
-public interface BPMNDiagram extends BPMNViewDefinition {
+public interface DiagramTypeService {
 
-    DiagramSet getDiagramSet();
+    void loadDiagramType(Metadata metadata);
+
+    ProjectType getProjectType(Metadata metadata);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/diagram/DiagramTypeServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/diagram/DiagramTypeServiceImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.diagram;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.Caller;
+import org.kie.workbench.common.stunner.bpmn.service.BPMNDiagramService;
+import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
+import org.kie.workbench.common.stunner.core.client.session.event.SessionDestroyedEvent;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+
+@ApplicationScoped
+public class DiagramTypeServiceImpl implements DiagramTypeService {
+
+    private final Caller<BPMNDiagramService> bpmnDiagramService;
+    private static final Map<String, ProjectType> projectTypeRegistry = new HashMap<>();
+
+    DiagramTypeServiceImpl() {
+        this(null);
+    }
+
+    @Inject
+    public DiagramTypeServiceImpl(Caller<BPMNDiagramService> bpmnDiagramService) {
+        this.bpmnDiagramService = bpmnDiagramService;
+    }
+
+    @Override
+    public void loadDiagramType(Metadata metadata) {
+        bpmnDiagramService
+                .call((r) -> setProjectType(metadata, (ProjectType) r))
+                .getProjectType(metadata.getRoot());
+    }
+
+    void setProjectType(final Metadata metadata, final ProjectType projectType) {
+        projectTypeRegistry.put(getDiagramId(metadata), projectType);
+    }
+
+    private String getDiagramId(Metadata metadata) {
+        return metadata.getCanvasRootUUID();
+    }
+
+    @Override
+    public ProjectType getProjectType(final Metadata metadata) {
+        return Optional.ofNullable(projectTypeRegistry.get(getDiagramId(metadata)))
+                .orElse(ProjectType.BPMN);
+    }
+
+    protected void onSessionClosed(@Observes final SessionDestroyedEvent event) {
+        projectTypeRegistry.remove(getDiagramId(event.getMetadata()));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProvider.java
@@ -34,10 +34,8 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.Diagram
 import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.forms.client.event.FormFieldChanged;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.kie.workbench.common.stunner.forms.client.formFilters.StunnerFormElementFilterProvider;
 
 @Dependent
@@ -46,7 +44,7 @@ public class BPMNDiagramFilterProvider implements StunnerFormElementFilterProvid
     private final SessionManager sessionManager;
     private final DiagramTypeService diagramTypeService;
     private final FieldChangeHandlerManager fieldChangeHandlerManager;
-    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+    private final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     BPMNDiagramFilterProvider() {
         this(null, null, null, null);
@@ -56,7 +54,7 @@ public class BPMNDiagramFilterProvider implements StunnerFormElementFilterProvid
     public BPMNDiagramFilterProvider(final SessionManager sessionManager,
                                      final DiagramTypeService diagramTypeService,
                                      final FieldChangeHandlerManager fieldChangeHandlerManager,
-                                     final Event<RefreshFormProperties> refreshFormPropertiesEvent) {
+                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent) {
         this.sessionManager = sessionManager;
         this.diagramTypeService = diagramTypeService;
         this.fieldChangeHandlerManager = fieldChangeHandlerManager;
@@ -69,7 +67,7 @@ public class BPMNDiagramFilterProvider implements StunnerFormElementFilterProvid
     }
 
     @Override
-    public Collection<FormElementFilter> provideFilters(String elementUUID, Element<? extends Definition<?>> element, Object definition) {
+    public Collection<FormElementFilter> provideFilters(String elementUUID, Object definition) {
         final BPMNDiagram diagram = (BPMNDiagram) definition;
         final Boolean isAdHoc = diagram.getDiagramSet().getAdHoc().getValue();
 
@@ -88,6 +86,6 @@ public class BPMNDiagramFilterProvider implements StunnerFormElementFilterProvid
             return;
         }
 
-        refreshFormPropertiesEvent.fire(new RefreshFormProperties(sessionManager.getCurrentSession(), formFieldChanged.getUuid()));
+        refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(sessionManager.getCurrentSession(), formFieldChanged.getUuid()));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.bpmn.client.forms.filters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.forms.adf.engine.shared.FormElementFilter;
+import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandlerManager;
+import org.kie.workbench.common.stunner.bpmn.client.diagram.DiagramTypeService;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
+import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.forms.client.event.FormFieldChanged;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.formFilters.StunnerFormElementFilterProvider;
+
+@Dependent
+public class BPMNDiagramFilterProvider implements StunnerFormElementFilterProvider {
+
+    private final SessionManager sessionManager;
+    private final DiagramTypeService diagramTypeService;
+    private final FieldChangeHandlerManager fieldChangeHandlerManager;
+    private final Event<RefreshFormProperties> refreshFormPropertiesEvent;
+
+    BPMNDiagramFilterProvider() {
+        this(null, null, null, null);
+    }
+
+    @Inject
+    public BPMNDiagramFilterProvider(final SessionManager sessionManager,
+                                     final DiagramTypeService diagramTypeService,
+                                     final FieldChangeHandlerManager fieldChangeHandlerManager,
+                                     final Event<RefreshFormProperties> refreshFormPropertiesEvent) {
+        this.sessionManager = sessionManager;
+        this.diagramTypeService = diagramTypeService;
+        this.fieldChangeHandlerManager = fieldChangeHandlerManager;
+        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
+    }
+
+    @Override
+    public Class<?> getDefinitionType() {
+        return BPMNDiagramImpl.class;
+    }
+
+    @Override
+    public Collection<FormElementFilter> provideFilters(String elementUUID, Element<? extends Definition<?>> element, Object definition) {
+        final BPMNDiagram diagram = (BPMNDiagram) definition;
+        final Boolean isAdHoc = diagram.getDiagramSet().getAdHoc().getValue();
+
+        final Metadata metadata = sessionManager.getCurrentSession().getCanvasHandler().getDiagram().getMetadata();
+        final ProjectType currentProjectType = diagramTypeService.getProjectType(metadata);
+
+        final Predicate predicate = t -> isAdHoc && Objects.equals(currentProjectType, ProjectType.CASE);
+        final FormElementFilter filter = new FormElementFilter(BPMNDiagramImpl.CASE_MANAGEMENT_SET, predicate);
+
+        return Arrays.asList(filter);
+    }
+
+    void onFormFieldChanged(@Observes FormFieldChanged formFieldChanged) {
+        final String adHocFieldName = BPMNDiagramImpl.DIAGRAM_SET + "." + DiagramSet.ADHOC;
+        if (!Objects.equals(formFieldChanged.getName(), adHocFieldName)) {
+            return;
+        }
+
+        refreshFormPropertiesEvent.fire(new RefreshFormProperties(sessionManager.getCurrentSession(), formFieldChanged.getUuid()));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializer.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.client.session;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.bpmn.client.diagram.DiagramTypeService;
 import org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientRegistry;
 import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
 import org.kie.workbench.common.stunner.core.client.session.impl.SessionInitializer;
@@ -30,21 +31,23 @@ import org.uberfire.mvp.Command;
 public class BPMNSessionInitializer implements SessionInitializer {
 
     private final WorkItemDefinitionClientRegistry workItemDefinitionService;
+    private final DiagramTypeService diagramTypeService;
 
     // CDI proxy.
     protected BPMNSessionInitializer() {
-        this(null);
+        this(null, null);
     }
 
     @Inject
-    public BPMNSessionInitializer(final WorkItemDefinitionClientRegistry workItemDefinitionService) {
+    public BPMNSessionInitializer(final WorkItemDefinitionClientRegistry workItemDefinitionService, final DiagramTypeService diagramTypeService) {
         this.workItemDefinitionService = workItemDefinitionService;
+        this.diagramTypeService = diagramTypeService;
     }
 
     @Override
     public void init(final Metadata metadata,
                      final Command completeCallback) {
-        workItemDefinitionService.load(metadata,
-                                       completeCallback);
+        diagramTypeService.loadDiagramType(metadata);
+        workItemDefinitionService.load(metadata, completeCallback);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnClient.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnClient.gwt.xml
@@ -29,6 +29,7 @@
   <inherits name="org.kie.workbench.common.stunner.forms.StunnerFormsClient"/>
   <inherits name="org.kie.workbench.common.stunner.client.StunnerWidgets"/>
   <inherits name="org.kie.soup.commons.KIESoupCommons"/>
+  <inherits name="org.kie.workbench.common.forms.processing.FormProcessingEngine"/>
 
   <source path="client"/>
   <source path="" includes="StunnerBPMNEntryPoint.java"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPointTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPointTest.java
@@ -65,8 +65,8 @@ public class StunnerBPMNEntryPointTest {
     @Test
     public void init() {
         tested.init();
-        FormFiltersProviderFactory.getFilterForDefinition(UUID, element, diagramDef);
-        verify(bpmnDiagramFilterProvider).provideFilters(UUID, element, diagramDef);
+        FormFiltersProviderFactory.getFilterForDefinition(UUID, diagramDef);
+        verify(bpmnDiagramFilterProvider).provideFilters(UUID, diagramDef);
     }
 }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPointTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/StunnerBPMNEntryPointTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.client.forms.filters.BPMNDiagramFilterProvider;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.forms.client.formFilters.FormFiltersProviderFactory;
+import org.kie.workbench.common.stunner.forms.client.formFilters.StunnerFormElementFilterProvider;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StunnerBPMNEntryPointTest {
+
+    private static final String UUID = "uuid";
+
+    private StunnerBPMNEntryPoint tested;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    private ManagedInstance<StunnerFormElementFilterProvider> managedFilters;
+
+    @Mock
+    private BPMNDiagramFilterProvider bpmnDiagramFilterProvider;
+
+    @Mock
+    private Element<? extends Definition<?>> element;
+
+    private BPMNDiagramImpl diagramDef;
+
+    @Before
+    public void setUp() throws Exception {
+        diagramDef = new BPMNDiagramImpl();
+        when(bpmnDiagramFilterProvider.getDefinitionType()).thenReturn((Class) BPMNDiagramImpl.class);
+        managedFilters = new ManagedInstanceStub(bpmnDiagramFilterProvider);
+        tested = new StunnerBPMNEntryPoint(sessionManager, managedFilters);
+    }
+
+    @Test
+    public void init() {
+        tested.init();
+        FormFiltersProviderFactory.getFilterForDefinition(UUID, element, diagramDef);
+        verify(bpmnDiagramFilterProvider).provideFilters(UUID, element, diagramDef);
+    }
+}
+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/diagram/DiagramTypeServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/diagram/DiagramTypeServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.diagram;
+
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.service.BPMNDiagramService;
+import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
+import org.kie.workbench.common.stunner.core.client.session.event.SessionDestroyedEvent;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.mocks.CallerMock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiagramTypeServiceTest {
+
+    private static final String ID = "ID";
+    private DiagramTypeServiceImpl tested;
+
+    @Mock
+    private BPMNDiagramService bpmnDiagramService;
+
+    @Mock
+    private Caller<BPMNDiagramService> bpmnDiagramServiceCaller;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
+    private SessionDestroyedEvent sessionDestroyedEvent;
+
+    @Mock
+    private Path path;
+
+    @Before
+    public void setUp() throws Exception {
+        when(sessionDestroyedEvent.getMetadata()).thenReturn(metadata);
+        when(metadata.getCanvasRootUUID()).thenReturn(ID);
+        when(metadata.getRoot()).thenReturn(path);
+        when(bpmnDiagramService.getProjectType(path)).thenReturn(ProjectType.CASE);
+
+        bpmnDiagramServiceCaller = new CallerMock<>(bpmnDiagramService);
+        tested = new DiagramTypeServiceImpl(bpmnDiagramServiceCaller);
+    }
+
+    @Test
+    public void loadDiagramType() {
+        tested.loadDiagramType(metadata);
+        final ProjectType projectType = tested.getProjectType(metadata);
+        assertThat(projectType).isEqualTo(ProjectType.CASE);
+    }
+
+    @Test
+    public void getNull() {
+        ProjectType projectType = tested.getProjectType(metadata);
+        assertThat(projectType).isEqualTo(ProjectType.BPMN);
+    }
+
+    @Test
+    public void onSessionClosed() {
+        tested.loadDiagramType(metadata);
+        ProjectType projectType = tested.getProjectType(metadata);
+        assertThat(projectType).isEqualTo(ProjectType.CASE);
+        tested.onSessionClosed(sessionDestroyedEvent);
+        projectType = tested.getProjectType(metadata);
+        assertThat(projectType).isEqualTo(ProjectType.BPMN);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProviderTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.bpmn.client.forms.filters;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.adf.engine.shared.FormElementFilter;
+import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandlerManager;
+import org.kie.workbench.common.stunner.bpmn.client.diagram.DiagramTypeService;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.AdHoc;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
+import org.kie.workbench.common.stunner.bpmn.service.ProjectType;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.forms.client.event.FormFieldChanged;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.EventSourceMock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BPMNDiagramFilterProviderTest {
+
+    private static final String UUID = "uuid";
+
+    private static final String ADHOC_FIELD_NAME = BPMNDiagramImpl.DIAGRAM_SET + "." + DiagramSet.ADHOC;
+
+    private BPMNDiagramFilterProvider tested;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private DiagramTypeService diagramTypeService;
+
+    @Mock
+    private FieldChangeHandlerManager fieldChangeHandlerManager;
+
+    @Mock
+    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+
+    @Mock
+    private BPMNDiagramImpl diagramDef;
+
+    @Mock
+    private Element<? extends Definition<?>> element;
+
+    @Mock
+    private FormFieldChanged formFieldChanged;
+
+    @Mock
+    private DiagramSet diagramSet;
+
+    @Mock
+    private AdHoc adHoc;
+
+    @Mock
+    private ClientSession session;
+
+    @Mock
+    private CanvasHandler canvasHandler;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    @Before
+    public void setUp() throws Exception {
+        when(formFieldChanged.getName()).thenReturn(ADHOC_FIELD_NAME);
+        when(formFieldChanged.getUuid()).thenReturn(UUID);
+        when(formFieldChanged.getValue()).thenReturn(true);
+        when(diagramDef.getDiagramSet()).thenReturn(diagramSet);
+        when(diagramSet.getAdHoc()).thenReturn(adHoc);
+        when(adHoc.getValue()).thenReturn(true);
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(diagramTypeService.getProjectType(metadata)).thenReturn(ProjectType.CASE);
+
+        tested = new BPMNDiagramFilterProvider(sessionManager, diagramTypeService, fieldChangeHandlerManager, refreshFormPropertiesEvent);
+    }
+
+    @Test
+    public void getDefinitionType() {
+        assertEquals(tested.getDefinitionType(), BPMNDiagramImpl.class);
+    }
+
+    @Test
+    public void provideFiltersCase() {
+        final FormElementFilter filter = testAndGetFormElementFilter();
+        assertTrue(filter.getPredicate().test(null));
+    }
+
+    @Test
+    public void provideFiltersBPMN() {
+        when(diagramTypeService.getProjectType(metadata)).thenReturn(ProjectType.BPMN);
+        final FormElementFilter filter = testAndGetFormElementFilter();
+        assertFalse(filter.getPredicate().test(null));
+    }
+
+    private FormElementFilter testAndGetFormElementFilter() {
+        final FormElementFilter filter = tested.provideFilters(UUID, element, diagramDef).stream().findFirst().get();
+        assertEquals(filter.getElementName(), BPMNDiagramImpl.CASE_MANAGEMENT_SET);
+        return filter;
+    }
+
+    @Test
+    public void onFormFieldChanged() {
+        tested.onFormFieldChanged(formFieldChanged);
+        final ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesArgumentCaptor = ArgumentCaptor.forClass(RefreshFormProperties.class);
+        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesArgumentCaptor.capture());
+        RefreshFormProperties refreshEvent = refreshFormPropertiesArgumentCaptor.getValue();
+        assertEquals(refreshEvent.getUuid(), UUID);
+        assertEquals(refreshEvent.getSession(), session);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/filters/BPMNDiagramFilterProviderTest.java
@@ -33,7 +33,7 @@ import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.forms.client.event.FormFieldChanged;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties;
+import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -64,7 +64,7 @@ public class BPMNDiagramFilterProviderTest {
     private FieldChangeHandlerManager fieldChangeHandlerManager;
 
     @Mock
-    private EventSourceMock<RefreshFormProperties> refreshFormPropertiesEvent;
+    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private BPMNDiagramImpl diagramDef;
@@ -129,7 +129,7 @@ public class BPMNDiagramFilterProviderTest {
     }
 
     private FormElementFilter testAndGetFormElementFilter() {
-        final FormElementFilter filter = tested.provideFilters(UUID, element, diagramDef).stream().findFirst().get();
+        final FormElementFilter filter = tested.provideFilters(UUID, diagramDef).stream().findFirst().get();
         assertEquals(filter.getElementName(), BPMNDiagramImpl.CASE_MANAGEMENT_SET);
         return filter;
     }
@@ -137,9 +137,9 @@ public class BPMNDiagramFilterProviderTest {
     @Test
     public void onFormFieldChanged() {
         tested.onFormFieldChanged(formFieldChanged);
-        final ArgumentCaptor<RefreshFormProperties> refreshFormPropertiesArgumentCaptor = ArgumentCaptor.forClass(RefreshFormProperties.class);
+        final ArgumentCaptor<RefreshFormPropertiesEvent> refreshFormPropertiesArgumentCaptor = ArgumentCaptor.forClass(RefreshFormPropertiesEvent.class);
         verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesArgumentCaptor.capture());
-        RefreshFormProperties refreshEvent = refreshFormPropertiesArgumentCaptor.getValue();
+        RefreshFormPropertiesEvent refreshEvent = refreshFormPropertiesArgumentCaptor.getValue();
         assertEquals(refreshEvent.getUuid(), UUID);
         assertEquals(refreshEvent.getSession(), session);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializerTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.client.session;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.client.diagram.DiagramTypeService;
 import org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientRegistry;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.mockito.Mock;
@@ -38,18 +39,20 @@ public class BPMNSessionInitializerTest {
 
     private BPMNSessionInitializer tested;
 
+    @Mock
+    private DiagramTypeService diagramTypeService;
+
     @Before
     public void setUp() {
-        tested = new BPMNSessionInitializer(workItemDefinitionService);
+        tested = new BPMNSessionInitializer(workItemDefinitionService, diagramTypeService);
     }
 
     @Test
     public void testInit() {
         Metadata metadata = mock(Metadata.class);
         Command callback = mock(Command.class);
-        tested.init(metadata,
-                    callback);
-        verify(workItemDefinitionService, times(1)).load(eq(metadata),
-                                                         eq(callback));
+        tested.init(metadata, callback);
+        verify(workItemDefinitionService, times(1)).load(eq(metadata), eq(callback));
+        verify(diagramTypeService).loadDiagramType(metadata);
     }
 }


### PR DESCRIPTION
Hide / Show Case Management Properties whether the diagram is under a case project and the `adhoc` property is set to **true**

To test it is necessary 2 conditions:
- the existence of **.caseproject** file on the root project filesystem on the .niogit, on the WB just create a case project should be enough because it creates this file.
- the property adhoc set to true or false on the forms

Since the adhoc condition can be changed at runtime, you can test setting to true/false and see the Case Management properties be shown/hide.

@romartin 
@LuboTerifaj 