### PR TITLE
DROOLS-2848 : Make the Verifier Web Worker connector reusable for different V&V types

### DIFF
--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-api/src/main/java/org/kie/workbench/common/services/verifier/api/client/api/Initialize.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-api/src/main/java/org/kie/workbench/common/services/verifier/api/client/api/Initialize.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.verifier.api.client.api;
+
+public interface Initialize {
+
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-api/src/main/java/org/kie/workbench/common/services/verifier/api/client/api/RequestStatus.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-api/src/main/java/org/kie/workbench/common/services/verifier/api/client/api/RequestStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.verifier.api.client.api;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class RequestStatus {
+
+    public RequestStatus( ) {
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/pom.xml
@@ -85,6 +85,17 @@
       <artifactId>gwtbootstrap3</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-html5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-jaxrs-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/AnalysisReporter.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/AnalysisReporter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+import java.util.Set;
+
+import org.drools.verifier.api.Reporter;
+import org.drools.verifier.api.Status;
+import org.drools.verifier.api.reporting.Issue;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReport;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
+import org.uberfire.mvp.PlaceRequest;
+
+public class AnalysisReporter
+        implements Reporter {
+
+    private PlaceRequest place;
+    private AnalysisReportScreen reportScreen;
+
+    public AnalysisReporter(final PlaceRequest place,
+                            final AnalysisReportScreen reportScreen) {
+        this.place = place;
+        this.reportScreen = reportScreen;
+    }
+
+    public void sendReport(final AnalysisReport report) {
+        reportScreen.showReport(report);
+    }
+
+    @Override
+    public void sendReport(final Set<Issue> issues) {
+        sendReport(new AnalysisReport(place,
+                                      issues));
+    }
+
+    @Override
+    public void sendStatus(final Status status) {
+        reportScreen.showStatus(status);
+    }
+
+    @Override
+    public void activate() {
+        reportScreen.setCurrentPlace(place);
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/Poster.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/Poster.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+import java.util.logging.Logger;
+
+import com.google.gwt.webworker.client.Worker;
+import org.jboss.errai.enterprise.client.jaxrs.MarshallingWrapper;
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.kie.workbench.common.services.verifier.api.client.api.Initialize;
+import org.kie.workbench.common.services.verifier.api.client.api.RequestStatus;
+
+public class Poster {
+
+    private static final Logger LOGGER = Logger.getLogger("DTable Analyzer");
+
+    private Worker worker;
+
+    public void setUp(final Worker worker) {
+        this.worker = PortablePreconditions.checkNotNull("worker",
+                                                         worker);
+    }
+
+    protected void postObject(final Object object) {
+
+        PortablePreconditions.checkNotNull("worker",
+                                           worker);
+        PortablePreconditions.checkNotNull("object",
+                                           object);
+
+        final String json = MarshallingWrapper.toJSON(object);
+
+        LOGGER.finest("Sending: " + json);
+
+        worker.postMessage(json);
+    }
+
+    public void post(final Initialize initialize) {
+        postObject(initialize);
+    }
+
+    public void post(final RequestStatus requestStatus) {
+        postObject(requestStatus);
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/Receiver.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/Receiver.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+import java.util.HashSet;
+import java.util.logging.Logger;
+
+import com.google.gwt.webworker.client.Worker;
+import org.drools.verifier.api.Status;
+import org.drools.verifier.api.reporting.Issues;
+import org.jboss.errai.enterprise.client.jaxrs.MarshallingWrapper;
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.kie.workbench.common.services.verifier.api.client.api.WebWorkerException;
+import org.kie.workbench.common.services.verifier.api.client.api.WebWorkerLogMessage;
+
+public class Receiver {
+
+    private static final Logger LOGGER = Logger.getLogger("DTable Analyzer");
+
+    private AnalysisReporter reporter;
+
+    public Receiver(final AnalysisReporter reporter) {
+        this.reporter = PortablePreconditions.checkNotNull("reporter",
+                                                           reporter);
+    }
+
+    public void activate() {
+        reporter.activate();
+    }
+
+    private void received(final String json) {
+
+        try {
+
+            LOGGER.finest("Receiving: " + json);
+
+            final Object o = MarshallingWrapper.fromJSON(json);
+
+            if (o instanceof WebWorkerLogMessage) {
+                LOGGER.info("Web Worker log message: " + ((WebWorkerLogMessage) o).getMessage());
+            } else if (o instanceof WebWorkerException) {
+                LOGGER.severe("Web Worker failed: " + ((WebWorkerException) o).getMessage());
+            } else if (o instanceof Status) {
+                reporter.sendStatus((Status) o);
+            } else if (o instanceof Issues) {
+                reporter.sendReport(new HashSet<>(((Issues) o).getSet()));
+            }
+        } catch (Exception e) {
+            LOGGER.severe("Could not manage received json: " + e.getMessage()
+                                  + " JSON: " + json);
+        }
+    }
+
+    public void setUp(final Worker worker) {
+        worker.setOnMessage(messageEvent -> received(messageEvent.getDataAsString()));
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnection.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnection.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+public interface VerifierWebWorkerConnection {
+
+    void activate();
+
+    void terminate();
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnectionImpl.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnectionImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+import java.util.logging.Logger;
+
+import com.google.gwt.webworker.client.Worker;
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.kie.workbench.common.services.verifier.api.client.api.Initialize;
+import org.kie.workbench.common.services.verifier.api.client.api.RequestStatus;
+
+public class VerifierWebWorkerConnectionImpl
+        implements VerifierWebWorkerConnection {
+
+    private static final Logger LOGGER = Logger.getLogger("DTable Analyzer");
+
+    private Worker worker = null;
+
+    private final Poster poster;
+    private final Receiver receiver;
+    private final Initialize initialize;
+    private final String pathToVerifier;
+
+    public VerifierWebWorkerConnectionImpl(final Initialize initialize,
+                                           final String pathToVerifier,
+                                           final Poster poster,
+                                           final Receiver receiver) {
+
+        this.initialize = PortablePreconditions.checkNotNull("initialize",
+                                                             initialize);
+
+        this.pathToVerifier = PortablePreconditions.checkNotNull("pathToVerifier",
+                                                                 pathToVerifier);
+        this.poster = PortablePreconditions.checkNotNull("poster",
+                                                         poster);
+        this.receiver = PortablePreconditions.checkNotNull("receiver",
+                                                           receiver);
+
+        LOGGER.finest("Created Web Worker");
+    }
+
+    private void startWorker() {
+        worker = Worker.create(pathToVerifier);
+
+        poster.setUp(worker);
+        receiver.setUp(worker);
+    }
+
+    @Override
+    public void activate() {
+
+        receiver.activate();
+
+        if (worker == null) {
+            startWorker();
+            poster.post(initialize);
+        } else {
+            poster.post(new RequestStatus());
+        }
+    }
+
+    @Override
+    public void terminate() {
+        if (worker != null) {
+            worker.terminate();
+        }
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/resources/org/kie/workbench/common/services/verifier/reporting/VerifierReporting.gwt.xml
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/resources/org/kie/workbench/common/services/verifier/reporting/VerifierReporting.gwt.xml
@@ -9,8 +9,13 @@
 	<inherits name="com.google.gwt.user.User" />
 
 	<inherits name="org.uberfire.commons.UberfireCommons"/>
+  <inherits name="com.google.gwt.webworker.WebWorker"/>
+  <inherits name="org.jboss.errai.enterprise.Jaxrs"/>
+	<inherits name="org.drools.verifier.VerifierAPI"/>
+  <inherits name="org.kie.workbench.common.widgets.decoratedgrid.KieWorkbenchDecoratedGridWidget"/>
+	<inherits name="org.kie.workbench.common.services.verifier.api.VerifierApi"/>
 
 
-  <source path='client'/>
+	<source path='client'/>
 
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2848

Some changes I found necessary when adding the V&V for DMN tables. I removed the changes for the table. Just pushing these in so the code does not get stale.

The PR bundle:
https://github.com/kiegroup/kie-wb-common/pull/2295
https://github.com/kiegroup/drools-wb/pull/1004