### PR TITLE
RHPAM-1681: Stunner - any change on the canvas scroll process to left-top corner in IE11

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/AbstractCanvasShortcutsControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/AbstractCanvasShortcutsControlImpl.java
@@ -45,7 +45,6 @@ public abstract class AbstractCanvasShortcutsControlImpl extends AbstractCanvasH
 
     @Override
     public void register(Element element) {
-        focusCanvasToActivateKeyboardCanvasControl();
     }
 
     @Override
@@ -83,9 +82,4 @@ public abstract class AbstractCanvasShortcutsControlImpl extends AbstractCanvasH
         }
     }
 
-    private void focusCanvasToActivateKeyboardCanvasControl() {
-        if (editorSession != null && editorSession.getCanvas() != null) {
-            editorSession.getCanvas().focus();
-        }
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
@@ -235,6 +235,7 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
                         shape.applyState(ShapeState.NONE);
                     }
                 });
+        getCanvas().focus();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/AbstractCanvasShortcutsControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/AbstractCanvasShortcutsControlImplTest.java
@@ -75,27 +75,6 @@ public class AbstractCanvasShortcutsControlImplTest {
     }
 
     @Test
-    public void testRegisterCauseCanvasFocus_SessionIsNull() {
-        final Element element = mock(Element.class);
-        canvasShortcutsControl.register(element);
-
-        verify(canvas, never()).focus();
-    }
-
-    @Test
-    public void testRegisterCauseCanvasFocus_CanvasIsNull() {
-        final EditorSession session = mock(EditorSession.class);
-        final KeyboardControl keyboardControl = mock(KeyboardControl.class);
-        doReturn(keyboardControl).when(session).getKeyboardControl();
-        canvasShortcutsControl.bind(session);
-
-        final Element element = mock(Element.class);
-        canvasShortcutsControl.register(element);
-
-        verify(canvas, never()).focus();
-    }
-
-    @Test
     public void testRegisterCauseCanvasFocus() {
         final EditorSession session = mock(EditorSession.class);
         final KeyboardControl keyboardControl = mock(KeyboardControl.class);
@@ -106,7 +85,9 @@ public class AbstractCanvasShortcutsControlImplTest {
         final Element element = mock(Element.class);
         canvasShortcutsControl.register(element);
 
-        verify(canvas).focus();
+        // Ensure never focus the canvas here, as it's probably not initialized yet, at least in IE11,
+        // so the focus will fail at runtime. See RHPAM-1681.
+        verify(canvas, never()).focus();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
@@ -231,6 +231,7 @@ public class MapSelectionControlTest {
         verify(shape, never()).applyState(eq(ShapeState.NONE));
         verify(shape, never()).applyState(eq(ShapeState.INVALID));
         verify(shape, never()).applyState(eq(ShapeState.HIGHLIGHT));
+        verify(canvas, times(1)).focus();
         final ArgumentCaptor<CanvasSelectionEvent> elementSelectedEventArgumentCaptor =
                 ArgumentCaptor.forClass(CanvasSelectionEvent.class);
         verify(elementSelectedEvent,
@@ -250,6 +251,7 @@ public class MapSelectionControlTest {
         verify(shape, never()).applyState(eq(ShapeState.NONE));
         verify(shape, never()).applyState(eq(ShapeState.INVALID));
         verify(shape, times(1)).applyState(eq(ShapeState.HIGHLIGHT));
+        verify(canvas, times(1)).focus();
     }
 
     @Test


### PR DESCRIPTION
Hey @jomarko 

Looking at the VCS history I see you created this stuff, so as I'm fixing a bug here, would like you to double check. 

The issue is about calling the `canvas.focus()` method on each `element` registration, in the `AbstractCanvasShortcutsControlImpl`. When opening an existing process in IE11 is causing some issues, as the canvas has not been yet well initialized. Also it's not correct because if you open a process with, let's say 100 elements, it will call `focus` also 100 times...

Anyway, probably this call is quite old as the canvas is being focused anyway when removing it. Please can you double check?

It depends on https://github.com/kiegroup/lienzo-core/pull/72

CC @hasys ^^

Thanks in advance!
Roger 
