### PR TITLE
DROOLS-3269: [DMN Designer] Context: Default can be any expression type

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextPropertyConverter.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.Objects;
+
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ContextEntry;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
@@ -38,6 +40,15 @@ public class ContextPropertyConverter {
             }
             result.getContextEntry().add(ceConverted);
         }
+
+        //The UI requires a ContextEntry for the _default_ result even if none has been defined
+        final int contextEntriesCount = result.getContextEntry().size();
+        if (contextEntriesCount == 0) {
+            result.getContextEntry().add(new ContextEntry());
+        } else if (!Objects.isNull(result.getContextEntry().get(contextEntriesCount - 1).getVariable())) {
+            result.getContextEntry().add(new ContextEntry());
+        }
+
         return result;
     }
 
@@ -54,6 +65,16 @@ public class ContextPropertyConverter {
             }
             result.getContextEntry().add(ceConverted);
         }
+
+        //The UI appends a ContextEntry for the _default_ result that may contain an undefined Expression.
+        //If this is the case then DMN does not require the ContextEntry to be written out to the XML.
+        //Conversion of ContextEntries will always create a _mock_ LiteralExpression if no Expression has
+        //been defined therefore remove the last entry from the org.kie.dmn.model if the WB had no Expression.
+        final int contextEntriesCount = result.getContextEntry().size();
+        if (Objects.isNull(wb.getContextEntry().get(contextEntriesCount - 1).getExpression())) {
+            result.getContextEntry().remove(contextEntriesCount - 1);
+        }
+
         return result;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DecisionWithContextWithDefaultResult.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DecisionWithContextWithDefaultResult.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dmn11:definitions xmlns="http://www.trisotech.com/dmn/definitions/_153e2b47-3bd2-4db0-828c-db3fce0b3199" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="6.1.6" id="_153e2b47-3bd2-4db0-828c-db3fce0b3199" name="Drawing 1" namespace="http://www.trisotech.com/dmn/definitions/_153e2b47-3bd2-4db0-828c-db3fce0b3199" triso:logoChoice="Default" xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd">
+  <dmn11:extensionElements/>
+  <dmn11:itemDefinition label="tPerson" name="tPerson">
+    <dmn11:itemComponent id="_9d959fad-6b6f-450e-b661-77793c8ea368" name="First Name">
+      <dmn11:typeRef>feel:string</dmn11:typeRef>
+    </dmn11:itemComponent>
+    <dmn11:itemComponent id="_66c2d19b-7b95-4d81-a141-d52639464a25" name="Last Name">
+      <dmn11:typeRef>feel:string</dmn11:typeRef>
+    </dmn11:itemComponent>
+  </dmn11:itemDefinition>
+  <dmn11:decision id="_30810b88-8416-4c02-8ed1-8c19b7606243" name="an hardcoded Person">
+    <dmn11:variable id="_561d31ba-a34b-4cf3-b9a4-537e21ce1013" name="an hardcoded Person" typeRef="tPerson"/>
+    <dmn11:context id="_0f38d114-5d6e-40dd-aa9c-9f031f9b0571" typeRef="tPerson">
+      <dmn11:contextEntry>
+        <dmn11:variable id="_e6d181fd-d46e-4159-bf0e-949366d52847" name="First Name" typeRef="feel:string"/>
+        <dmn11:literalExpression id="_3cb6879c-2b08-4a8e-9666-af6064eb6cd1">
+          <dmn11:text>"John"</dmn11:text>
+        </dmn11:literalExpression>
+      </dmn11:contextEntry>
+      <dmn11:contextEntry>
+        <dmn11:literalExpression id="_6614e534-3f4e-48ed-b692-2afe370b1012">
+          <dmn11:text>"Doe"</dmn11:text>
+        </dmn11:literalExpression>
+      </dmn11:contextEntry>
+    </dmn11:context>
+  </dmn11:decision>
+</dmn11:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DecisionWithContextWithoutDefaultResult.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DecisionWithContextWithoutDefaultResult.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dmn11:definitions xmlns="http://www.trisotech.com/dmn/definitions/_153e2b47-3bd2-4db0-828c-db3fce0b3199" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="6.1.6" id="_153e2b47-3bd2-4db0-828c-db3fce0b3199" name="Drawing 1" namespace="http://www.trisotech.com/dmn/definitions/_153e2b47-3bd2-4db0-828c-db3fce0b3199" triso:logoChoice="Default" xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd">
+  <dmn11:extensionElements/>
+  <dmn11:itemDefinition label="tPerson" name="tPerson">
+    <dmn11:itemComponent id="_9d959fad-6b6f-450e-b661-77793c8ea368" name="First Name">
+      <dmn11:typeRef>feel:string</dmn11:typeRef>
+    </dmn11:itemComponent>
+    <dmn11:itemComponent id="_66c2d19b-7b95-4d81-a141-d52639464a25" name="Last Name">
+      <dmn11:typeRef>feel:string</dmn11:typeRef>
+    </dmn11:itemComponent>
+  </dmn11:itemDefinition>
+  <dmn11:decision id="_30810b88-8416-4c02-8ed1-8c19b7606243" name="an hardcoded Person">
+    <dmn11:variable id="_561d31ba-a34b-4cf3-b9a4-537e21ce1013" name="an hardcoded Person" typeRef="tPerson"/>
+    <dmn11:context id="_0f38d114-5d6e-40dd-aa9c-9f031f9b0571" typeRef="tPerson">
+      <dmn11:contextEntry>
+        <dmn11:variable id="_e6d181fd-d46e-4159-bf0e-949366d52847" name="First Name" typeRef="feel:string"/>
+        <dmn11:literalExpression id="_3cb6879c-2b08-4a8e-9666-af6064eb6cd1">
+          <dmn11:text>"John"</dmn11:text>
+        </dmn11:literalExpression>
+      </dmn11:contextEntry>
+    </dmn11:context>
+  </dmn11:decision>
+</dmn11:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ContextEntry;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
-import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
@@ -110,15 +109,12 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
 
             //Add (default) "result" entry
             final ContextEntry resultEntry = new ContextEntry();
