### PR TITLE
DROOLS-3173 : Scenario Simulation Docks support improvements

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocks.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocks.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.workbench.client.docks;
 
 import java.util.Collection;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
@@ -109,6 +110,7 @@ public class AuthoringWorkbenchDocks {
     }
 
     public void setActiveHandler(WorkbenchDocksHandler handler) {
+
         if (!isAuthoringActive()) {
             return;
         }
@@ -148,6 +150,7 @@ public class AuthoringWorkbenchDocks {
     }
 
     public void hide() {
+
         if (componentPaletteEnabled) {
             uberfireDocks.remove(componentPaletteDock);
             componentPaletteEnabled = false;
@@ -158,6 +161,7 @@ public class AuthoringWorkbenchDocks {
     }
 
     public void show() {
+
         uberfireDocks.show(UberfireDockPosition.WEST,
                              authoringPerspectiveIdentifier);
         projectExplorerEnabled = true;
@@ -174,6 +178,14 @@ public class AuthoringWorkbenchDocks {
     public void expandProjectExplorer() {
         if (projectExplorerDock != null && !componentPaletteEnabled) {
             uberfireDocks.open(projectExplorerDock);
+        }
+    }
+
+    public void expandAuthoringDock(final UberfireDock dockToOpen) {
+        uberfireDocks.show(UberfireDockPosition.EAST, authoringPerspectiveIdentifier);
+
+        if (dockToOpen != null) {
+            uberfireDocks.open(dockToOpen);
         }
     }
 
@@ -220,7 +232,6 @@ public class AuthoringWorkbenchDocks {
             uberfireDocks.open(dockToOpen);
         }
     }
-
     public void onLayoutEditorFocus(@Observes LayoutEditorFocusEvent event) {
         refreshWestDocks(true, componentPaletteDock);
     }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestReportingDocksHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestReportingDocksHandler.java
@@ -19,27 +19,35 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import javax.enterprise.context.Dependent;
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 
+import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
 import org.kie.workbench.common.workbench.client.docks.impl.AbstractWorkbenchDocksHandler;
 import org.kie.workbench.common.workbench.client.resources.i18n.DefaultWorkbenchConstants;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
-@Dependent
+@ApplicationScoped
 public class TestReportingDocksHandler
         extends AbstractWorkbenchDocksHandler {
+
+    @Inject
+    private AuthoringWorkbenchDocks authoringWorkbenchDocks;
+
+    private UberfireDock testReportDock;
 
     @Override
     public Collection<UberfireDock> provideDocks(String perspectiveIdentifier) {
         List<UberfireDock> result = new ArrayList<>();
 
-        result.add(new UberfireDock(UberfireDockPosition.EAST,
-                                    "PLAY_CIRCLE",
-                                    new DefaultPlaceRequest("org.kie.guvnor.TestResults"),
-                                    perspectiveIdentifier).withSize(450).withLabel(DefaultWorkbenchConstants.INSTANCE.TestReport()));
+        testReportDock = new UberfireDock(UberfireDockPosition.EAST,
+                                          "PLAY_CIRCLE",
+                                          new DefaultPlaceRequest("org.kie.guvnor.TestResults"),
+                                          perspectiveIdentifier);
+        result.add(testReportDock.withSize(450).withLabel(DefaultWorkbenchConstants.INSTANCE.TestReport()));
 
         return result;
     }
@@ -54,4 +62,7 @@ public class TestReportingDocksHandler
                      true);
     }
 
+    public void expandTestResultsDock() {
+        authoringWorkbenchDocks.expandAuthoringDock(testReportDock);
+    }
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
@@ -22,10 +22,6 @@
         <div class="col-xs-9 tab-content kie-tab-content--filters" style="width: 100%;">
             <!-- GENERAL -->
             <div class="tab-pane kie__dock active" id="kieDockPanel1">
-                <h3 class="kie-dock__heading">
-                    <span data-i18n-key="TestReport"></span>
-                </h3>
-                <hr class="kie-dock__divider"/>
 
                 <h5 class="kie-dock__heading--section"><span data-i18n-key="Overview"></span></h5>
 

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/WorkbenchConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/WorkbenchConstants.properties
@@ -16,7 +16,6 @@
 TestRunnerReportingViewImpl.PASSED=PASSED
 TestRunnerReportingViewImpl.FAILED=FAILED
 TestRunnerReportingViewImpl.TEST=TEST
-TestRunnerReportingViewImpl.TestReport=Test Report
 TestRunnerReportingViewImpl.TestResults=Test Results
 TestRunnerReportingViewImpl.CompletedAt=Completed at
 TestRunnerReportingViewImpl.ScenariosRun=Scenarios run

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocksTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocksTest.java
@@ -39,8 +39,18 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.rpc.SessionInfo;
 
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class AuthoringWorkbenchDocksTest {
@@ -268,6 +278,25 @@ public class AuthoringWorkbenchDocksTest {
 
         verify(authoringWorkbenchDocks,
                never()).setProjectExplorerExpandedPreference(anyBoolean());
+    }
+
+    @Test
+    public void expandAuthoringDock() {
+        final UberfireDock dockToOpen = mock(UberfireDock.class);
+        authoringWorkbenchDocks.expandAuthoringDock(dockToOpen);
+
+        verify(uberfireDocks).show(UberfireDockPosition.EAST, AUTHORING_PERSPECTIVE);
+        verify(uberfireDocks).open(dockToOpen);
+    }
+
+    @Test
+    public void doNotExpandAuthoringDockWhenTheDockIsNull() {
+        reset(uberfireDocks);
+
+        authoringWorkbenchDocks.expandAuthoringDock(null);
+
+        verify(uberfireDocks).show(UberfireDockPosition.EAST, AUTHORING_PERSPECTIVE);
+        verify(uberfireDocks, never()).open(any());
     }
 
     private UberfireDocksInteractionEvent createUberfireDocksInteractionEvent(final UberfireDock uberfireDock,

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestReportingDocksHandlerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestReportingDocksHandlerTest.java
@@ -15,17 +15,39 @@
  */
 package org.kie.workbench.common.workbench.client.test;
 
+import java.util.Collection;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.client.workbench.docks.UberfireDock;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class TestReportingDocksHandlerTest {
 
+    @Mock
+    private AuthoringWorkbenchDocks authoringWorkbenchDocks;
+
+    @InjectMocks
+    private TestReportingDocksHandler testReportingDocksHandler;
+
     @Test
     public void amountOfItems() {
-        assertEquals(1, new TestReportingDocksHandler().provideDocks("id").size());
+        assertEquals(1, testReportingDocksHandler.provideDocks("id").size());
+    }
+
+    @Test
+    public void expandTestResultsDock() {
+        final Collection<UberfireDock> docks = testReportingDocksHandler.provideDocks("id");
+        final UberfireDock dock = docks.iterator().next();
+
+        testReportingDocksHandler.expandTestResultsDock();
+        verify(authoringWorkbenchDocks).expandAuthoringDock(dock);
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3173

Fixes several smaller issues. 

Does not cover "Clean alert panel when a run succeed"
Does cover opening the test results panel automatically for the legacy test scenarios.

https://github.com/kiegroup/kie-wb-common/pull/2223
https://github.com/kiegroup/drools-wb/pull/981