### PR TITLE
DROOLS-3109: [DMN Designer] Add additional Properties to drill-down

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/DMNDefinitionSet.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/DMNDefinitionSet.java
@@ -25,12 +25,15 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.AuthorityRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNDiagram;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
+import org.kie.workbench.common.dmn.api.definition.v1_1.ImportedValues;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
 import org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
+import org.kie.workbench.common.dmn.api.definition.v1_1.UnaryTests;
 import org.kie.workbench.common.dmn.api.factory.DMNGraphFactory;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.stunner.core.definition.annotation.DefinitionSet;
@@ -56,6 +59,9 @@ import org.kie.workbench.common.stunner.core.rule.annotation.Occurrences;
                 KnowledgeRequirement.class,
                 AuthorityRequirement.class,
                 LiteralExpression.class,
+                ImportedValues.class,
+                UnaryTests.class,
+                InformationItem.class,
                 NOPDomainObject.class
         },
         builder = DMNDefinitionSet.DMNDefinitionSetBuilder.class

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Association.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Association.java
@@ -52,10 +52,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class Association extends Artifact {
 
     @Category
-    public static final transient String stunnerCategory = Categories.CONNECTORS;
+    private static final String stunnerCategory = Categories.CONNECTORS;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("association")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/AuthorityRequirement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/AuthorityRequirement.java
@@ -51,10 +51,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class AuthorityRequirement extends DMNModelInstrumentedBase {
 
     @Category
-    public static final transient String stunnerCategory = Categories.CONNECTORS;
+    private static final String stunnerCategory = Categories.CONNECTORS;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("authority-requirement")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsS
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
@@ -37,6 +38,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -48,13 +50,14 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
-                                                                  DMNViewDefinition {
+                                                                  DMNViewDefinition,
+                                                                  DomainObject {
 
     @Category
-    public static final transient String stunnerCategory = Categories.NODES;
+    private static final String stunnerCategory = Categories.NODES;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("business-knowledge-model")
             .build();
 
@@ -173,6 +176,20 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
 
     public void setEncapsulatedLogic(final FunctionDefinition value) {
         this.encapsulatedLogic = value;
+    }
+
+    // ------------------------------------------------------
+    // DomainObject requirements - to use in Properties Panel
+    // ------------------------------------------------------
+
+    @Override
+    public String getDomainObjectUUID() {
+        return getId().getValue();
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return DMNAPIConstants.BusinessKnowledgeModel_DomainObjectName;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNDiagram.java
@@ -58,10 +58,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class DMNDiagram extends DMNModelInstrumentedBase implements DMNDefinition {
 
     @Category
-    public static final transient String stunnerCategory = Categories.DIAGRAM;
+    private static final String stunnerCategory = Categories.DIAGRAM;
 
     @Labels
-    public static final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("dmn_diagram")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.Question;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
@@ -41,6 +42,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -53,13 +55,14 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id", defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
 public class Decision extends DRGElement implements HasExpression,
                                                     HasVariable,
-                                                    DMNViewDefinition {
+                                                    DMNViewDefinition,
+                                                    DomainObject {
 
     @Category
-    public static final transient String stunnerCategory = Categories.NODES;
+    private static final String stunnerCategory = Categories.NODES;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("decision")
             .build();
 
@@ -212,6 +215,20 @@ public class Decision extends DRGElement implements HasExpression,
     @Override
     public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
         return this;
+    }
+
+    // ------------------------------------------------------
+    // DomainObject requirements - to use in Properties Panel
+    // ------------------------------------------------------
+
+    @Override
+    public String getDomainObjectUUID() {
+        return getId().getValue();
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return DMNAPIConstants.Decision_DomainObjectName;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Definitions.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Definitions.java
@@ -25,6 +25,7 @@ import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
@@ -57,7 +58,11 @@ public class Definitions extends DMNElement implements HasName,
     private List<Artifact> artifact;
     private List<ElementCollection> elementCollection;
     private List<BusinessContextElement> businessContextElement;
-    private String expressionLanguage;
+
+    @Property
+    @FormField(afterElement = "name")
+    protected ExpressionLanguage expressionLanguage;
+
     private String typeLanguage;
     private String namespace;
     private String exporter;
@@ -73,7 +78,7 @@ public class Definitions extends DMNElement implements HasName,
              new ArrayList<>(),
              new ArrayList<>(),
              new ArrayList<>(),
-             null,
+             new ExpressionLanguage(),
              null,
              null,
              null,
@@ -89,7 +94,7 @@ public class Definitions extends DMNElement implements HasName,
                        final List<Artifact> artifact,
                        final List<ElementCollection> elementCollection,
                        final List<BusinessContextElement> businessContextElement,
-                       final String expressionLanguage,
+                       final ExpressionLanguage expressionLanguage,
                        final String typeLanguage,
                        final String namespace,
                        final String exporter,
@@ -166,15 +171,15 @@ public class Definitions extends DMNElement implements HasName,
         return this.businessContextElement;
     }
 
-    public String getExpressionLanguage() {
+    public ExpressionLanguage getExpressionLanguage() {
         if (expressionLanguage == null) {
-            return DEFAULT_EXPRESSION_LANGUAGE;
+            return new ExpressionLanguage(DEFAULT_EXPRESSION_LANGUAGE);
         } else {
             return expressionLanguage;
         }
     }
 
-    public void setExpressionLanguage(final String value) {
+    public void setExpressionLanguage(final ExpressionLanguage value) {
         this.expressionLanguage = value;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ImportedValues.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ImportedValues.java
@@ -15,17 +15,50 @@
  */
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
+import java.util.Set;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
+import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
+import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
+
 @Portable
-public class ImportedValues extends Import implements DMNPropertySet {
+@Bindable
+@Definition(graphFactory = NodeFactory.class)
+@FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
+public class ImportedValues extends Import implements DMNPropertySet,
+                                                      DomainObject {
+
+    @Category
+    private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
+
+    @Labels
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>().build();
+
+    private final String UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
 
     protected String importedElement;
 
-    protected String expressionLanguage;
+    @Property
+    @FormField
+    protected ExpressionLanguage expressionLanguage;
 
     public ImportedValues() {
         this(null,
@@ -39,12 +72,24 @@ public class ImportedValues extends Import implements DMNPropertySet {
                           final LocationURI locationURI,
                           final String importType,
                           final String importedElement,
-                          final String expressionLanguage) {
+                          final ExpressionLanguage expressionLanguage) {
         super(namespace,
               locationURI,
               importType);
         this.importedElement = importedElement;
         this.expressionLanguage = expressionLanguage;
+    }
+
+    // -----------------------
+    // Stunner core properties
+    // -----------------------
+
+    public String getStunnerCategory() {
+        return stunnerCategory;
+    }
+
+    public Set<String> getStunnerLabels() {
+        return stunnerLabels;
     }
 
     // -----------------------
@@ -59,12 +104,26 @@ public class ImportedValues extends Import implements DMNPropertySet {
         this.importedElement = importedElement;
     }
 
-    public String getExpressionLanguage() {
+    public ExpressionLanguage getExpressionLanguage() {
         return expressionLanguage;
     }
 
-    public void setExpressionLanguage(final String expressionLanguage) {
+    public void setExpressionLanguage(final ExpressionLanguage expressionLanguage) {
         this.expressionLanguage = expressionLanguage;
+    }
+
+    // ------------------------------------------------------
+    // DomainObject requirements - to use in Properties Panel
+    // ------------------------------------------------------
+
+    @Override
+    public String getDomainObjectUUID() {
+        return UUID;
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return DMNAPIConstants.ImportedValues_DomainObjectName;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItem.java
@@ -15,10 +15,13 @@
  */
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
@@ -28,23 +31,34 @@ import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.QNameFieldType;
 import org.kie.workbench.common.dmn.api.property.dmn.QNameHolder;
+import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 @Bindable
 @PropertySet
+@Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id")
-public class InformationItem extends DMNElement implements HasName,
-                                                           HasTypeRef,
-                                                           DMNPropertySet {
+public class InformationItem extends NamedElement implements HasName,
+                                                             HasTypeRef,
+                                                             DMNPropertySet,
+                                                             DomainObject {
 
-    //InformationItem should extend NamedElement however we do not want to expose Name as a @FormField
-    protected Name name;
+    @Category
+    private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
+
+    @Labels
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>().build();
 
     protected QName typeRef;
 
@@ -65,25 +79,27 @@ public class InformationItem extends DMNElement implements HasName,
                            final Name name,
                            final QName typeRef) {
         super(id,
-              description);
-        this.name = name;
+              description,
+              name);
         this.typeRef = typeRef;
         this.typeRefHolder = new QNameHolder(typeRef);
     }
 
     // -----------------------
-    // DMN properties
+    // Stunner core properties
     // -----------------------
 
-    @Override
-    public Name getName() {
-        return name;
+    public String getStunnerCategory() {
+        return stunnerCategory;
     }
 
-    @Override
-    public void setName(final Name name) {
-        this.name = name;
+    public Set<String> getStunnerLabels() {
+        return stunnerLabels;
     }
+
+    // -----------------------
+    // DMN properties
+    // -----------------------
 
     @Override
     public QName getTypeRef() {
@@ -109,6 +125,20 @@ public class InformationItem extends DMNElement implements HasName,
 
     public void setTypeRefHolder(final QNameHolder typeRefHolder) {
         this.typeRefHolder = typeRefHolder;
+    }
+
+    // ------------------------------------------------------
+    // DomainObject requirements - to use in Properties Panel
+    // ------------------------------------------------------
+
+    @Override
+    public String getDomainObjectUUID() {
+        return getId().getValue();
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return DMNAPIConstants.InformationItem_DomainObjectName;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationRequirement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationRequirement.java
@@ -48,10 +48,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class InformationRequirement extends DMNModelInstrumentedBase {
 
     @Category
-    public static final transient String stunnerCategory = Categories.CONNECTORS;
+    private static final String stunnerCategory = Categories.CONNECTORS;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("information-requirement")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
@@ -51,10 +51,10 @@ public class InputData extends DRGElement implements DMNViewDefinition,
                                                      HasVariable {
 
     @Category
-    public static final transient String stunnerCategory = Categories.NODES;
+    private static final String stunnerCategory = Categories.NODES;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("input-data")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeRequirement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeRequirement.java
@@ -48,10 +48,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class KnowledgeRequirement extends DMNModelInstrumentedBase {
 
     @Category
-    public static final transient String stunnerCategory = Categories.CONNECTORS;
+    private static final String stunnerCategory = Categories.CONNECTORS;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("knowledge-requirement")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
@@ -52,10 +52,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class KnowledgeSource extends DRGElement implements DMNViewDefinition {
 
     @Category
-    public static final transient String stunnerCategory = Categories.NODES;
+    private static final String stunnerCategory = Categories.NODES;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("knowledge-source")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
@@ -47,10 +47,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class LiteralExpression extends Expression implements DomainObject {
 
     @Category
-    public static final transient String stunnerCategory = Categories.DOMAIN_OBJECTS;
+    private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>().build();
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>().build();
 
     protected String text;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
@@ -51,10 +51,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class TextAnnotation extends Artifact implements DMNViewDefinition {
 
     @Category
-    public static final transient String stunnerCategory = Categories.NODES;
+    private static final String stunnerCategory = Categories.NODES;
 
     @Labels
-    private final Set<String> stunnerLabels = new Sets.Builder<String>()
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>()
             .add("text-annotation")
             .build();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/UnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/UnaryTests.java
@@ -15,33 +15,80 @@
  */
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
+import java.util.Set;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
+import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
+import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
+
 @Portable
-public class UnaryTests extends DMNElement {
+@Bindable
+@Definition(graphFactory = NodeFactory.class)
+@FormDefinition(policy = FieldPolicy.ONLY_MARKED, defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)})
+public class UnaryTests extends DMNElement implements DomainObject {
+
+    @Category
+    private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
+
+    @Labels
+    private static final Set<String> stunnerLabels = new Sets.Builder<String>().build();
 
     private String text;
-    private String expressionLanguage;
+
+    @Property
+    @FormField(afterElement = "description")
+    protected ExpressionLanguage expressionLanguage;
 
     public UnaryTests() {
         this(new Id(),
              new Description(),
              null,
-             null);
+             new ExpressionLanguage());
     }
 
     public UnaryTests(final Id id,
                       final Description description,
                       final String text,
-                      final String expressionLanguage) {
+                      final ExpressionLanguage expressionLanguage) {
         super(id,
               description);
         this.text = text;
         this.expressionLanguage = expressionLanguage;
     }
+
+    // -----------------------
+    // Stunner core properties
+    // -----------------------
+
+    public String getStunnerCategory() {
+        return stunnerCategory;
+    }
+
+    public Set<String> getStunnerLabels() {
+        return stunnerLabels;
+    }
+
+    // -----------------------
+    // DMN properties
+    // -----------------------
 
     public String getText() {
         return text;
@@ -51,12 +98,26 @@ public class UnaryTests extends DMNElement {
         this.text = value;
     }
 
-    public String getExpressionLanguage() {
+    public ExpressionLanguage getExpressionLanguage() {
         return expressionLanguage;
     }
 
-    public void setExpressionLanguage(final String value) {
+    public void setExpressionLanguage(final ExpressionLanguage value) {
         this.expressionLanguage = value;
+    }
+
+    // ------------------------------------------------------
+    // DomainObject requirements - to use in Properties Panel
+    // ------------------------------------------------------
+
+    @Override
+    public String getDomainObjectUUID() {
+        return getId().getValue();
+    }
+
+    @Override
+    public String getDomainObjectNameTranslationKey() {
+        return DMNAPIConstants.UnaryTests_DomainObjectName;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/resource/i18n/DMNAPIConstants.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/resource/i18n/DMNAPIConstants.java
@@ -24,4 +24,19 @@ public class DMNAPIConstants {
 
     @TranslationKey(defaultValue = "")
     public static final String LiteralExpression_DomainObjectName = "LiteralExpression.DomainObjectName";
+
+    @TranslationKey(defaultValue = "")
+    public static final String ImportedValues_DomainObjectName = "ImportedValues.DomainObjectName";
+
+    @TranslationKey(defaultValue = "")
+    public static final String UnaryTests_DomainObjectName = "UnaryTests.DomainObjectName";
+
+    @TranslationKey(defaultValue = "")
+    public static final String InformationItem_DomainObjectName = "InformationItem.DomainObjectName";
+
+    @TranslationKey(defaultValue = "")
+    public static final String Decision_DomainObjectName = "Decision.DomainObjectName";
+
+    @TranslationKey(defaultValue = "")
+    public static final String BusinessKnowledgeModel_DomainObjectName = "BusinessKnowledgeModel.DomainObjectName";
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
@@ -109,3 +109,8 @@ org.kie.workbench.common.dmn.api.property.font.FontSize.description=The fonts si
 #######################
 NOP.DomainObjectName=NOP
 LiteralExpression.DomainObjectName=Literal Expression
+ImportedValues.DomainObjectName=Imported Values
+UnaryTests.DomainObjectName=Unary Tests
+InformationItem.DomainObjectName=Information Item
+Decision.DomainObjectName=Decision
+BusinessKnowledgeModel.DomainObjectName=Business Knowledge Model

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportedValuesConverter.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.ImportedValues;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
 
 public class ImportedValuesConverter {
@@ -29,7 +30,7 @@ public class ImportedValuesConverter {
         LocationURI locationURI = new LocationURI(dmn.getLocationURI());
         String importType = dmn.getImportType();
         String importedElement = dmn.getImportedElement();
-        String expressionLanguage = dmn.getExpressionLanguage();
+        ExpressionLanguage expressionLanguage = ExpressionLanguagePropertyConverter.wbFromDMN(dmn.getExpressionLanguage());
         ImportedValues wb = new ImportedValues(namespace,
                                                locationURI,
                                                importType,
@@ -47,7 +48,7 @@ public class ImportedValuesConverter {
         dmn.setLocationURI(wb.getLocationURI().getValue());
         dmn.setImportType(wb.getImportType());
         dmn.setImportedElement(wb.getImportedElement());
-        dmn.setExpressionLanguage(wb.getExpressionLanguage());
+        dmn.setExpressionLanguage(ExpressionLanguagePropertyConverter.dmnFromWB(wb.getExpressionLanguage()));
         return dmn;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.UnaryTests;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 
 public class UnaryTestsPropertyConverter {
@@ -28,8 +29,11 @@ public class UnaryTestsPropertyConverter {
         }
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
-
-        UnaryTests result = new UnaryTests(id, description, dmn.getText(), dmn.getExpressionLanguage());
+        ExpressionLanguage expressionLanguage = ExpressionLanguagePropertyConverter.wbFromDMN(dmn.getExpressionLanguage());
+        UnaryTests result = new UnaryTests(id,
+                                           description,
+                                           dmn.getText(),
+                                           expressionLanguage);
         return result;
     }
 
@@ -41,7 +45,7 @@ public class UnaryTestsPropertyConverter {
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setText(wb.getText());
-        result.setExpressionLanguage(wb.getExpressionLanguage());
+        result.setExpressionLanguage(ExpressionLanguagePropertyConverter.dmnFromWB(wb.getExpressionLanguage()));
 
         return result;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -47,9 +47,9 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanelContainer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 
@@ -75,7 +75,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     private SessionManager sessionManager;
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
-    private Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
+    private Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     private DMNGridPanel gridPanel;
     private DMNGridLayer gridLayer;
@@ -96,7 +96,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                     final SessionManager sessionManager,
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                     final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
-                                    final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent) {
+                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent) {
         this.returnToDRG = returnToDRG;
         this.expressionType = expressionType;
         this.gridPanelContainer = gridPanelContainer;
@@ -107,7 +107,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
-        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
+        this.domainObjectSelectionEvent = domainObjectSelectionEvent;
     }
 
     @Override
@@ -148,7 +148,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                                               getExpressionGridCacheSupplier(),
                                                               this::setExpressionTypeText,
                                                               this::setReturnToDRGText,
-                                                              refreshFormPropertiesEvent);
+                                                              domainObjectSelectionEvent);
         gridLayer.removeAll();
         gridLayer.add(expressionContainerGrid);
         gridLayer.select(expressionContainerGrid);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 public abstract class BaseEditorDefinition<E extends Expression, D extends GridData> implements ExpressionEditorDefinition<E> {
@@ -44,7 +43,6 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
     protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     protected CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     protected Event<ExpressionEditorChanged> editorSelectedEvent;
-    protected Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     protected Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
     protected ListSelectorView.Presenter listSelector;
     protected TranslationService translationService;
@@ -58,7 +56,6 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
                                 final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                 final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                 final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                 final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                 final ListSelectorView.Presenter listSelector,
                                 final TranslationService translationService) {
@@ -67,7 +64,6 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
         this.sessionCommandManager = sessionCommandManager;
         this.canvasCommandFactory = canvasCommandFactory;
         this.editorSelectedEvent = editorSelectedEvent;
-        this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
         this.domainObjectSelectionEvent = domainObjectSelectionEvent;
         this.listSelector = listSelector;
         this.translationService = translationService;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
@@ -48,7 +48,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class ContextEditorDefinition extends BaseEditorDefinition<Context, ContextGridData> {
@@ -66,7 +65,6 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
                                    final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                   final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                    final ListSelectorView.Presenter listSelector,
                                    final TranslationService translationService,
@@ -77,7 +75,6 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -144,7 +141,6 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
                                            sessionCommandManager,
                                            canvasCommandFactory,
                                            editorSelectedEvent,
-                                           refreshFormPropertiesEvent,
                                            domainObjectSelectionEvent,
                                            getCellEditorControls(),
                                            listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -58,7 +58,6 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
@@ -87,7 +86,6 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                        final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                        final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                        final Event<ExpressionEditorChanged> editorSelectedEvent,
-                       final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                        final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                        final CellEditorControlsView.Presenter cellEditorControls,
                        final ListSelectorView.Presenter listSelector,
@@ -109,7 +107,6 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
@@ -310,12 +307,25 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
                                                                          uiModelMapper,
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectCell(uiRowIndex, ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX, false, false);
+                                                                             selectExpressionEditorFirstCell(uiRowIndex, ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX);
                                                                          },
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
                                                                              selectExpressionEditorFirstCell(uiRowIndex, ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX);
                                                                          }));
         });
+    }
+
+    @Override
+    protected void doAfterSelectionChange(final int uiRowIndex,
+                                          final int uiColumnIndex) {
+        if (uiRowIndex < model.getRowCount() - 1) {
+            if (expression.isPresent()) {
+                final Context context = expression.get();
+                fireDomainObjectSelectionEvent(context.getContextEntry().get(uiRowIndex).getVariable());
+                return;
+            }
+        }
+        super.doAfterSelectionChange(uiRowIndex, uiColumnIndex);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
@@ -43,7 +43,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class DecisionTableEditorDefinition extends BaseEditorDefinition<DecisionTable, DecisionTableGridData> {
@@ -62,7 +61,6 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
                                          final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                          final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                         final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                          final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                          final ListSelectorView.Presenter listSelector,
                                          final TranslationService translationService,
@@ -74,7 +72,6 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -125,7 +122,6 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
                                                  sessionCommandManager,
                                                  canvasCommandFactory,
                                                  editorSelectedEvent,
-                                                 refreshFormPropertiesEvent,
                                                  domainObjectSelectionEvent,
                                                  getCellEditorControls(),
                                                  listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -70,7 +70,6 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.mvp.Command;
@@ -114,7 +113,6 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                              final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                              final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                              final Event<ExpressionEditorChanged> editorSelectedEvent,
-                             final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                              final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                              final CellEditorControlsView.Presenter cellEditorControls,
                              final ListSelectorView.Presenter listSelector,
@@ -136,7 +134,6 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefinition, DMNGridData> {
@@ -68,7 +67,6 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                     final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                    final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                     final ListSelectorView.Presenter listSelector,
                                     final TranslationService translationService,
@@ -81,7 +79,6 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -138,7 +135,6 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
                                             sessionCommandManager,
                                             canvasCommandFactory,
                                             editorSelectedEvent,
-                                            refreshFormPropertiesEvent,
                                             domainObjectSelectionEvent,
                                             getCellEditorControls(),
                                             listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -63,7 +63,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.mvp.Command;
@@ -90,7 +89,6 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                         final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                         final CellEditorControlsView.Presenter cellEditorControls,
                         final ListSelectorView.Presenter listSelector,
@@ -114,7 +112,6 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
@@ -364,7 +361,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                                                          uiModelMapper,
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectCell(0, 0, false, false);
+                                                                             selectExpressionEditorFirstCell(0, 0);
                                                                          },
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
@@ -43,7 +43,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEditorDefinition<Context, FunctionSupplementaryGridData> {
 
@@ -58,7 +57,6 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
                                                      final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                                      final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                                      final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                                      final ListSelectorView.Presenter listSelector,
                                                      final TranslationService translationService,
@@ -68,7 +66,6 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -116,7 +113,6 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
                                                          sessionCommandManager,
                                                          canvasCommandFactory,
                                                          editorSelectedEvent,
-                                                         refreshFormPropertiesEvent,
                                                          domainObjectSelectionEvent,
                                                          getCellEditorControls(),
                                                          listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
@@ -70,7 +69,6 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Funct
                                      final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                      final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                      final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                      final CellEditorControlsView.Presenter cellEditorControls,
                                      final ListSelectorView.Presenter listSelector,
@@ -91,7 +89,6 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Funct
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
@@ -40,7 +40,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @Dependent
 @FunctionGridSupplementaryEditor
@@ -60,7 +59,6 @@ public class JavaFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
                                         final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                         final ListSelectorView.Presenter listSelector,
                                         final TranslationService translationService,
@@ -70,7 +68,6 @@ public class JavaFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
@@ -40,7 +40,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @Dependent
 @FunctionGridSupplementaryEditor
@@ -60,7 +59,6 @@ public class PMMLFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
                                         final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                         final ListSelectorView.Presenter listSelector,
                                         final TranslationService translationService,
@@ -70,7 +68,6 @@ public class PMMLFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
@@ -48,7 +48,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation, InvocationGridData> {
@@ -66,7 +65,6 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
                                       final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                       final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                       final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                      final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                       final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                       final ListSelectorView.Presenter listSelector,
                                       final TranslationService translationService,
@@ -77,7 +75,6 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -140,7 +137,6 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
                                               sessionCommandManager,
                                               canvasCommandFactory,
                                               editorSelectedEvent,
-                                              refreshFormPropertiesEvent,
                                               domainObjectSelectionEvent,
                                               getCellEditorControls(),
                                               listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -61,7 +61,6 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
@@ -86,7 +85,6 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                           final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                           final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                           final Event<ExpressionEditorChanged> editorSelectedEvent,
-                          final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                           final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                           final CellEditorControlsView.Presenter cellEditorControls,
                           final ListSelectorView.Presenter listSelector,
@@ -108,7 +106,6 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
@@ -309,7 +306,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                                                                          uiModelMapper,
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                             selectCell(uiRowIndex, InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX, false, false);
+                                                                             selectExpressionEditorFirstCell(uiRowIndex, InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX);
                                                                          },
                                                                          () -> {
                                                                              resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
@@ -42,7 +42,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<LiteralExpression, DMNGridData> {
@@ -59,7 +58,6 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
                                              final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                              final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                              final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                             final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                              final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                              final ListSelectorView.Presenter listSelector,
                                              final TranslationService translationService,
@@ -69,7 +67,6 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -111,7 +108,6 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
                                                      sessionCommandManager,
                                                      canvasCommandFactory,
                                                      editorSelectedEvent,
-                                                     refreshFormPropertiesEvent,
                                                      domainObjectSelectionEvent,
                                                      getCellEditorControls(),
                                                      listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -46,7 +46,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
@@ -69,7 +68,6 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
                                  final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                  final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                  final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                 final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                  final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                  final CellEditorControlsView.Presenter cellEditorControls,
                                  final ListSelectorView.Presenter listSelector,
@@ -90,7 +88,6 @@ public class LiteralExpressionGrid extends BaseExpressionGrid<LiteralExpression,
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
@@ -44,7 +44,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class RelationEditorDefinition extends BaseEditorDefinition<Relation, RelationGridData> {
@@ -61,7 +60,6 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                     final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                    final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                     final ListSelectorView.Presenter listSelector,
                                     final TranslationService translationService,
@@ -71,7 +69,6 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -133,7 +130,6 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
                                             sessionCommandManager,
                                             canvasCommandFactory,
                                             editorSelectedEvent,
-                                            refreshFormPropertiesEvent,
                                             domainObjectSelectionEvent,
                                             getCellEditorControls(),
                                             listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -55,7 +55,6 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
@@ -78,7 +77,6 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
                         final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                         final Event<ExpressionEditorChanged> editorSelectedEvent,
-                        final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                         final CellEditorControlsView.Presenter cellEditorControls,
                         final ListSelectorView.Presenter listSelector,
@@ -99,7 +97,6 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
@@ -45,7 +45,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 
 @ApplicationScoped
 public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Expression, DMNGridData> {
@@ -62,7 +61,6 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                                final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                                final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                               final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                                final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                                final ListSelectorView.Presenter listSelector,
                                                final TranslationService translationService,
@@ -72,7 +70,6 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               listSelector,
               translationService);
@@ -114,7 +111,6 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
                                                        sessionCommandManager,
                                                        canvasCommandFactory,
                                                        editorSelectedEvent,
-                                                       refreshFormPropertiesEvent,
                                                        domainObjectSelectionEvent,
                                                        getCellEditorControls(),
                                                        listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionGrid.java
@@ -27,6 +27,7 @@ import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.undefined.SetCellValueCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
@@ -52,8 +53,8 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
@@ -80,7 +81,6 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
                                    final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
-                                   final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                    final CellEditorControlsView.Presenter cellEditorControls,
                                    final ListSelectorView.Presenter listSelector,
@@ -102,7 +102,6 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
               sessionCommandManager,
               canvasCommandFactory,
               editorSelectedEvent,
-              refreshFormPropertiesEvent,
               domainObjectSelectionEvent,
               cellEditorControls,
               listSelector,
@@ -255,10 +254,13 @@ public class UndefinedExpressionGrid extends BaseExpressionGrid<Expression, DMNG
         final ClientSession session = sessionManager.getCurrentSession();
         if (session != null) {
             if (nodeUUID.isPresent()) {
-                refreshFormPropertiesEvent.fire(new RefreshFormPropertiesEvent(session, nodeUUID.get()));
-            } else {
-                super.doAfterSelectionChange(uiRowIndex, uiColumnIndex);
+                final DMNModelInstrumentedBase base = hasExpression.asDMNModelInstrumentedBase();
+                if (base instanceof DomainObject) {
+                    fireDomainObjectSelectionEvent((DomainObject) base);
+                    return;
+                }
             }
         }
+        super.doAfterSelectionChange(uiRowIndex, uiColumnIndex);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRenderer.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.property.dmn;
 
+import java.util.Objects;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -50,10 +52,11 @@ public class QNameFieldRenderer extends FieldRenderer<QNameFieldDefinition, Defa
     @Override
     public void init(final FormRenderingContext renderingContext,
                      final QNameFieldDefinition field) {
-        // Extract the DMNModelInstrumentedBase from the FormRenderingContext. Only the parent model is
-        // available as Forms' SubFormFieldRenderer does not provide the model on the context. This should
-        // be sufficient in all cases, as the InformationItem cannot have its NameSpace context set.
-        final Object model = renderingContext.getParentContext().getModel();
+        // Extract the DMNModelInstrumentedBase from the FormRenderingContext.
+        Object model = renderingContext.getModel();
+        if (Objects.isNull(model)) {
+            model = renderingContext.getParentContext().getModel();
+        }
         if (model instanceof DMNModelInstrumentedBase) {
             typePicker.setDMNModel((DMNModelInstrumentedBase) model);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControl.java
@@ -18,8 +18,10 @@ package org.kie.workbench.common.dmn.client.widgets.layer;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 
-public interface DMNGridLayerControl extends CanvasControl<AbstractCanvas> {
+public interface DMNGridLayerControl extends CanvasControl<AbstractCanvas>,
+                                             CanvasControl.SessionAware<ClientSession> {
 
     DMNGridLayer getGridLayer();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImpl.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.widgets.layer;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javax.enterprise.context.Dependent;
 
@@ -65,28 +66,33 @@ public class DMNGridLayerControlImpl extends AbstractCanvasControl<AbstractCanva
 
     @Override
     protected void doInit() {
-        session.ifPresent(s -> {
-            final CanvasHandler canvasHandler = s.getCanvasHandler();
-            if (canvasHandler instanceof AbstractCanvasHandler) {
-                final AbstractCanvasHandler abstractCanvasHandler = (AbstractCanvasHandler) canvasHandler;
-                abstractCanvasHandler.addRegistrationListener(redrawElementListener);
-                abstractCanvasHandler.addDomainObjectListener(redrawDomainObjectListener);
-            }
+        withCanvasHandler(abstractCanvasHandler -> {
+            abstractCanvasHandler.addRegistrationListener(redrawElementListener);
+            abstractCanvasHandler.addDomainObjectListener(redrawDomainObjectListener);
         });
     }
 
     @Override
     protected void doDestroy() {
-        session.ifPresent(s -> {
-            final CanvasHandler canvasHandler = s.getCanvasHandler();
-            if (canvasHandler instanceof AbstractCanvasHandler) {
-                final AbstractCanvasHandler abstractCanvasHandler = (AbstractCanvasHandler) canvasHandler;
-                abstractCanvasHandler.removeRegistrationListener(redrawElementListener);
-                abstractCanvasHandler.removeDomainObjectListener(redrawDomainObjectListener);
-            }
+        withCanvasHandler(abstractCanvasHandler -> {
+            abstractCanvasHandler.removeRegistrationListener(redrawElementListener);
+            abstractCanvasHandler.removeDomainObjectListener(redrawDomainObjectListener);
         });
+
         session = Optional.empty();
         gridLayer = null;
+    }
+
+    private void withCanvasHandler(final Consumer<AbstractCanvasHandler> consumer) {
+        session.ifPresent(s -> {
+
+            final CanvasHandler canvasHandler = s.getCanvasHandler();
+
+            if (canvasHandler instanceof AbstractCanvasHandler) {
+                final AbstractCanvasHandler abstractCanvasHandler = (AbstractCanvasHandler) canvasHandler;
+                consumer.accept(abstractCanvasHandler);
+            }
+        });
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImpl.java
@@ -16,17 +16,39 @@
 
 package org.kie.workbench.common.dmn.client.widgets.layer;
 
+import java.util.Optional;
+
 import javax.enterprise.context.Dependent;
-import javax.enterprise.event.Observes;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasControl;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementUpdatedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElementListener;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.kie.workbench.common.stunner.core.graph.Element;
 
 @Dependent
 public class DMNGridLayerControlImpl extends AbstractCanvasControl<AbstractCanvas> implements DMNGridLayerControl {
 
     private DMNGridLayer gridLayer;
+    private Optional<ClientSession> session = Optional.empty();
+
+    private CanvasElementListener redrawElementListener = new CanvasElementListener() {
+        @Override
+        public void update(final Element item) {
+            gridLayer.batch();
+        }
+    };
+
+    private CanvasDomainObjectListener redrawDomainObjectListener = new CanvasDomainObjectListener() {
+        @Override
+        public void update(final DomainObject domainObject) {
+            gridLayer.batch();
+        }
+    };
 
     public DMNGridLayerControlImpl() {
         this.gridLayer = makeGridLayer();
@@ -37,21 +59,38 @@ public class DMNGridLayerControlImpl extends AbstractCanvasControl<AbstractCanva
     }
 
     @Override
+    public void bind(final ClientSession session) {
+        this.session = Optional.ofNullable(session);
+    }
+
+    @Override
     protected void doInit() {
+        session.ifPresent(s -> {
+            final CanvasHandler canvasHandler = s.getCanvasHandler();
+            if (canvasHandler instanceof AbstractCanvasHandler) {
+                final AbstractCanvasHandler abstractCanvasHandler = (AbstractCanvasHandler) canvasHandler;
+                abstractCanvasHandler.addRegistrationListener(redrawElementListener);
+                abstractCanvasHandler.addDomainObjectListener(redrawDomainObjectListener);
+            }
+        });
     }
 
     @Override
     protected void doDestroy() {
+        session.ifPresent(s -> {
+            final CanvasHandler canvasHandler = s.getCanvasHandler();
+            if (canvasHandler instanceof AbstractCanvasHandler) {
+                final AbstractCanvasHandler abstractCanvasHandler = (AbstractCanvasHandler) canvasHandler;
+                abstractCanvasHandler.removeRegistrationListener(redrawElementListener);
+                abstractCanvasHandler.removeDomainObjectListener(redrawDomainObjectListener);
+            }
+        });
+        session = Optional.empty();
         gridLayer = null;
     }
 
     @Override
     public DMNGridLayer getGridLayer() {
         return gridLayer;
-    }
-
-    @SuppressWarnings("unused")
-    public void onCanvasElementUpdatedEvent(final @Observes CanvasElementUpdatedEvent event) {
-        gridLayer.batch();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -51,8 +51,8 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanelContainer;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -121,7 +121,7 @@ public class ExpressionEditorViewImplTest {
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
     private ExpressionEditorDefinition undefinedExpressionEditorDefinition;
@@ -199,7 +199,7 @@ public class ExpressionEditorViewImplTest {
                                                      sessionManager,
                                                      sessionCommandManager,
                                                      expressionEditorDefinitionsSupplier,
-                                                     refreshFormPropertiesEvent));
+                                                     domainObjectSelectionEvent));
         view.init(presenter);
         view.bind(session);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -110,9 +109,6 @@ public class ContextEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     private Optional<HasName> hasName = Optional.empty();
@@ -132,7 +128,6 @@ public class ContextEditorDefinitionTest {
                                                       sessionCommandManager,
                                                       canvasCommandFactory,
                                                       editorSelectedEvent,
-                                                      refreshFormPropertiesEvent,
                                                       domainObjectSelectionEvent,
                                                       listSelector,
                                                       translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
@@ -45,7 +45,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
@@ -97,9 +96,6 @@ public class ExpressionEditorColumnTest {
 
     @Mock
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
-
-    @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
@@ -406,7 +402,6 @@ public class ExpressionEditorColumnTest {
                                       sessionCommandManager,
                                       canvasCommandFactory,
                                       editorSelectedEvent,
-                                      refreshFormPropertiesEvent,
                                       domainObjectSelectionEvent,
                                       cellEditorControls,
                                       listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
@@ -53,7 +53,6 @@ import org.kie.workbench.common.stunner.core.graph.impl.GraphImpl;
 import org.kie.workbench.common.stunner.core.graph.store.GraphNodeStoreImpl;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -107,9 +106,6 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
@@ -141,7 +137,6 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
                                                             sessionCommandManager,
                                                             canvasCommandFactory,
                                                             editorSelectedEvent,
-                                                            refreshFormPropertiesEvent,
                                                             domainObjectSelectionEvent,
                                                             listSelector,
                                                             translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
@@ -92,7 +92,6 @@ import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecution
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -237,9 +236,6 @@ public class DecisionTableGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Captor
@@ -298,7 +294,6 @@ public class DecisionTableGridTest {
                                                             sessionCommandManager,
                                                             canvasCommandFactory,
                                                             editorSelectedEvent,
-                                                            refreshFormPropertiesEvent,
                                                             domainObjectSelectionEvent,
                                                             listSelector,
                                                             translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
@@ -49,7 +49,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -116,9 +115,6 @@ public class FunctionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     private Optional<HasName> hasName = Optional.empty();
@@ -138,7 +134,6 @@ public class FunctionEditorDefinitionTest {
                                                        sessionCommandManager,
                                                        canvasCommandFactory,
                                                        editorSelectedEvent,
-                                                       refreshFormPropertiesEvent,
                                                        domainObjectSelectionEvent,
                                                        listSelector,
                                                        translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
@@ -79,7 +79,6 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -106,6 +105,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -186,9 +186,6 @@ public class FunctionGridTest {
 
     @Mock
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
-
-    @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
@@ -273,7 +270,6 @@ public class FunctionGridTest {
                                                   sessionCommandManager,
                                                   canvasCommandFactory,
                                                   editorSelectedEvent,
-                                                  refreshFormPropertiesEvent,
                                                   domainObjectSelectionEvent,
                                                   listSelector,
                                                   translationService,
@@ -286,7 +282,6 @@ public class FunctionGridTest {
                                                                                       sessionCommandManager,
                                                                                       canvasCommandFactory,
                                                                                       editorSelectedEvent,
-                                                                                      refreshFormPropertiesEvent,
                                                                                       domainObjectSelectionEvent,
                                                                                       listSelector,
                                                                                       translationService,
@@ -740,11 +735,8 @@ public class FunctionGridTest {
         clearExpressionTypeCommand.execute(canvasHandler);
 
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(grid);
-        verify(grid).selectCell(eq(0),
-                                eq(0),
-                                eq(false),
-                                eq(false));
+        verify(gridLayer).select(literalExpressionEditor);
+        verify(literalExpressionEditor).selectFirstCell();
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         redrawCommandCaptor.getValue().execute();
         verify(gridLayer).draw();
@@ -759,7 +751,7 @@ public class FunctionGridTest {
 
         verify(grid).selectExpressionEditorFirstCell(eq(0), eq(0));
         verify(gridLayer).select(literalExpressionEditor);
-        verify(literalExpressionEditor).selectFirstCell();
+        verify(literalExpressionEditor, times(2)).selectFirstCell();
 
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         assertThat(redrawCommandCaptor.getAllValues()).hasSize(2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
@@ -98,9 +97,6 @@ public abstract class BaseFunctionSupplementaryGridTest<D extends ExpressionEdit
 
     @Mock
     protected EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
-
-    @Mock
-    protected EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     protected EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/JavaFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/JavaFunctionSupplementaryGridTest.java
@@ -29,7 +29,6 @@ public class JavaFunctionSupplementaryGridTest extends BaseFunctionSupplementary
                                                 sessionCommandManager,
                                                 canvasCommandFactory,
                                                 editorSelectedEvent,
-                                                refreshFormPropertiesEvent,
                                                 domainObjectSelectionEvent,
                                                 listSelector,
                                                 translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/PMMLFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/PMMLFunctionSupplementaryGridTest.java
@@ -29,7 +29,6 @@ public class PMMLFunctionSupplementaryGridTest extends BaseFunctionSupplementary
                                                 sessionCommandManager,
                                                 canvasCommandFactory,
                                                 editorSelectedEvent,
-                                                refreshFormPropertiesEvent,
                                                 domainObjectSelectionEvent,
                                                 listSelector,
                                                 translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -105,9 +104,6 @@ public class JavaFunctionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     private Optional<HasName> hasName = Optional.empty();
@@ -127,7 +123,6 @@ public class JavaFunctionEditorDefinitionTest {
                                                            sessionCommandManager,
                                                            canvasCommandFactory,
                                                            editorSelectedEvent,
-                                                           refreshFormPropertiesEvent,
                                                            domainObjectSelectionEvent,
                                                            listSelector,
                                                            translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -105,9 +104,6 @@ public class PMMLFunctionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     private Optional<HasName> hasName = Optional.empty();
@@ -127,7 +123,6 @@ public class PMMLFunctionEditorDefinitionTest {
                                                            sessionCommandManager,
                                                            canvasCommandFactory,
                                                            editorSelectedEvent,
-                                                           refreshFormPropertiesEvent,
                                                            domainObjectSelectionEvent,
                                                            listSelector,
                                                            translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
@@ -47,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -110,9 +109,6 @@ public class InvocationEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     private Optional<HasName> hasName = Optional.empty();
@@ -132,7 +128,6 @@ public class InvocationEditorDefinitionTest {
                                                          sessionCommandManager,
                                                          canvasCommandFactory,
                                                          editorSelectedEvent,
-                                                         refreshFormPropertiesEvent,
                                                          domainObjectSelectionEvent,
                                                          listSelector,
                                                          translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
@@ -81,7 +81,6 @@ import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecution
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -113,6 +112,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -223,9 +223,6 @@ public class InvocationGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Captor
@@ -271,7 +268,6 @@ public class InvocationGridTest {
                                                     sessionCommandManager,
                                                     canvasCommandFactory,
                                                     editorSelectedEvent,
-                                                    refreshFormPropertiesEvent,
                                                     domainObjectSelectionEvent,
                                                     listSelector,
                                                     translationService,
@@ -694,11 +690,8 @@ public class InvocationGridTest {
         clearExpressionTypeCommand.execute(canvasHandler);
 
         verify(grid).resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-        verify(gridLayer).select(grid);
-        verify(grid).selectCell(eq(0),
-                                eq(InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX),
-                                eq(false),
-                                eq(false));
+        verify(gridLayer).select(undefinedExpressionEditor);
+        verify(undefinedExpressionEditor).selectFirstCell();
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         redrawCommandCaptor.getValue().execute();
         verify(gridLayer).draw();
@@ -713,7 +706,7 @@ public class InvocationGridTest {
 
         verify(grid).selectExpressionEditorFirstCell(eq(0), eq(InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX));
         verify(gridLayer).select(undefinedExpressionEditor);
-        verify(undefinedExpressionEditor).selectFirstCell();
+        verify(undefinedExpressionEditor, times(2)).selectFirstCell();
 
         verify(gridLayer).batch(redrawCommandCaptor.capture());
         assertThat(redrawCommandCaptor.getAllValues()).hasSize(2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
@@ -43,7 +43,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -96,9 +95,6 @@ public class LiteralExpressionEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
@@ -121,7 +117,6 @@ public class LiteralExpressionEditorDefinitionTest {
                                                                 sessionCommandManager,
                                                                 canvasCommandFactory,
                                                                 editorSelectedEvent,
-                                                                refreshFormPropertiesEvent,
                                                                 domainObjectSelectionEvent,
                                                                 listSelector,
                                                                 translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -64,7 +64,6 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -171,9 +170,6 @@ public class LiteralExpressionGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
@@ -210,7 +206,6 @@ public class LiteralExpressionGridTest {
                                                            sessionCommandManager,
                                                            canvasCommandFactory,
                                                            editorSelectedEvent,
-                                                           refreshFormPropertiesEvent,
                                                            domainObjectSelectionEvent,
                                                            listSelector,
                                                            translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
@@ -44,7 +44,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
@@ -100,9 +99,6 @@ public class RelationEditorDefinitionTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
@@ -125,7 +121,6 @@ public class RelationEditorDefinitionTest {
                                                        sessionCommandManager,
                                                        canvasCommandFactory,
                                                        editorSelectedEvent,
-                                                       refreshFormPropertiesEvent,
                                                        domainObjectSelectionEvent,
                                                        listSelector,
                                                        translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
@@ -70,7 +70,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -188,9 +187,6 @@ public class RelationGridTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
-    private EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
-
-    @Mock
     private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
 
     @Mock
@@ -244,7 +240,6 @@ public class RelationGridTest {
                                                   sessionCommandManager,
                                                   canvasCommandFactory,
                                                   editorSelectedEvent,
-                                                  refreshFormPropertiesEvent,
                                                   domainObjectSelectionEvent,
                                                   listSelector,
                                                   translationService,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRendererTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRendererTest.java
@@ -64,6 +64,8 @@ public class QNameFieldRendererTest {
     public void setup() {
         this.renderer = spy(new QNameFieldRenderer(typePicker));
         this.renderer.setFormGroup(formGroupInstance);
+
+        when(context.getModel()).thenReturn(null);
         when(context.getParentContext()).thenReturn(parentContext);
         when(parentContext.getModel()).thenReturn(dmnModel);
         when(formGroupInstance.get()).thenReturn(formGroup);
@@ -71,6 +73,17 @@ public class QNameFieldRendererTest {
 
     @Test
     public void testInit() {
+        renderer.init(context,
+                      definition);
+
+        verify(typePicker).setDMNModel(eq(dmnModel));
+        verify(renderer).superInit(eq(context), eq(definition));
+    }
+
+    @Test
+    public void testInitNoParent() {
+        when(context.getModel()).thenReturn(dmnModel);
+
         renderer.init(context,
                       definition);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridGeneralTest.java
@@ -61,7 +61,6 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.UUID;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -83,6 +82,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -124,9 +124,6 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
 
     @Captor
     private ArgumentCaptor<Command> commandCaptor;
-
-    @Captor
-    private ArgumentCaptor<RefreshFormPropertiesEvent> refreshFormPropertiesEventCaptor;
 
     @Captor
     private ArgumentCaptor<DomainObjectSelectionEvent> domainObjectSelectionEventCaptor;
@@ -171,7 +168,6 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
                                       sessionCommandManager,
                                       canvasCommandFactory,
                                       editorSelectedEvent,
-                                      refreshFormPropertiesEvent,
                                       domainObjectSelectionEvent,
                                       cellEditorControls,
                                       listSelector,
@@ -483,19 +479,20 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testClearDisplayNameConsumerWhenNotNested() {
-        final String uuid = UUID.uuid();
-        doReturn(Optional.of(uuid)).when(grid).getNodeUUID();
+        grid.fireDomainObjectSelectionEvent(decision);
+        reset(domainObjectSelectionEvent);
 
         doTestClearDisplayNameConsumer(false,
                                        DeleteHasNameCommand.class);
 
         verify(gridLayer).batch();
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
 
-        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
-        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isEqualTo(decision);
+        assertThat(domainObjectSelectionEvent.getCanvasHandler()).isEqualTo(canvasHandler);
     }
 
     @Test
@@ -507,7 +504,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testClearDisplayNameConsumerWhenNotNestedAndUpdateStunnerTitle() {
+        grid.fireDomainObjectSelectionEvent(decision);
+        reset(domainObjectSelectionEvent);
+
         final String uuid = UUID.uuid();
         doReturn(Optional.of(uuid)).when(grid).getNodeUUID();
         when(index.get(uuid)).thenReturn(element);
@@ -519,11 +520,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
 
         verify(gridLayer).batch();
         verify(updateElementPropertyCommand).execute(eq(canvasHandler));
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
 
-        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
-        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isEqualTo(decision);
+        assertThat(domainObjectSelectionEvent.getCanvasHandler()).isEqualTo(canvasHandler);
     }
 
     @SuppressWarnings("unchecked")
@@ -550,19 +551,20 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSetDisplayNameConsumerWhenNotNested() {
-        final String uuid = UUID.uuid();
-        doReturn(Optional.of(uuid)).when(grid).getNodeUUID();
+        grid.fireDomainObjectSelectionEvent(decision);
+        reset(domainObjectSelectionEvent);
 
         doTestSetDisplayNameConsumer(false,
                                      SetHasNameCommand.class);
 
         verify(gridLayer).batch();
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
 
-        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
-        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isEqualTo(decision);
+        assertThat(domainObjectSelectionEvent.getCanvasHandler()).isEqualTo(canvasHandler);
     }
 
     @Test
@@ -574,7 +576,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSetDisplayNameConsumerWhenNotNestedAndUpdateStunnerTitle() {
+        grid.fireDomainObjectSelectionEvent(decision);
+        reset(domainObjectSelectionEvent);
+
         final String uuid = UUID.uuid();
         doReturn(Optional.of(uuid)).when(grid).getNodeUUID();
         when(index.get(uuid)).thenReturn(element);
@@ -586,11 +592,11 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
 
         verify(gridLayer).batch();
         verify(updateElementPropertyCommand).execute(eq(canvasHandler));
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
 
-        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
-        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isEqualTo(decision);
+        assertThat(domainObjectSelectionEvent.getCanvasHandler()).isEqualTo(canvasHandler);
     }
 
     @SuppressWarnings("unchecked")
@@ -616,18 +622,19 @@ public class BaseExpressionGridGeneralTest extends BaseExpressionGridTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSetTypeRefConsumerWhenNotNested() {
-        final String uuid = UUID.uuid();
-        doReturn(Optional.of(uuid)).when(grid).getNodeUUID();
+        grid.fireDomainObjectSelectionEvent(decision);
+        reset(domainObjectSelectionEvent);
 
         doTestSetTypeRefConsumer();
 
         verify(gridLayer).batch();
-        verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
+        verify(domainObjectSelectionEvent).fire(domainObjectSelectionEventCaptor.capture());
 
-        final RefreshFormPropertiesEvent refreshFormPropertiesEvent = refreshFormPropertiesEventCaptor.getValue();
-        assertThat(refreshFormPropertiesEvent.getUuid()).isEqualTo(uuid);
-        assertThat(refreshFormPropertiesEvent.getSession()).isEqualTo(session);
+        final DomainObjectSelectionEvent domainObjectSelectionEvent = domainObjectSelectionEventCaptor.getValue();
+        assertThat(domainObjectSelectionEvent.getDomainObject()).isEqualTo(decision);
+        assertThat(domainObjectSelectionEvent.getCanvasHandler()).isEqualTo(canvasHandler);
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridRenderingTest.java
@@ -168,7 +168,6 @@ public class BaseExpressionGridRenderingTest extends BaseExpressionGridTest {
                                       sessionCommandManager,
                                       canvasCommandFactory,
                                       editorSelectedEvent,
-                                      refreshFormPropertiesEvent,
                                       domainObjectSelectionEvent,
                                       cellEditorControls,
                                       listSelector,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
@@ -35,7 +35,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Domai
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
-import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
@@ -91,9 +90,6 @@ public abstract class BaseExpressionGridTest {
 
     @Mock
     protected EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
-
-    @Mock
-    protected EventSourceMock<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
 
     @Mock
     protected EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImplTest.java
@@ -20,15 +20,23 @@ import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementUpdatedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElementListener;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class DMNGridLayerControlImplTest {
@@ -37,10 +45,22 @@ public class DMNGridLayerControlImplTest {
     private DMNGridLayer gridLayer;
 
     @Mock
-    private CanvasHandler canvasHandler;
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private ClientSession session;
 
     @Mock
     private Element element;
+
+    @Mock
+    private DomainObject domainObject;
+
+    @Captor
+    private ArgumentCaptor<CanvasElementListener> canvasElementListenerCaptor;
+
+    @Captor
+    private ArgumentCaptor<CanvasDomainObjectListener> domainObjectListenerCaptor;
 
     private DMNGridLayerControlImpl control;
 
@@ -52,6 +72,8 @@ public class DMNGridLayerControlImplTest {
                 return gridLayer;
             }
         };
+
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
     }
 
     @Test
@@ -73,20 +95,52 @@ public class DMNGridLayerControlImplTest {
     }
 
     @Test
+    public void testDoInitWithBoundSession() {
+        control.bind(session);
+
+        control.doInit();
+
+        assertEquals(gridLayer,
+                     control.getGridLayer());
+
+        verify(canvasHandler).addRegistrationListener(canvasElementListenerCaptor.capture());
+        final CanvasElementListener canvasElementListener = canvasElementListenerCaptor.getValue();
+        canvasElementListener.update(element);
+        verify(gridLayer).batch();
+
+        reset(gridLayer);
+
+        verify(canvasHandler).addDomainObjectListener(domainObjectListenerCaptor.capture());
+        final CanvasDomainObjectListener domainObjectListener = domainObjectListenerCaptor.getValue();
+        domainObjectListener.update(domainObject);
+        verify(gridLayer).batch();
+    }
+
+    @Test
+    public void testDoDestroyWithBoundSession() {
+        control.bind(session);
+
+        control.doInit();
+
+        verify(canvasHandler).addRegistrationListener(canvasElementListenerCaptor.capture());
+        verify(canvasHandler).addDomainObjectListener(domainObjectListenerCaptor.capture());
+        final CanvasElementListener canvasElementListener = canvasElementListenerCaptor.getValue();
+        final CanvasDomainObjectListener domainObjectListener = domainObjectListenerCaptor.getValue();
+
+        control.doDestroy();
+
+        assertNull(control.getGridLayer());
+
+        verify(canvasHandler).removeRegistrationListener(eq(canvasElementListener));
+        verify(canvasHandler).removeDomainObjectListener(eq(domainObjectListener));
+    }
+
+    @Test
     public void testGetGridLayer() {
         final DMNGridLayer gridLayer = control.getGridLayer();
 
         //Check same instance is re-used
         assertEquals(gridLayer,
                      control.getGridLayer());
-    }
-
-    @Test
-    public void testOnCanvasElementUpdatedEvent() {
-        final CanvasElementUpdatedEvent event = new CanvasElementUpdatedEvent(canvasHandler, element);
-
-        control.onCanvasElementUpdatedEvent(event);
-
-        verify(gridLayer).batch();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerControlImplTest.java
@@ -140,7 +140,8 @@ public class DMNGridLayerControlImplTest {
         final DMNGridLayer gridLayer = control.getGridLayer();
 
         //Check same instance is re-used
-        assertEquals(gridLayer,
+        assertEquals("GridLayer instances should be identical.",
+                     gridLayer,
                      control.getGridLayer());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/HasDomainObjectListeners.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/HasDomainObjectListeners.java
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.kie.workbench.common.stunner.core.client.canvas.listener;
 
-import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
-import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+public interface HasDomainObjectListeners<L extends CanvasDomainObjectListener> {
 
-public interface CanvasDomainObjectListener extends CanvasListener<CanvasHandler, DomainObject> {
+    HasDomainObjectListeners<L> addDomainObjectListener(final L instance);
 
-    /**
-     * A DomainObject has been updated on the canvas.
-     */
-    void update(final DomainObject domainObject);
+    HasDomainObjectListeners<L> removeDomainObjectListener(final L instance);
+
+    HasDomainObjectListeners<L> clearDomainObjectListeners();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.function.Consumer;
 
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -101,8 +100,7 @@ public interface CanvasCommandFactory<H extends CanvasHandler> {
                                          final String propertyId,
                                          final Object value);
 
-    CanvasCommand<H> updateDomainObjectPropertyValue(final CanvasDomainObjectListener domainObjectCanvasListener,
-                                                     final DomainObject domainObject,
+    CanvasCommand<H> updateDomainObjectPropertyValue(final DomainObject domainObject,
                                                      final String propertyId,
                                                      final Object value);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
@@ -23,13 +23,16 @@ import java.util.Optional;
 
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElementListener;
 import org.kie.workbench.common.stunner.core.client.canvas.listener.HasCanvasListeners;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.HasDomainObjectListeners;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
 import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
@@ -50,10 +53,12 @@ import org.kie.workbench.common.stunner.core.util.UUID;
  */
 public abstract class AbstractCanvasHandler<D extends Diagram, C extends AbstractCanvas>
         implements CanvasHandler<D, C>,
-                   HasCanvasListeners<CanvasElementListener> {
+                   HasCanvasListeners<CanvasElementListener>,
+                   HasDomainObjectListeners<CanvasDomainObjectListener> {
 
     private final String uuid;
     private final List<CanvasElementListener> listeners = new LinkedList<>();
+    private final List<CanvasDomainObjectListener> domainObjectListeners = new LinkedList<>();
 
     public AbstractCanvasHandler() {
         this.uuid = UUID.uuid();
@@ -243,7 +248,7 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
     public void deregister(final Element element,
                            final boolean fireEvents) {
         final Shape shape = getCanvas().getShape(element.getUUID());
-        if(Objects.isNull(shape)){
+        if (Objects.isNull(shape)) {
             //already not exists on canvas
             return;
         }
@@ -342,13 +347,22 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
         return this;
     }
 
-    /**
-     * Notifies an element removed to the listeners.
-     */
-    public void notifyCanvasElementRemoved(final Element candidate) {
-        for (final CanvasElementListener instance : listeners) {
-            instance.deregister(candidate);
-        }
+    @Override
+    public HasDomainObjectListeners<CanvasDomainObjectListener> addDomainObjectListener(final CanvasDomainObjectListener instance) {
+        domainObjectListeners.add(instance);
+        return this;
+    }
+
+    @Override
+    public HasDomainObjectListeners<CanvasDomainObjectListener> removeDomainObjectListener(final CanvasDomainObjectListener instance) {
+        domainObjectListeners.remove(instance);
+        return this;
+    }
+
+    @Override
+    public HasDomainObjectListeners<CanvasDomainObjectListener> clearDomainObjectListeners() {
+        domainObjectListeners.clear();
+        return this;
     }
 
     /**
@@ -357,6 +371,15 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
     public void notifyCanvasElementAdded(final Element candidate) {
         for (final CanvasElementListener instance : listeners) {
             instance.register(candidate);
+        }
+    }
+
+    /**
+     * Notifies an element removed to the listeners.
+     */
+    public void notifyCanvasElementRemoved(final Element candidate) {
+        for (final CanvasElementListener instance : listeners) {
+            instance.deregister(candidate);
         }
     }
 
@@ -378,9 +401,46 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
         }
     }
 
+    /**
+     * Notifies a DomainObject added to the listeners.
+     */
+    public void notifyCanvasDomainObjectAdded(final DomainObject domainObject) {
+        for (final CanvasDomainObjectListener instance : domainObjectListeners) {
+            instance.register(domainObject);
+        }
+    }
+
+    /**
+     * Notifies a DomainObject removed to the listeners.
+     */
+    public void notifyCanvasDomainObjectRemoved(final DomainObject domainObject) {
+        for (final CanvasDomainObjectListener instance : domainObjectListeners) {
+            instance.deregister(domainObject);
+        }
+    }
+
+    /**
+     * Notifies a DomainObject updated to the listeners.
+     */
+    public void notifyCanvasDomainObjectUpdated(final DomainObject domainObject) {
+        for (final CanvasDomainObjectListener instance : domainObjectListeners) {
+            instance.update(domainObject);
+        }
+    }
+
+    /**
+     * Notifies a clean canvas to the listeners.
+     */
+    public void notifyCanvasDomainObjectClear() {
+        for (final CanvasDomainObjectListener instance : domainObjectListeners) {
+            instance.clear();
+        }
+    }
+
     public void clearCanvas() {
         if (null != getCanvas()) {
             notifyCanvasClear();
+            notifyCanvasDomainObjectClear();
             getCanvas().clear();
         }
     }
@@ -407,6 +467,7 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
         getCanvas().destroy();
         doDestroy();
         listeners.clear();
+        domainObjectListeners.clear();
     }
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
@@ -402,7 +402,7 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
     }
 
     /**
-     * Notifies a DomainObject added to the listeners.
+     * Notifies {@link CanvasDomainObjectListener}s that a {@link DomainObject} has been added.
      */
     public void notifyCanvasDomainObjectAdded(final DomainObject domainObject) {
         for (final CanvasDomainObjectListener instance : domainObjectListeners) {
@@ -411,7 +411,7 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
     }
 
     /**
-     * Notifies a DomainObject removed to the listeners.
+     * Notifies {@link CanvasDomainObjectListener}s that a {@link DomainObject} has been removed.
      */
     public void notifyCanvasDomainObjectRemoved(final DomainObject domainObject) {
         for (final CanvasDomainObjectListener instance : domainObjectListeners) {
@@ -420,7 +420,7 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
     }
 
     /**
-     * Notifies a DomainObject updated to the listeners.
+     * Notifies {@link CanvasDomainObjectListener}s that a {@link DomainObject} has been updated.
      */
     public void notifyCanvasDomainObjectUpdated(final DomainObject domainObject) {
         for (final CanvasDomainObjectListener instance : domainObjectListeners) {
@@ -429,7 +429,7 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
     }
 
     /**
-     * Notifies a clean canvas to the listeners.
+     * Notifies {@link CanvasDomainObjectListener}s that the {@link Canvas} has been cleared.
      */
     public void notifyCanvasDomainObjectClear() {
         for (final CanvasDomainObjectListener instance : domainObjectListeners) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
@@ -211,12 +210,10 @@ public class DefaultCanvasCommandFactory implements CanvasCommandFactory<Abstrac
     }
 
     @Override
-    public CanvasCommand<AbstractCanvasHandler> updateDomainObjectPropertyValue(final CanvasDomainObjectListener domainObjectCanvasListener,
-                                                                                final DomainObject domainObject,
+    public CanvasCommand<AbstractCanvasHandler> updateDomainObjectPropertyValue(final DomainObject domainObject,
                                                                                 final String propertyId,
                                                                                 final Object value) {
-        return new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
-                                                     domainObject,
+        return new UpdateDomainObjectPropertyCommand(domainObject,
                                                      propertyId,
                                                      value);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommand.java
@@ -16,7 +16,6 @@
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -28,7 +27,6 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 public class UpdateDomainObjectPropertyCommand extends AbstractCanvasGraphCommand {
 
-    private final CanvasDomainObjectListener domainObjectCanvasListener;
     private final DomainObject domainObject;
     private final String propertyId;
     private final Object value;
@@ -37,22 +35,20 @@ public class UpdateDomainObjectPropertyCommand extends AbstractCanvasGraphComman
 
         @Override
         public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
-            domainObjectCanvasListener.update(domainObject);
+            context.notifyCanvasDomainObjectUpdated(domainObject);
             return CanvasCommandResultBuilder.SUCCESS;
         }
 
         @Override
         public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
-            domainObjectCanvasListener.update(domainObject);
+            context.notifyCanvasDomainObjectUpdated(domainObject);
             return CanvasCommandResultBuilder.SUCCESS;
         }
     }
 
-    public UpdateDomainObjectPropertyCommand(final CanvasDomainObjectListener domainObjectCanvasListener,
-                                             final DomainObject domainObject,
+    public UpdateDomainObjectPropertyCommand(final DomainObject domainObject,
                                              final String propertyId,
                                              final Object value) {
-        this.domainObjectCanvasListener = domainObjectCanvasListener;
         this.domainObject = domainObject;
         this.propertyId = propertyId;
         this.value = value;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.ShapeSet;
 import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.shape.ElementShape;
 import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
@@ -38,6 +39,7 @@ import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapte
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetRuleAdapter;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -129,6 +131,10 @@ public class BaseCanvasHandlerTest {
     Object defSet;
     @Mock
     Object defBean;
+    @Mock
+    DomainObject domainObject;
+    @Mock
+    CanvasDomainObjectListener domainObjectListener;
 
     private BaseCanvasHandlerStub tested;
 
@@ -358,6 +364,51 @@ public class BaseCanvasHandlerTest {
                times(1)).destroyGraphIndex(any(Command.class));
         verify(canvas,
                times(1)).destroy();
+    }
+
+    @Test
+    public void testClearCanvas() {
+        tested.clearCanvas();
+
+        verify(tested).notifyCanvasClear();
+        verify(tested).notifyCanvasDomainObjectClear();
+        verify(canvas).clear();
+    }
+
+    @Test
+    public void testNotifyCanvasDomainObjectAdded() {
+        tested.addDomainObjectListener(domainObjectListener);
+
+        tested.notifyCanvasDomainObjectAdded(domainObject);
+
+        verify(domainObjectListener).register(domainObject);
+    }
+
+    @Test
+    public void testNotifyCanvasDomainObjectRemoved() {
+        tested.addDomainObjectListener(domainObjectListener);
+
+        tested.notifyCanvasDomainObjectRemoved(domainObject);
+
+        verify(domainObjectListener).deregister(domainObject);
+    }
+
+    @Test
+    public void testNotifyCanvasDomainObjectUpdated() {
+        tested.addDomainObjectListener(domainObjectListener);
+
+        tested.notifyCanvasDomainObjectUpdated(domainObject);
+
+        verify(domainObjectListener).update(domainObject);
+    }
+
+    @Test
+    public void testNotifyCanvasDomainObjectClear() {
+        tested.addDomainObjectListener(domainObjectListener);
+
+        tested.notifyCanvasDomainObjectClear();
+
+        verify(domainObjectListener).clear();
     }
 
     private class BaseCanvasHandlerStub extends BaseCanvasHandler<Diagram, AbstractCanvas> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommandTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.core.client.canvas.command;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -45,15 +44,11 @@ public class UpdateDomainObjectPropertyCommandTest {
     private AbstractCanvasHandler canvasHandler;
 
     @Mock
-    private CanvasDomainObjectListener domainObjectCanvasListener;
-
-    @Mock
     private DomainObject domainObject;
 
     @Test
     public void testNewGraphCommand() {
-        final Command<GraphCommandExecutionContext, RuleViolation> command = new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
-                                                                                                                   domainObject,
+        final Command<GraphCommandExecutionContext, RuleViolation> command = new UpdateDomainObjectPropertyCommand(domainObject,
                                                                                                                    PROPERTY_ID,
                                                                                                                    VALUE).newGraphCommand(canvasHandler);
 
@@ -62,8 +57,7 @@ public class UpdateDomainObjectPropertyCommandTest {
 
     @Test
     public void testNewCanvasCommandExecute() {
-        final CanvasCommand<AbstractCanvasHandler> command = new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
-                                                                                                   domainObject,
+        final CanvasCommand<AbstractCanvasHandler> command = new UpdateDomainObjectPropertyCommand(domainObject,
                                                                                                    PROPERTY_ID,
                                                                                                    VALUE).newCanvasCommand(canvasHandler);
 
@@ -71,13 +65,12 @@ public class UpdateDomainObjectPropertyCommandTest {
 
         assertThat(command.execute(canvasHandler)).isEqualTo(CanvasCommandResultBuilder.SUCCESS);
 
-        verify(domainObjectCanvasListener).update(eq(domainObject));
+        verify(canvasHandler).notifyCanvasDomainObjectUpdated(eq(domainObject));
     }
 
     @Test
     public void testNewCanvasCommandUndo() {
-        final CanvasCommand<AbstractCanvasHandler> command = new UpdateDomainObjectPropertyCommand(domainObjectCanvasListener,
-                                                                                                   domainObject,
+        final CanvasCommand<AbstractCanvasHandler> command = new UpdateDomainObjectPropertyCommand(domainObject,
                                                                                                    PROPERTY_ID,
                                                                                                    VALUE).newCanvasCommand(canvasHandler);
 
@@ -85,6 +78,6 @@ public class UpdateDomainObjectPropertyCommandTest {
 
         assertThat(command.undo(canvasHandler)).isEqualTo(CanvasCommandResultBuilder.SUCCESS);
 
-        verify(domainObjectCanvasListener).update(eq(domainObject));
+        verify(canvasHandler).notifyCanvasDomainObjectUpdated(eq(domainObject));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -183,6 +183,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3109

This also incorporates https://issues.jboss.org/browse/DROOLS-3117

This PR adds "drill down" for `Context` expressions. `Invocation` already works as required.

`DecisionTable` and `Function` to follow in a new PR (and new JIRA). 

Please note due to https://issues.jboss.org/browse/JBPM-7166 the "Name" and "Description" properties in the Properties Panel do not work correctly. Editing the graph _node_ _name_ or _description_ updates the `InformationItem` _name_ or _description_. Furthermore when adding new nodes to the diagram their _name_ appears empty. This is because, due to the same JIRA, the value is taken from the `InformationItem` and not the graph _node_. @danielzhe is working on JBPM-7166 this sprint.

This behaviour has long existed however we hid _name_ from `InformationItem`. _Description_ was still broken and had been observed by @jomarko previously. The need for "drill down" has brought the need for _name_ on `InformationItem` back and hence JBPM-7166 is now a blocker.