### PR TITLE
DROOLS-3268: [DMN Designer] Data-types: Check for use of built-in-type should be case sensitive

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtils.java
@@ -26,11 +26,7 @@ public class BuiltInTypeUtils {
 
     public static boolean isDefault(final String type) {
         return builtInTypeNames()
-                .anyMatch(builtInTypeName -> Objects.equals(upperCase(builtInTypeName), upperCase(type)));
-    }
-
-    private static String upperCase(final String value) {
-        return value == null ? null : value.toUpperCase();
+                .anyMatch(builtInTypeName -> Objects.equals(builtInTypeName, type));
     }
 
     private static Stream<String> builtInTypeNames() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/BuiltInTypeUtilsTest.java
@@ -34,8 +34,8 @@ public class BuiltInTypeUtilsTest {
     }
 
     @Test
-    public void testIsDefaultWhenTypeIsDefaultWithAnUpperCaseCharacter() {
-        assertTrue(BuiltInTypeUtils.isDefault("String"));
+    public void testIsNotDefaultWhenTypeIsDefaultWithAnUpperCaseCharacter() {
+        assertFalse(BuiltInTypeUtils.isDefault("String"));
     }
 
     @Test


### PR DESCRIPTION
DROOLS-3268: [DMN Designer] Data-types: Check for use of built-in-type should be case sensitive