### PR TITLE
DROOLS-3334: [DMN Designer] Data Types - "Structure" Data Types are being set as "Undefined"

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
@@ -36,7 +36,7 @@ public class QName implements DMNProperty {
 
     public QName() {
         this(NULL_NS_URI,
-             BuiltInType.UNDEFINED.getName());
+             BuiltInType.ANY.getName());
     }
 
     public QName(final String namespaceURI,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInType.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/types/BuiltInType.java
@@ -32,8 +32,7 @@ public enum BuiltInType {
     //Requested by Edson Tirelli
     ANY("Any"),
     DATE("date"),
-    CONTEXT("context"),
-    UNDEFINED("<Undefined>");
+    CONTEXT("context");
 
     private final String[] names;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameTest.java
@@ -64,7 +64,7 @@ public class QNameTest {
     public void testZeroArgumentConstructor() {
         final QName implicitQName = new QName();
         final QName explicitQName = new QName(QName.NULL_NS_URI,
-                                              BuiltInType.UNDEFINED.getName(),
+                                              BuiltInType.ANY.getName(),
                                               DMNModelInstrumentedBase.Namespace.FEEL.getPrefix());
 
         assertEquals(explicitQName, implicitQName);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverter.java
@@ -22,7 +22,6 @@ import java.util.function.Consumer;
 
 import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
-import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
 public class QNamePropertyConverter {
 
@@ -31,7 +30,7 @@ public class QNamePropertyConverter {
      */
     public static QName wbFromDMN(final javax.xml.namespace.QName qName, final DMNModelInstrumentedBase parent) {
         if (Objects.isNull(qName)) {
-            return BuiltInType.UNDEFINED.asQName();
+            return null;
         }
         //Convert DMN1.1 QName typeRefs to DMN1.2 (the editor only supports DMN1.2)
         if (parent instanceof org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase && parent.getURIFEEL().equals(parent.getNamespaceURI(qName.getPrefix()))) {
@@ -54,9 +53,6 @@ public class QNamePropertyConverter {
 
     public static Optional<javax.xml.namespace.QName> dmnFromWB(final QName wb) {
         if (wb != null) {
-            if (Objects.equals(wb, BuiltInType.UNDEFINED.asQName())) {
-                return Optional.empty();
-            }
             return Optional.of(new javax.xml.namespace.QName(wb.getNamespaceURI(),
                                                              wb.getLocalPart(),
                                                              wb.getPrefix()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverterTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
-import java.util.Optional;
-
 import javax.xml.XMLConstants;
 
 import org.junit.Test;
@@ -31,13 +29,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class QNamePropertyConverterTest {
 
     static final Decision parent11 = new org.kie.dmn.model.v1_1.TDecision();
-
     static {
         parent11.getNsContext().put(Namespace.FEEL.getPrefix(), parent11.getURIFEEL());
     }
-
     static final Decision parent12 = new org.kie.dmn.model.v1_2.TDecision();
-
     static {
         parent12.getNsContext().put(Namespace.FEEL.getPrefix(), parent12.getURIFEEL());
     }
@@ -46,16 +41,7 @@ public class QNamePropertyConverterTest {
     public void testWBfromDMNnull() {
         final QName wb = QNamePropertyConverter.wbFromDMN(null, parent11);
 
-        assertThat(wb).isNotNull();
-        assertThat(wb).isEqualTo(BuiltInType.UNDEFINED.asQName());
-    }
-
-    @Test
-    public void testDMNfromWBnull() {
-        Optional<javax.xml.namespace.QName> dmn = QNamePropertyConverter.dmnFromWB(new QName(XMLConstants.NULL_NS_URI,
-                                                                                             BuiltInType.UNDEFINED.getName(),
-                                                                                             Namespace.FEEL.getPrefix()));
-        assertThat(dmn).isEmpty();
+        assertThat(wb).isNull();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
@@ -62,12 +62,7 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
 
     static final String CSS_DISPLAY_NONE = "none";
 
-    static final Comparator<BuiltInType> BUILT_IN_TYPE_COMPARATOR = Comparator.comparing(o -> {
-        if (o == BuiltInType.UNDEFINED) {
-            return "";
-        }
-        return o.getName();
-    });
+    static final Comparator<BuiltInType> BUILT_IN_TYPE_COMPARATOR = Comparator.comparing(o -> o.getName());
 
     static final Comparator<ItemDefinition> ITEM_DEFINITION_COMPARATOR = Comparator.comparing(o -> o.getName().getValue());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeUtils.java
@@ -46,7 +46,6 @@ public class DataTypeUtils {
     public List<DataType> defaultDataTypes() {
         return Stream
                 .of(BuiltInType.values())
-                .filter(builtInType -> !builtInType.equals(BuiltInType.UNDEFINED))
                 .map(bit -> dataTypeManager.from(bit).get())
                 .sorted(Comparator.comparing(DataType::getType))
                 .collect(toList());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -467,7 +467,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         final List<OutputClause> output = model.getOutput();
         assertThat(output.size()).isEqualTo(1);
         assertThat(output.get(0).getName()).isEqualTo("output-1");
-        assertThat(output.get(0).getTypeRef()).isEqualTo(BuiltInType.UNDEFINED.asQName());
+        assertThat(output.get(0).getTypeRef()).isEqualTo(BuiltInType.ANY.asQName());
 
         assertStandardDecisionRuleEnrichment(model, 1, 1);
         assertParentHierarchyEnrichment(model, 1, 1);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
@@ -70,7 +70,7 @@ public class DataTypePickerWidgetTest {
 
     private static final QName VALUE = new QName();
 
-    private static final String WIDGET_VALUE = "[][<Undefined>][]";
+    private static final String WIDGET_VALUE = "[][Any][]";
 
     @Mock
     private Anchor typeButton;
@@ -198,9 +198,6 @@ public class DataTypePickerWidgetTest {
 
         //Check the items were sorted correctly
         assertTrue(Ordering.from(DataTypePickerWidget.BUILT_IN_TYPE_COMPARATOR).isOrdered(builtInTypesAddedToWidget));
-
-        //First item must be "<Undefined>"
-        assertEquals(builtInTypesAddedToWidget.get(0).getName(), BuiltInType.UNDEFINED.getName());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeSelectViewTest.java
@@ -198,10 +198,8 @@ public class DataTypeSelectViewTest {
 
         view.setupDropdownItems();
 
-        final int visibleItems = BuiltInType.values().length - 1;
-
-        //Check all items were added to the group minus the UNDEFINED item
-        verify(view, times(visibleItems + customDataTypes.size())).makeOption(dataTypeCaptor.capture(), any(Function.class));
+        //Check all items were added to the group
+        verify(view, times(BuiltInType.values().length + customDataTypes.size())).makeOption(dataTypeCaptor.capture(), any(Function.class));
         final List<DataType> dataTypes = dataTypeCaptor.getAllValues();
 
         //Check the items were sorted correctly
@@ -216,7 +214,7 @@ public class DataTypeSelectViewTest {
         assertEquals("time", dataTypes.get(8).getType());
         assertEquals("years and months duration", dataTypes.get(9).getType());
 
-        final int customDataTypesOffset = visibleItems;
+        final int customDataTypesOffset = BuiltInType.values().length;
         assertEquals("a", dataTypes.get(customDataTypesOffset).getType());
         assertEquals("b", dataTypes.get(customDataTypesOffset + 1).getType());
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3334

---

This PR reverts the https://github.com/kiegroup/kie-wb-common/pull/2266 to solve the [DROOLS-3334](https://issues.jboss.org/browse/DROOLS-3334).

In a future PR (on master), we  can differentiate `Structure` DTs and `Undefined` DTs, but for the `7.14.x` branch, we're following the most secure approach, so we're reverting the change.

---

<img width="786" alt="screen shot 2018-11-19 at 3 46 24 pm" src="https://user-images.githubusercontent.com/1079279/48725237-b5e43b00-ec12-11e8-91d1-e57085350435.png">
