### PR TITLE
DROOLS-2890: [DMN Designer] DMNDiagram properties

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Definitions.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Definitions.java
@@ -18,8 +18,6 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.validation.Valid;
-
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.definition.HasName;
@@ -28,6 +26,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
@@ -39,18 +38,12 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
 @Bindable
 @PropertySet
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id")
-public class Definitions extends DMNElement implements HasName,
-                                                       DMNPropertySet {
+public class Definitions extends NamedElement implements HasName,
+                                                         DMNPropertySet {
 
     public static final String DEFAULT_EXPRESSION_LANGUAGE = Namespace.FEEL.getUri();
 
     public static final String DEFAULT_TYPE_LANGUAGE = Namespace.FEEL.getUri();
-
-    //Definitions should extend NamedElement however we want Name to be read-only
-    @Property
-    @FormField(afterElement = "description", readonly = true)
-    @Valid
-    private Name name;
 
     private List<Import> _import;
     private List<ItemDefinition> itemDefinition;
@@ -64,7 +57,11 @@ public class Definitions extends DMNElement implements HasName,
     protected ExpressionLanguage expressionLanguage;
 
     private String typeLanguage;
-    private String namespace;
+
+    @Property
+    @FormField(afterElement = "expressionLanguage")
+    private Text namespace;
+
     private String exporter;
     private String exporterVersion;
 
@@ -80,7 +77,7 @@ public class Definitions extends DMNElement implements HasName,
              new ArrayList<>(),
              new ExpressionLanguage(),
              null,
-             null,
+             new Text(),
              null,
              null);
     }
@@ -96,12 +93,12 @@ public class Definitions extends DMNElement implements HasName,
                        final List<BusinessContextElement> businessContextElement,
                        final ExpressionLanguage expressionLanguage,
                        final String typeLanguage,
-                       final String namespace,
+                       final Text namespace,
                        final String exporter,
                        final String exporterVersion) {
         super(id,
-              description);
-        this.name = name;
+              description,
+              name);
         this._import = _import;
         this.itemDefinition = itemDefinition;
         this.drgElement = drgElement;
@@ -118,16 +115,6 @@ public class Definitions extends DMNElement implements HasName,
     // -----------------------
     // DMN properties
     // -----------------------
