### PR TITLE
DROOLS-3266: [DMN Designer] Remove some properties from the Properties Panel / DROOLS-3259: [DMN Designer] `inputData` and `variable` must have the same name value

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/DMNDefinitionSet.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/DMNDefinitionSet.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.DMNDiagram;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ImportedValues;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputClause;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
@@ -64,6 +65,7 @@ import org.kie.workbench.common.stunner.core.rule.annotation.Occurrences;
                 ImportedValues.class,
                 UnaryTests.class,
                 InformationItem.class,
+                InformationItemPrimary.class,
                 InputClause.class,
                 OutputClause.class,
                 NOPDomainObject.class

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasVariable.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasVariable.java
@@ -16,13 +16,13 @@
 package org.kie.workbench.common.dmn.api.definition;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
-import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.IsInformationItem;
 
-public interface HasVariable {
+public interface HasVariable<T extends IsInformationItem> {
 
-    InformationItem getVariable();
+    T getVariable();
 
-    void setVariable(final InformationItem informationItem);
+    void setVariable(final T informationItem);
 
     DMNModelInstrumentedBase asDMNModelInstrumentedBase();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Binding.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Binding.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 public class Binding extends DMNModelInstrumentedBase implements HasExpression,
-                                                                 HasVariable {
+                                                                 HasVariable<InformationItem> {
 
     private InformationItem parameter;
     private Expression expression;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModel.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.Valid;
@@ -52,7 +53,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         startElement = "id")
-public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
+public class BusinessKnowledgeModel extends DRGElement implements HasVariable<InformationItemPrimary>,
                                                                   DMNViewDefinition,
                                                                   DomainObject {
 
@@ -67,7 +68,7 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
     @PropertySet
     @FormField(afterElement = "name")
     @Valid
-    protected InformationItem variable;
+    protected InformationItemPrimary variable;
 
     protected FunctionDefinition encapsulatedLogic;
 
@@ -90,7 +91,7 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
         this(new Id(),
              new org.kie.workbench.common.dmn.api.property.dmn.Description(),
              new Name(),
-             new InformationItem(),
+             new InformationItemPrimary(),
              null,
              new BackgroundSet(),
              new FontSet(),
@@ -100,7 +101,7 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
     public BusinessKnowledgeModel(final Id id,
                                   final org.kie.workbench.common.dmn.api.property.dmn.Description description,
                                   final Name name,
-                                  final InformationItem variable,
+                                  final InformationItemPrimary variable,
                                   final FunctionDefinition encapsulatedLogic,
                                   final BackgroundSet backgroundSet,
                                   final FontSet fontSet,
@@ -113,12 +114,13 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
         this.backgroundSet = backgroundSet;
         this.fontSet = fontSet;
         this.dimensionsSet = dimensionsSet;
+
+        setVariableParent();
     }
 
     // -----------------------
     // Stunner core properties
     // -----------------------
-
     public String getStunnerCategory() {
         return stunnerCategory;
     }
@@ -157,14 +159,13 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
     // -----------------------
     // DMN properties
     // -----------------------
-
     @Override
-    public InformationItem getVariable() {
+    public InformationItemPrimary getVariable() {
         return variable;
     }
 
     @Override
-    public void setVariable(final InformationItem variable) {
+    public void setVariable(final InformationItemPrimary variable) {
         this.variable = variable;
     }
 
@@ -208,7 +209,6 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
     // ------------------------------------------------------
     // DomainObject requirements - to use in Properties Panel
     // ------------------------------------------------------
-
     @Override
     public String getDomainObjectUUID() {
         return getId().getValue();
@@ -264,5 +264,9 @@ public class BusinessKnowledgeModel extends DRGElement implements HasVariable,
                                          backgroundSet != null ? backgroundSet.hashCode() : 0,
                                          fontSet != null ? fontSet.hashCode() : 0,
                                          dimensionsSet != null ? dimensionsSet.hashCode() : 0);
+    }
+
+    private void setVariableParent() {
+        Optional.ofNullable(variable).ifPresent(v -> v.setParent(this));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextEntry.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextEntry.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 @Portable
 public class ContextEntry extends DMNModelInstrumentedBase implements HasExpression,
-                                                                      HasVariable {
+                                                                      HasVariable<InformationItem> {
 
     private InformationItem variable;
     private Expression expression;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Decision.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.Valid;
@@ -55,10 +56,10 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         startElement = "id")
-public class Decision extends DRGElement implements HasExpression,
-                                                    HasVariable,
+public class Decision extends DRGElement implements DomainObject,
+                                                    HasExpression,
                                                     DMNViewDefinition,
-                                                    DomainObject {
+                                                    HasVariable<InformationItemPrimary> {
 
     @Category
     private static final String stunnerCategory = Categories.NODES;
@@ -81,7 +82,7 @@ public class Decision extends DRGElement implements HasExpression,
     @PropertySet
     @FormField(afterElement = "allowedAnswers")
     @Valid
-    protected InformationItem variable;
+    protected InformationItemPrimary variable;
 
     protected Expression expression;
 
@@ -106,7 +107,7 @@ public class Decision extends DRGElement implements HasExpression,
              new Name(),
              new Question(),
              new AllowedAnswers(),
-             new InformationItem(),
+             new InformationItemPrimary(),
              null,
              new BackgroundSet(),
              new FontSet(),
@@ -118,7 +119,7 @@ public class Decision extends DRGElement implements HasExpression,
                     final Name name,
                     final Question question,
                     final AllowedAnswers allowedAnswers,
-                    final InformationItem variable,
+                    final InformationItemPrimary variable,
                     final Expression expression,
                     final BackgroundSet backgroundSet,
                     final FontSet fontSet,
@@ -133,6 +134,8 @@ public class Decision extends DRGElement implements HasExpression,
         this.backgroundSet = backgroundSet;
         this.fontSet = fontSet;
         this.dimensionsSet = dimensionsSet;
+
+        setVariableParent();
     }
 
     // -----------------------
@@ -195,12 +198,12 @@ public class Decision extends DRGElement implements HasExpression,
     }
 
     @Override
-    public InformationItem getVariable() {
+    public InformationItemPrimary getVariable() {
         return variable;
     }
 
     @Override
-    public void setVariable(final InformationItem variable) {
+    public void setVariable(final InformationItemPrimary variable) {
         this.variable = variable;
     }
 
@@ -287,5 +290,9 @@ public class Decision extends DRGElement implements HasExpression,
                                          backgroundSet != null ? backgroundSet.hashCode() : 0,
                                          fontSet != null ? fontSet.hashCode() : 0,
                                          dimensionsSet != null ? dimensionsSet.hashCode() : 0);
+    }
+
+    private void setVariableParent() {
+        Optional.ofNullable(variable).ifPresent(v -> v.setParent(this));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItem.java
@@ -23,7 +23,6 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.dmn.api.definition.HasName;
-import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
@@ -40,7 +39,6 @@ import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
-import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -50,9 +48,8 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "id")
 public class InformationItem extends NamedElement implements HasName,
-                                                             HasTypeRef,
                                                              DMNPropertySet,
-                                                             DomainObject {
+                                                             IsInformationItem {
 
     @Category
     private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
@@ -138,7 +135,7 @@ public class InformationItem extends NamedElement implements HasName,
 
     @Override
     public String getDomainObjectNameTranslationKey() {
-        return DMNAPIConstants.InformationItem_DomainObjectName;
+        return DMNAPIConstants.InformationItemPrimary_DomainObjectName;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItemPrimary.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItemPrimary.java
@@ -13,47 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.Set;
 
+import javax.validation.Valid;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.soup.commons.util.Sets;
+import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
-import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.QNameFieldType;
+import org.kie.workbench.common.dmn.api.property.dmn.QNameHolder;
 import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
-import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
-import org.kie.workbench.common.forms.adf.definitions.annotations.i18n.I18nSettings;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
+import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
 import org.kie.workbench.common.stunner.core.definition.annotation.definition.Labels;
-import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
-import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
-
 /**
- * This is in essence a clone of {@link LiteralExpression} specifically for {@link OutputClause}
- * to expose the {@link Text} as a Form Property to the Dynamic Forms Engine with a specific
- * label for "Default Output value".
+ * This is in essence a clone of {@link InformationItem} specifically for use with {@link BusinessKnowledgeModel},
+ * {@link Decision} and {@link InputData} to expose only the {@link QNameHolder}.
  */
 @Portable
 @Bindable
+@PropertySet
 @Definition(graphFactory = NodeFactory.class)
-@FormDefinition(policy = FieldPolicy.ONLY_MARKED,
-        defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseLiteralExpression"),
-        startElement = "id")
-public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase implements IsLiteralExpression,
-                                                                                       DomainObject {
+@FormDefinition(policy = FieldPolicy.ONLY_MARKED, startElement = "typeRefHolder")
+public class InformationItemPrimary extends DMNModelInstrumentedBase implements DMNPropertySet,
+                                                                                IsInformationItem {
 
     @Category
     private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
@@ -61,31 +58,25 @@ public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase impl
     @Labels
     private static final Set<String> stunnerLabels = new Sets.Builder<String>().build();
 
-    @Property
-    @FormField(afterElement = "description", labelKey = "text")
-    protected Text text;
-
     protected Id id;
 
     protected QName typeRef;
 
-    protected ImportedValues importedValues;
+    @Property
+    @FormField(type = QNameFieldType.class)
+    @Valid
+    protected QNameHolder typeRefHolder;
 
-    public OutputClauseLiteralExpression() {
+    public InformationItemPrimary() {
         this(new Id(),
-             new QName(),
-             new Text(),
-             null);
+             new QName());
     }
 
-    public OutputClauseLiteralExpression(final Id id,
-                                         final QName typeRef,
-                                         final Text text,
-                                         final ImportedValues importedValues) {
+    public InformationItemPrimary(final Id id,
+                                  final QName typeRef) {
         this.id = id;
         this.typeRef = typeRef;
-        this.text = text;
-        this.importedValues = importedValues;
+        this.typeRefHolder = new QNameHolder(typeRef);
     }
 
     // -----------------------
@@ -105,31 +96,29 @@ public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase impl
     // -----------------------
 
     @Override
-    public Id getId() {
-        return id;
-    }
-
-    @Override
     public QName getTypeRef() {
-        return typeRef;
+        return typeRefHolder.getValue();
     }
 
     @Override
-    public Text getText() {
-        return text;
-    }
-
-    public void setText(final Text text) {
-        this.text = text;
+    public void setTypeRef(final QName typeRef) {
+        this.typeRefHolder.setValue(typeRef);
     }
 
     @Override
-    public ImportedValues getImportedValues() {
-        return importedValues;
+    public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+        return this;
     }
 
-    public void setImportedValues(final ImportedValues importedValues) {
-        this.importedValues = importedValues;
+    // ------------------
+    // Errai Data Binding
+    // ------------------
+    public QNameHolder getTypeRefHolder() {
+        return typeRefHolder;
+    }
+
+    public void setTypeRefHolder(final QNameHolder typeRefHolder) {
+        this.typeRefHolder = typeRefHolder;
     }
 
     // ------------------------------------------------------
@@ -141,9 +130,13 @@ public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase impl
         return getId().getValue();
     }
 
+    public Id getId() {
+        return id;
+    }
+
     @Override
     public String getDomainObjectNameTranslationKey() {
-        return DMNAPIConstants.LiteralExpression_DomainObjectName;
+        return DMNAPIConstants.InformationItem_DomainObjectName;
     }
 
     @Override
@@ -151,11 +144,11 @@ public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase impl
         if (this == o) {
             return true;
         }
-        if (!(o instanceof OutputClauseLiteralExpression)) {
+        if (!(o instanceof InformationItemPrimary)) {
             return false;
         }
 
-        final OutputClauseLiteralExpression that = (OutputClauseLiteralExpression) o;
+        final InformationItemPrimary that = (InformationItemPrimary) o;
 
         if (id != null ? !id.equals(that.id) : that.id != null) {
             return false;
@@ -163,17 +156,13 @@ public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase impl
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
-        if (text != null ? !text.equals(that.text) : that.text != null) {
-            return false;
-        }
-        return importedValues != null ? importedValues.equals(that.importedValues) : that.importedValues == null;
+        return typeRefHolder != null ? typeRefHolder.equals(that.typeRefHolder) : that.typeRefHolder == null;
     }
 
     @Override
     public int hashCode() {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
-                                         text != null ? text.hashCode() : 0,
-                                         importedValues != null ? importedValues.hashCode() : 0);
+                                         typeRefHolder != null ? typeRefHolder.hashCode() : 0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClauseUnaryTests.java
@@ -19,8 +19,6 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
-import org.kie.workbench.common.dmn.api.property.dmn.Description;
-import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -46,38 +44,35 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests"),
-        startElement = "id")
-public class InputClauseUnaryTests extends DMNElement implements IsUnaryTests,
-                                                                 DMNPropertySet {
+        startElement = "text")
+public class InputClauseUnaryTests extends DMNModelInstrumentedBase implements IsUnaryTests,
+                                                                               DMNPropertySet {
+
+    protected Id id;
 
     @Property
     @FormField(afterElement = "description", labelKey = "text")
     protected Text text;
 
-    @Property
-    @FormField(afterElement = "text")
-    protected ExpressionLanguage expressionLanguage;
-
     public InputClauseUnaryTests() {
         this(new Id(),
-             new Description(),
-             new Text(),
-             new ExpressionLanguage());
+             new Text());
     }
 
     public InputClauseUnaryTests(final Id id,
-                                 final Description description,
-                                 final Text text,
-                                 final ExpressionLanguage expressionLanguage) {
-        super(id,
-              description);
+                                 final Text text) {
+        this.id = id;
         this.text = text;
-        this.expressionLanguage = expressionLanguage;
     }
 
     // -----------------------
     // DMN properties
     // -----------------------
+
+    @Override
+    public Id getId() {
+        return id;
+    }
 
     @Override
     public Text getText() {
@@ -86,15 +81,6 @@ public class InputClauseUnaryTests extends DMNElement implements IsUnaryTests,
 
     public void setText(final Text value) {
         this.text = value;
-    }
-
-    @Override
-    public ExpressionLanguage getExpressionLanguage() {
-        return expressionLanguage;
-    }
-
-    public void setExpressionLanguage(final ExpressionLanguage value) {
-        this.expressionLanguage = value;
     }
 
     @Override
@@ -111,20 +97,12 @@ public class InputClauseUnaryTests extends DMNElement implements IsUnaryTests,
         if (id != null ? !id.equals(that.id) : that.id != null) {
             return false;
         }
-        if (description != null ? !description.equals(that.description) : that.description != null) {
-            return false;
-        }
-        if (text != null ? !text.equals(that.text) : that.text != null) {
-            return false;
-        }
-        return expressionLanguage != null ? expressionLanguage.equals(that.expressionLanguage) : that.expressionLanguage == null;
+        return text != null ? text.equals(that.text) : that.text == null;
     }
 
     @Override
     public int hashCode() {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
-                                         description != null ? description.hashCode() : 0,
-                                         text != null ? text.hashCode() : 0,
-                                         expressionLanguage != null ? expressionLanguage.hashCode() : 0);
+                                         text != null ? text.hashCode() : 0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputData.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.Valid;
@@ -50,7 +51,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         startElement = "id")
 public class InputData extends DRGElement implements DMNViewDefinition,
-                                                     HasVariable {
+                                                     HasVariable<InformationItemPrimary> {
 
     @Category
     private static final String stunnerCategory = Categories.NODES;
@@ -63,7 +64,7 @@ public class InputData extends DRGElement implements DMNViewDefinition,
     @PropertySet
     @FormField(afterElement = "name")
     @Valid
-    protected InformationItem variable;
+    protected InformationItemPrimary variable;
 
     @PropertySet
     @FormField(afterElement = "variable")
@@ -84,7 +85,7 @@ public class InputData extends DRGElement implements DMNViewDefinition,
         this(new Id(),
              new org.kie.workbench.common.dmn.api.property.dmn.Description(),
              new Name(),
-             new InformationItem(),
+             new InformationItemPrimary(),
              new BackgroundSet(),
              new FontSet(),
              new RectangleDimensionsSet());
@@ -93,7 +94,7 @@ public class InputData extends DRGElement implements DMNViewDefinition,
     public InputData(final Id id,
                      final org.kie.workbench.common.dmn.api.property.dmn.Description description,
                      final Name name,
-                     final InformationItem variable,
+                     final InformationItemPrimary variable,
                      final BackgroundSet backgroundSet,
                      final FontSet fontSet,
                      final RectangleDimensionsSet dimensionsSet) {
@@ -104,6 +105,8 @@ public class InputData extends DRGElement implements DMNViewDefinition,
         this.backgroundSet = backgroundSet;
         this.fontSet = fontSet;
         this.dimensionsSet = dimensionsSet;
+
+        setVariableParent();
     }
 
     // -----------------------
@@ -150,12 +153,12 @@ public class InputData extends DRGElement implements DMNViewDefinition,
     // -----------------------
 
     @Override
-    public InformationItem getVariable() {
+    public InformationItemPrimary getVariable() {
         return variable;
     }
 
     @Override
-    public void setVariable(final InformationItem variable) {
+    public void setVariable(final InformationItemPrimary variable) {
         this.variable = variable;
     }
 
@@ -205,5 +208,9 @@ public class InputData extends DRGElement implements DMNViewDefinition,
                                          backgroundSet != null ? backgroundSet.hashCode() : 0,
                                          fontSet != null ? fontSet.hashCode() : 0,
                                          dimensionsSet != null ? dimensionsSet.hashCode() : 0);
+    }
+
+    private void setVariableParent() {
+        Optional.ofNullable(variable).ifPresent(v -> v.setParent(this));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/IsInformationItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/IsInformationItem.java
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.backend.definition.v1_1;
+package org.kie.workbench.common.dmn.api.definition.v1_1;
 
-import org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseUnaryTests;
+import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
-import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 
-public class OutputClauseUnaryTestsPropertyConverter {
+public interface IsInformationItem extends DomainObject,
+                                           HasTypeRef {
 
-    public static OutputClauseUnaryTests wbFromDMN(final org.kie.dmn.model.api.UnaryTests dmn) {
-        if (dmn == null) {
-            return null;
-        }
-        Id id = new Id(dmn.getId());
-        OutputClauseUnaryTests result = new OutputClauseUnaryTests(id, new Text(dmn.getText()));
-        return result;
-    }
+    Id getId();
+
+    DMNModelInstrumentedBase getParent();
+
+    void setParent(final DMNModelInstrumentedBase parent);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/IsLiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/IsLiteralExpression.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
-import org.kie.workbench.common.dmn.api.property.dmn.Description;
-import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
@@ -26,13 +24,9 @@ public interface IsLiteralExpression {
 
     Id getId();
 
-    Description getDescription();
-
     QName getTypeRef();
 
     Text getText();
-
-    ExpressionLanguage getExpressionLanguage();
 
     ImportedValues getImportedValues();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/IsUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/IsUnaryTests.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.dmn.api.definition.v1_1;
 
-import org.kie.workbench.common.dmn.api.property.dmn.Description;
-import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 
@@ -26,8 +24,4 @@ public interface IsUnaryTests {
     Id getId();
 
     Text getText();
-
-    Description getDescription();
-
-    ExpressionLanguage getExpressionLanguage();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
@@ -121,7 +121,6 @@ public class LiteralExpression extends Expression implements IsLiteralExpression
         this.importedValues = importedValues;
     }
 
-    @Override
     public ExpressionLanguage getExpressionLanguage() {
         return expressionLanguage;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClauseUnaryTests.java
@@ -19,8 +19,6 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
-import org.kie.workbench.common.dmn.api.property.dmn.Description;
-import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -46,38 +44,35 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
         i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseUnaryTests"),
-        startElement = "id")
-public class OutputClauseUnaryTests extends DMNElement implements IsUnaryTests,
-                                                                  DMNPropertySet {
+        startElement = "text")
+public class OutputClauseUnaryTests extends DMNModelInstrumentedBase implements IsUnaryTests,
+                                                                                DMNPropertySet {
+
+    protected Id id;
 
     @Property
-    @FormField(afterElement = "description", labelKey = "text")
+    @FormField(labelKey = "text")
     protected Text text;
-
-    @Property
-    @FormField(afterElement = "text")
-    protected ExpressionLanguage expressionLanguage;
 
     public OutputClauseUnaryTests() {
         this(new Id(),
-             new Description(),
-             new Text(),
-             new ExpressionLanguage());
+             new Text());
     }
 
     public OutputClauseUnaryTests(final Id id,
-                                  final Description description,
-                                  final Text text,
-                                  final ExpressionLanguage expressionLanguage) {
-        super(id,
-              description);
+                                  final Text text) {
+        this.id = id;
         this.text = text;
-        this.expressionLanguage = expressionLanguage;
     }
 
     // -----------------------
     // DMN properties
     // -----------------------
+
+    @Override
+    public Id getId() {
+        return id;
+    }
 
     @Override
     public Text getText() {
@@ -86,15 +81,6 @@ public class OutputClauseUnaryTests extends DMNElement implements IsUnaryTests,
 
     public void setText(final Text value) {
         this.text = value;
-    }
-
-    @Override
-    public ExpressionLanguage getExpressionLanguage() {
-        return expressionLanguage;
-    }
-
-    public void setExpressionLanguage(final ExpressionLanguage value) {
-        this.expressionLanguage = value;
     }
 
     @Override
@@ -111,20 +97,13 @@ public class OutputClauseUnaryTests extends DMNElement implements IsUnaryTests,
         if (id != null ? !id.equals(that.id) : that.id != null) {
             return false;
         }
-        if (description != null ? !description.equals(that.description) : that.description != null) {
-            return false;
-        }
-        if (text != null ? !text.equals(that.text) : that.text != null) {
-            return false;
-        }
-        return expressionLanguage != null ? expressionLanguage.equals(that.expressionLanguage) : that.expressionLanguage == null;
+
+        return text != null ? text.equals(that.text) : that.text == null;
     }
 
     @Override
     public int hashCode() {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
-                                         description != null ? description.hashCode() : 0,
-                                         text != null ? text.hashCode() : 0,
-                                         expressionLanguage != null ? expressionLanguage.hashCode() : 0);
+                                         text != null ? text.hashCode() : 0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/resource/i18n/DMNAPIConstants.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/resource/i18n/DMNAPIConstants.java
@@ -35,6 +35,9 @@ public class DMNAPIConstants {
     public static final String InformationItem_DomainObjectName = "InformationItem.DomainObjectName";
 
     @TranslationKey(defaultValue = "")
+    public static final String InformationItemPrimary_DomainObjectName = "InformationItemPrimary.DomainObjectName";
+
+    @TranslationKey(defaultValue = "")
     public static final String Decision_DomainObjectName = "Decision.DomainObjectName";
 
     @TranslationKey(defaultValue = "")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
@@ -54,6 +54,7 @@ org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression.label=Literal
 org.kie.workbench.common.dmn.api.definition.v1_1.ImportedValues.label=Imported values
 org.kie.workbench.common.dmn.api.definition.v1_1.Import.label=Import
 org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem.label=Information item
+org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary.label=Information item
 
 #######################
 # Background property
@@ -120,6 +121,7 @@ LiteralExpression.DomainObjectName=Literal Expression
 ImportedValues.DomainObjectName=Imported Values
 UnaryTests.DomainObjectName=Unary Tests
 InformationItem.DomainObjectName=Information Item
+InformationItemPrimary.DomainObjectName=Information Item
 Decision.DomainObjectName=Decision
 BusinessKnowledgeModel.DomainObjectName=Business Knowledge Model
 InputClause.DomainObjectName=Input Clause

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModelTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModelTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.v1_1;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
+import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.font.FontSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class BusinessKnowledgeModelTest {
+
+    @Test
+    public void testConstructor() {
+
+        final Id id = mock(Id.class);
+        final Description description = mock(Description.class);
+        final Name name = mock(Name.class);
+        final FunctionDefinition functionDefinition = mock(FunctionDefinition.class);
+        final BackgroundSet backgroundSet = mock(BackgroundSet.class);
+        final FontSet fontSet = mock(FontSet.class);
+        final RectangleDimensionsSet rectangleDimensionSset = mock(RectangleDimensionsSet.class);
+
+        final InformationItemPrimary variable = new InformationItemPrimary();
+        final BusinessKnowledgeModel expectedParent = new BusinessKnowledgeModel(id,
+                                                                                 description,
+                                                                                 name,
+                                                                                 variable,
+                                                                                 functionDefinition,
+                                                                                 backgroundSet,
+                                                                                 fontSet,
+                                                                                 rectangleDimensionSset);
+
+        final DMNModelInstrumentedBase actualParent = variable.getParent();
+
+        assertEquals(expectedParent, actualParent);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.v1_1;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
+import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dmn.AllowedAnswers;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.Question;
+import org.kie.workbench.common.dmn.api.property.font.FontSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class DecisionTest {
+
+    @Test
+    public void testConstructor() {
+
+        final Id id = mock(Id.class);
+        final Description description = mock(Description.class);
+        final Name name = mock(Name.class);
+        final Question question = mock(Question.class);
+        final AllowedAnswers allowedAnswers = mock(AllowedAnswers.class);
+        final Expression expression = mock(Expression.class);
+        final BackgroundSet backgroundSet = mock(BackgroundSet.class);
+        final FontSet fontSet = mock(FontSet.class);
+        final RectangleDimensionsSet dimensionsSet = mock(RectangleDimensionsSet.class);
+
+        final InformationItemPrimary variable = new InformationItemPrimary();
+        final Decision expectedParent = new Decision(id,
+                                                     description,
+                                                     name,
+                                                     question,
+                                                     allowedAnswers,
+                                                     variable,
+                                                     expression,
+                                                     backgroundSet,
+                                                     fontSet,
+                                                     dimensionsSet);
+
+        final DMNModelInstrumentedBase actualParent = variable.getParent();
+
+        assertEquals(expectedParent, actualParent);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItemPrimaryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItemPrimaryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.v1_1;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.dmn.api.property.dmn.QNameHolder;
+
+import static org.junit.Assert.assertEquals;
+
+public class InformationItemPrimaryTest {
+
+    private InformationItemPrimary informationItemPrimary;
+
+    @Before
+    public void setup() {
+        this.informationItemPrimary = new InformationItemPrimary();
+    }
+
+    @Test
+    public void testTypeRefHolderWrapsTypeRef() {
+
+        final QName typeRef = informationItemPrimary.getTypeRef();
+        final QNameHolder typeRefHolder = informationItemPrimary.getTypeRefHolder();
+
+        assertEquals(typeRef, typeRefHolder.getValue());
+    }
+
+    @Test
+    public void testTypeRefHolderWrapsTypeRefAfterSettingTypeRef() {
+
+        final QName typeRef = new QName();
+
+        informationItemPrimary.setTypeRef(typeRef);
+        assertEquals(typeRef, informationItemPrimary.getTypeRef());
+
+        final QNameHolder typeRefHolder = informationItemPrimary.getTypeRefHolder();
+
+        assertEquals(typeRef, typeRefHolder.getValue());
+    }
+
+    @Test
+    public void testTypeRefHolderWrapsTYpeRefAfterSettingTypeRefHolder() {
+
+        final QName typeRef = informationItemPrimary.getTypeRef();
+        final QNameHolder typeRefHolder = new QNameHolder();
+
+        informationItemPrimary.setTypeRefHolder(typeRefHolder);
+
+        assertEquals(typeRef, informationItemPrimary.getTypeRefHolder().getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputDataTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.v1_1;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
+import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.font.FontSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class InputDataTest {
+
+    @Test
+    public void testConstructor() {
+
+        final Id id = mock(Id.class);
+        final Description description = mock(Description.class);
+        final Name name = mock(Name.class);
+        final BackgroundSet backgroundSet = mock(BackgroundSet.class);
+        final FontSet fontSet = mock(FontSet.class);
+        final RectangleDimensionsSet dimensionsSet = mock(RectangleDimensionsSet.class);
+
+        final InformationItemPrimary variable = new InformationItemPrimary();
+        final InputData expectedParent = new InputData(id,
+                                                       description,
+                                                       name,
+                                                       variable,
+                                                       backgroundSet,
+                                                       fontSet,
+                                                       dimensionsSet);
+
+        final DMNModelInstrumentedBase actualParent = variable.getParent();
+
+        assertEquals(expectedParent, actualParent);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
@@ -232,6 +232,19 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-core</artifactId>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
-import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
 import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
@@ -51,7 +51,7 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         Name name = new Name(dmn.getName());
-        InformationItem informationItem = InformationItemPropertyConverter.wbFromDMN(dmn.getVariable());
+        InformationItemPrimary informationItem = InformationItemPrimaryPropertyConverter.wbFromDMN(dmn.getVariable());
         FunctionDefinition functionDefinition = FunctionDefinitionPropertyConverter.wbFromDMN(dmn.getEncapsulatedLogic());
         BusinessKnowledgeModel bkm = new BusinessKnowledgeModel(id,
                                                                 description,
@@ -80,7 +80,7 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());
-        org.kie.dmn.model.api.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(source.getVariable());
+        org.kie.dmn.model.api.InformationItem variable = InformationItemPrimaryPropertyConverter.dmnFromWB(source.getVariable());
         if (variable != null) {
             variable.setParent(result);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
-import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
 import org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
@@ -55,7 +55,7 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.De
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         Name name = new Name(dmn.getName());
-        InformationItem informationItem = InformationItemPropertyConverter.wbFromDMN(dmn.getVariable());
+        InformationItemPrimary informationItem = InformationItemPrimaryPropertyConverter.wbFromDMN(dmn.getVariable());
         Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
         Decision decision = new Decision(id,
                                          description,
@@ -86,7 +86,7 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.De
         d.setId(source.getId().getValue());
         d.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         d.setName(source.getName().getValue());
-        org.kie.dmn.model.api.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(source.getVariable());
+        org.kie.dmn.model.api.InformationItem variable = InformationItemPrimaryPropertyConverter.dmnFromWB(source.getVariable());
         if (variable != null) {
             variable.setParent(d);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPrimaryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPrimaryPropertyConverter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.Optional;
+
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.v1_2.TInformationItem;
+import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.QName;
+
+public class InformationItemPrimaryPropertyConverter {
+
+    private static final String DEFAULT_NAME = "";
+
+    public static InformationItemPrimary wbFromDMN(final InformationItem dmn) {
+
+        if (dmn == null) {
+            return null;
+        }
+
+        final Id id = new Id(dmn.getId());
+        final QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef(), dmn);
+
+        return new InformationItemPrimary(id, typeRef);
+    }
+
+    public static TInformationItem dmnFromWB(final InformationItemPrimary wb) {
+
+        if (wb == null) {
+            return null;
+        }
+
+        final TInformationItem result = new TInformationItem();
+        final QName typeRef = wb.getTypeRef();
+
+        result.setId(wb.getId().getValue());
+        result.setName(getName(wb));
+
+        QNamePropertyConverter.setDMNfromWB(typeRef, result::setTypeRef);
+
+        return result;
+    }
+
+    static String getName(final InformationItemPrimary wb) {
+
+        final DMNModelInstrumentedBase parent = wb.getParent();
+
+        if (parent instanceof HasName) {
+
+            final HasName hasName = (HasName) wb.getParent();
+            final Optional<Name> name = Optional.ofNullable(hasName.getName());
+
+            return name.map(Name::getValue).orElse(DEFAULT_NAME);
+        }
+
+        return DEFAULT_NAME;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClauseUnaryTestsPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputClauseUnaryTestsPropertyConverter.java
@@ -17,8 +17,6 @@
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests;
-import org.kie.workbench.common.dmn.api.property.dmn.Description;
-import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 
@@ -29,12 +27,8 @@ public class InputClauseUnaryTestsPropertyConverter {
             return null;
         }
         Id id = new Id(dmn.getId());
-        Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
-        ExpressionLanguage expressionLanguage = ExpressionLanguagePropertyConverter.wbFromDMN(dmn.getExpressionLanguage());
         InputClauseUnaryTests result = new InputClauseUnaryTests(id,
-                                                                 description,
-                                                                 new Text(dmn.getText()),
-                                                                 expressionLanguage);
+                                                                 new Text(dmn.getText()));
         return result;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
@@ -16,7 +16,7 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
-import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
 import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
@@ -45,7 +45,7 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.api.I
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         Name name = new Name(dmn.getName());
-        InformationItem informationItem = InformationItemPropertyConverter.wbFromDMN(dmn.getVariable());
+        InformationItemPrimary informationItem = InformationItemPrimaryPropertyConverter.wbFromDMN(dmn.getVariable());
         InputData inputData = new InputData(id,
                                             description,
                                             name,
@@ -69,7 +69,7 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.api.I
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));
         result.setName(source.getName().getValue());
-        org.kie.dmn.model.api.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(source.getVariable());
+        org.kie.dmn.model.api.InformationItem variable = InformationItemPrimaryPropertyConverter.dmnFromWB(source.getVariable());
         if (variable != null) {
             variable.setParent(result);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -55,11 +55,9 @@ public class LiteralExpressionPropertyConverter {
         }
         org.kie.dmn.model.api.LiteralExpression result = new org.kie.dmn.model.v1_2.TLiteralExpression();
         result.setId(wb.getId().getValue());
-        result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
         result.setText(wb.getText().getValue());
-        result.setExpressionLanguage(ExpressionLanguagePropertyConverter.dmnFromWB(wb.getExpressionLanguage()));
         org.kie.dmn.model.api.ImportedValues importedValues = ImportedValuesConverter.dmnFromWB(wb.getImportedValues());
         if (importedValues != null) {
             importedValues.setParent(result);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClauseLiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/OutputClauseLiteralExpressionPropertyConverter.java
@@ -18,8 +18,6 @@ package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.ImportedValues;
 import org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseLiteralExpression;
-import org.kie.workbench.common.dmn.api.property.dmn.Description;
-import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
@@ -31,17 +29,13 @@ public class OutputClauseLiteralExpressionPropertyConverter {
             return null;
         }
         Id id = new Id(dmn.getId());
-        Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef(), dmn);
         Text text = new Text(dmn.getText());
-        ExpressionLanguage expressionLanguage = ExpressionLanguagePropertyConverter.wbFromDMN(dmn.getExpressionLanguage());
         ImportedValues importedValues = ImportedValuesConverter.wbFromDMN(dmn.getImportedValues());
         OutputClauseLiteralExpression result = new OutputClauseLiteralExpression(id,
-                                                                                 description,
                                                                                  typeRef,
                                                                                  text,
-                                                                                 importedValues,
-                                                                                 expressionLanguage);
+                                                                                 importedValues);
         if (importedValues != null) {
             importedValues.setParent(result);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverter.java
@@ -45,9 +45,7 @@ public class UnaryTestsPropertyConverter {
         }
         org.kie.dmn.model.api.UnaryTests result = new org.kie.dmn.model.v1_2.TUnaryTests();
         result.setId(wb.getId().getValue());
-        result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setText(wb.getText().getValue());
-        result.setExpressionLanguage(ExpressionLanguagePropertyConverter.dmnFromWB(wb.getExpressionLanguage()));
 
         return result;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPrimaryPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InformationItemPrimaryPropertyConverterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.api.InformationItem;
+import org.kie.dmn.model.v1_2.TInformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@PrepareForTest({QNamePropertyConverter.class, InformationItemPrimaryPropertyConverter.class})
+@RunWith(PowerMockRunner.class)
+public class InformationItemPrimaryPropertyConverterTest {
+
+    @Test
+    public void testWbFromDMNWhenDMNIsNull() {
+
+        final InformationItem dmn = null;
+        final InformationItemPrimary informationItemPrimary = InformationItemPrimaryPropertyConverter.wbFromDMN(dmn);
+
+        assertNull(informationItemPrimary);
+    }
+
+    @Test
+    public void testWbFromDMNWhenDMNIsNotNull() {
+
+        final String id = "id";
+        final Id expectedId = new Id(id);
+        final QName expectedTypeRef = mock(QName.class);
+        final javax.xml.namespace.QName qName = mock(javax.xml.namespace.QName.class);
+        final org.kie.dmn.model.api.InformationItem dmn = mock(org.kie.dmn.model.api.InformationItem.class);
+
+        when(dmn.getId()).thenReturn(id);
+        when(dmn.getTypeRef()).thenReturn(qName);
+
+        PowerMockito.mockStatic(QNamePropertyConverter.class);
+        PowerMockito.when(QNamePropertyConverter.wbFromDMN(qName, dmn)).thenReturn(expectedTypeRef);
+
+        final InformationItemPrimary informationItemPrimary = InformationItemPrimaryPropertyConverter.wbFromDMN(dmn);
+        final Id actualId = informationItemPrimary.getId();
+        final QName actualTypeRef = informationItemPrimary.getTypeRef();
+
+        assertEquals(expectedId, actualId);
+        assertEquals(expectedTypeRef, actualTypeRef);
+    }
+
+    @Test
+    public void testDmnFromWBWhenWBIsNull() {
+
+        final InformationItemPrimary wb = null;
+        final InformationItem informationItem = InformationItemPrimaryPropertyConverter.dmnFromWB(wb);
+
+        assertNull(informationItem);
+    }
+
+    @Test
+    public void testDmnFromWBWhenWBIsNotNull() {
+
+        final String expectedId = "id";
+        final String expectedName = "name";
+        final Id id = new Id(expectedId);
+        final InformationItemPrimary wb = mock(InformationItemPrimary.class);
+        final QName qName = PowerMockito.mock(QName.class);
+        final javax.xml.namespace.QName expectedQName = mock(javax.xml.namespace.QName.class);
+        final Optional<javax.xml.namespace.QName> optionalExpectedQName = Optional.of(expectedQName);
+
+        when(wb.getId()).thenReturn(id);
+        when(wb.getTypeRef()).thenReturn(qName);
+
+        PowerMockito.stub(PowerMockito.method(InformationItemPrimaryPropertyConverter.class, "getName", InformationItemPrimary.class)).toReturn(expectedName);
+        PowerMockito.stub(PowerMockito.method(QNamePropertyConverter.class, "dmnFromWB", QName.class)).toReturn(optionalExpectedQName);
+
+        final TInformationItem informationItem = InformationItemPrimaryPropertyConverter.dmnFromWB(wb);
+        final String actualId = informationItem.getId();
+        final String actualName = informationItem.getName();
+        final javax.xml.namespace.QName actualQName = informationItem.getTypeRef();
+
+        assertEquals(expectedId, actualId);
+        assertEquals(expectedName, actualName);
+        assertEquals(expectedQName, actualQName);
+    }
+
+    @Test
+    public void testGetNameWhenParentDoesNotHaveName() {
+
+        final InformationItemPrimary informationItem = mock(InformationItemPrimary.class);
+        final InformationItemPrimary parent = mock(InformationItemPrimary.class);
+
+        when(informationItem.getParent()).thenReturn(parent);
+
+        final String name = InformationItemPrimaryPropertyConverter.getName(informationItem);
+
+        assertTrue(name.isEmpty());
+    }
+
+    @Test
+    public void testGetNameWhenParentHasNullName() {
+
+        final InformationItemPrimary informationItem = mock(InformationItemPrimary.class);
+        final InputData parent = mock(InputData.class);
+
+        when(informationItem.getParent()).thenReturn(parent);
+        when(parent.getName()).thenReturn(null);
+
+        final String name = InformationItemPrimaryPropertyConverter.getName(informationItem);
+
+        assertTrue(name.isEmpty());
+    }
+
+    @Test
+    public void testGetNameWhenParentHasName() {
+
+        final InformationItemPrimary informationItem = mock(InformationItemPrimary.class);
+        final InputData parent = mock(InputData.class);
+        final Name parentName = mock(Name.class);
+        final String expectedName = "name";
+
+        when(informationItem.getParent()).thenReturn(parent);
+        when(parent.getName()).thenReturn(parentName);
+        when(parentName.getValue()).thenReturn(expectedName);
+
+        final String actualName = InformationItemPrimaryPropertyConverter.getName(informationItem);
+
+        assertEquals(expectedName, actualName);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Definitions;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputClause;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
@@ -402,7 +403,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
     @Test
     public void testModelEnrichmentWhenHasExpressionIsHasVariable() {
         final Decision decision = new Decision();
-        final InformationItem variable = new InformationItem();
+        final InformationItemPrimary variable = new InformationItemPrimary();
         variable.setTypeRef(OUTPUT_DATA_QNAME);
         decision.setVariable(variable);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
@@ -39,7 +39,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTableOrientation;
 import org.kie.workbench.common.dmn.api.definition.v1_1.HitPolicy;
-import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
@@ -1390,7 +1390,7 @@ public class DecisionTableGridTest {
         setupGrid(makeHasNameForDecision(), 0);
 
         assertThat(extractHeaderMetaData(0, 1).asDMNModelInstrumentedBase()).isInstanceOf(LiteralExpression.class);
-        assertThat(extractHeaderMetaData(0, 2).asDMNModelInstrumentedBase()).isInstanceOf(InformationItem.class);
+        assertThat(extractHeaderMetaData(0, 2).asDMNModelInstrumentedBase()).isInstanceOf(InformationItemPrimary.class);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.v1_1.List;
@@ -910,6 +911,8 @@ public class RelationGridTest {
     public void testAsDMNModelInstrumentedBase() {
         setupGrid(0);
 
-        assertThat(extractHeaderMetaData().asDMNModelInstrumentedBase()).isInstanceOf(hasExpression.getVariable().getClass());
+        final DMNModelInstrumentedBase actual = extractHeaderMetaData().asDMNModelInstrumentedBase();
+
+        assertThat(actual).isInstanceOf(InformationItem.class);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/util/TypeRefUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/util/TypeRefUtilsTest.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
-import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -43,7 +43,7 @@ public class TypeRefUtilsTest {
     private Decision decision;
 
     @Mock
-    private InformationItem decisionVariable;
+    private InformationItemPrimary decisionVariable;
 
     @Mock
     private DecisionTable expression;


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/DROOLS-3266
- https://issues.jboss.org/browse/DROOLS-3259
- https://issues.jboss.org/browse/DROOLS-3250
- https://issues.jboss.org/browse/DROOLS-1942

---

Removed properties:
![2018-11-08 11 10 47 am](https://user-images.githubusercontent.com/1079279/48214711-b570b800-e367-11e8-8232-8a4ca0510a2f.gif)

Fixed `name` attribute:
![2018-11-08 1 26 29 pm](https://user-images.githubusercontent.com/1079279/48214674-9b36da00-e367-11e8-9a9a-36eb552019ad.gif)


