### PR TITLE
DROOLS-3211 [DMN Designer] Marshaller fix typeRef errros.

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
@@ -46,8 +46,17 @@ public class BindingPropertyConverter {
             return null;
         }
         org.kie.dmn.model.api.Binding result = new org.kie.dmn.model.v1_2.TBinding();
-        result.setParameter(InformationItemPropertyConverter.dmnFromWB(wb.getParameter()));
-        result.setExpression(ExpressionPropertyConverter.dmnFromWB(wb.getExpression()));
+        org.kie.dmn.model.api.InformationItem convertedParameter = InformationItemPropertyConverter.dmnFromWB(wb.getParameter());
+        org.kie.dmn.model.api.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+
+        if (convertedParameter != null) {
+            convertedParameter.setParent(result);
+        }
+        result.setParameter(convertedParameter);
+        if (convertedExpression != null) {
+            convertedExpression.setParent(result);
+        }
+        result.setExpression(convertedExpression);
 
         return result;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
@@ -85,7 +85,11 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
             variable.setParent(result);
         }
         result.setVariable(variable);
-        result.setEncapsulatedLogic(FunctionDefinitionPropertyConverter.dmnFromWB(source.getEncapsulatedLogic()));
+        org.kie.dmn.model.api.FunctionDefinition functionDefinition = FunctionDefinitionPropertyConverter.dmnFromWB(source.getEncapsulatedLogic());
+        if (functionDefinition != null) {
+            functionDefinition.setParent(result);
+        }
+        result.setEncapsulatedLogic(functionDefinition);
         // DMN spec table 2: Requirements connection rules
         List<Edge<?, ?>> inEdges = (List<Edge<?, ?>>) node.getInEdges();
         for (Edge<?, ?> e : inEdges) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