-
-    @Override
-    public Name getName() {
-        return name;
-    }
-
-    @Override
-    public void setName(final Name name) {
-        this.name = name;
-    }
 
     public List<Import> getImport() {
         if (_import == null) {
@@ -195,11 +182,11 @@ public class Definitions extends DMNElement implements HasName,
         this.typeLanguage = value;
     }
 
-    public String getNamespace() {
+    public Text getNamespace() {
         return namespace;
     }
 
-    public void setNamespace(final String value) {
+    public void setNamespace(final Text value) {
         this.namespace = value;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/factory/AbstractDMNDiagramFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/factory/AbstractDMNDiagramFactory.java
@@ -21,6 +21,8 @@ import java.util.stream.Stream;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNDiagram;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Definitions;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.factory.impl.BindableDiagramFactory;
@@ -76,11 +78,11 @@ public abstract class AbstractDMNDiagramFactory<M extends Metadata, D extends Di
                 .filter(namespace -> !dmnDefinitions.getNsContext().containsValue(namespace.getUri()))
                 .forEach(namespace -> dmnDefinitions.getNsContext().put(namespace.getPrefix(), namespace.getUri()));
 
-        String defaultNamespace = !StringUtils.isEmpty(dmnDefinitions.getNamespace())
-                ? dmnDefinitions.getNamespace()
+        String defaultNamespace = !StringUtils.isEmpty(dmnDefinitions.getNamespace().getValue())
+                ? dmnDefinitions.getNamespace().getValue()
                 : DMNModelInstrumentedBase.Namespace.DEFAULT.getUri() + UUID.uuid();
 
-        dmnDefinitions.setNamespace(defaultNamespace);
+        dmnDefinitions.setNamespace(new Text(defaultNamespace));
         dmnDefinitions.getNsContext().put(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix(),
                                           defaultNamespace);
     }
@@ -89,6 +91,9 @@ public abstract class AbstractDMNDiagramFactory<M extends Metadata, D extends Di
                             final String name) {
         final DMNDiagram dmnDiagram = diagramNode.getContent().getDefinition();
         final Definitions dmnDefinitions = dmnDiagram.getDefinitions();
-        dmnDefinitions.getName().setValue(name);
+        final Name dmnName = dmnDefinitions.getName();
+        if (StringUtils.isEmpty(dmnName.getValue())) {
+            dmnName.setValue(name);
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/factory/DMNDiagramFactoryImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/factory/DMNDiagramFactoryImplTest.java
@@ -48,6 +48,8 @@ public class DMNDiagramFactoryImplTest {
 
     private static final String NAME = "name";
 
+    private static final String EXISTING_NAME = "existing-name";
+
     @Mock
     private Metadata metadata;
 
@@ -97,7 +99,7 @@ public class DMNDiagramFactoryImplTest {
                      dmnDefaultNameSpaces.get(DMNModelInstrumentedBase.Namespace.KIE.getPrefix()));
 
         assertTrue(dmnDefaultNameSpaces.containsKey(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix()));
-        assertEquals(dmnDefinitions.getNamespace(),
+        assertEquals(dmnDefinitions.getNamespace().getValue(),
                      dmnDefaultNameSpaces.get(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix()));
     }
 
@@ -113,5 +115,21 @@ public class DMNDiagramFactoryImplTest {
         final Definitions dmnDefinitions = dmnDiagram.getDefinitions();
 
         assertEquals(NAME, dmnDefinitions.getName().getValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testModelNameWithNonEmptyExistingName() {
+        final Node<View, Edge> existingRoot = (Node<View, Edge>) graph.nodes().iterator().next();
+        final DMNDiagram existingDMNDiagram = (DMNDiagram) existingRoot.getContent().getDefinition();
+        final Definitions existingDMNDefinitions = existingDMNDiagram.getDefinitions();
+        existingDMNDefinitions.getName().setValue(EXISTING_NAME);
+
+        final Diagram<Graph, Metadata> newDiagram = factory.build(NAME, metadata, graph);
+        final Node<View, Edge> newRoot = (Node<View, Edge>) newDiagram.getGraph().nodes().iterator().next();
+        final DMNDiagram newDMNDiagram = (DMNDiagram) newRoot.getContent().getDefinition();
+        final Definitions newDMNDefinitions = newDMNDiagram.getDefinitions();
+
+        assertEquals(EXISTING_NAME, newDMNDefinitions.getName().getValue());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.stunner.core.util.StringUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
 
@@ -41,7 +42,7 @@ public class DefinitionsConverter {
         Definitions result = new Definitions();
         result.setId(id);
         result.setName(name);
-        result.setNamespace(namespace);
+        result.setNamespace(new Text(namespace));
         result.getNsContext().put(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix(),
                                   namespace);
         result.setDescription(description);
@@ -88,13 +89,13 @@ public class DefinitionsConverter {
 
         // TODO currently DMN wb UI does not offer feature to set these required DMN properties, setting some hardcoded defaults for now.
         String defaultId = (wb.getId() != null) ? wb.getId().getValue() : UUID.uuid();
-        String defaulName = (wb.getName() != null) ? wb.getName().getValue() : UUID.uuid(8);
-        String defaultNamespace = !StringUtils.isEmpty(wb.getNamespace())
-                ? wb.getNamespace()
+        String defaultName = (wb.getName() != null) ? wb.getName().getValue() : UUID.uuid(8);
+        String defaultNamespace = !StringUtils.isEmpty(wb.getNamespace().getValue())
+                ? wb.getNamespace().getValue()
                 : DMNModelInstrumentedBase.Namespace.DEFAULT.getUri() + UUID.uuid();
 
         result.setId(defaultId);
-        result.setName(defaulName);
+        result.setName(defaultName);
         result.setNamespace(defaultNamespace);
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.getNsContext().putAll(wb.getNsContext());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverterTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Definitions;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -42,13 +43,15 @@ public class DefinitionsConverterTest {
     public void wbFromDMN() {
         Definitions wb = DefinitionsConverter.wbFromDMN(apiDefinitions);
         String defaultNs = wb.getNsContext().get(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix());
-        String namespace = wb.getNamespace();
+        String namespace = wb.getNamespace().getValue();
 
         assertEquals(defaultNs, namespace);
     }
 
     @Test
     public void dmnFromWB() {
+        when(wbDefinitions.getNamespace()).thenReturn(new Text());
+
         org.kie.dmn.model.api.Definitions dmn = DefinitionsConverter.dmnFromWB(wbDefinitions);
         String defaultNs = dmn.getNsContext().get(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix());
         String namespace = dmn.getNamespace();
@@ -56,7 +59,7 @@ public class DefinitionsConverterTest {
         assertNotNull(defaultNs);
         assertEquals(defaultNs, namespace);
 
-        when(wbDefinitions.getNamespace()).thenReturn(NAMESPACE);
+        when(wbDefinitions.getNamespace()).thenReturn(new Text(NAMESPACE));
 
         dmn = DefinitionsConverter.dmnFromWB(wbDefinitions);
         defaultNs = dmn.getNsContext().get(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix());


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2890

This PR adds `Namespace` to the UI (hurrah!) and makes `Name` editable (a _default_ is now only set if the value in the model is empty). `ID` and `Description` were already present.