### PR TITLE
RHDM-797: Use other place request constructor

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
@@ -662,7 +662,7 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
     }
 
     PathPlaceRequest createPathPlaceRequest(final Path path) {
-        return new PathPlaceRequest(path, Collections.emptyMap());
+        return new PathPlaceRequest(path, path.getFileName());
     }
 
     void closeLibraryPlaces() {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.screens.library.client.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -661,7 +662,7 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
     }
 
     PathPlaceRequest createPathPlaceRequest(final Path path) {
-        return new PathPlaceRequest(path);
+        return new PathPlaceRequest(path, Collections.emptyMap());
     }
 
     void closeLibraryPlaces() {


### PR DESCRIPTION
This PR changes used constructor to avoid using "[null]" as identifier of org.uberfire.mvp.impl.PathPlaceRequest
The identifier is used in meassge telling user what place can't be opened

@manstis 

Ensemble with kiegroup/appformer#539