### PR TITLE
RHPAM-1534 - Stunner - Not possible to use Undo action immediately

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNEditorSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNEditorSession.java
@@ -52,14 +52,14 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.select.Selec
 import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.ToolboxControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistry;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.DefaultEditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
+import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 import org.uberfire.mvp.Command;
 
@@ -69,17 +69,15 @@ public class DMNEditorSession extends DefaultEditorSession implements DMNSession
 
     @Inject
     public DMNEditorSession(final ManagedSession session,
-                            final RegistryFactory registryFactory,
                             final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager,
                             final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                             final @Request SessionCommandManager<AbstractCanvasHandler> requestCommandManager,
-                            final StunnerPreferencesRegistry stunnerPreferencesRegistry) {
+                            final ClientCommandRegistry<org.kie.workbench.common.stunner.core.command.Command<AbstractCanvasHandler, CanvasViolation>> clientCommandRegistry) {
         super(session,
-              registryFactory,
               canvasCommandManager,
               sessionCommandManager,
               requestCommandManager,
-              stunnerPreferencesRegistry);
+              clientCommandRegistry);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNEditorSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNEditorSessionTest.java
@@ -41,10 +41,12 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.Abs
 import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.resize.ResizeControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.ToolboxControl;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistry;
+import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.mockito.Mock;
 
 import static org.mockito.Matchers.eq;
