### PR TITLE
DROOLS-3185: [DMN Designer] Change Literal Expression to Decision Table

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
@@ -17,7 +17,6 @@ package org.kie.workbench.common.dmn.api.property.dmn;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.soup.commons.validation.PortablePreconditions;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace;
 import org.kie.workbench.common.dmn.api.property.DMNProperty;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
@@ -37,8 +36,7 @@ public class QName implements DMNProperty {
 
     public QName() {
         this(NULL_NS_URI,
-             BuiltInType.STRING.getName(),
-             Namespace.FEEL.getPrefix());
+             BuiltInType.STRING.getName());
     }
 
     public QName(final String namespaceURI,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInType.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInType.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.dmn.api.property.dmn.types;
 
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 public enum BuiltInType {
@@ -50,7 +49,7 @@ public enum BuiltInType {
     }
 
     public QName asQName() {
-        return new QName(Namespace.FEEL.getUri(),
+        return new QName(QName.NULL_NS_URI,
                          getName());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInTypeTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInTypeTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.dmn.api.property.dmn.types;
 import java.util.Arrays;
 
 import org.junit.Test;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 import static org.junit.Assert.assertEquals;
@@ -35,7 +34,7 @@ public class BuiltInTypeTest {
         final QName typeRef = bit.asQName();
         assertEquals(bit.getName(),
                      typeRef.getLocalPart());
-        assertEquals(Namespace.FEEL.getUri(),
+        assertEquals(QName.NULL_NS_URI,
                      typeRef.getNamespaceURI());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandler.java
@@ -32,9 +32,7 @@ import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
 import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 
-import static org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace.FEEL;
 import static org.kie.workbench.common.dmn.api.property.dmn.QName.NULL_NS_URI;
-import static org.kie.workbench.common.dmn.client.editors.types.common.BuiltInTypeUtils.isDefault;
 import static org.kie.workbench.common.stunner.core.util.StringUtils.isEmpty;
 
 @Dependent
@@ -94,11 +92,7 @@ public class ItemDefinitionUpdateHandler {
     }
 
     QName makeQName(final DataType dataType) {
-        if (isDefault(dataType.getType())) {
-            return normaliseTypeRef(new QName(FEEL.getUri(), dataType.getType()));
-        } else {
-            return normaliseTypeRef(new QName(NULL_NS_URI, dataType.getType()));
-        }
+        return normaliseTypeRef(new QName(NULL_NS_URI, dataType.getType()));
     }
 
     QName normaliseTypeRef(final QName typeRef) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
@@ -832,7 +831,7 @@ public class ContextGridTest {
     public void testSetTypeRef() {
         setupGrid(0);
 
-        extractHeaderMetaData().setTypeRef(new QName(DMNModelInstrumentedBase.Namespace.FEEL.getUri(),
+        extractHeaderMetaData().setTypeRef(new QName(QName.NULL_NS_URI,
                                                      BuiltInType.DATE.getName()));
 
         verify(sessionCommandManager).execute(eq(canvasHandler),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BuiltinAggregator;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTableOrientation;
@@ -1110,7 +1109,7 @@ public class DecisionTableGridTest {
     public void testSetTypeRef() {
         setupGrid(makeHasNameForDecision(), 0);
 
-        final Consumer<NameAndDataTypeHeaderMetaData> test = (md) -> md.setTypeRef(new QName(DMNModelInstrumentedBase.Namespace.FEEL.getUri(),
+        final Consumer<NameAndDataTypeHeaderMetaData> test = (md) -> md.setTypeRef(new QName(QName.NULL_NS_URI,
                                                                                              BuiltInType.DATE.getName()));
 
         assertHeaderMetaDataTest(0, 1, test, SetTypeRefCommand.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
@@ -865,7 +864,7 @@ public class FunctionGridTest {
     public void testSetTypeRef() {
         setupGrid(0);
 
-        extractHeaderMetaData().setTypeRef(new QName(DMNModelInstrumentedBase.Namespace.FEEL.getUri(),
+        extractHeaderMetaData().setTypeRef(new QName(QName.NULL_NS_URI,
                                                      BuiltInType.DATE.getName()));
 
         verify(sessionCommandManager).execute(eq(canvasHandler),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
@@ -32,7 +32,6 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
@@ -815,7 +814,7 @@ public class InvocationGridTest {
     public void testSetTypeRef() {
         setupGrid(0);
 
-        extractHeaderMetaData().setTypeRef(new QName(DMNModelInstrumentedBase.Namespace.FEEL.getUri(),
+        extractHeaderMetaData().setTypeRef(new QName(QName.NULL_NS_URI,
                                                      BuiltInType.DATE.getName()));
 
         verify(sessionCommandManager).execute(eq(canvasHandler),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasName;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
@@ -494,7 +493,7 @@ public class LiteralExpressionGridTest {
     public void testSetTypeRef() {
         setupGrid(0);
 
-        extractHeaderMetaData().setTypeRef(new QName(Namespace.FEEL.getUri(),
+        extractHeaderMetaData().setTypeRef(new QName(QName.NULL_NS_URI,
                                                      BuiltInType.DATE.getName()));
 
         verify(sessionCommandManager).execute(eq(canvasHandler),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
-import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.v1_1.List;
@@ -803,7 +802,7 @@ public class RelationGridTest {
     public void testSetTypeRef() {
         setupGrid(0);
 
-        extractHeaderMetaData().setTypeRef(new QName(Namespace.FEEL.getUri(),
+        extractHeaderMetaData().setTypeRef(new QName(QName.NULL_NS_URI,
                                                      BuiltInType.DATE.getName()));
 
         verify(sessionCommandManager).execute(eq(canvasHandler),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
@@ -68,7 +68,7 @@ public class DataTypePickerWidgetTest {
 
     private static final QName VALUE = new QName();
 
-    private static final String WIDGET_VALUE = "[][string][feel]";
+    private static final String WIDGET_VALUE = "[][string][]";
 
     @Mock
     private Anchor typeButton;
@@ -238,12 +238,12 @@ public class DataTypePickerWidgetTest {
 
         final QName normalisedQName = qNameCaptor.getValue();
         assertEquals("", normalisedQName.getNamespaceURI());
-        assertEquals(Namespace.FEEL.getPrefix(), normalisedQName.getPrefix());
+        assertEquals(QName.NULL_NS_URI, normalisedQName.getPrefix());
         assertEquals(bit.getName(), normalisedQName.getLocalPart());
 
         assertTrue(oo.isPresent());
         assertEquals(bit.getName(), optionTextCaptor.getValue());
-        assertEquals("[][any][feel]", optionValueCaptor.getValue());
+        assertEquals("[][any][]", optionValueCaptor.getValue());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/QNameConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/QNameConverterTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(MockitoJUnitRunner.class)
 public class QNameConverterTest {
 
-    private static final String ENCODED_FEEL_DATE = "[][date][" + DMNModelInstrumentedBase.Namespace.FEEL.getPrefix() + "]";
+    private static final String ENCODED_FEEL_DATE = "[][date][]";
 
     private static final String ENCODED_DMN_UNKNOWN = "[" + org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_DMN + "]" +
             "[unknown]" +
@@ -101,7 +101,7 @@ public class QNameConverterTest {
     @Test
     public void testToModelValueWithCorrectlyEncodedValue() {
         final QName typeRef = converter.toModelValue(ENCODED_FEEL_DATE);
-        assertEquals(DMNModelInstrumentedBase.Namespace.FEEL.getPrefix(),
+        assertEquals(QName.NULL_NS_URI,
                      typeRef.getPrefix());
         assertEquals("",
                      typeRef.getNamespaceURI());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandlerTest.java
@@ -135,6 +135,7 @@ public class ItemDefinitionUpdateHandlerTest {
         final String actualName = name.getLocalPart();
 
         assertEquals(expectedName, actualName);
+        assertEquals(QName.NULL_NS_URI, name.getNamespaceURI());
     }
 
     @Test
@@ -150,6 +151,7 @@ public class ItemDefinitionUpdateHandlerTest {
         final String expected = "tAddress";
 
         assertEquals(expected, actual);
+        assertEquals(QName.NULL_NS_URI, name.getNamespaceURI());
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3185

This PR requires https://github.com/kiegroup/kie-wb-common/pull/2204 to be first merged (this PR has one commit itself but 10 more - at the time of writing - for the related PR, for DROOLS-3143)...

This PR also fixes some other issues with the change for "Built in types" in DMN 1.2 (meaning they no longer require a name space prefix or URI). 