@@ -42,7 +42,13 @@ public class ContextEntryPropertyConverter {
         org.kie.dmn.model.api.ContextEntry result = new org.kie.dmn.model.v1_2.TContextEntry();
 
         org.kie.dmn.model.api.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
+        if (variable != null) {
+            variable.setParent(result);
+        }
         org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        if (expression != null) {
+            expression.setParent(result);
+        }
 
         result.setVariable(variable);
         result.setExpression(expression);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
@@ -49,6 +49,9 @@ public class ContextPropertyConverter {
                                             result::setTypeRef);
         for (ContextEntry ce : wb.getContextEntry()) {
             org.kie.dmn.model.api.ContextEntry ceConverted = ContextEntryPropertyConverter.dmnFromWB(ce);
+            if (ceConverted != null) {
+                ceConverted.setParent(result);
+            }
             result.getContextEntry().add(ceConverted);
         }
         return result;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionRulePropertyConverter.java
@@ -56,10 +56,18 @@ public class DecisionRulePropertyConverter {
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
 
         for (UnaryTests ie : wb.getInputEntry()) {
-            result.getInputEntry().add(UnaryTestsPropertyConverter.dmnFromWB(ie));
+            org.kie.dmn.model.api.UnaryTests inputEntryConverted = UnaryTestsPropertyConverter.dmnFromWB(ie);
+            if (inputEntryConverted != null) {
+                inputEntryConverted.setParent(inputEntryConverted);
+            }
+            result.getInputEntry().add(inputEntryConverted);
         }
         for (LiteralExpression oe : wb.getOutputEntry()) {
-            result.getOutputEntry().add(LiteralExpressionPropertyConverter.dmnFromWB(oe));
+            org.kie.dmn.model.api.LiteralExpression outputEntryConverted = LiteralExpressionPropertyConverter.dmnFromWB(oe);
+            if (outputEntryConverted != null) {
+                outputEntryConverted.setParent(result);
+            }
+            result.getOutputEntry().add(outputEntryConverted);
         }
 
         return result;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
@@ -94,13 +94,19 @@ public class DefinitionsConverter {
         result.getNsContext().putAll(wb.getNsContext());
 
         for (ItemDefinition itemDef : wb.getItemDefinition()) {
-            org.kie.dmn.model.api.ItemDefinition itemDefConvered = ItemDefinitionPropertyConverter.dmnFromWB(itemDef);
-            itemDefConvered.setParent(result);
-            result.getItemDefinition().add(itemDefConvered);
+            org.kie.dmn.model.api.ItemDefinition itemDefConverted = ItemDefinitionPropertyConverter.dmnFromWB(itemDef);
+            if (itemDefConverted != null) {
+                itemDefConverted.setParent(result);
+            }
+            result.getItemDefinition().add(itemDefConverted);
         }
 
         for (Import i : wb.getImport()) {
-            result.getImport().add(ImportConverter.dmnFromWb(i));
+            org.kie.dmn.model.api.Import importConverted = ImportConverter.dmnFromWb(i);
+            if (importConverted != null) {
+                importConverted.setParent(result);
+            }
+            result.getImport().add(importConverted);
         }
 
         return result;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
@@ -99,6 +99,9 @@ public class FunctionDefinitionPropertyConverter {
 
         for (InformationItem ii : wb.getFormalParameter()) {
             org.kie.dmn.model.api.InformationItem iiConverted = InformationItemPropertyConverter.dmnFromWB(ii);
+            if (iiConverted != null) {
+                iiConverted.setParent(result);
+            }
             result.getFormalParameter().add(iiConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClausePropertyConverter.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import org.kie.dmn.model.api.UnaryTests;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputClause;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
@@ -50,11 +51,16 @@ public class InputClausePropertyConverter {
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         org.kie.dmn.model.api.LiteralExpression expression = LiteralExpressionPropertyConverter.dmnFromWB(wb.getInputExpression());
+        UnaryTests inputValues = UnaryTestsPropertyConverter.dmnFromWB(wb.getInputValues());
+
         if (expression != null) {
             expression.setParent(result);
         }
         result.setInputExpression(expression);
-        result.setInputValues(UnaryTestsPropertyConverter.dmnFromWB(wb.getInputValues()));
+        if (inputValues != null) {
+            inputValues.setParent(result);
+        }
+        result.setInputValues(inputValues);
 
         return result;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
@@ -66,10 +66,16 @@ public class InvocationPropertyConverter {
                                             result::setTypeRef);
 
         org.kie.dmn.model.api.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        if (convertedExpression != null) {
+            convertedExpression.setParent(result);
+        }
         result.setExpression(convertedExpression);
 
         for (Binding b : wb.getBinding()) {
             org.kie.dmn.model.api.Binding bConverted = BindingPropertyConverter.dmnFromWB(b);
+            if (bConverted != null) {
+                bConverted.setParent(result);
+            }
             result.getBinding().add(bConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ItemDefinitionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ItemDefinitionPropertyConverter.java
@@ -74,7 +74,11 @@ public class ItemDefinitionPropertyConverter {
         result.setTypeLanguage(wb.getTypeLanguage());
         result.setIsCollection(wb.isIsCollection());
 
-        result.setAllowedValues(UnaryTestsPropertyConverter.dmnFromWB(wb.getAllowedValues()));
+        org.kie.dmn.model.api.UnaryTests utConverted = UnaryTestsPropertyConverter.dmnFromWB(wb.getAllowedValues());
+        if (utConverted != null) {
+            utConverted.setParent(result);
+        }
+        result.setAllowedValues(utConverted);
 
         for (ItemDefinition child : wb.getItemComponent()) {
             org.kie.dmn.model.api.ItemDefinition convertedChild = ItemDefinitionPropertyConverter.dmnFromWB(child);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
@@ -55,6 +55,9 @@ public class ListPropertyConverter {
 
         for (Expression e : wb.getExpression()) {
             org.kie.dmn.model.api.Expression eConverted = ExpressionPropertyConverter.dmnFromWB(e);
+            if (eConverted != null) {
+                eConverted.setParent(result);
+            }
             result.getExpression().add(eConverted);
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -60,7 +60,11 @@ public class LiteralExpressionPropertyConverter {
                                             result::setTypeRef);
         result.setText(wb.getText().getValue());
         result.setExpressionLanguage(ExpressionLanguagePropertyConverter.dmnFromWB(wb.getExpressionLanguage()));
-        result.setImportedValues(ImportedValuesConverter.dmnFromWB(wb.getImportedValues()));
+        org.kie.dmn.model.api.ImportedValues importedValues = ImportedValuesConverter.dmnFromWB(wb.getImportedValues());
+        if (importedValues != null) {
+            importedValues.setParent(result);
+        }
+        result.setImportedValues(importedValues);
         return result;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClausePropertyConverter.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import org.kie.dmn.model.api.LiteralExpression;
+import org.kie.dmn.model.api.UnaryTests;
 import org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause;
 import org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseLiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseUnaryTests;
@@ -55,8 +57,16 @@ public class OutputClausePropertyConverter {
         result.setId(wb.getId().getValue());
         result.setName(wb.getName());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
-        result.setOutputValues(UnaryTestsPropertyConverter.dmnFromWB(wb.getOutputValues()));
-        result.setDefaultOutputEntry(LiteralExpressionPropertyConverter.dmnFromWB(wb.getDefaultOutputEntry()));
+        UnaryTests outputValues = UnaryTestsPropertyConverter.dmnFromWB(wb.getOutputValues());
+        if (outputValues != null) {
+            outputValues.setParent(result);
+        }
+        result.setOutputValues(outputValues);
+        LiteralExpression defaultOutputEntry = LiteralExpressionPropertyConverter.dmnFromWB(wb.getDefaultOutputEntry());
+        if (defaultOutputEntry != null) {
+            defaultOutputEntry.setParent(result);
+        }
+        result.setDefaultOutputEntry(defaultOutputEntry);
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(), result::setTypeRef);
 
         return result;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverter.java
@@ -61,11 +61,17 @@ public class RelationPropertyConverter {
 
         for (InformationItem iitem : wb.getColumn()) {
             org.kie.dmn.model.api.InformationItem iitemConverted = InformationItemPropertyConverter.dmnFromWB(iitem);
+            if (iitemConverted != null) {
+                iitemConverted.setParent(result);
+            }
             result.getColumn().add(iitemConverted);
         }
 
         for (org.kie.workbench.common.dmn.api.definition.v1_1.List list : wb.getRow()) {
             org.kie.dmn.model.api.List listConverted = ListPropertyConverter.dmnFromWB(list);
+            if (listConverted != null) {
+                listConverted.setParent(result);
+            }
             result.getRow().add(listConverted);
         }
 


### PR DESCRIPTION
DROOLS-3211
[DMN Designer] Marshaller: Conversion from 1.1 to 1.2 leads to 'Unable
to resolve type reference' errors

/cc @jomarko @manstis 

> Pick a backend marshaller unit test, any test (well almost any but run the whole suite and you'll see lots).

Hence this test suite now check if the origin XML is a valid (no-error) DMN file, it will assert also on the other side of roundtrip marshalling there are no errors on the model.

@jomarko on DROOLS-3211 I have no additional DMN model. If you believe some model created with the editor exhibit still the same issue with this change, please to attach/send them.