### PR TITLE
JBPM-7890 add caseIdPrefix to the CaseManagementSet on BPMN

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseIdPrefix.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseIdPrefix.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.definition.property.cm;
+
+import java.util.Objects;
+
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldValue;
+import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.I18nMode;
+import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.property.Value;
+import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
+
+@Portable
+@Bindable
+@FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
+@Property(meta = PropertyMetaTypes.NAME)
+public class CaseIdPrefix {
+
+    @Value
+    @FieldValue
+    @NotNull
+    @NotEmpty
+    private String value;
+
+    public CaseIdPrefix() {
+        this("");
+    }
+
+    public CaseIdPrefix(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.combineHashCodes(Objects.hashCode(value));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof CaseIdPrefix) {
+            CaseIdPrefix other = (CaseIdPrefix) o;
+            return Objects.equals(value, other.value);
+        }
+        return false;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.stunner.bpmn.forms.model.VariablesEditorFieldTyp
 import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldType;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 @Bindable

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseManagementSet.java
@@ -26,25 +26,30 @@ import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.type.TextBoxFieldType;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNPropertySet;
 import org.kie.workbench.common.stunner.bpmn.forms.model.VariablesEditorFieldType;
 import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldType;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
-import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 @Bindable
 @PropertySet
 @FormDefinition(
         policy = FieldPolicy.ONLY_MARKED,
-        startElement = "caseRoles"
+        startElement = "caseIdPrefix"
 )
 public class CaseManagementSet implements BPMNPropertySet {
 
     @Property
+    @FormField(type = TextBoxFieldType.class)
+    private CaseIdPrefix caseIdPrefix;
+
+    @Property
     @FormField(
-            type = RolesEditorFieldType.class
+            type = RolesEditorFieldType.class,
+            afterElement = "caseIdPrefix"
     )
     @Valid
     private CaseRoles caseRoles;
@@ -57,13 +62,23 @@ public class CaseManagementSet implements BPMNPropertySet {
     private CaseFileVariables caseFileVariables;
 
     public CaseManagementSet() {
-        this(new CaseRoles(), new CaseFileVariables());
+        this(new CaseIdPrefix(), new CaseRoles(), new CaseFileVariables());
     }
 
-    public CaseManagementSet(final @MapsTo("caseRoles") CaseRoles caseRoles,
+    public CaseManagementSet(final @MapsTo("caseIdPrefix") CaseIdPrefix caseIdPrefix,
+                             final @MapsTo("caseRoles") CaseRoles caseRoles,
                              final @MapsTo("caseFileVariables") CaseFileVariables caseFileVariables) {
         this.caseRoles = caseRoles;
         this.caseFileVariables = caseFileVariables;
+        this.caseIdPrefix = caseIdPrefix;
+    }
+
+    public CaseIdPrefix getCaseIdPrefix() {
+        return caseIdPrefix;
+    }
+
+    public void setCaseIdPrefix(CaseIdPrefix caseIdPrefix) {
+        this.caseIdPrefix = caseIdPrefix;
     }
 
     public CaseRoles getCaseRoles() {
@@ -84,7 +99,7 @@ public class CaseManagementSet implements BPMNPropertySet {
 
     @Override
     public int hashCode() {
-        return HashUtil.combineHashCodes(caseRoles.hashCode(),
+        return HashUtil.combineHashCodes(caseIdPrefix.hashCode(), caseRoles.hashCode(),
                                          caseFileVariables.hashCode());
     }
 
@@ -96,6 +111,12 @@ public class CaseManagementSet implements BPMNPropertySet {
                     Objects.equals(caseFileVariables, other.caseFileVariables);
 
         }
-        return false;
+        if (!(o instanceof CaseManagementSet)) {
+            return false;
+        }
+        CaseManagementSet that = (CaseManagementSet) o;
+        return  Objects.equals(getCaseIdPrefix(), that.getCaseIdPrefix())
+                && Objects.equals(getCaseIdPrefix(), that.getCaseIdPrefix())
+                && Objects.equals(getCaseRoles(), that.getCaseRoles());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomElement.java
@@ -38,6 +38,7 @@ public class CustomElement<T> {
             return getStringValue(element).orElse(defaultValue);
         }
     };
+    public static final ElementDefinition<String> caseIdPrefix = new StringElement("customCaseIdPrefix", "");
     public static final ElementDefinition<String> caseRole = new StringElement("customCaseRoles", "");
 
     private final ElementDefinition<T> elementDefinition;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
@@ -22,8 +22,8 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Defi
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
-import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverter.java
@@ -22,6 +22,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Defi
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
@@ -74,6 +75,9 @@ public class RootProcessConverter {
         p.setProcessVariables(processData.getProcessVariables());
 
         //Case Management
+        final CaseIdPrefix caseIdPrefix = definition.getCaseManagementSet().getCaseIdPrefix();
+        p.setCaseIdPrefix(caseIdPrefix);
+
         final CaseRoles caseRoles = definition.getCaseManagementSet().getCaseRoles();
         p.setCaseRoles(caseRoles);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.DeclarationList;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.ElementContainer;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables;
@@ -192,6 +193,10 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());
         });
+    }
+
+    public void setCaseIdPrefix(CaseIdPrefix caseIdPrefix) {
+        CustomElement.caseIdPrefix.of(process).set(caseIdPrefix.getValue());
     }
 
     public void setCaseRoles(CaseRoles roles) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -44,8 +44,8 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.DeclarationList;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.ElementContainer;
-import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessVariables;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.Defini
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.ProcessPropertyReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.PropertyReaderFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
@@ -105,9 +106,10 @@ public class RootProcessConverter {
         );
 
         definition.setCaseManagementSet(new CaseManagementSet(
+                new CaseIdPrefix(e.getCaseIdPrefix()),
                 new CaseRoles(e.getCaseRoles()),
-                new CaseFileVariables(e.getCaseFileVariables()))
-        );
+                new CaseFileVariables(e.getCaseFileVariables())
+        ));
 
         definition.setProcessData(new ProcessData(
                 new ProcessVariables(e.getProcessVariables())

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/RootProcessConverter.java
@@ -28,8 +28,8 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.Defini
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.ProcessPropertyReader;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.PropertyReaderFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
-import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.AdHoc;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessPropertyReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessPropertyReader.java
@@ -66,6 +66,10 @@ public class ProcessPropertyReader extends BasePropertyReader {
         return ProcessVariableReader.getProcessVariables(process.getProperties());
     }
 
+    public String getCaseIdPrefix() {
+        return CustomElement.caseIdPrefix.of(process).get();
+    }
+
     public String getCaseFileVariables() {
         return CaseFileVariableReader.getCaseFileVariables(process.getProperties());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
@@ -32,8 +32,8 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.lane
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
-import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/processes/RootProcessConverterTest.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.lane
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.ProcessPropertyWriter;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.PropertyWriterFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
@@ -86,6 +87,9 @@ public class RootProcessConverterTest {
     @Mock
     private LaneConverter laneConverter;
 
+    @Mock
+    private CaseIdPrefix caseIdPrefix;
+
     @Before
     public void setUp() throws Exception {
         diagram = new BPMNDiagramImpl();
@@ -97,6 +101,7 @@ public class RootProcessConverterTest {
         when(propertyWriterFactory.of(Matchers.any(Process.class))).thenReturn(processPropertyWriter);
         when(node.getContent()).thenReturn(content);
         when(content.getDefinition()).thenReturn(diagram);
+        when(caseManagementSet.getCaseIdPrefix()).thenReturn(caseIdPrefix);
         when(caseManagementSet.getCaseRoles()).thenReturn(caseRoles);
         when(caseManagementSet.getCaseFileVariables()).thenReturn(caseFileVariables);
         when(converterFactory.subProcessConverter()).thenReturn(subProcessConverter);
@@ -105,8 +110,9 @@ public class RootProcessConverterTest {
     }
 
     @Test
-    public void convertProcessWithCaseRoles() {
+    public void convertProcessWithCaseProperties() {
         final ProcessPropertyWriter propertyWriter = converter.convertProcess();
+        verify(propertyWriter).setCaseIdPrefix(caseIdPrefix);
         verify(propertyWriter).setCaseRoles(caseRoles);
         verify(propertyWriter).setCaseFileVariables(caseFileVariables);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -98,6 +99,14 @@ public class ProcessPropertyWriterTest {
         p.setCaseRoles(caseRole);
         String cdata = CustomElement.caseRole.of(p.getProcess()).get();
         assertThat("role").isEqualTo(CustomElement.caseRole.stripCData(cdata));
+    }
+
+    @Test
+    public void caseIdPrefix() {
+        CaseIdPrefix caseIdPrefix = new CaseIdPrefix("caseIdPrefix");
+        p.setCaseIdPrefix(caseIdPrefix);
+        String cdata = CustomElement.caseIdPrefix.of(p.getProcess()).get();
+        assertThat("caseIdPrefix").isEqualTo(CustomElement.caseIdPrefix.stripCData(cdata));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -23,8 +23,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
-import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.mockito.runners.MockitoJUnitRunner;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariableProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariableProviderTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorDataProvider;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseFileVariables;
+import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseIdPrefix;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseManagementSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.cm.CaseRoles;
 import org.kie.workbench.common.stunner.bpmn.definition.property.variables.ProcessData;
@@ -120,6 +121,7 @@ public class VariableProviderTest
         BPMNDiagramImpl rootNode = new BPMNDiagramImpl();
         rootNode.setProcessData(new ProcessData(new ProcessVariables(processVariables)));
         rootNode.setCaseManagementSet((new CaseManagementSet(
+                new CaseIdPrefix(""),
                 new CaseRoles(""),
                 new CaseFileVariables(caseFileVariables))));
         return mockNode(rootNode);


### PR DESCRIPTION
Adding a new property **CaseIdPrefix** to the CaseManagementSet on the `BPMNDiagramImpl`.
This property is a String input, the new marshallers were updated to support the new property.

@romartin 
@evacchi 
@LuboTerifaj 