### PR TITLE
Remove useless property overrides

### DIFF
--- a/kie-wb-common-dmn/pom.xml
+++ b/kie-wb-common-dmn/pom.xml
@@ -31,9 +31,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <!-- See https://github.com/AppFormer/uberfire/commit/a4cf2e727c01a48fdf91ec5dd58f82dc1422913a#commitcomment-23311379 -->
-    <version.org.eclipse.jgit>4.8.0.201706111038-r</version.org.eclipse.jgit>
-    <version.org.apache.sshd>1.6.0</version.org.apache.sshd>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <checkstyle.logViolationsToConsole>true</checkstyle.logViolationsToConsole>
     <jacoco.haltOnFailure>true</jacoco.haltOnFailure>


### PR DESCRIPTION
```
kie-wb-common-dmn overrides 'version.org.apache.sshd' defined in jboss-integration-platform-parent from '1.6.0' to '1.6.0'
kie-wb-common-dmn overrides 'version.org.eclipse.jgit' defined in jboss-integration-platform-parent from '4.8.0.201706111038-r' to '4.8.0.201706111038-r'
```

These overrides are no longer necessare and keeping them in will introduce unnecessary inconsitencies in the future. @manstis please check and merge