### PR TITLE
Process Designer: Clear selection when delete group of nodes

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommand.java
@@ -98,6 +98,7 @@ public class DeleteSelectionSessionCommand extends AbstractSelectionAwareSession
             final Collection<String> selectedItems = selectionControl.getSelectedItems();
 
             clearSelectionEvent.fire(new CanvasClearSelectionEvent(canvasHandler));
+            selectionControl.clearSelection();
 
             if (selectedItems != null && !selectedItems.isEmpty()) {
                 // Execute the commands.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
@@ -18,13 +18,20 @@ package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
 import javax.enterprise.event.Event;
 
+import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
+import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboardSelectionAwareTest {
@@ -32,12 +39,37 @@ public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboar
     @Mock
     private Event<CanvasClearSelectionEvent> canvasClearSelectionEventEvent;
 
-    @Override
+    @Mock
+    private ClientSessionCommand.Callback callback;
 
+    @Mock
+    private EditorSession session;
+
+    @Mock
+    private KeyboardControl keyboardControl;
+
+    @Mock
+    private SelectionControl selectionControl;
+
+    @Override
     protected AbstractClientSessionCommand<EditorSession> getCommand() {
         return new DeleteSelectionSessionCommand(sessionCommandManager,
                                                  canvasCommandFactory,
                                                  canvasClearSelectionEventEvent);
+    }
+
+    @Test
+    public void testClearSessionInvoked() {
+        DeleteSelectionSessionCommand deleteCommand = (DeleteSelectionSessionCommand) getCommand();
+
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+        when(session.getSelectionControl()).thenReturn(selectionControl);
+
+        deleteCommand.bind(session);
+
+        deleteCommand.execute(callback);
+
+        verify(selectionControl).clearSelection();
     }
 
     @Override


### PR DESCRIPTION
Hi @tiagodolphine, @LuboTerifaj,

this line was removed (see link below) and I am not sure, should we return it or not, but with this line I can't reproduce issue any more. https://github.com/kiegroup/kie-wb-common/commit/490271a1ea9403447892229075762e90034fc5dd#diff-75800ba6215a86b707fa744b75e5c7a2L116

Steps To Reproduce:
1. model process with more then one node
2. select all or part of them by group selection
3. press Delete button

Before fixt:
Nodes disappear but selection box is still visible.

After fix:
Nodes disappear and selection box is also not visible any more.