-            final LiteralExpression literalExpression = new LiteralExpression();
-            resultEntry.setExpression(literalExpression);
             context.getContextEntry().add(resultEntry);
 
             //Setup parent relationships
             contextEntry.setParent(context);
             informationItem.setParent(contextEntry);
             resultEntry.setParent(context);
-            literalExpression.setParent(resultEntry);
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGrid.java
@@ -206,31 +206,29 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
     public List<ListSelectorItem> getItems(final int uiRowIndex,
                                            final int uiColumnIndex) {
         final List<ListSelectorItem> items = new ArrayList<>();
-        if (uiRowIndex == model.getRowCount() - 1) {
-            return items;
-        }
-
         final boolean isMultiRow = SelectionUtils.isMultiRow(model);
         final boolean isMultiSelect = SelectionUtils.isMultiSelect(model);
 
-        items.add(ListSelectorTextItem.build(translationService.format(DMNEditorConstants.ContextEditor_InsertContextEntryAbove),
-                                             !isMultiRow,
-                                             () -> {
-                                                 cellEditorControls.hide();
-                                                 expression.ifPresent(e -> addContextEntry(uiRowIndex));
-                                             }));
-        items.add(ListSelectorTextItem.build(translationService.format(DMNEditorConstants.ContextEditor_InsertContextEntryBelow),
-                                             !isMultiRow,
-                                             () -> {
-                                                 cellEditorControls.hide();
-                                                 expression.ifPresent(e -> addContextEntry(uiRowIndex + 1));
-                                             }));
-        items.add(ListSelectorTextItem.build(translationService.format(DMNEditorConstants.ContextEditor_DeleteContextEntry),
-                                             !isMultiRow && model.getRowCount() > 2 && uiRowIndex < model.getRowCount() - 1,
-                                             () -> {
-                                                 cellEditorControls.hide();
-                                                 deleteContextEntry(uiRowIndex);
-                                             }));
+        if (uiRowIndex < model.getRowCount() - 1) {
+            items.add(ListSelectorTextItem.build(translationService.format(DMNEditorConstants.ContextEditor_InsertContextEntryAbove),
+                                                 !isMultiRow,
+                                                 () -> {
+                                                     cellEditorControls.hide();
+                                                     expression.ifPresent(e -> addContextEntry(uiRowIndex));
+                                                 }));
+            items.add(ListSelectorTextItem.build(translationService.format(DMNEditorConstants.ContextEditor_InsertContextEntryBelow),
+                                                 !isMultiRow,
+                                                 () -> {
+                                                     cellEditorControls.hide();
+                                                     expression.ifPresent(e -> addContextEntry(uiRowIndex + 1));
+                                                 }));
+            items.add(ListSelectorTextItem.build(translationService.format(DMNEditorConstants.ContextEditor_DeleteContextEntry),
+                                                 !isMultiRow && model.getRowCount() > 2 && uiRowIndex < model.getRowCount() - 1,
+                                                 () -> {
+                                                     cellEditorControls.hide();
+                                                     deleteContextEntry(uiRowIndex);
+                                                 }));
+        }
 
         //If not ExpressionEditor column don't add extra items
         if (ContextUIModelMapperHelper.getSection(uiColumnIndex) != ContextUIModelMapperHelper.ContextSection.EXPRESSION) {
@@ -248,7 +246,9 @@ public class ContextGrid extends BaseExpressionGrid<Context, ContextGridData, Co
             return items;
         }
 
-        items.add(new ListSelectorDividerItem());
+        if (items.size() > 0) {
+            items.add(new ListSelectorDividerItem());
+        }
         items.add(ListSelectorTextItem.build(translationService.format(DMNEditorConstants.ExpressionEditor_Clear),
                                              !isMultiSelect,
                                              () -> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapper.java
@@ -38,7 +38,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowS
 
 public class ContextUIModelMapper extends BaseUIModelMapper<Context> {
 
-    public static final String DEFAULT_ROW_CAPTION = "default";
+    public static final String DEFAULT_ROW_CAPTION = "<result>";
 
     private final GridWidget gridWidget;
 
@@ -111,16 +111,11 @@ public class ContextUIModelMapper extends BaseUIModelMapper<Context> {
                                                                                  expression,
                                                                                  Optional.ofNullable(ce.getVariable()),
                                                                                  nesting + 1);
-                        if (!isLastRow) {
-                            uiModel.get().setCell(rowIndex,
-                                                  columnIndex,
-                                                  () -> new ContextGridCell<>(new ExpressionCellValue(editor),
-                                                                              listSelector));
-                        } else {
-                            uiModel.get().setCell(rowIndex,
-                                                  columnIndex,
-                                                  () -> new DMNGridCell<>(new ExpressionCellValue(editor)));
-                        }
+
+                        uiModel.get().setCell(rowIndex,
+                                              columnIndex,
+                                              () -> new ContextGridCell<>(new ExpressionCellValue(editor),
+                                                                          listSelector));
                     });
             }
         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -130,7 +130,9 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
 
             if (dtable.getOutput().size() > 0) {
                 final HasTypeRef hasTypeRef = TypeRefUtils.getTypeRefOfExpression(dtable, hasExpression);
-                dtable.getOutput().get(0).setTypeRef(hasTypeRef.getTypeRef());
+                if (!Objects.isNull(hasTypeRef)) {
+                    dtable.getOutput().get(0).setTypeRef(hasTypeRef.getTypeRef());
+                }
             }
         });
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.function;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -110,7 +109,7 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
               gridPanel,
               gridLayer,
               gridData,
