### PR TITLE
Reuse version.org.wildfly from kie-parent

### DIFF
--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
@@ -21,7 +21,6 @@
     <container.host>localhost</container.host>
     <container.port>8090</container.port>
     <kie.compiler.url>http://${container.host}:${container.port}/${deployable.context}</kie.compiler.url>
-    <version.wildfly14>14.0.1.Final</version.wildfly14>
   </properties>
 
   <dependencyManagement>
@@ -325,7 +324,7 @@
                 <artifactItem>
                   <groupId>org.wildfly</groupId>
                   <artifactId>wildfly-dist</artifactId>
-                  <version>14.0.1.Final</version>
+                  <version>${version.org.wildfly}</version>
                   <type>zip</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}</outputDirectory>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/src/test/resources/arquillian.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
 
   <container qualifier="widlfly-managed" default="true">
     <configuration>
-      <property name="jbossHome">${project.basedir}/target/wildfly-14.0.1.Final</property>
+      <property name="jbossHome">${project.basedir}/target/wildfly-${version.org.wildfly}</property>
       <property name="org.uberfire.nio.git.daemon.enabled">false</property>
       <property name="org.uberfire.nio.git.ssh.enabled">false</property>
       <!-- enable for remote debug


### PR DESCRIPTION
@desmax74 please check. We should not re-declare version that's already present on master. Also, having a (part of) version number in property name is not a good idea.