### PR TITLE
[DO NOT MERGE] BAQE-650: Remove drools.datetimeformat property

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/preferences/ApplicationPreferences.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/preferences/ApplicationPreferences.java
@@ -25,7 +25,6 @@ import java.util.Map;
 public class ApplicationPreferences {
 
     public static final String DATE_FORMAT = "drools.dateformat";
-    public static final String DATE_TIME_FORMAT = "drools.datetimeformat";
     public static final String DEFAULT_LANGUAGE = "drools.defaultlanguage";
     public static final String DEFAULT_COUNTRY = "drools.defaultcountry";
     public static final String KIE_VERSION_PROPERTY_NAME = "kie_version";
@@ -53,10 +52,6 @@ public class ApplicationPreferences {
 
     public static String getDroolsDateFormat() {
         return getStringPref(DATE_FORMAT);
-    }
-
-    public static String getDroolsDateTimeFormat() {
-        return getStringPref(DATE_TIME_FORMAT);
     }
 
     public static String getCurrentDroolsVersion() {

--- a/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/preferences/ApplicationPreferencesTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/preferences/ApplicationPreferencesTest.java
@@ -30,7 +30,6 @@ public class ApplicationPreferencesTest {
         assertNull( ApplicationPreferences.getStringPref( "any" ) );
         assertNull( ApplicationPreferences.getCurrentDroolsVersion() );
         assertNull( ApplicationPreferences.getDroolsDateFormat() );
-        assertNull( ApplicationPreferences.getDroolsDateTimeFormat() );
         assertFalse( ApplicationPreferences.getBooleanPref( "any" ) );
     }
 
@@ -40,7 +39,6 @@ public class ApplicationPreferencesTest {
         assertNull( ApplicationPreferences.getStringPref( "any" ) );
         assertNull( ApplicationPreferences.getCurrentDroolsVersion() );
         assertNull( ApplicationPreferences.getDroolsDateFormat() );
-        assertNull( ApplicationPreferences.getDroolsDateTimeFormat() );
         assertFalse( ApplicationPreferences.getBooleanPref( "any" ) );
 
         ApplicationPreferences.setUp( new HashMap<String, String>() {{
@@ -52,8 +50,6 @@ public class ApplicationPreferencesTest {
                  "version" );
             put( ApplicationPreferences.DATE_FORMAT,
                  "dd-MM-yyyy" );
-            put( ApplicationPreferences.DATE_TIME_FORMAT,
-                 "dd-MM-yyyy hh:mm:ss" );
         }} );
 
         assertEquals( "string",
@@ -62,8 +58,6 @@ public class ApplicationPreferencesTest {
                       ApplicationPreferences.getCurrentDroolsVersion() );
         assertEquals( "dd-MM-yyyy",
                       ApplicationPreferences.getDroolsDateFormat() );
-        assertEquals( "dd-MM-yyyy hh:mm:ss",
-                      ApplicationPreferences.getDroolsDateTimeFormat() );
         assertTrue( ApplicationPreferences.getBooleanPref( "boolean" ) );
     }
 

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/DroolsApplicationPreferencesLoader.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/DroolsApplicationPreferencesLoader.java
@@ -36,8 +36,6 @@ public class DroolsApplicationPreferencesLoader implements ApplicationPreference
         addSystemProperty( preferences,
                            ApplicationPreferences.DATE_FORMAT );
         addSystemProperty( preferences,
-                           ApplicationPreferences.DATE_TIME_FORMAT );
-        addSystemProperty( preferences,
                            ApplicationPreferences.DEFAULT_LANGUAGE );
         addSystemProperty( preferences,
                            ApplicationPreferences.DEFAULT_COUNTRY );

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/DroolsSystemPropertiesInitializer.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/preferences/DroolsSystemPropertiesInitializer.java
@@ -31,8 +31,6 @@ public class DroolsSystemPropertiesInitializer implements SystemPropertiesInitia
         setSystemProperty(preferences,
                           ApplicationPreferences.DATE_FORMAT);
         setSystemProperty(preferences,
-                          ApplicationPreferences.DATE_TIME_FORMAT);
-        setSystemProperty(preferences,
                           ApplicationPreferences.DEFAULT_LANGUAGE);
         setSystemProperty(preferences,
                           ApplicationPreferences.DEFAULT_COUNTRY);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/java/org/kie/workbench/common/stunner/project/backend/server/AppSetup.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/java/org/kie/workbench/common/stunner/project/backend/server/AppSetup.java
@@ -102,8 +102,6 @@ public class AppSetup extends BaseAppSetup {
                                                                       "");
         group.addConfigItem(configurationFactory.newConfigItem("drools.dateformat",
                                                                "dd-MMM-yyyy"));
-        group.addConfigItem(configurationFactory.newConfigItem("drools.datetimeformat",
-                                                               "dd-MMM-yyyy hh:mm:ss"));
         group.addConfigItem(configurationFactory.newConfigItem("drools.defaultlanguage",
                                                                "en"));
         group.addConfigItem(configurationFactory.newConfigItem("drools.defaultcountry",


### PR DESCRIPTION
After investigating the codebase it seems that the system property drools.datetimeformat is set, but never used. So this PR removest. The time format pask for dates can be set using drools.dateformat property.

Ensemble with:
- https://github.com/kiegroup/drools-wb/pull/954
- https://github.com/kiegroup/kie-wb-distributions/pull/826
- https://github.com/kiegroup/optaplanner-wb/pull/307