-              new FunctionGridRenderer(nesting > 0),
+              new FunctionGridRenderer(gridData),
               definitionUtils,
               sessionManager,
               sessionCommandManager,
@@ -150,22 +149,26 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
 
     @Override
     protected void initialiseUiColumns() {
+        final List<GridColumn.HeaderMetaData> headerMetaData = new ArrayList<>();
+        if (nesting == 0) {
+            headerMetaData.add(new FunctionColumnNameHeaderMetaData(hasExpression,
+                                                                    expression,
+                                                                    hasName,
+                                                                    clearDisplayNameConsumer(true),
+                                                                    setDisplayNameConsumer(true),
+                                                                    setTypeRefConsumer(),
+                                                                    cellEditorControls,
+                                                                    headerEditor,
+                                                                    Optional.of(translationService.getTranslation(DMNEditorConstants.FunctionEditor_EditExpression))));
+        }
+        headerMetaData.add(new FunctionColumnParametersHeaderMetaData(expression::get,
+                                                                      translationService,
+                                                                      cellEditorControls,
+                                                                      parametersEditor,
+                                                                      Optional.of(translationService.getTranslation(DMNEditorConstants.FunctionEditor_EditParameters)),
+                                                                      this));
         final GridColumn expressionColumn = new FunctionColumn(gridLayer,
-                                                               Arrays.asList(new FunctionColumnNameHeaderMetaData(hasExpression,
-                                                                                                                  expression,
-                                                                                                                  hasName,
-                                                                                                                  clearDisplayNameConsumer(true),
-                                                                                                                  setDisplayNameConsumer(true),
-                                                                                                                  setTypeRefConsumer(),
-                                                                                                                  cellEditorControls,
-                                                                                                                  headerEditor,
-                                                                                                                  Optional.of(translationService.getTranslation(DMNEditorConstants.FunctionEditor_EditExpression))),
-                                                                             new FunctionColumnParametersHeaderMetaData(expression::get,
-                                                                                                                        translationService,
-                                                                                                                        cellEditorControls,
-                                                                                                                        parametersEditor,
-                                                                                                                        Optional.of(translationService.getTranslation(DMNEditorConstants.FunctionEditor_EditParameters)),
-                                                                                                                        this)),
+                                                               headerMetaData,
                                                                this);
 
         model.appendColumn(expressionColumn);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridRenderer.java
@@ -16,27 +16,28 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.function;
 
-import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridRenderer;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRenderer;
 
-public class FunctionGridRenderer extends BaseExpressionGridRenderer {
+public class FunctionGridRenderer extends BaseGridRenderer {
 
     static final double HEADER_ROW_HEIGHT = 48;
 
-    static final double HEADER_HEIGHT = HEADER_ROW_HEIGHT * 2;
+    private final DMNGridData gridData;
 
-    @SuppressWarnings("unused")
-    public FunctionGridRenderer(final boolean isHeaderHidden) {
-        //TODO {manstis} We need to hide only the first header row when header is hidden
-        super(false);
+    public FunctionGridRenderer(final DMNGridData gridData) {
+        super(new BaseExpressionGridTheme());
+        this.gridData = gridData;
     }
 
     @Override
-    protected double getRequiredHeaderHeight(final boolean isHeaderHidden) {
-        return isHeaderHidden ? 0.0 : HEADER_HEIGHT;
+    public double getHeaderHeight() {
+        return HEADER_ROW_HEIGHT * gridData.getHeaderRowCount();
     }
 
     @Override
-    protected double getRequiredHeaderRowHeight(final boolean isHeaderHidden) {
-        return isHeaderHidden ? 0.0 : HEADER_ROW_HEIGHT;
+    public double getHeaderRowHeight() {
+        return HEADER_ROW_HEIGHT;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGrid.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.invocation;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -65,6 +64,7 @@ import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
@@ -103,7 +103,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
               gridPanel,
               gridLayer,
               gridData,
-              new InvocationGridRenderer(nesting > 0),
+              new InvocationGridRenderer(gridData),
               definitionUtils,
               sessionManager,
               sessionCommandManager,
@@ -143,16 +143,25 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
         final InvocationColumnExpressionHeaderMetaData expressionHeaderMetaData = new InvocationColumnExpressionHeaderMetaData(this::getExpressionText,
                                                                                                                                this::setExpressionText,
                                                                                                                                getHeaderTextAreaFactory());
-        final InvocationParameterColumn nameColumn = new InvocationParameterColumn(Arrays.asList(new InvocationColumnHeaderMetaData(hasExpression,
-                                                                                                                                    expression,
-                                                                                                                                    hasName,
-                                                                                                                                    clearDisplayNameConsumer(true),
-                                                                                                                                    setDisplayNameConsumer(true),
-                                                                                                                                    setTypeRefConsumer(),
-                                                                                                                                    cellEditorControls,
-                                                                                                                                    headerEditor,
-                                                                                                                                    Optional.of(translationService.getTranslation(DMNEditorConstants.InvocationEditor_EditExpression))),
-                                                                                                 expressionHeaderMetaData),
+        final List<GridColumn.HeaderMetaData> nameColumnHeaderMetaData = new ArrayList<>();
+        final List<GridColumn.HeaderMetaData> expressionColumnHeaderMetaData = new ArrayList<>();
+        if (nesting == 0) {
+            nameColumnHeaderMetaData.add(new InvocationColumnHeaderMetaData(hasExpression,
+                                                                            expression,
+                                                                            hasName,
+                                                                            clearDisplayNameConsumer(true),
+                                                                            setDisplayNameConsumer(true),
+                                                                            setTypeRefConsumer(),
+                                                                            cellEditorControls,
+                                                                            headerEditor,
+                                                                            Optional.of(translationService.getTranslation(DMNEditorConstants.InvocationEditor_EditExpression))));
+            expressionColumnHeaderMetaData.add(new BaseHeaderMetaData("",
+                                                                      EXPRESSION_COLUMN_GROUP));
+        }
+        nameColumnHeaderMetaData.add(expressionHeaderMetaData);
+        expressionColumnHeaderMetaData.add(expressionHeaderMetaData);
+
+        final InvocationParameterColumn nameColumn = new InvocationParameterColumn(nameColumnHeaderMetaData,
                                                                                    this,
                                                                                    rowIndex -> true,
                                                                                    clearDisplayNameConsumer(false),
@@ -162,9 +171,7 @@ public class InvocationGrid extends BaseExpressionGrid<Invocation, InvocationGri
                                                                                    headerEditor,
                                                                                    Optional.of(translationService.getTranslation(DMNEditorConstants.InvocationEditor_EditParameter)));
         final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(gridLayer,
-                                                                                   Arrays.asList(new BaseHeaderMetaData("",
-                                                                                                                        EXPRESSION_COLUMN_GROUP),
-                                                                                                 expressionHeaderMetaData),
+                                                                                   expressionColumnHeaderMetaData,
                                                                                    this);
 
         model.appendColumn(new RowNumberColumn());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridRenderer.java
@@ -16,27 +16,27 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.invocation;
 
-import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridRenderer;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRenderer;
 
-public class InvocationGridRenderer extends BaseExpressionGridRenderer {
+public class InvocationGridRenderer extends BaseGridRenderer {
 
     static final double HEADER_ROW_HEIGHT = 48;
 
-    static final double HEADER_HEIGHT = HEADER_ROW_HEIGHT * 2;
+    private final InvocationGridData gridData;
 
-    @SuppressWarnings("unused")
-    public InvocationGridRenderer(final boolean isHeaderHidden) {
-        //TODO {manstis} We need to hide only the first header row when header is hidden
-        super(false);
+    public InvocationGridRenderer(final InvocationGridData gridData) {
+        super(new BaseExpressionGridTheme());
+        this.gridData = gridData;
     }
 
     @Override
-    protected double getRequiredHeaderHeight(final boolean isHeaderHidden) {
-        return isHeaderHidden ? 0.0 : HEADER_HEIGHT;
+    public double getHeaderHeight() {
+        return HEADER_ROW_HEIGHT * gridData.getHeaderRowCount();
     }
 
     @Override
-    protected double getRequiredHeaderRowHeight(final boolean isHeaderHidden) {
-        return isHeaderHidden ? 0.0 : HEADER_ROW_HEIGHT;
+    public double getHeaderRowHeight() {
+        return HEADER_ROW_HEIGHT;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/BaseContextUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/BaseContextUIModelMapperTest.java
@@ -70,13 +70,13 @@ public abstract class BaseContextUIModelMapperTest<M extends ContextUIModelMappe
     private ExpressionEditorDefinition literalExpressionEditorDefinition;
 
     @Mock
-    private LiteralExpressionGrid literalExpressionEditor;
+    protected LiteralExpressionGrid literalExpressionEditor;
 
     @Mock
     private UndefinedExpressionEditorDefinition undefinedExpressionEditorDefinition;
 
     @Mock
-    private BaseExpressionGrid undefinedExpressionEditor;
+    protected BaseExpressionGrid undefinedExpressionEditor;
 
     private LiteralExpression literalExpression = new LiteralExpression();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
-import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -173,14 +172,12 @@ public class ContextEditorDefinitionTest {
                      model.getContextEntry().get(0).getVariable().getName().getValue());
 
         assertNull(model.getContextEntry().get(1).getVariable());
-        assertTrue(model.getContextEntry().get(1).getExpression() instanceof LiteralExpression);
+        assertNull(model.getContextEntry().get(1).getExpression());
 
         model.getContextEntry().forEach(ce -> assertEquals(model, ce.getParent()));
 
         assertEquals(model.getContextEntry().get(0),
                      model.getContextEntry().get(0).getVariable().getParent());
-        assertEquals(model.getContextEntry().get(1),
-                     model.getContextEntry().get(1).getExpression().getParent());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridTest.java
@@ -372,7 +372,7 @@ public class ContextGridTest {
                      ((InformationItemCell.HasNameCell) uiModel.getCell(1, 1).getValue().getValue()).getName().getValue());
         assertTrue(uiModel.getCell(1, 2).getValue() instanceof ExpressionCellValue);
         final ExpressionCellValue dcv1 = (ExpressionCellValue) uiModel.getCell(1, 2).getValue();
-        assertEquals(literalExpressionEditor,
+        assertEquals(undefinedExpressionEditor,
                      dcv1.getValue().get());
     }
 
@@ -472,6 +472,49 @@ public class ContextGridTest {
                                true);
 
         ((HasListSelectorControl.ListSelectorTextItem) items.get(CLEAR_EXPRESSION_TYPE)).getCommand().execute();
+        verify(cellEditorControls).hide();
+        verify(sessionCommandManager).execute(eq(canvasHandler),
+                                              any(ClearExpressionTypeCommand.class));
+    }
+
+    @Test
+    public void testGetItemsRowNumberColumnDefaultResultRow() {
+        setupGrid(0);
+
+        assertThat(grid.getItems(1, 0)).isEmpty();
+    }
+
+    @Test
+    public void testOnItemSelectedNameColumnDefaultResultRow() {
+        setupGrid(0);
+
+        assertThat(grid.getItems(1, 1)).isEmpty();
+    }
+
+    @Test
+    public void testOnItemSelectedExpressionColumnUndefinedExpressionTypeDefaultResultRow() {
+        setupGrid(0);
+
+        assertThat(grid.getItems(1, 2)).isEmpty();
+    }
+
+    @Test
+    public void testOnItemSelectedExpressionColumnDefinedExpressionTypeDefaultResultRow() {
+        setupGrid(0);
+
+        //Set an editor for expression at (1, 2)
+        final BaseExpressionGrid editor = mock(BaseExpressionGrid.class);
+        grid.getModel().setCellValue(1, 2, new ExpressionCellValue(Optional.of(editor)));
+
+        final List<HasListSelectorControl.ListSelectorItem> items = grid.getItems(1, 2);
+
+        assertThat(items.size()).isEqualTo(1);
+
+        assertListSelectorItem(items.get(0),
+                               DMNEditorConstants.ExpressionEditor_Clear,
+                               true);
+
+        ((HasListSelectorControl.ListSelectorTextItem) items.get(0)).getCommand().execute();
         verify(cellEditorControls).hide();
         verify(sessionCommandManager).execute(eq(canvasHandler),
                                               any(ClearExpressionTypeCommand.class));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapperTest.java
@@ -21,12 +21,17 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridCell;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowSelectionStrategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.expressions.types.context.ContextUIModelMapperHelper.EXPRESSION_COLUMN_INDEX;
+import static org.kie.workbench.common.dmn.client.editors.expressions.types.context.ContextUIModelMapperHelper.NAME_COLUMN_INDEX;
+import static org.kie.workbench.common.dmn.client.editors.expressions.types.context.ContextUIModelMapperHelper.ROW_COLUMN_INDEX;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContextUIModelMapperTest extends BaseContextUIModelMapperTest<ContextUIModelMapper> {
@@ -43,41 +48,61 @@ public class ContextUIModelMapperTest extends BaseContextUIModelMapperTest<Conte
 
     @Test
     public void testFromDMNModelRowNumber() {
-        mapper.fromDMNModel(0, 0);
-        mapper.fromDMNModel(1, 0);
+        mapper.fromDMNModel(0, ROW_COLUMN_INDEX);
+        mapper.fromDMNModel(1, ROW_COLUMN_INDEX);
 
-        assertThat(uiModel.getCell(0, 0).getValue().getValue()).isEqualTo(1);
-        assertThat(uiModel.getCell(0, 0).getSelectionStrategy()).isSameAs(RowSelectionStrategy.INSTANCE);
+        assertThat(uiModel.getCell(0, ROW_COLUMN_INDEX).getValue().getValue()).isEqualTo(1);
+        assertThat(uiModel.getCell(0, ROW_COLUMN_INDEX).getSelectionStrategy()).isSameAs(RowSelectionStrategy.INSTANCE);
 
-        assertThat(uiModel.getCell(1, 0).getValue().getValue()).isNull();
-        assertThat(uiModel.getCell(1, 0).getSelectionStrategy()).isSameAs(RowSelectionStrategy.INSTANCE);
+        assertThat(uiModel.getCell(1, ROW_COLUMN_INDEX).getValue().getValue()).isNull();
+        assertThat(uiModel.getCell(1, ROW_COLUMN_INDEX).getSelectionStrategy()).isSameAs(RowSelectionStrategy.INSTANCE);
     }
 
     @Test
     public void testFromDMNModelName() {
-        mapper.fromDMNModel(0, 1);
-        mapper.fromDMNModel(1, 1);
+        mapper.fromDMNModel(0, NAME_COLUMN_INDEX);
+        mapper.fromDMNModel(1, NAME_COLUMN_INDEX);
 
         assertEquals("ii1",
-                     ((InformationItemCell.HasNameCell) uiModel.getCell(0, 1).getValue().getValue()).getName().getValue());
+                     ((InformationItemCell.HasNameCell) uiModel.getCell(0, NAME_COLUMN_INDEX).getValue().getValue()).getName().getValue());
         assertEquals(ContextUIModelMapper.DEFAULT_ROW_CAPTION,
-                     ((InformationItemCell.HasNameCell) uiModel.getCell(1, 1).getValue().getValue()).getName().getValue());
+                     ((InformationItemCell.HasNameCell) uiModel.getCell(1, NAME_COLUMN_INDEX).getValue().getValue()).getName().getValue());
+    }
+
+    @Test
+    public void testFromDMNModelExpression() {
+        mapper.fromDMNModel(0, EXPRESSION_COLUMN_INDEX);
+        mapper.fromDMNModel(1, EXPRESSION_COLUMN_INDEX);
+
+        assertUndefinedExpressionGridCellEditor(0, undefinedExpressionEditor);
+        assertUndefinedExpressionGridCellEditor(1, literalExpressionEditor);
+    }
+
+    private void assertUndefinedExpressionGridCellEditor(final int uiRowIndex,
+                                                         final BaseExpressionGrid editor) {
+        assertTrue(uiModel.getCell(uiRowIndex, EXPRESSION_COLUMN_INDEX) instanceof ContextGridCell);
+        final ContextGridCell contextGridCell1 = (ContextGridCell) uiModel.getCell(uiRowIndex, EXPRESSION_COLUMN_INDEX);
+        assertTrue(contextGridCell1.getEditor().isPresent());
+        assertEquals(listSelector, contextGridCell1.getEditor().get());
+        assertTrue(contextGridCell1.getValue() instanceof ExpressionCellValue);
+        assertTrue(contextGridCell1.getValue().getValue() instanceof Optional);
+        assertEquals(editor, ((Optional) contextGridCell1.getValue().getValue()).get());
     }
 
     @Test
     public void testFromDMNModelCellTypes() {
         IntStream.range(0, 2).forEach(rowIndex -> {
-            mapper.fromDMNModel(rowIndex, 0);
-            mapper.fromDMNModel(rowIndex, 1);
-            mapper.fromDMNModel(rowIndex, 2);
+            mapper.fromDMNModel(rowIndex, ROW_COLUMN_INDEX);
+            mapper.fromDMNModel(rowIndex, NAME_COLUMN_INDEX);
+            mapper.fromDMNModel(rowIndex, EXPRESSION_COLUMN_INDEX);
         });
 
-        assertThat(uiModel.getCell(0, 0)).isInstanceOf(ContextGridCell.class);
-        assertThat(uiModel.getCell(0, 1)).isInstanceOf(ContextGridCell.class);
-        assertThat(uiModel.getCell(0, 2)).isInstanceOf(ContextGridCell.class);
+        assertThat(uiModel.getCell(0, ROW_COLUMN_INDEX)).isInstanceOf(ContextGridCell.class);
+        assertThat(uiModel.getCell(0, NAME_COLUMN_INDEX)).isInstanceOf(ContextGridCell.class);
+        assertThat(uiModel.getCell(0, EXPRESSION_COLUMN_INDEX)).isInstanceOf(ContextGridCell.class);
 
-        assertThat(uiModel.getCell(1, 0)).isInstanceOf(DMNGridCell.class);
-        assertThat(uiModel.getCell(1, 1)).isInstanceOf(DMNGridCell.class);
-        assertThat(uiModel.getCell(1, 2)).isInstanceOf(DMNGridCell.class);
+        assertThat(uiModel.getCell(1, ROW_COLUMN_INDEX)).isInstanceOf(DMNGridCell.class);
+        assertThat(uiModel.getCell(1, NAME_COLUMN_INDEX)).isInstanceOf(DMNGridCell.class);
+        assertThat(uiModel.getCell(1, EXPRESSION_COLUMN_INDEX)).isInstanceOf(DMNGridCell.class);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -256,7 +256,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testModelEnrichmentWhenTopLevelDecisionTableWithMultipleHierachyCustomTypes() {
+    public void testModelEnrichmentWhenTopLevelDecisionTableWithMultipleHierarchyCustomTypes() {
         setupGraph();
 
         final Definitions definitions = diagram.getDefinitions();
@@ -377,14 +377,16 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     @Test
     public void testModelEnrichmentWhenParentIsContextEntry() {
-        final String NAME = "context-entry";
+        final String name = "context-entry";
+        final QName typeRef = BuiltInType.DATE.asQName();
         final ContextEntry contextEntry = new ContextEntry();
         final InformationItem variable = new InformationItem();
-        variable.getName().setValue(NAME);
+        variable.getName().setValue(name);
         contextEntry.setVariable(variable);
 
         final Optional<DecisionTable> oModel = definition.getModelClass();
         oModel.get().setParent(contextEntry);
+        oModel.get().setTypeRef(typeRef);
 
         definition.enrich(Optional.empty(), hasExpression, oModel);
 
@@ -394,7 +396,31 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final List<OutputClause> output = model.getOutput();
         assertThat(output.size()).isEqualTo(1);
-        assertThat(output.get(0).getName()).isEqualTo(NAME);
+        assertThat(output.get(0).getName()).isEqualTo(name);
+        assertThat(output.get(0).getTypeRef()).isEqualTo(typeRef);
+
+        assertStandardDecisionRuleEnrichment(model, 1, 1);
+        assertParentHierarchyEnrichment(model, 1, 1);
+    }
+
+    @Test
+    public void testModelEnrichmentWhenParentIsContextEntryDefaultResult() {
+        final String name = "output-1";
+        final ContextEntry contextEntry = new ContextEntry();
+
+        final Optional<DecisionTable> oModel = definition.getModelClass();
+        oModel.get().setParent(contextEntry);
+
+        definition.enrich(Optional.of(NODE_UUID), hasExpression, oModel);
+
+        final DecisionTable model = oModel.get();
+        assertBasicEnrichment(model);
+        assertStandardInputClauseEnrichment(model);
+
+        final List<OutputClause> output = model.getOutput();
+        assertThat(output.size()).isEqualTo(1);
+        assertThat(output.get(0).getName()).isEqualTo(name);
+        assertThat(output.get(0).getTypeRef()).isEqualTo(new QName());
 
         assertStandardDecisionRuleEnrichment(model, 1, 1);
         assertParentHierarchyEnrichment(model, 1, 1);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridRendererTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridRendererTest.java
@@ -16,18 +16,34 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.function;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class FunctionGridRendererTest {
 
-    @Test
-    public void testHeaderDimensionsWhenHeaderNotHidden() {
-        final GridRenderer renderer = new FunctionGridRenderer(false);
+    @Mock
+    private DMNGridData gridData;
 
-        assertEquals(FunctionGridRenderer.HEADER_HEIGHT,
+    private FunctionGridRenderer renderer;
+
+    @Before
+    public void setup() {
+        this.renderer = new FunctionGridRenderer(gridData);
+    }
+
+    @Test
+    public void testHeaderDimensionsWhenHeaderHasOneRow() {
+        when(gridData.getHeaderRowCount()).thenReturn(1);
+
+        assertEquals(FunctionGridRenderer.HEADER_ROW_HEIGHT,
                      renderer.getHeaderHeight(),
                      0.0);
         assertEquals(FunctionGridRenderer.HEADER_ROW_HEIGHT,
@@ -36,10 +52,10 @@ public class FunctionGridRendererTest {
     }
 
     @Test
-    public void testHeaderDimensionsWhenHeaderIsNotHidden() {
-        final GridRenderer renderer = new FunctionGridRenderer(true);
+    public void testHeaderDimensionsWhenHeaderHasTwoRows() {
+        when(gridData.getHeaderRowCount()).thenReturn(2);
 
-        assertEquals(FunctionGridRenderer.HEADER_HEIGHT,
+        assertEquals(FunctionGridRenderer.HEADER_ROW_HEIGHT * 2,
                      renderer.getHeaderHeight(),
                      0.0);
         assertEquals(FunctionGridRenderer.HEADER_ROW_HEIGHT,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
@@ -414,6 +414,25 @@ public class FunctionGridTest {
     }
 
     @Test
+    public void testColumnMetaDataWhenNested() {
+        setupGrid(1);
+
+        final GridColumn<?> column = grid.getModel().getColumns().get(0);
+        final List<GridColumn.HeaderMetaData> header = column.getHeaderMetaData();
+
+        assertEquals(1,
+                     header.size());
+        assertTrue(header.get(0) instanceof FunctionColumnParametersHeaderMetaData);
+
+        final FunctionColumnParametersHeaderMetaData md1 = (FunctionColumnParametersHeaderMetaData) header.get(0);
+
+        assertEquals("F",
+                     md1.getExpressionLanguageTitle());
+        assertEquals("(" + PARAMETER_NAME + ")",
+                     md1.getFormalParametersTitle());
+    }
+
+    @Test
     public void testOnItemSelectedExpressionColumnDefinedExpressionType() {
         setupGrid(0);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridRendererTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridRendererTest.java
@@ -16,18 +16,33 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.invocation;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class InvocationGridRendererTest {
 
-    @Test
-    public void testHeaderDimensionsWhenHeaderNotHidden() {
-        final GridRenderer renderer = new InvocationGridRenderer(false);
+    @Mock
+    private InvocationGridData gridData;
 
-        assertEquals(InvocationGridRenderer.HEADER_HEIGHT,
+    private InvocationGridRenderer renderer;
+
+    @Before
+    public void setup() {
+        this.renderer = new InvocationGridRenderer(gridData);
+    }
+
+    @Test
+    public void testHeaderDimensionsWhenHeaderHasOneRow() {
+        when(gridData.getHeaderRowCount()).thenReturn(1);
+
+        assertEquals(InvocationGridRenderer.HEADER_ROW_HEIGHT,
                      renderer.getHeaderHeight(),
                      0.0);
         assertEquals(InvocationGridRenderer.HEADER_ROW_HEIGHT,
@@ -36,10 +51,10 @@ public class InvocationGridRendererTest {
     }
 
     @Test
-    public void testHeaderDimensionsWhenHeaderIsNotHidden() {
-        final GridRenderer renderer = new InvocationGridRenderer(true);
+    public void testHeaderDimensionsWhenHeaderHasTwoRows() {
+        when(gridData.getHeaderRowCount()).thenReturn(2);
 
-        assertEquals(InvocationGridRenderer.HEADER_HEIGHT,
+        assertEquals(InvocationGridRenderer.HEADER_ROW_HEIGHT * 2,
                      renderer.getHeaderHeight(),
                      0.0);
         assertEquals(InvocationGridRenderer.HEADER_ROW_HEIGHT,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
@@ -413,6 +413,23 @@ public class InvocationGridTest {
     }
 
     @Test
+    public void testNameColumnMetaDataWhenNested() {
+        setupGrid(1);
+
+        final GridColumn<?> column = grid.getModel().getColumns().get(InvocationUIModelMapper.BINDING_PARAMETER_COLUMN_INDEX);
+        final List<GridColumn.HeaderMetaData> header = column.getHeaderMetaData();
+
+        assertEquals(1,
+                     header.size());
+        assertTrue(header.get(0) instanceof InvocationColumnExpressionHeaderMetaData);
+
+        final InvocationColumnExpressionHeaderMetaData md1 = (InvocationColumnExpressionHeaderMetaData) header.get(0);
+
+        assertEquals("invocation-expression",
+                     md1.getTitle());
+    }
+
+    @Test
     public void testExpressionColumnMetaData() {
         setupGrid(0);
 
@@ -431,6 +448,23 @@ public class InvocationGridTest {
                      md1.getTitle());
         assertEquals("invocation-expression",
                      md2.getTitle());
+    }
+
+    @Test
+    public void testExpressionColumnMetaDataWhenNested() {
+        setupGrid(1);
+
+        final GridColumn<?> column = grid.getModel().getColumns().get(InvocationUIModelMapper.BINDING_EXPRESSION_COLUMN_INDEX);
+        final List<GridColumn.HeaderMetaData> header = column.getHeaderMetaData();
+
+        assertEquals(1,
+                     header.size());
+        assertTrue(header.get(0) instanceof InvocationColumnExpressionHeaderMetaData);
+
+        final InvocationColumnExpressionHeaderMetaData md1 = (InvocationColumnExpressionHeaderMetaData) header.get(0);
+
+        assertEquals("invocation-expression",
+                     md1.getTitle());
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3269

Video of manual testing: https://youtu.be/Yc7SXcWT1N8

@tarilabs I'd like you just to look at the backend marshalling changes that [create](https://github.com/kiegroup/kie-wb-common/pull/2255/files#diff-a3d8fc8bd84bfda135fff7c119953302R44) and [remove](https://github.com/kiegroup/kie-wb-common/pull/2255/files#diff-a3d8fc8bd84bfda135fff7c119953302R69) a `ContextEntry` for the _default result_ row required by the UI (but not DMN XML, if no default result is defined).