### PR TITLE
AF-1717: ProfilePreferences should not use a String constant

### DIFF
--- a/kie-wb-common-profile/kie-wb-common-profile-api/src/main/java/org/kie/workbench/common/profile/api/preferences/Profile.java
+++ b/kie-wb-common-profile/kie-wb-common-profile-api/src/main/java/org/kie/workbench/common/profile/api/preferences/Profile.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.workbench.common.profile.api.preferences;
 
 import java.util.Arrays;

--- a/kie-wb-common-profile/kie-wb-common-profile-api/src/main/java/org/kie/workbench/common/profile/api/preferences/ProfilePreferences.java
+++ b/kie-wb-common-profile/kie-wb-common-profile-api/src/main/java/org/kie/workbench/common/profile/api/preferences/ProfilePreferences.java
@@ -26,8 +26,6 @@ import org.uberfire.preferences.shared.bean.BasePreference;
 @WorkbenchPreference(identifier = "ProfilePreferences", bundleKey = "ProfilePreferences.Label")
 public class ProfilePreferences implements BasePreference<ProfilePreferences> {
     
-    private static final String INITIAL_PROFILE_PROPERTY = "org.kie.workbench.profile";
-
     private static Logger logger = Logger.getLogger(ProfilePreferences.class.getName());
 
     @Property(bundleKey = "ProfilePreferences.Profiles", 

--- a/kie-wb-common-profile/kie-wb-common-profile-api/src/main/java/org/kie/workbench/common/profile/api/preferences/ProfilePreferences.java
+++ b/kie-wb-common-profile/kie-wb-common-profile-api/src/main/java/org/kie/workbench/common/profile/api/preferences/ProfilePreferences.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.workbench.common.profile.api.preferences;
 
 import java.util.logging.Logger;
@@ -29,7 +45,7 @@ public class ProfilePreferences implements BasePreference<ProfilePreferences> {
 
     @Override
     public ProfilePreferences defaultValue(ProfilePreferences defaultValue) {
-        String profileStr = System.getProperty(INITIAL_PROFILE_PROPERTY, Profile.FULL.name());
+        String profileStr = System.getProperty("org.kie.workbench.profile", Profile.FULL.name());
         Profile defaultProfile = Profile.FULL;
         try {
             defaultProfile = Profile.valueOf(profileStr);


### PR DESCRIPTION
It breaks GWT superdevmode. Also, adding license headers.