### PR TITLE
DROOLS-3116 empty Literal Expression is preserved

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
@@ -28,15 +28,6 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
 public class ExpressionPropertyConverter {
 
     public static Expression wbFromDMN(final org.kie.dmn.model.api.Expression dmn) {
-        // SPECIAL CASE: to represent a partially edited DMN file.
-        // consider a LiteralExpression with null text as missing expression altogether.
-        if (dmn instanceof org.kie.dmn.model.api.LiteralExpression) {
-            org.kie.dmn.model.api.LiteralExpression literalExpression = (org.kie.dmn.model.api.LiteralExpression) dmn;
-            if (literalExpression.getText() == null) {
-                return null;
-            }
-        }
-
         if (dmn instanceof org.kie.dmn.model.api.LiteralExpression) {
             return LiteralExpressionPropertyConverter.wbFromDMN((org.kie.dmn.model.api.LiteralExpression) dmn);
         } else if (dmn instanceof org.kie.dmn.model.api.Context) {
@@ -56,13 +47,6 @@ public class ExpressionPropertyConverter {
     }
 
     public static org.kie.dmn.model.api.Expression dmnFromWB(final Expression wb) {
-        // SPECIAL CASE: to represent a partially edited DMN file.
-        // reference above.
-        if (wb == null) {
-            org.kie.dmn.model.api.LiteralExpression mockedExpression = new org.kie.dmn.model.v1_1.TLiteralExpression();
-            return mockedExpression;
-        }
-
         if (wb instanceof LiteralExpression) {
             return LiteralExpressionPropertyConverter.dmnFromWB((LiteralExpression) wb);
         } else if (wb instanceof Context) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -1058,7 +1058,7 @@ public class DMNMarshallerTest {
         org.kie.dmn.model.api.Context d0c = (org.kie.dmn.model.api.Context) d0.getDecision().getExpression();
         org.kie.dmn.model.api.Expression contextEntryValue = d0c.getContextEntry().get(0).getExpression();
         assertTrue(contextEntryValue instanceof org.kie.dmn.model.api.LiteralExpression);
-        assertEquals(null, ((org.kie.dmn.model.api.LiteralExpression) contextEntryValue).getText());
+        assertNull(((org.kie.dmn.model.api.LiteralExpression) contextEntryValue).getText());
 
         // -- Stunner side.
         DMNMarshaller m = new DMNMarshaller(new XMLEncoderDiagramMetadataMarshaller(), applicationFactoryManager);
@@ -1096,7 +1096,7 @@ public class DMNMarshallerTest {
         // the identified DMN Decision is composed a literal expression missing text (text is null).
         org.kie.dmn.model.api.Expression d0le = d0.getDecision().getExpression();
         assertTrue(d0le instanceof org.kie.dmn.model.api.LiteralExpression);
-        assertEquals(null, ((org.kie.dmn.model.api.LiteralExpression) d0le).getText());
+        assertNull(((org.kie.dmn.model.api.LiteralExpression) d0le).getText());
 
         // -- Stunner side.
         DMNMarshaller m = new DMNMarshaller(new XMLEncoderDiagramMetadataMarshaller(), applicationFactoryManager);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -1088,7 +1088,6 @@ public class DMNMarshallerTest {
 
         // identify the error message for the Decision with a Literal Expression decision logic missing the text.
         DMNMessage m0 = dmnModel.getMessages(DMNMessage.Severity.ERROR).get(0);
-        System.out.println(m0);
         assertTrue("expected a message identifying the problem on a decision named 'my decision'",
                    m0.getMessage().startsWith("No expression defined for name 'my decision'"));
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -130,6 +130,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -1041,9 +1042,6 @@ public class DMNMarshallerTest {
     @SuppressWarnings("unchecked")
     public void test_wrong_context() throws IOException {
         // DROOLS-2217
-        // SPECIAL CASE: to represent a partially edited DMN file.
-        // consider a LiteralExpression with null text as missing expression altogether.
-
         final DMNRuntime runtime = roundTripUnmarshalMarshalThenUnmarshalDMN(this.getClass().getResourceAsStream("/wrong_context.dmn"));
         DMNModel dmnModel = runtime.getModels().get(0);
 
@@ -1072,9 +1070,48 @@ public class DMNMarshallerTest {
 
         // the identified DMN Decision is composed of a DMN Context where the first context-entry has missing Expression.
         Context expression = (Context) view.getDefinition().getExpression();
-        assertEquals("a literalexpression with null text is threated as a missing expression altogether.",
-                     null,
-                     expression.getContextEntry().get(0).getExpression());
+        assertNotNull(expression.getContextEntry().get(0).getExpression()); // DROOLS-3116 empty Literal Expression is preserved
+        assertEquals(LiteralExpression.class, expression.getContextEntry().get(0).getExpression().getClass());
+        LiteralExpression le = (LiteralExpression) expression.getContextEntry().get(0).getExpression();
+        assertNull(le.getText());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test_wrong_decision() throws IOException {
+        // DROOLS-3116 empty Literal Expression to be preserved
+        final DMNRuntime runtime = roundTripUnmarshalMarshalThenUnmarshalDMN(this.getClass().getResourceAsStream("/wrong_decision.dmn"));
+        DMNModel dmnModel = runtime.getModels().get(0);
+
+        // the DMN file is schema valid but is not a valid-DMN (a decision logic is a literal expression missing text, which is null)
+        assertTrue(dmnModel.hasErrors());
+
+        // identify the error message for the Decision with a Literal Expression decision logic missing the text.
+        DMNMessage m0 = dmnModel.getMessages(DMNMessage.Severity.ERROR).get(0);
+        System.out.println(m0);
+        assertTrue("expected a message identifying the problem on a decision named 'my decision'",
+                   m0.getMessage().startsWith("No expression defined for name 'my decision'"));
+
+        DecisionNode d0 = dmnModel.getDecisionById("_cce32679-9395-444d-a4bf-96af8ee727a0");
+        // the identified DMN Decision is composed a literal expression missing text (text is null).
+        org.kie.dmn.model.api.Expression d0le = d0.getDecision().getExpression();
+        assertTrue(d0le instanceof org.kie.dmn.model.api.LiteralExpression);
+        assertEquals(null, ((org.kie.dmn.model.api.LiteralExpression) d0le).getText());
+
+        // -- Stunner side.
+        DMNMarshaller m = new DMNMarshaller(new XMLEncoderDiagramMetadataMarshaller(), applicationFactoryManager);
+        Graph<?, ?> g = m.unmarshall(null, this.getClass().getResourceAsStream("/wrong_decision.dmn"));
+
+        Node<?, ?> decisionNode = g.getNode("_cce32679-9395-444d-a4bf-96af8ee727a0");
+        assertNodeContentDefinitionIs(decisionNode, Decision.class);
+        View<Decision> view = ((View<Decision>) decisionNode.getContent());
+
+        // the identified DMN Decision is composed a literal expression missing text (text is null).
+        Expression expression = view.getDefinition().getExpression();
+        assertNotNull(expression); // DROOLS-3116 empty Literal Expression is preserved
+        assertEquals(LiteralExpression.class, expression.getClass());
+        LiteralExpression le = (LiteralExpression) expression;
+        assertNull(le.getText());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/wrong_decision.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/wrong_decision.dmn
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dmn11:definitions xmlns="http://www.trisotech.com/dmn/definitions/_edfed70d-07af-4141-8263-8297fafb826c" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="6.1.11.1" id="_edfed70d-07af-4141-8263-8297fafb826c" name="Drawing 1" namespace="http://www.trisotech.com/dmn/definitions/_edfed70d-07af-4141-8263-8297fafb826c" triso:logoChoice="Default" xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd">
+  <dmn11:extensionElements/>
+  <dmn11:decision id="_cce32679-9395-444d-a4bf-96af8ee727a0" name="my decision">
+    <dmn11:variable id="_e8a42dc7-eb73-41f5-8e58-8ef07d995056" name="my decision"/>
+    <dmn11:literalExpression id="_36dd163c-4862-4308-92bf-40a998b24e39"/>
+  </dmn11:decision>
+</dmn11:definitions>


### PR DESCRIPTION
/cc @jomarko @manstis @etirelli requirement change as per DROOLS-3116