### PR TITLE
DROOLS-3234 : Add a Donut widget to improve the visualisation of test report screen

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
@@ -167,6 +167,14 @@
       <artifactId>dashbuilder-navigation-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-displayer-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-displayer-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-dataset-api</artifactId>
     </dependency>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/WorkbenchConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/WorkbenchConstants.java
@@ -9,4 +9,10 @@ public class WorkbenchConstants {
 
     @TranslationKey(defaultValue = "FAILED")
     public static final String FAILED = "TestRunnerReportingViewImpl.FAILED";
+
+    @TranslationKey(defaultValue = "Passed")
+    public static final String Passed = "TestResultDonutPresenter.Passed";
+
+    @TranslationKey(defaultValue = "Failed")
+    public static final String Failed = "TestResultDonutPresenter.Failed";
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestResultDonutPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestResultDonutPresenter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.workbench.client.test;
+
+import javax.inject.Inject;
+
+import elemental2.dom.HTMLDivElement;
+import org.dashbuilder.dataset.DataSetFactory;
+import org.dashbuilder.displayer.DisplayerSettingsFactory;
+import org.dashbuilder.displayer.Position;
+import org.dashbuilder.displayer.client.Displayer;
+import org.dashbuilder.displayer.client.DisplayerCoordinator;
+import org.dashbuilder.displayer.client.DisplayerLocator;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.workbench.client.resources.i18n.WorkbenchConstants;
+
+public class TestResultDonutPresenter {
+
+    private TranslationService translationService;
+
+    private Elemental2DomUtil elemental2DomUtil;
+    private DisplayerLocator displayerLocator;
+    private DisplayerCoordinator displayerCoordinator;
+    private Displayer displayer;
+    private HTMLDivElement container;
+
+    public TestResultDonutPresenter() {
+        //CDI
+    }
+
+    @Inject
+    public TestResultDonutPresenter(final DisplayerLocator displayerLocator,
+                                    final Elemental2DomUtil elemental2DomUtil,
+                                    final DisplayerCoordinator displayerCoordinator,
+                                    final TranslationService translationService) {
+        this.displayerLocator = displayerLocator;
+        this.elemental2DomUtil = elemental2DomUtil;
+        this.displayerCoordinator = displayerCoordinator;
+        this.translationService = translationService;
+    }
+
+    public void init(final HTMLDivElement container) {
+        this.container = container;
+    }
+
+    public void showSuccessFailureDiagram(final int passed,
+                                          final int failed) {
+
+        if (displayer != null) {
+            elemental2DomUtil.removeAllElementChildren(container);
+            displayerCoordinator.removeDisplayer(displayer);
+        }
+
+        displayer = makeDisplayer(passed,
+                                  failed);
+
+        displayerCoordinator.addDisplayer(displayer);
+        displayerCoordinator.drawAll();
+
+        elemental2DomUtil.appendWidgetToElement(container,
+                                                displayer.asWidget());
+    }
+
+    private Displayer makeDisplayer(final int passed,
+                                    final int failed) {
+        return displayerLocator.lookupDisplayer(DisplayerSettingsFactory.newPieChartSettings()
+                                                        .height(350)
+                                                        .width(200)
+                                                        .titleVisible(true)
+                                                        .subType_Donut()
+                                                        .margins(1, 100, 1, 1)
+                                                        .legendOn(Position.BOTTOM)
+                                                        .column("testCount").format("testCount", "#")
+                                                        .dataset(DataSetFactory.newDataSetBuilder()
+                                                                         .label("STATUS")
+                                                                         .number("testCount")
+                                                                         .row(translationService.format(WorkbenchConstants.Passed),
+                                                                              passed)
+                                                                         .row(translationService.format(WorkbenchConstants.Failed),
+                                                                              failed)
+                                                                         .buildDataSet())
+                                                        .buildSettings());
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
@@ -55,11 +55,14 @@ public class TestRunnerReportingScreen
     }
 
     @Inject
-    public TestRunnerReportingScreen(TestRunnerReportingView view,
-                                     Event<PublishBatchMessagesEvent> publishBatchMessagesEvent) {
+    public TestRunnerReportingScreen(final TestRunnerReportingView view,
+                                     final Event<PublishBatchMessagesEvent> publishBatchMessagesEvent) {
         this.view = view;
         this.publishBatchMessagesEvent = publishBatchMessagesEvent;
         view.setPresenter(this);
+
+        view.showSuccessFailureDiagram(1,
+                                       0);
     }
 
     @DefaultPosition
@@ -91,7 +94,7 @@ public class TestRunnerReportingScreen
         publishBatchMessagesEvent.fire(messagesEvent);
     }
 
-    public void onTestRun(@Observes TestResultMessage testResultMessage) {
+    public void onTestRun(final @Observes TestResultMessage testResultMessage) {
         reset();
 
         if (testResultMessage.wasSuccessful()) {
@@ -99,15 +102,21 @@ public class TestRunnerReportingScreen
         } else {
             if (testResultMessage.getFailures() != null) {
                 systemMessages = testResultMessage.getFailures().stream().map(this::convert).collect(Collectors.toList());
+
             }
             view.showFailure();
         }
+
+        int failures = testResultMessage.getFailures().size();
+        view.showSuccessFailureDiagram((testResultMessage.getRunCount() - failures),
+                                       failures);
+
         view.setRunStatus(getCompletedAt(),
                           getScenariosRun(testResultMessage),
                           getDuration(testResultMessage));
     }
 
-    private SystemMessage convert(Failure failure) {
+    private SystemMessage convert(final Failure failure) {
         SystemMessage systemMessage = new SystemMessage();
         systemMessage.setMessageType("TestResults");
         systemMessage.setLevel(Level.ERROR);
@@ -120,13 +129,13 @@ public class TestRunnerReportingScreen
         return timeFormat.format(new Date());
     }
 
-    private String getScenariosRun(TestResultMessage testResultMessage) {
+    private String getScenariosRun(final TestResultMessage testResultMessage) {
         return String.valueOf(testResultMessage.getRunCount());
     }
 
-    private String getDuration(TestResultMessage testResultMessage) {
-        Long runTime = testResultMessage.getRunTime();
-        Date runtime = new Date(runTime);
+    private String getDuration(final TestResultMessage testResultMessage) {
+        final Long runTime = testResultMessage.getRunTime();
+        final Date runtime = new Date(runTime);
 
         String milliseconds = formatMilliseconds(DateTimeFormat.getFormat("SSS").format(runtime)) + " milliseconds";
         String seconds = DateTimeFormat.getFormat("s").format(runtime) + " seconds";
@@ -141,7 +150,7 @@ public class TestRunnerReportingScreen
         }
     }
 
-    String formatMilliseconds(String originalFormat) {
+    String formatMilliseconds(final String originalFormat) {
         return originalFormat.replaceFirst("^0+(?!$)", "");
     }
 

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
@@ -61,8 +61,7 @@ public class TestRunnerReportingScreen
         this.publishBatchMessagesEvent = publishBatchMessagesEvent;
         view.setPresenter(this);
 
-        view.showSuccessFailureDiagram(1,
-                                       0);
+        view.resetDonut();
     }
 
     @DefaultPosition

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingView.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingView.java
@@ -38,6 +38,8 @@ public interface TestRunnerReportingView
 
     void showFailure();
 
+    void showSuccessFailureDiagram(final int passed, final int failed);
+
     void setRunStatus(String completedAt,
                       String ScenariosRun,
                       String duration);

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingView.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingView.java
@@ -24,7 +24,6 @@ import org.guvnor.messageconsole.events.SystemMessage;
 public interface TestRunnerReportingView
         extends IsWidget {
 
-
     interface Presenter {
 
         void onViewAlerts();
@@ -37,6 +36,8 @@ public interface TestRunnerReportingView
     void showSuccess();
 
     void showFailure();
+
+    void resetDonut();
 
     void showSuccessFailureDiagram(final int passed, final int failed);
 

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.css
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.css
@@ -57,8 +57,8 @@ a:hover {
 }
 
 .kie-dock__divider {
-  margin-top: 25px;
-  margin-bottom: 15px;
+  margin-top: 30px;
+  margin-bottom: 25px;
 }
 
 .kie-dock-selector__tab {
@@ -82,4 +82,10 @@ a:hover {
   min-height: 1px;
   padding-left: 20px;
   padding-right: 20px;
+}
+
+.donut-container {
+  margin-left: auto;
+  margin-right: auto;
+  width: 200px;
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
@@ -57,8 +57,10 @@
                     <span data-i18n-key="ViewAlerts"></span></a>
 
                 <hr class="kie-dock__divider"/>
-                <h5 class="kie-dock__heading--section"><span data-i18n-key="ScenarioStatus"></span></h5>
-                <span class="donut-container" data-field="donutDiv"></span>
+                <div data-field="donutDivContainer">
+                    <h5 class="kie-dock__heading--section"><span data-i18n-key="ScenarioStatus"></span></h5>
+                    <span class="donut-container" data-field="donutDiv"></span>
+                </div>
 
                 <br/>
             </div>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
@@ -56,6 +56,10 @@
                 <a data-field="viewAlerts">
                     <span data-i18n-key="ViewAlerts"></span></a>
 
+                <hr class="kie-dock__divider"/>
+                <h5 class="kie-dock__heading--section"><span data-i18n-key="ScenarioStatus"></span></h5>
+                <span class="donut-container" data-field="donutDiv"></span>
+
                 <br/>
             </div>
         </div>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.java
@@ -16,18 +16,12 @@
 
 package org.kie.workbench.common.workbench.client.test;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.user.client.ui.Widget;
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
-import org.guvnor.messageconsole.events.PublishBatchMessagesEvent;
-import org.guvnor.messageconsole.events.SystemMessage;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
@@ -62,7 +56,35 @@ public class TestRunnerReportingViewImpl
     @DataField
     private HTMLAnchorElement viewAlerts;
 
+    @DataField
+    private HTMLDivElement donutDiv;
+
+    private TestResultDonutPresenter testResultDonutPresenter;
     private TranslationService translationService;
+
+    @Inject
+    public TestRunnerReportingViewImpl(final HTMLDivElement resultPanel,
+                                       final HTMLDivElement testResultIcon,
+                                       final HTMLDivElement testResultText,
+                                       final HTMLDivElement scenariosRun,
+                                       final HTMLDivElement completedAt,
+                                       final HTMLDivElement duration,
+                                       final HTMLAnchorElement viewAlerts,
+                                       final HTMLDivElement donutDiv,
+                                       final TestResultDonutPresenter testResultDonutPresenter,
+                                       final TranslationService translationService) {
+        this.resultPanel = resultPanel;
+        this.testResultIcon = testResultIcon;
+        this.testResultText = testResultText;
+        this.scenariosRun = scenariosRun;
+        this.completedAt = completedAt;
+        this.duration = duration;
+        this.viewAlerts = viewAlerts;
+        this.donutDiv = donutDiv;
+        this.testResultDonutPresenter = testResultDonutPresenter;
+        this.translationService = translationService;
+        testResultDonutPresenter.init(donutDiv);
+    }
 
     @EventHandler("viewAlerts")
     public void onClickEvent(ClickEvent event) {
@@ -104,23 +126,10 @@ public class TestRunnerReportingViewImpl
         this.duration.textContent = duration;
     }
 
-    @Inject
-    public TestRunnerReportingViewImpl(HTMLDivElement resultPanel,
-                                       HTMLDivElement testResultIcon,
-                                       HTMLDivElement testResultText,
-                                       HTMLDivElement scenariosRun,
-                                       HTMLDivElement completedAt,
-                                       HTMLDivElement duration,
-                                       HTMLAnchorElement viewAlerts,
-                                       TranslationService translationService) {
-        this.resultPanel = resultPanel;
-        this.testResultIcon = testResultIcon;
-        this.testResultText = testResultText;
-        this.scenariosRun = scenariosRun;
-        this.completedAt = completedAt;
-        this.duration = duration;
-        this.viewAlerts = viewAlerts;
-        this.translationService = translationService;
+    public void showSuccessFailureDiagram(final int passed,
+                                          final int failed) {
+        testResultDonutPresenter.showSuccessFailureDiagram(passed,
+                                                           failed);
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.java
@@ -57,6 +57,9 @@ public class TestRunnerReportingViewImpl
     private HTMLAnchorElement viewAlerts;
 
     @DataField
+    private HTMLDivElement donutDivContainer;
+
+    @DataField
     private HTMLDivElement donutDiv;
 
     private TestResultDonutPresenter testResultDonutPresenter;
@@ -70,6 +73,7 @@ public class TestRunnerReportingViewImpl
                                        final HTMLDivElement completedAt,
                                        final HTMLDivElement duration,
                                        final HTMLAnchorElement viewAlerts,
+                                       final HTMLDivElement donutDivContainer,
                                        final HTMLDivElement donutDiv,
                                        final TestResultDonutPresenter testResultDonutPresenter,
                                        final TranslationService translationService) {
@@ -80,6 +84,7 @@ public class TestRunnerReportingViewImpl
         this.completedAt = completedAt;
         this.duration = duration;
         this.viewAlerts = viewAlerts;
+        this.donutDivContainer = donutDivContainer;
         this.donutDiv = donutDiv;
         this.testResultDonutPresenter = testResultDonutPresenter;
         this.translationService = translationService;
@@ -98,6 +103,7 @@ public class TestRunnerReportingViewImpl
         this.duration.textContent = "";
         this.completedAt.textContent = "";
         this.scenariosRun.textContent = "";
+        resetDonut();
     }
 
     @Override
@@ -126,8 +132,15 @@ public class TestRunnerReportingViewImpl
         this.duration.textContent = duration;
     }
 
+    @Override
+    public void resetDonut() {
+        donutDivContainer.hidden = true;
+    }
+
+    @Override
     public void showSuccessFailureDiagram(final int passed,
                                           final int failed) {
+        donutDivContainer.hidden = false;
         testResultDonutPresenter.showSuccessFailureDiagram(passed,
                                                            failed);
     }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/KieDefaultWorkbenchClient.gwt.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/KieDefaultWorkbenchClient.gwt.xml
@@ -29,6 +29,8 @@
   <inherits name="org.dashbuilder.JSON"/>
   <inherits name="org.dashbuilder.NavigationAPI"/>
   <inherits name="org.dashbuilder.DatasetAPI"/>
+  <inherits name="org.dashbuilder.DisplayerAPI"/>
+  <inherits name="org.dashbuilder.DisplayerClient"/>
 
   <source path="client"/>
   <source path="shared"/>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/WorkbenchConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/WorkbenchConstants.properties
@@ -23,3 +23,5 @@ TestRunnerReportingViewImpl.Duration=Duration
 TestRunnerReportingViewImpl.Overview=Overview
 TestRunnerReportingViewImpl.ViewAlerts=View Alerts
 TestRunnerReportingViewImpl.ScenarioStatus=Scenario Status
+TestResultDonutPresenter.Passed=Passed
+TestResultDonutPresenter.Failed=Failed

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestResultDonutPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestResultDonutPresenterTest.java
@@ -1,0 +1,78 @@
+package org.kie.workbench.common.workbench.client.test;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLDivElement;
+import org.dashbuilder.displayer.client.Displayer;
+import org.dashbuilder.displayer.client.DisplayerCoordinator;
+import org.dashbuilder.displayer.client.DisplayerLocator;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class TestResultDonutPresenterTest {
+
+    @Mock
+    DisplayerLocator displayerLocator;
+
+    @Mock
+    Elemental2DomUtil elemental2DomUtil;
+
+    @Mock
+    DisplayerCoordinator displayerCoordinator;
+
+    @Mock
+    TranslationService translationService;
+
+    @InjectMocks
+    TestResultDonutPresenter donutPresenter;
+
+    @Mock
+    Displayer displayer;
+
+    @Before
+    public void setUp() throws Exception {
+        when(displayerLocator.lookupDisplayer(any())).thenReturn(displayer);
+    }
+
+    @Test
+    public void showSuccessFailureDiagram() {
+        HTMLDivElement container = mock(HTMLDivElement.class);
+        donutPresenter.init(container);
+
+        donutPresenter.showSuccessFailureDiagram(1, 1);
+
+        verify(displayerCoordinator).addDisplayer(displayer);
+        verify(displayerCoordinator).drawAll();
+
+        elemental2DomUtil.appendWidgetToElement(eq(container),
+                                                any());
+    }
+
+    @Test
+    public void showSuccessFailureDiagramSecondRun() {
+        HTMLDivElement container = mock(HTMLDivElement.class);
+        donutPresenter.init(container);
+
+        donutPresenter.showSuccessFailureDiagram(1, 1);
+
+        verify(elemental2DomUtil, never()).removeAllElementChildren(any());
+        verify(displayerCoordinator, never()).removeDisplayer(any());
+
+        donutPresenter.showSuccessFailureDiagram(2, 2);
+
+        verify(elemental2DomUtil).removeAllElementChildren(any());
+        verify(displayerCoordinator).removeDisplayer(any());
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreenTest.java
@@ -99,8 +99,7 @@ public class TestRunnerReportingScreenTest {
 
     @Test
     public void initFailureDiagram() {
-        verify(view).showSuccessFailureDiagram(1,
-                                               0);
+        verify(view).resetDonut();
     }
 
     @Test

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreenTest.java
@@ -35,6 +35,7 @@ import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -97,6 +98,12 @@ public class TestRunnerReportingScreenTest {
     }
 
     @Test
+    public void initFailureDiagram() {
+        verify(view).showSuccessFailureDiagram(1,
+                                               0);
+    }
+
+    @Test
     public void testSuccessfulRun() {
         screen.onTestRun(createTRMWithoutFailures(250));
         verify(view).showSuccess();
@@ -107,11 +114,15 @@ public class TestRunnerReportingScreenTest {
 
     @Test
     public void testUnSuccessfulRun() {
+        reset(view);
+
         when(failure.getDisplayName()).thenReturn("Expected true but was false.");
         when(failure.getMessage()).thenReturn("This is a non-null message");
 
         screen.onTestRun(createTRMWithFailures());
         verify(view).showFailure();
+        verify(view).showSuccessFailureDiagram(0,
+                                               1);
         verify(view).setRunStatus(any(),
                                   eq("1"),
                                   eq("2 seconds and 500 milliseconds"));
@@ -119,8 +130,12 @@ public class TestRunnerReportingScreenTest {
 
     @Test
     public void testRunTimeInMinutes() {
+        reset(view);
+
         screen.onTestRun(createTRMWithoutFailures(125000));
         verify(view).showSuccess();
+        verify(view).showSuccessFailureDiagram(1,
+                                               0);
         verify(view).setRunStatus(any(),
                                   eq("1"),
                                   eq("2 minutes and 5 seconds"));


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3234

This has been a time sink for few reasons. I suggest this layout since if we make the donut look like the wireframe we need to edit the widget and that is even more time consuming.

Optionally we can drop the legend specified in the Donut widget and make a custom separate item that looks like the original design. This will not take that long.

![image](https://user-images.githubusercontent.com/331092/48694828-21fc7a00-ebe6-11e8-851a-302e7c1f1424.png)
