### PR TITLE
JBPM-7166 Dynamic Form Properties with nested hierarchy binds

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
@@ -48,7 +48,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class)
+@Definition(graphFactory = NodeFactory.class, nameField = "name")
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         startElement = "id")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
@@ -78,7 +78,7 @@ public class Decision extends DRGElement implements HasExpression,
     @Valid
     protected AllowedAnswers allowedAnswers;
 
-    @PropertySet()
+    @PropertySet
     @FormField(afterElement = "allowedAnswers")
     @Valid
     protected InformationItem variable;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
@@ -51,7 +51,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class)
+@Definition(graphFactory = NodeFactory.class, nameField = "name")
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         startElement = "id")
@@ -78,7 +78,7 @@ public class Decision extends DRGElement implements HasExpression,
     @Valid
     protected AllowedAnswers allowedAnswers;
 
-    @PropertySet
+    @PropertySet()
     @FormField(afterElement = "allowedAnswers")
     @Valid
     protected InformationItem variable;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
@@ -45,7 +45,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class)
+@Definition(graphFactory = NodeFactory.class, nameField = "name")
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         startElement = "id")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/KnowledgeSource.java
@@ -47,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class)
+@Definition(graphFactory = NodeFactory.class, nameField = "name")
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         startElement = "id")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/TextAnnotation.java
@@ -47,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@Definition(graphFactory = NodeFactory.class)
+@Definition(graphFactory = NodeFactory.class, nameField = "text")
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation"),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
@@ -20,7 +20,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
-import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProvider;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
@@ -28,19 +27,23 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
 public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvider {
 
     private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefinitionUtils definitionUtils;
 
     public TextAnnotationTextPropertyProviderImpl() {
         //CDI proxy
     }
 
     @Inject
-    public TextAnnotationTextPropertyProviderImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory) {
+    public TextAnnotationTextPropertyProviderImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                                  final DefinitionUtils definitionUtils) {
         this.canvasCommandFactory = canvasCommandFactory;
+        this.definitionUtils = definitionUtils;
     }
 
     @Override