@@ -67,7 +69,7 @@ public class DMNEditorSessionTest extends BaseDMNSessionTest<DMNEditorSession> {
     private SessionCommandManager<AbstractCanvasHandler> requestCommandManager;
 
     @Mock
-    private StunnerPreferencesRegistry stunnerPreferencesRegistry;
+    private ClientCommandRegistry<Command<AbstractCanvasHandler, CanvasViolation>> clientCommandRegistry;
 
     @Mock
     private ResizeControl resizeControl;
@@ -120,14 +122,12 @@ public class DMNEditorSessionTest extends BaseDMNSessionTest<DMNEditorSession> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected DMNEditorSession getSession() {
         final DMNEditorSession session = new DMNEditorSession(managedSession,
-                                                              registryFactory,
                                                               canvasCommandManager,
                                                               sessionCommandManager,
                                                               requestCommandManager,
-                                                              stunnerPreferencesRegistry);
+                                                              clientCommandRegistry);
         session.constructInstance();
         return session;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/registration/CommandRegisteredEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/registration/CommandRegisteredEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.event.registration;
+
+import org.uberfire.workbench.events.UberFireEvent;
+
+public class CommandRegisteredEvent implements UberFireEvent {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/registration/RegisterChangedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/registration/RegisterChangedEvent.java
@@ -18,6 +18,6 @@ package org.kie.workbench.common.stunner.core.client.canvas.event.registration;
 
 import org.uberfire.workbench.events.UberFireEvent;
 
-public class CommandRegisteredEvent implements UberFireEvent {
+public class RegisterChangedEvent implements UberFireEvent {
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -29,6 +30,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseDownEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseUpEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CommandRegisteredEvent;
 import org.kie.workbench.common.stunner.core.client.session.event.SessionDestroyedEvent;
 import org.kie.workbench.common.stunner.core.client.session.event.SessionOpenedEvent;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -58,17 +60,19 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
 
     private final SessionManager sessionManager;
     private Stack<Command<AbstractCanvasHandler, CanvasViolation>> commands;
+    private Event<CommandRegisteredEvent> commandRegisteredEvent;
 
     private boolean roolback;
 
     protected RequestCommandManager() {
-        this(null);
+        this(null, null);
     }
 
     @Inject
-    public RequestCommandManager(final SessionManager sessionManager) {
+    public RequestCommandManager(final SessionManager sessionManager, Event<CommandRegisteredEvent> commandRegisteredEvent) {
         this.sessionManager = sessionManager;
         this.roolback = false;
+        this.commandRegisteredEvent = commandRegisteredEvent;
     }
 
     @Override
@@ -218,6 +222,7 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
                 getRegistry().register(new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
                                                .addCommands(commands.stream().collect(Collectors.toList()))
                                                .build());
+                commandRegisteredEvent.fire(new CommandRegisteredEvent());
             }
             LOGGER.log(Level.FINEST,
                        "Current client request completed.");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
@@ -16,13 +16,12 @@
 
 package org.kie.workbench.common.stunner.core.client.command;
 
+import java.util.ArrayList;
 import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -30,7 +29,6 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseDownEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseUpEvent;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CommandRegisteredEvent;
 import org.kie.workbench.common.stunner.core.client.session.event.SessionDestroyedEvent;
 import org.kie.workbench.common.stunner.core.client.session.event.SessionOpenedEvent;
 import org.kie.workbench.common.stunner.core.command.Command;
@@ -60,19 +58,17 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
 
     private final SessionManager sessionManager;
     private Stack<Command<AbstractCanvasHandler, CanvasViolation>> commands;
-    private Event<CommandRegisteredEvent> commandRegisteredEvent;
 
     private boolean roolback;
 
     protected RequestCommandManager() {
-        this(null, null);
+        this(null);
     }
 
     @Inject
-    public RequestCommandManager(final SessionManager sessionManager, Event<CommandRegisteredEvent> commandRegisteredEvent) {
+    public RequestCommandManager(final SessionManager sessionManager) {
         this.sessionManager = sessionManager;
         this.roolback = false;
-        this.commandRegisteredEvent = commandRegisteredEvent;
     }
 
     @Override
@@ -220,9 +216,8 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
                 LOGGER.log(Level.FINEST,
                            "Adding commands for current request into registry [size=" + commands.size() + "]");
                 getRegistry().register(new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
-                                               .addCommands(commands.stream().collect(Collectors.toList()))
+                                               .addCommands(new ArrayList<>(commands))
                                                .build());
-                commandRegisteredEvent.fire(new CommandRegisteredEvent());
             }
             LOGGER.log(Level.FINEST,
                        "Current client request completed.");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
@@ -16,17 +16,13 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
-import java.util.Objects;
-
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
-import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CommandRegisteredEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
@@ -88,7 +84,7 @@ public class UndoSessionCommand extends AbstractClientSessionCommand<EditorSessi
                      callback);
         final SessionCommandManager<AbstractCanvasHandler> scm = getSessionCommandManager();
         if (null != scm) {
-            final CommandResult<CanvasViolation> result = getSessionCommandManager().undo((AbstractCanvasHandler) getSession().getCanvasHandler());
+            final CommandResult<CanvasViolation> result = getSessionCommandManager().undo(getSession().getCanvasHandler());
             checkState();
             if (CommandUtils.isError(result)) {
                 callback.onError((V) result);
@@ -99,31 +95,10 @@ public class UndoSessionCommand extends AbstractClientSessionCommand<EditorSessi
         }
     }
 
-    void onCommandExecuted(final @Observes CanvasCommandExecutedEvent commandExecutedEvent) {
-        checkNotNull("commandExecutedEvent",
-                     commandExecutedEvent);
+    void onCommandAdded(final @Observes RegisterChangedEvent registerChangedEvent) {
+        checkNotNull("registerChangedEvent",
+                     registerChangedEvent);
         checkState();
-    }
-
-    void onCommandUndoExecuted(final @Observes CanvasUndoCommandExecutedEvent commandUndoExecutedEvent) {
-        checkNotNull("commandUndoExecutedEvent",
-                     commandUndoExecutedEvent);
-        checkState();
-    }
-
-    void onCommandAdded(final @Observes CommandRegisteredEvent commandRegisteredEvent) {
-        checkNotNull("commandRegisteredEvent",
-                     commandRegisteredEvent);
-        checkState();
-    }
-
-    void onClearSessionExecuted(final @Observes ClearSessionCommandExecutedEvent event) {
-        checkNotNull("event",
-                     event);
-        if (Objects.equals(getSession(),
-                           event.getClientSession())) {
-            checkState();
-        }
     }
 
     private void checkState() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CommandRegisteredEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
@@ -107,6 +108,12 @@ public class UndoSessionCommand extends AbstractClientSessionCommand<EditorSessi
     void onCommandUndoExecuted(final @Observes CanvasUndoCommandExecutedEvent commandUndoExecutedEvent) {
         checkNotNull("commandUndoExecutedEvent",
                      commandUndoExecutedEvent);
+        checkState();
+    }
+
+    void onCommandAdded(final @Observes CommandRegisteredEvent commandRegisteredEvent) {
+        checkNotNull("commandRegisteredEvent",
+                     commandRegisteredEvent);
         checkState();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
@@ -50,13 +50,12 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistry;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.uberfire.mvp.Command;
 
 @Dependent
@@ -67,22 +66,19 @@ public class DefaultEditorSession
     private final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private final SessionCommandManager<AbstractCanvasHandler> requestCommandManager;
-    private final StunnerPreferencesRegistry stunnerPreferencesRegistry;
     private final CommandRegistry<org.kie.workbench.common.stunner.core.command.Command<AbstractCanvasHandler, CanvasViolation>> commandRegistry;
 
     @Inject
     public DefaultEditorSession(final ManagedSession session,
-                                final RegistryFactory registryFactory,
                                 final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager,
                                 final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                 final @Request SessionCommandManager<AbstractCanvasHandler> requestCommandManager,
-                                final StunnerPreferencesRegistry stunnerPreferencesRegistry) {
+                                final ClientCommandRegistry<org.kie.workbench.common.stunner.core.command.Command<AbstractCanvasHandler, CanvasViolation>> clientCommandRegistry) {
         this.session = session;
-        this.commandRegistry = registryFactory.newCommandRegistry();
+        this.commandRegistry = clientCommandRegistry;
         this.sessionCommandManager = sessionCommandManager;
         this.requestCommandManager = requestCommandManager;
         this.canvasCommandManager = canvasCommandManager;
-        this.stunnerPreferencesRegistry = stunnerPreferencesRegistry;
     }
 
     @PostConstruct

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManagerTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.stunner.core.client.command;
 
-import javax.enterprise.event.Event;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +24,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseDownEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseUpEvent;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CommandRegisteredEvent;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -72,12 +69,11 @@ public class RequestCommandManagerTest {
     CanvasMouseDownEvent mouseDownEvent;
     @Mock
     CanvasMouseUpEvent mouseUpEvent;
-    @Mock
-    Event<CommandRegisteredEvent> commandRegisteredEvent;
 
     private RequestCommandManager tested;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         CanvasCommandManagerImpl commandManager = new CanvasCommandManagerImpl();
         when(canvasHandler.getCanvas()).thenReturn(canvas);
@@ -85,7 +81,7 @@ public class RequestCommandManagerTest {
         when(editorSession.getCanvasHandler()).thenReturn(canvasHandler);
         when(editorSession.getCommandRegistry()).thenReturn(commandRegistry);
         when(editorSession.getCommandManager()).thenReturn(commandManager);
-        this.tested = new RequestCommandManager(clientSessionManager, commandRegisteredEvent);
+        this.tested = new RequestCommandManager(clientSessionManager);
     }
 
     @Test
@@ -133,7 +129,6 @@ public class RequestCommandManagerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testSingleExecuteFailed() {
         when(command.execute(eq(canvasHandler))).thenReturn(CanvasCommandResultBuilder.FAILED);
         tested.onCanvasMouseDownEvent(mouseDownEvent);
@@ -149,7 +144,6 @@ public class RequestCommandManagerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testMultipleExecuteFailed() {
         when(command.execute(eq(canvasHandler))).thenReturn(CanvasCommandResultBuilder.SUCCESS);
         when(command1.execute(eq(canvasHandler))).thenReturn(CanvasCommandResultBuilder.SUCCESS);
@@ -173,7 +167,6 @@ public class RequestCommandManagerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testSingleUndoSuccess() {
         when(command.undo(eq(canvasHandler))).thenReturn(CanvasCommandResultBuilder.SUCCESS);
         tested.onCanvasMouseDownEvent(mouseDownEvent);
@@ -189,7 +182,6 @@ public class RequestCommandManagerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testSingleUndoFailed() {
         when(command.undo(eq(canvasHandler))).thenReturn(CanvasCommandResultBuilder.FAILED);
         tested.onCanvasMouseDownEvent(mouseDownEvent);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManagerTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.client.command;
 
+import javax.enterprise.event.Event;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseDownEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseUpEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CommandRegisteredEvent;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
@@ -69,6 +72,8 @@ public class RequestCommandManagerTest {
     CanvasMouseDownEvent mouseDownEvent;
     @Mock
     CanvasMouseUpEvent mouseUpEvent;
+    @Mock
+    Event<CommandRegisteredEvent> commandRegisteredEvent;
 
     private RequestCommandManager tested;
 
@@ -80,7 +85,7 @@ public class RequestCommandManagerTest {
         when(editorSession.getCanvasHandler()).thenReturn(canvasHandler);
         when(editorSession.getCommandRegistry()).thenReturn(commandRegistry);
         when(editorSession.getCommandManager()).thenReturn(commandManager);
-        this.tested = new RequestCommandManager(clientSessionManager);
+        this.tested = new RequestCommandManager(clientSessionManager, commandRegisteredEvent);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
@@ -23,8 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
-import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasUndoCommandExecutedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
@@ -127,59 +126,13 @@ public class UndoSessionCommandTest extends BaseSessionCommandKeyboardTest {
         command.bind(session);
         command.listen(statusCallback);
 
-        ((UndoSessionCommand) command).onCommandExecuted(new CanvasCommandExecutedEvent(null,
-                                                                                        null,
-                                                                                        null));
+        ((UndoSessionCommand) command).onCommandAdded(new RegisterChangedEvent());
         assertFalse(command.isEnabled());
 
         commandHistory.add(mock(Command.class));
 
-        ((UndoSessionCommand) command).onCommandExecuted(new CanvasCommandExecutedEvent(null,
-                                                                                        null,
-                                                                                        null));
+        ((UndoSessionCommand) command).onCommandAdded(new RegisterChangedEvent());
         assertTrue(command.isEnabled());
-        verify(statusCallback,
-               times(2)).execute();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testOnCommandUndoExecuted() {
-        command.bind(session);
-        command.listen(statusCallback);
-
-        ((UndoSessionCommand) command).onCommandUndoExecuted(new CanvasUndoCommandExecutedEvent(null,
-                                                                                                null,
-                                                                                                null));
-        assertFalse(command.isEnabled());
-
-        commandHistory.add(mock(Command.class));
-
-        ((UndoSessionCommand) command).onCommandUndoExecuted(new CanvasUndoCommandExecutedEvent(null,
-                                                                                                null,
-                                                                                                null));
-        assertTrue(command.isEnabled());
-
-        verify(statusCallback,
-               times(2)).execute();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testOnClearSessionExecuted() {
-        command.bind(session);
-        command.listen(statusCallback);
-
-        ((UndoSessionCommand) command).onClearSessionExecuted(new ClearSessionCommandExecutedEvent(mock(ClearSessionCommand.class),
-                                                                                                   session));
-        assertFalse(command.isEnabled());
-
-        commandHistory.add(mock(Command.class));
-
-        ((UndoSessionCommand) command).onClearSessionExecuted(new ClearSessionCommandExecutedEvent(mock(ClearSessionCommand.class),
-                                                                                                   session));
-        assertTrue(command.isEnabled());
-
         verify(statusCallback,
                times(2)).execute();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
@@ -42,11 +42,10 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.select.Selec
 import org.kie.workbench.common.stunner.core.client.canvas.controls.toolbox.ToolboxControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistry;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
-import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mvp.Command;
@@ -65,12 +64,6 @@ public class DefaultEditorSessionTest {
     private ManagedSession managedSession;
 
     @Mock
-    private CommandRegistry commandRegistry;
-
-    @Mock
-    private RegistryFactory registryFactory;
-
-    @Mock
     private CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
 
     @Mock
@@ -80,14 +73,13 @@ public class DefaultEditorSessionTest {
     private SessionCommandManager<AbstractCanvasHandler> requestCommandManage;
 
     @Mock
-    private StunnerPreferencesRegistry preferencesRegistry;
+    private ClientCommandRegistry<org.kie.workbench.common.stunner.core.command.Command<AbstractCanvasHandler, CanvasViolation>> clientCommandRegistry;
 
     private DefaultEditorSession tested;
 
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() {
-        when(registryFactory.newCommandRegistry()).thenReturn(commandRegistry);
         when(managedSession.onCanvasControlRegistered(any(Consumer.class))).thenReturn(managedSession);
         when(managedSession.onCanvasControlDestroyed(any(Consumer.class))).thenReturn(managedSession);
         when(managedSession.onCanvasHandlerControlRegistered(any(Consumer.class))).thenReturn(managedSession);
@@ -99,11 +91,10 @@ public class DefaultEditorSessionTest {
         when(managedSession.registerCanvasHandlerControl(any(Class.class),
                                                          any(Class.class))).thenReturn(managedSession);
         tested = new DefaultEditorSession(managedSession,
-                                          registryFactory,
                                           canvasCommandManager,
                                           sessionCommandManager,
                                           requestCommandManage,
-                                          preferencesRegistry);
+                                          clientCommandRegistry);
     }
 
     @Test
@@ -117,7 +108,6 @@ public class DefaultEditorSessionTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testInit() {
         Metadata metadata = mock(Metadata.class);
         Command command = mock(Command.class);
@@ -147,17 +137,15 @@ public class DefaultEditorSessionTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testOpen() {
         tested.open();
         verify(managedSession, times(1)).open();
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testDestroy() {
         tested.destroy();
-        verify(commandRegistry, times(1)).clear();
+        verify(clientCommandRegistry, times(1)).clear();
         verify(managedSession, times(1)).destroy();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
@@ -15,8 +15,6 @@
  */
 package org.kie.workbench.common.stunner.core.command.util;
 
-import java.util.logging.Logger;
-
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -24,8 +22,8 @@ import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 
 /**
  * This handler is an util class that achieves command "re-do" features.
@@ -46,8 +44,6 @@ import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 @Dependent
 public class RedoCommandHandler<C extends Command> {
 
-    private static Logger LOGGER = Logger.getLogger(RedoCommandHandler.class.getName());
-
     private final CommandRegistry<C> registry;
 
     protected RedoCommandHandler() {
@@ -55,8 +51,8 @@ public class RedoCommandHandler<C extends Command> {
     }
 
     @Inject
-    public RedoCommandHandler(final RegistryFactory registryFactory) {
-        this.registry = registryFactory.newCommandRegistry();
+    public RedoCommandHandler(final ClientCommandRegistry<C> clientCommandRegistry) {
+        this.registry = clientCommandRegistry;
     }
 
     public boolean onUndoCommandExecuted(final C command) {
@@ -64,7 +60,6 @@ public class RedoCommandHandler<C extends Command> {
         return isEnabled();
     }
 
-    @SuppressWarnings("unchecked")
     public boolean onCommandExecuted(final C command) {
         if (isEnabled()) {
             final C last = registry.peek();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/ClientCommandRegistry.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/ClientCommandRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.registry.impl;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
+import org.kie.workbench.common.stunner.core.command.Command;
+
+/**
+ * The client implementation for the CommandRegistry type.
+ * Note: The Stack class behavior when using the iterator is not the expected one, so used
+ * ArrayDeque instead of an Stack to provide right iteration order.
+ */
+@Dependent
+public class ClientCommandRegistry<C extends Command> extends CommandRegistryImpl<C> {
+
+    private Event<RegisterChangedEvent> registerChangedEvent;
+
+    @Inject
+    public ClientCommandRegistry(Event<RegisterChangedEvent> registerChangedEvent) {
+        this.registerChangedEvent = registerChangedEvent;
+    }
+
+    public ClientCommandRegistry() {
+    }
+
+    @Override
+    public void register(final C command) {
+        super.register(command);
+        registerChangedEvent.fire(new RegisterChangedEvent());
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        registerChangedEvent.fire(new RegisterChangedEvent());
+    }
+
+    @Override
+    public C pop() {
+        C command = super.pop();
+        registerChangedEvent.fire(new RegisterChangedEvent());
+        return command;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementEditorSession.java
@@ -40,14 +40,14 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.select.Selec
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SingleSelection;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistry;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.DefaultEditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
+import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.uberfire.mvp.Command;
 
 @Dependent
@@ -57,17 +57,15 @@ public class CaseManagementEditorSession
 
     @Inject
     public CaseManagementEditorSession(final ManagedSession session,
-                                       final RegistryFactory registryFactory,
                                        final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager,
                                        final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
                                        final @Request SessionCommandManager<AbstractCanvasHandler> requestCommandManager,
-                                       final StunnerPreferencesRegistry stunnerPreferencesRegistry) {
+                                       final ClientCommandRegistry<org.kie.workbench.common.stunner.core.command.Command<AbstractCanvasHandler, CanvasViolation>> clientCommandRegistry) {
         super(session,
-              registryFactory,
               canvasCommandManager,
               sessionCommandManager,
               requestCommandManager,
-              stunnerPreferencesRegistry);
+              clientCommandRegistry);
     }
 
     @Override


### PR DESCRIPTION
Hi @romartin, @LuboTerifaj,

I investigated this issued and there are my findings:

**Short version:**
There are two EventHandlers for `MouseUp` event: on **lienzo-core** side and on **Stunner** side. Both handlers are executed when we finishing drag an element, but **lienzo** side handler is **_first_** in the queue of handlers and it execute check of command registry are there any commands to undo or not.

**Stunner** handler executes **_after_** **lienzo-core** handler and this handler adding new command to command registry and that's why first action doesn't unlock undo button, but works for second and following actions (and that's why it is possible to undo first action if button already unlocked).

As _temporary_ solution I added new event after new command added to registry and handle it in undo command. As long term solution I see **refactoring of Undo/Redo** commands.

My idea is fire RegistryChanged event in Client registry (probably we should create child of the existing registry to use GWT events only on client side and "vanilla" existing simple registry on server side) and handle this event in Undo/Redo commands.

So Undo/Redo commands won't be observer `any command executed`, but `registry changed`. (also `registry cleared` and `Redo/Undo command`  executed for `Undo/Redo` commands accordingly.

In my opinion it will simplify overall Undo/Redo functionality and will make it more robust. WDYT about it?

 