@@ -58,9 +61,11 @@ public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvi
                         final CanvasCommandManager<AbstractCanvasHandler> commandManager,
                         final Element<? extends Definition> element,
                         final String text) {
-        final CanvasCommand<AbstractCanvasHandler> command = canvasCommandFactory.updatePropertyValue(element,
-                                                                                                      Text.class.getName(),
-                                                                                                      text);
+        final Object definition = element.getContent().getDefinition();
+        final CanvasCommand<AbstractCanvasHandler> command =
+                canvasCommandFactory.updatePropertyValue(element,
+                                                         definitionUtils.getNameIdentifier(definition),
+                                                         text);
         commandManager.execute(canvasHandler,
                                command);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImplTest.java
@@ -35,6 +35,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -76,7 +77,7 @@ public class TextAnnotationTextPropertyProviderImplTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setup() {
-        this.provider = new TextAnnotationTextPropertyProviderImpl(canvasCommandFactory);
+        this.provider = new TextAnnotationTextPropertyProviderImpl(canvasCommandFactory, definitionUtils);
         when(element.getContent()).thenReturn(content);
         when(content.getDefinition()).thenReturn(definition);
         when(definition.getText()).thenReturn(text);
@@ -120,8 +121,9 @@ public class TextAnnotationTextPropertyProviderImplTest {
                          element,
                          "text");
 
+        //todo:tiago fix
         verify(canvasCommandFactory).updatePropertyValue(eq(element),
-                                                         eq(Text.class.getName()),
+                                                         any(),
                                                          eq("text"));
         verify(commandManager).execute(eq(canvasHandler),
                                        eq(command));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapter.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.definition.adapter;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
@@ -64,6 +65,14 @@ public interface DefinitionAdapter<T> extends PriorityAdapter {
     Set<?> getProperties(final T pojo);
 
     /**
+     * Returns the property instance with the given name.
+     * @param pojo definition
+     * @param propertyName property field name on the class
+     * @return
+     */
+    Optional<?> getProperty(final T pojo, final String propertyName);
+
+    /**
      * Returns the property bean instance for the given meta-property type..
      * Stunner provides some built-in features that could require model updates,
      * so this meta-properties are used for binding these features with the property beans.
@@ -75,4 +84,11 @@ public interface DefinitionAdapter<T> extends PriorityAdapter {
      * Returns the definition's graph element factory class for a given pojo.
      */
     Class<? extends ElementFactory> getGraphFactoryType(final T pojo);
+
+    /**
+     * Respective name field with namespace (i.e. attribue1.attribue2.name)
+     * @param pojo definition
+     * @return the field with namespace if applied
+     */
+    Optional<String> getNameField(final T pojo);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapterWrapper.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapterWrapper.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.definition.adapter;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
@@ -49,6 +50,11 @@ public abstract class DefinitionAdapterWrapper<T, A extends DefinitionAdapter<T>
     }
 
     @Override
+    public Optional<String> getNameField(T pojo) {
+        return adapter.getNameField(pojo);
+    }
+
+    @Override
     public String getDescription(final T pojo) {
         return adapter.getDescription(pojo);
     }
@@ -66,6 +72,11 @@ public abstract class DefinitionAdapterWrapper<T, A extends DefinitionAdapter<T>
     @Override
     public Set<?> getProperties(final T pojo) {
         return adapter.getProperties(pojo);
+    }
+
+    @Override
+    public Optional<?> getProperty(T pojo, String propertyName) {
+        return adapter.getProperty(pojo, propertyName);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/PropertySetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/PropertySetAdapter.java
@@ -37,4 +37,10 @@ public interface PropertySetAdapter<T> extends PriorityAdapter {
      * Returns the property set's properties for a given pojo.
      */
     Set<?> getProperties(final T pojo);
+
+    /**
+     * Returns property of a given pojo and the property name.
+     */
+    //todo:tiago return optional
+    <P> P getProperty(final T pojo, final String propertyName);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/PropertySetAdapterWrapper.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/PropertySetAdapterWrapper.java
@@ -46,6 +46,16 @@ public abstract class PropertySetAdapterWrapper<T, A extends PropertySetAdapter<
     }
 
     @Override
+    public <P> P getProperty(T pojo, String propertyName) {
+        return adapter.getProperty(pojo, propertyName);
+    }
+
+    @Override
+    public boolean isPojoModel() {
+        return false;
+    }
+
+    @Override
     public int getPriority() {
         return adapter.getPriority();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/BindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/BindableDefinitionAdapter.java
@@ -35,7 +35,8 @@ public interface BindableDefinitionAdapter<T> extends DefinitionAdapter<T>,
                      Map<Class, String> propertyLabelsFieldNames,
                      Map<Class, String> propertyTitleFieldNames,
                      Map<Class, String> propertyCategoryFieldNames,
-                     Map<Class, String> propertyDescriptionFieldNames);
+                     Map<Class, String> propertyDescriptionFieldNames,
+                     Map<Class, String> propertyNameFields);
 
     Class<? extends ElementFactory> getGraphFactory(final Class<?> type);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/Definition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/Definition.java
@@ -34,4 +34,6 @@ public @interface Definition {
 
     @Deprecated
     Class<? extends Builder<?>> builder() default VoidBuilder.class;
+
+    String nameField() default "";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/Definition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/annotation/Definition.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.kie.workbench.common.stunner.core.definition.builder.Builder;
 import org.kie.workbench.common.stunner.core.definition.builder.VoidBuilder;
+import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
 
 @Inherited
@@ -35,5 +36,18 @@ public @interface Definition {
     @Deprecated
     Class<? extends Builder<?>> builder() default VoidBuilder.class;
 
+    /**
+     * Corresponds to the field that represents the <b>Name</b> of the annotated class.
+     * The name field should be expressed with the namespace if applied.
+     * </br>
+     *
+     * Example: nameField = "general.text"
+     * "general" is the attribute name on the current Definition(annotated class) and "text" is the attribute name
+     * contained in "general".     *
+     * </br>
+     *
+     * Note: If nameField is not set, than the first attribute annotated with {@link PropertyMetaTypes#NAME}
+     * will be used to return the name as a default behavior.
+     */
     String nameField() default "";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/ReflectionAdapterUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/ReflectionAdapterUtils.java
@@ -21,7 +21,10 @@ import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 
@@ -140,6 +143,10 @@ public class ReflectionAdapterUtils {
             }
         }
         return null;
+    }
+
+    public static List<Field> getFields(final Class<?> sourceType) throws IllegalAccessException {
+        return Stream.of(sourceType.getDeclaredFields()).collect(Collectors.toList());
     }
 
     public static <T extends Annotation> T getClassAnnotation(final Class<?> type,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/ReflectionAdapterUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/ReflectionAdapterUtils.java
@@ -119,7 +119,7 @@ public class ReflectionAdapterUtils {
     }
 
     public static <T> Field getField(final T object,
-                                     final String fieldName) throws IllegalAccessException {
+                                     final String fieldName) throws SecurityException {
         Class<?> c = object.getClass();
         while (!c.getName().equals(Object.class.getName())) {
             Field result = getField(c,
@@ -133,7 +133,7 @@ public class ReflectionAdapterUtils {
     }
 
     public static Field getField(final Class<?> sourceType,
-                                 final String fieldName) throws IllegalAccessException {
+                                 final String fieldName) throws SecurityException {
         Field[] fields = sourceType.getDeclaredFields();
         if (null != fields) {
             for (Field field : fields) {
@@ -145,7 +145,7 @@ public class ReflectionAdapterUtils {
         return null;
     }
 
-    public static List<Field> getFields(final Class<?> sourceType) throws IllegalAccessException {
+    public static List<Field> getFields(final Class<?> sourceType) throws SecurityException {
         return Stream.of(sourceType.getDeclaredFields()).collect(Collectors.toList());
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindableDefinitionAdapter.java
@@ -17,6 +17,8 @@
 package org.kie.workbench.common.stunner.core.backend.definition.adapter.bind;
 
 import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.AbstractBindableDefinitionAdapter;
@@ -82,6 +84,16 @@ class BackendBindableDefinitionAdapter<T> extends AbstractBindableDefinitionAdap
     }
 
     @Override
+    public Optional<String> getNameField(T definition) {
+        try {
+            return getFieldValue(definition, propertyNameFields.get(definition.getClass()));
+        } catch (IllegalAccessException e) {
+            LOG.error("Error obtaining title for Definition with id " + getId(definition));
+            return Optional.empty();
+        }
+    }
+
+    @Override
     public String getDescription(final T definition) {
         Class<?> type = definition.getClass();
         try {
@@ -131,5 +143,21 @@ class BackendBindableDefinitionAdapter<T> extends AbstractBindableDefinitionAdap
             LOG.error("Error obtaining properties for Definition with id " + getId(definition));
         }
         return Collections.emptySet();
+    }
+
+    @Override
+    public Optional<?> getProperty(T definition, String propertyName) {
+        return propertiesFieldNames.get(definition.getClass()).stream()
+                .filter(name -> Objects.equals(name, propertyName))
+                .findFirst()
+                .map(prop -> {
+                         try {
+                             return getFieldValue(definition, prop);
+                         } catch (IllegalAccessException e) {
+                             LOG.error("Error obtaining properties for Definition with id " + getId(definition));
+                             return null;
+                         }
+                     }
+                );
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindablePropertySetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindablePropertySetAdapter.java
@@ -16,6 +16,7 @@
 package org.kie.workbench.common.stunner.core.backend.definition.adapter.bind;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.backend.definition.adapter.AbstractReflectAdapter;
@@ -69,6 +70,22 @@ class BackendBindablePropertySetAdapter<T> extends AbstractReflectAdapter<T>
             LOG.error("Error obtaining properties for Property Set with id " + getId(propertySet));
         }
         return null;
+    }
+
+    @Override
+    public <P> P getProperty(T pojo, String propertyName) {
+        return (P) propertiesFieldNames.get(pojo.getClass()).stream()
+                .filter(name -> Objects.equals(name, propertyName))
+                .findFirst()
+                .map(prop -> {
+                    try {
+                        return getFieldValue(pojo, prop);
+                    } catch (IllegalAccessException e) {
+                        LOG.error("Error obtaining properties for Property Set with id " + getId(pojo));
+                        return null;
+                    }
+                })
+                .orElse(null);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapter.java
@@ -22,12 +22,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.backend.definition.adapter.AbstractReflectAdapter;
+import org.kie.workbench.common.stunner.core.backend.definition.adapter.ReflectionAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.HasInheritance;
@@ -133,6 +136,12 @@ public class BackendDefinitionAdapter<T> extends AbstractReflectAdapter<T>
     }
 
     @Override
+    public Optional<String> getNameField(T definition) {
+        return Optional.ofNullable(getDefinitionAnnotation(definition.getClass()))
+                .map(Definition::nameField);
+    }
+
+    @Override
     public String getDescription(final T definition) {
         try {
             return getAnnotatedFieldValue(definition,
@@ -201,6 +210,18 @@ public class BackendDefinitionAdapter<T> extends AbstractReflectAdapter<T>
             }
         }
         return Collections.emptySet();
+    }
+
+    @Override
+    public Optional<?> getProperty(T pojo, String propertyName) {
+        try {
+            return ReflectionAdapterUtils.getFields(pojo.getClass()).stream()
+                    .filter(f -> Objects.equals(propertyName, f.getName()))
+                    .findFirst();
+        } catch (IllegalAccessException e) {
+            LOG.error("Error obtaining fields from definition " + getId(pojo));
+            return Optional.empty();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapter.java
@@ -218,7 +218,7 @@ public class BackendDefinitionAdapter<T> extends AbstractReflectAdapter<T>
             return ReflectionAdapterUtils.getFields(pojo.getClass()).stream()
                     .filter(f -> Objects.equals(propertyName, f.getName()))
                     .findFirst();
-        } catch (IllegalAccessException e) {
+        } catch (SecurityException e) {
             LOG.error("Error obtaining fields from definition " + getId(pojo));
             return Optional.empty();
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendPropertySetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendPropertySetAdapter.java
@@ -17,11 +17,13 @@ package org.kie.workbench.common.stunner.core.backend.definition.adapter.reflect
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.enterprise.context.Dependent;
 
 import org.kie.workbench.common.stunner.core.backend.definition.adapter.AbstractReflectAdapter;
+import org.kie.workbench.common.stunner.core.backend.definition.adapter.ReflectionAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.PropertySetAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.annotation.Name;
@@ -75,6 +77,20 @@ public class BackendPropertySetAdapter<T> extends AbstractReflectAdapter<T> impl
             }
         }
         return result;
+    }
+
+    @Override
+    public <P> P getProperty(T pojo, String propertyName) {
+        try {
+            return ReflectionAdapterUtils.getFields(pojo.getClass()).stream()
+                    .filter(f -> Objects.equals(propertyName, f.getName()))
+                    .findFirst()
+                    .map(property -> (P) property)
+                    .orElse(null);
+        } catch (IllegalAccessException e) {
+            LOG.error("Error obtaining annotated properties for T with id " + getId(pojo));
+            return null;
+        }
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendPropertySetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendPropertySetAdapter.java
@@ -87,7 +87,7 @@ public class BackendPropertySetAdapter<T> extends AbstractReflectAdapter<T> impl
                     .findFirst()
                     .map(property -> (P) property)
                     .orElse(null);
-        } catch (IllegalAccessException e) {
+        } catch (SecurityException e) {
             LOG.error("Error obtaining annotated properties for T with id " + getId(pojo));
             return null;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindableDefinitionAdapter.java
@@ -18,7 +18,10 @@ package org.kie.workbench.common.stunner.core.client.definition.adapter.binding;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.AbstractBindableDefinitionAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
@@ -65,6 +68,11 @@ class ClientBindableDefinitionAdapter extends AbstractBindableDefinitionAdapter<
     }
 
     @Override
+    public Optional<String> getNameField(Object pojo) {
+        return Optional.ofNullable(propertyNameFields.get(pojo.getClass()));
+    }
+
+    @Override
     public String getDescription(final Object pojo) {
         String description = translationService.getDefinitionDescription(pojo.getClass().getName());
         if (description != null) {
@@ -92,6 +100,17 @@ class ClientBindableDefinitionAdapter extends AbstractBindableDefinitionAdapter<
     protected Set<?> getBindProperties(final Object pojo) {
         return getProxiedSet(pojo,
                              getPropertiesFieldNames().get(pojo.getClass()));
+    }
+
+    @Override
+    public Optional<?> getProperty(Object pojo, String propertyName) {
+        return Stream.concat(Optional.ofNullable(getPropertiesFieldNames().get(pojo.getClass()))
+                                     .orElse(Collections.emptySet()).stream(),
+                             Optional.ofNullable(getPropertySetsFieldNames().get(pojo.getClass()))
+                                     .orElse(Collections.emptySet()).stream())
+                .filter(name -> Objects.equals(name, propertyName))
+                .findFirst()
+                .map(prop -> getProxiedValue(pojo, prop));
     }
 
     private <T, R> R getProxiedValue(final T pojo,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindablePropertySetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindablePropertySetAdapter.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.core.client.definition.adapter.binding;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
@@ -58,6 +59,15 @@ class ClientBindablePropertySetAdapter extends AbstractClientBindableAdapter<Obj
     public Set<?> getProperties(final Object pojo) {
         return getProxiedSet(pojo,
                              getPropertiesFieldNames().get(pojo.getClass()));
+    }
+
+    @Override
+    public <P> P getProperty(Object pojo, String propertyName) {
+        return (P) getPropertiesFieldNames().get(pojo.getClass()).stream()
+                .filter(name -> Objects.equals(name, propertyName))
+                .findFirst()
+                .map(prop -> getProxiedValue(pojo , prop))
+                .orElse(null);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
@@ -131,6 +131,12 @@
       <artifactId>errai-validation</artifactId>
     </dependency>
 
+    <!--Logs-->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- Test scope. -->
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/AbstractBindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/AbstractBindableDefinitionAdapter.java
@@ -40,6 +40,7 @@ public abstract class AbstractBindableDefinitionAdapter<T> implements BindableDe
     protected Map<Class, String> propertyTitleFieldNames;
     protected Map<Class, String> propertyCategoryFieldNames;
     protected Map<Class, String> propertyDescriptionFieldNames;
+    protected Map<Class, String> propertyNameFields;
 
     public AbstractBindableDefinitionAdapter(final DefinitionUtils definitionUtils) {
         this.definitionUtils = definitionUtils;
@@ -57,7 +58,9 @@ public abstract class AbstractBindableDefinitionAdapter<T> implements BindableDe
                             final Map<Class, String> propertyLabelsFieldNames,
                             final Map<Class, String> propertyTitleFieldNames,
                             final Map<Class, String> propertyCategoryFieldNames,
-                            final Map<Class, String> propertyDescriptionFieldNames) {
+                            final Map<Class, String> propertyDescriptionFieldNames,
+                            final Map<Class, String> propertyNameFields
+    ) {
         this.metaPropertyTypeClasses = metaPropertyTypeClasses;
         this.baseTypes = baseTypes;
         this.propertySetsFieldNames = propertySetsFieldNames;
@@ -68,6 +71,7 @@ public abstract class AbstractBindableDefinitionAdapter<T> implements BindableDe
         this.propertyTitleFieldNames = propertyTitleFieldNames;
         this.propertyCategoryFieldNames = propertyCategoryFieldNames;
         this.propertyDescriptionFieldNames = propertyDescriptionFieldNames;
+        this.propertyNameFields = propertyNameFields;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapDefinitionAdapter.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.definition.adapter.bootstrap;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
@@ -47,6 +48,11 @@ class BootstrapDefinitionAdapter implements DefinitionAdapter<Object> {
     }
 
     @Override
+    public Optional<String> getNameField(Object pojo) {
+        return getWrapped(pojo).getNameField(pojo);
+    }
+
+    @Override
     public String getDescription(final Object pojo) {
         return getWrapped(pojo).getDescription(pojo);
     }
@@ -64,6 +70,11 @@ class BootstrapDefinitionAdapter implements DefinitionAdapter<Object> {
     @Override
     public Set<?> getProperties(final Object pojo) {
         return getWrapped(pojo).getProperties(pojo);
+    }
+
+    @Override
+    public Optional<?> getProperty(Object pojo, String propertyName) {
+        return getWrapped(pojo).getProperty(pojo, propertyName);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapPropertySetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapPropertySetAdapter.java
@@ -45,6 +45,11 @@ class BootstrapPropertySetAdapter implements PropertySetAdapter<Object> {
     }
 
     @Override
+    public <P> P getProperty(Object pojo, String propertyName) {
+        return getWrapped(pojo).getProperty(pojo, propertyName);
+    }
+
+    @Override
     public int getPriority() {
         return 0;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommand.java
@@ -60,9 +60,7 @@ public final class UpdateDomainObjectPropertyValueCommand extends AbstractGraphC
     @SuppressWarnings("unchecked")
     public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
         final DefinitionManager definitionManager = context.getDefinitionManager();
-        final Object p = GraphUtils.getProperty(definitionManager,
-                                                domainObject,
-                                                propertyId);
+        final Object p = GraphUtils.getPropertyByField(definitionManager, domainObject, propertyId);
         final AdapterManager adapterManager = definitionManager.adapters();
         final AdapterRegistry adapterRegistry = adapterManager.registry();
         final PropertyAdapter<Object, Object> adapter = (PropertyAdapter<Object, Object>) adapterRegistry.getPropertyAdapter(p.getClass());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/Exceptions.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/Exceptions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class that allows working with functional programming and streams easier when having exceptions.
+ */
+public class Exceptions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Exceptions.class);
+
+    public static <T> T swallow(final Supplier<T> supplier, final T defaultReturn) {
+        try {
+            return supplier.get();
+        } catch (Exception e) {
+            LOGGER.info("Exception swallowed", e);
+            return defaultReturn;
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
-import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
@@ -82,15 +81,6 @@ public class GraphUtils {
                 : property;
     }
 
-    public static Object getProperty(final DefinitionManager definitionManager,
-                                     final DomainObject domainObject,
-                                     final String id) {
-        return Optional.ofNullable(domainObject)
-                .map(o -> getProperty(definitionManager,
-                                      definitionManager.adapters().forDefinition().getProperties(domainObject),
-                                      id))
-                .orElse(null);
-    }
 
     public static Object getProperty(final DefinitionManager definitionManager,
                                      final Set properties,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
@@ -54,7 +54,7 @@ public class GraphUtils {
         return Optional.ofNullable(element)
                 .map(Element::getContent)
                 .map(Definition::getDefinition)
-                .map(def -> Exceptions.swallow(() -> definitionManager.adapters().forDefinition().getProperties(def),
+                .map(def -> Exceptions.<Set>swallow(() -> definitionManager.adapters().forDefinition().getProperties(def),
                                                Collections.emptySet()))
                 .map(properties -> Exceptions.swallow(() -> getProperty(definitionManager, properties, id), null))
                 .orElseGet(

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.core.graph.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,30 +51,49 @@ public class GraphUtils {
     public static Object getProperty(final DefinitionManager definitionManager,
                                      final Element<? extends Definition> element,
                                      final String id) {
-        if (null != element) {
-            final Object def = element.getContent().getDefinition();
-            final Set<?> properties = definitionManager.adapters().forDefinition().getProperties(def);
-            return getProperty(definitionManager,
-                               properties,
-                               id);
-        }
-        return null;
+
+        return Optional.ofNullable(element)
+                .map(Element::getContent)
+                .map(Definition::getDefinition)
+                .map(def -> Exceptions.swallow(() -> definitionManager.adapters().forDefinition().getProperties(def),
+                                               Collections.emptySet()))
+                .map(properties -> Exceptions.swallow(() -> getProperty(definitionManager, properties, id), null))
+                .orElseGet(
+                        //getting by field if not found by the id (class name)
+                        () -> Optional.ofNullable(element)
+                                .map(e -> getPropertyByField(definitionManager, e.getContent().getDefinition(), id))
+                                .orElse(null)
+                );
+    }
+
+    public static Object getPropertyByField(final DefinitionManager definitionManager,
+                                            final Object definition,
+                                            final String field) {
+
+        final int index = field.indexOf('.');
+        final String firstField = index > -1 ? field.substring(0, index) : field;
+        final Object property =
+                Exceptions.<Optional>swallow(() -> definitionManager.adapters().forDefinition().getProperty(definition
+                        , firstField), Optional.empty())
+                        .orElseGet(() -> Exceptions.swallow(() -> definitionManager.adapters().forPropertySet().getProperty(definition, firstField), null));
+
+        return (index > 0 && Objects.nonNull(property))
+                ? getPropertyByField(definitionManager, property, field.substring(index + 1))
+                : property;
     }
 
     public static Object getProperty(final DefinitionManager definitionManager,
                                      final DomainObject domainObject,
                                      final String id) {
-        if (null != domainObject) {
-            final Set<?> properties = definitionManager.adapters().forDefinition().getProperties(domainObject);
-            return getProperty(definitionManager,
-                               properties,
-                               id);
-        }
-        return null;
+        return Optional.ofNullable(domainObject)
+                .map(o -> getProperty(definitionManager,
+                                      definitionManager.adapters().forDefinition().getProperties(domainObject),
+                                      id))
+                .orElse(null);
     }
 
     public static Object getProperty(final DefinitionManager definitionManager,
-                                     final Set<?> properties,
+                                     final Set properties,
                                      final String id) {
         if (null != id && null != properties) {
             for (final Object property : properties) {
@@ -333,12 +353,14 @@ public class GraphUtils {
                 .collect(Collectors.toList());
     }
 
-    public static List<Edge<? extends ViewConnector<?>, Node>> getSourceConnections(final Node<?, ? extends Edge> element) {
+    public static List<Edge<? extends ViewConnector<?>, Node>> getSourceConnections(
+            final Node<?, ? extends Edge> element) {
         Objects.requireNonNull(element.getOutEdges());
         return getConnections(element.getOutEdges());
     }
 
-    public static List<Edge<? extends ViewConnector<?>, Node>> getTargetConnections(final Node<?, ? extends Edge> element) {
+    public static List<Edge<? extends ViewConnector<?>, Node>> getTargetConnections(
+            final Node<?, ? extends Edge> element) {
         Objects.requireNonNull(element.getInEdges());
         return getConnections(element.getInEdges());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateDomainObjectPropertyValueCommandTest.java
@@ -15,12 +15,11 @@
  */
 package org.kie.workbench.common.stunner.core.graph.command.impl;
 
-import java.util.Set;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.Mock;
@@ -37,7 +36,9 @@ public class UpdateDomainObjectPropertyValueCommandTest extends AbstractGraphCom
 
     private static final String PROPERTY = "property";
 
-    private static final String PROPERTY_ID = "property.id";
+    private static final String PROPERTY_FIELD = "property.name";
+
+    private static final String NAME_FIELD = "name";
 
     private static final String PROPERTY_VALUE = "value";
 
@@ -48,18 +49,22 @@ public class UpdateDomainObjectPropertyValueCommandTest extends AbstractGraphCom
 
     private UpdateDomainObjectPropertyValueCommand command;
 
+    @Mock
+    private Object property;
+
+    @Mock
+    private Object nameProperty;
+
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         super.init(500, 500);
-
-        final Set<Object> properties = new Sets.Builder<>().add(PROPERTY).build();
-        when(definitionAdapter.getProperties(eq(domainObject))).thenReturn(properties);
-        when(propertyAdapter.getId(eq(PROPERTY))).thenReturn(PROPERTY_ID);
-        when(propertyAdapter.getValue(eq(PROPERTY))).thenReturn(PROPERTY_OLD_VALUE);
+        when(definitionAdapter.getProperty(domainObject, PROPERTY)).thenReturn(Optional.of(property));
+        when(definitionAdapter.getProperty(property, NAME_FIELD)).thenReturn(Optional.of(nameProperty));
+        when(propertyAdapter.getValue(nameProperty)).thenReturn(PROPERTY_OLD_VALUE);
 
         this.command = new UpdateDomainObjectPropertyValueCommand(domainObject,
-                                                                  PROPERTY_ID,
+                                                                  PROPERTY_FIELD,
                                                                   PROPERTY_VALUE);
     }
 
@@ -75,8 +80,8 @@ public class UpdateDomainObjectPropertyValueCommandTest extends AbstractGraphCom
         assertEquals(CommandResult.Type.INFO,
                      command.execute(graphCommandExecutionContext).getType());
 
-        verify(propertyAdapter).getValue(eq(PROPERTY));
-        verify(propertyAdapter).setValue(eq(PROPERTY), eq(PROPERTY_VALUE));
+        verify(propertyAdapter).getValue(eq(nameProperty));
+        verify(propertyAdapter).setValue(eq(nameProperty), eq(PROPERTY_VALUE));
     }
 
     @Test
@@ -84,16 +89,16 @@ public class UpdateDomainObjectPropertyValueCommandTest extends AbstractGraphCom
     public void testUndo() {
         command.execute(graphCommandExecutionContext);
 
-        verify(propertyAdapter).getValue(eq(PROPERTY));
-        verify(propertyAdapter).setValue(eq(PROPERTY),
+        verify(propertyAdapter).getValue(eq(nameProperty));
+        verify(propertyAdapter).setValue(eq(nameProperty),
                                          eq(PROPERTY_VALUE));
 
         assertEquals(CommandResult.Type.INFO,
                      command.undo(graphCommandExecutionContext).getType());
 
         //One read for the execute, one read for the undo. Resetting the mock would require it to be setup again.
-        verify(propertyAdapter, times(2)).getValue(eq(PROPERTY));
-        verify(propertyAdapter).setValue(eq(PROPERTY),
+        verify(propertyAdapter, times(2)).getValue(eq(nameProperty));
+        verify(propertyAdapter).setValue(eq(nameProperty),
                                          eq(PROPERTY_OLD_VALUE));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
@@ -173,19 +173,6 @@ public class GraphUtilsTest {
         assertEquals(PROPERTY, GraphUtils.getProperty(definitionManager, element, PROPERTY_ID));
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testGetPropertyForNullDomainObject() {
-        assertNull(GraphUtils.getProperty(definitionManager, (DomainObject) null, PROPERTY_ID));
-    }
-
-    @Test
-    public void testGetPropertyForNonNullDomainObject() {
-        setupDefinitionManager();
-
-        assertEquals(PROPERTY, GraphUtils.getProperty(definitionManager, domainObject, PROPERTY_ID));
-    }
-
     @SuppressWarnings("unchecked")
     private void setupDefinitionManager() {
         final Definition<String> definition = mock(Definition.class);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/MainProcessor.java
@@ -463,6 +463,13 @@ public class MainProcessor extends AbstractErrorAbsorbingProcessor {
             String fqcn = mirror.toString();
             processingContext.getDefinitionAnnotations().getGraphFactoryFieldNames().put(defintionClassName,
                                                                                          fqcn);
+
+            //Title Field
+            if (StringUtils.isNotBlank(definitionAnn.nameField())) {
+                processingContext.getDefinitionAnnotations().getNameFields().put(defintionClassName,
+                                                                                 definitionAnn.nameField());
+            }
+
             // PropertySets fields.
             Map<String, Element> propertySetElements = getFieldNames(classElement,
                                                                      ANNOTATION_PROPERTY_SET);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/ProcessingDefinitionAnnotations.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/ProcessingDefinitionAnnotations.java
@@ -35,6 +35,8 @@ public class ProcessingDefinitionAnnotations {
     private final Map<String, String> descriptionFieldNames = new HashMap<>();
     private final Map<String, TypeConstructor> builderFieldNames = new HashMap<>();
     private final Map<String, String[]> shapeDefs = new HashMap<>();
+    private final Map<String, String> nameFields = new HashMap<>();
+
 
     public Map<String, String> getBaseTypes() {
         return baseTypes;
@@ -78,5 +80,9 @@ public class ProcessingDefinitionAnnotations {
 
     public Map<String, String[]> getShapeDefinitions() {
         return shapeDefs;
+    }
+
+    public Map<String, String> getNameFields() {
+        return nameFields;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definition/BindableDefinitionAdapterGenerator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/definition/BindableDefinitionAdapterGenerator.java
@@ -80,6 +80,9 @@ public class BindableDefinitionAdapterGenerator extends AbstractBindableAdapterG
         addSetFields("propertiesFieldNames",
                      root,
                      processingDefinitionAnnotations.getPropertyFieldNames());
+        addFields("nameFields",
+                  root,
+                  processingDefinitionAnnotations.getNameFields());
 
         // Meta-properties.
         final Map<String, String> metaMap = new LinkedHashMap<>();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/resources/org/kie/workbench/common/stunner/core/processors/definition/templates/BindableDefinitionAdapter.ftl
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/resources/org/kie/workbench/common/stunner/core/processors/definition/templates/BindableDefinitionAdapter.ftl
@@ -72,7 +72,7 @@ public class ${className} extends ${parentAdapterClassName}<Object> {
 
     private static final Map<Class, Class> graphFactoryFieldNames = new HashMap<Class, Class>(${graphFactoryFieldNamesSize}) {{
         <#list graphFactoryFieldNames as graphFactoryFieldName>
-              put( ${graphFactoryFieldName.className}.class, ${graphFactoryFieldName.methodName}.class );
+            put( ${graphFactoryFieldName.className}.class, ${graphFactoryFieldName.methodName}.class );
         </#list>
     }};
 
@@ -102,6 +102,12 @@ public class ${className} extends ${parentAdapterClassName}<Object> {
         </#list>
     }};
 
+    private static final Map<Class, String> nameFields = new HashMap<Class, String>(${nameFieldsSize}) {{
+        <#list nameFields as field>
+            put(${field.className}.class, "${field.methodName}");
+        </#list>
+    }};
+
     protected ${className}() {
     }
 
@@ -121,7 +127,8 @@ public class ${className} extends ${parentAdapterClassName}<Object> {
                 labelsFieldNames,
                 titleFieldNames,
                 categoryFieldNames,
-                descriptionFieldNames);
+                descriptionFieldNames,
+                nameFields);
     }
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -24,8 +24,6 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import org.jboss.errai.databinding.client.HasProperties;
-import org.jboss.errai.databinding.client.api.DataBinder;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -160,21 +158,6 @@ public class FormsCanvasSessionHandler {
         final CommandResult result = sessionCommandManager.execute(getCanvasHandler(), command);
         listener.endProcessing();
         return !CommandUtils.isError(result);
-    }
-
-    private String getModifiedPropertyId(HasProperties model, String fieldName) {
-        int separatorIndex = fieldName.indexOf(".");
-        // Check if it is a nested property, if it is we must obtain the nested property
-        // instead of the root one.
-        if (separatorIndex != -1) {
-            String rootProperty = fieldName.substring(0, separatorIndex);
-            fieldName = fieldName.substring(separatorIndex + 1);
-            Object property = model.get(rootProperty);
-            model = (HasProperties) DataBinder.forModel(property).getModel();
-            return getModifiedPropertyId(model, fieldName);
-        }
-        Object property = model.get(fieldName);
-        return definitionManager.adapters().forProperty().getId(property);
     }
 
     void onRefreshFormPropertiesEvent(@Observes RefreshFormPropertiesEvent event) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -143,16 +143,11 @@ public class FormsCanvasSessionHandler {
     public boolean executeUpdateProperty(final Element<? extends Definition<?>> element,
                                          final String fieldName,
                                          final Object value) {
-        final Object definition = element.getContent().getDefinition();
-        final HasProperties hasProperties = (HasProperties) DataBinder.forModel(definition).getModel();
-        final String propertyId = getModifiedPropertyId(hasProperties, fieldName);
         canvasListener.startProcessing();
         final CommandResult result =
                sessionCommandManager
                         .execute(getCanvasHandler(),
-                                 commandFactory.updatePropertyValue(element,
-                                                                    propertyId,
-                                                                    value));
+                                 commandFactory.updatePropertyValue(element, fieldName, value));
         canvasListener.endProcessing();
         return !CommandUtils.isError(result);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseIdPrefix.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/cm/CaseIdPrefix.java
@@ -28,13 +28,12 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.Fiel
 import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.I18nMode;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.property.Value;
-import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 @Bindable
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
-@Property(meta = PropertyMetaTypes.NAME)
+@Property
 public class CaseIdPrefix {
 
     @Value


### PR DESCRIPTION
[JBPM-7166](https://issues.jboss.org/browse/JBPM-7166) **Dynamic Form Properties with nested hierarchy binds to wrong object/widget**

Now it is possible to set the name field for each definition, if not set the old behavior will be applied, that uses the Metadata NAME.
It was configured the name fields for the DMN definitions for now, but it will be great to set this for BPMN as well, but no problem for now since the old behavior is kept. 

NOTE: this PR is in progress, but it is possible to test and start the review.

@romartin @manstis @etirelli @danielzhe 
