### PR TITLE
[AF-1715-7.14.x]: Added null checking condition for credentials

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
@@ -208,7 +208,7 @@ public class ProjectImportServiceImpl extends BaseProjectImportService implement
             configurations.setBranches(getBranches(rootPath,
                                                    importProject.getRoot()));
             Credentials credentials = importProject.getCredentials();
-            if (credentials != null) {
+            if (credentials != null && credentials.getUsername() != null && credentials.getPassword() != null) {
                 configurations.setUserName(credentials.getUsername());
                 configurations.setPassword(credentials.getPassword());
             }

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImplTest.java
@@ -38,6 +38,7 @@ import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
 import org.guvnor.structure.organizationalunit.impl.OrganizationalUnitImpl;
 import org.guvnor.structure.repositories.Branch;
+import org.guvnor.structure.repositories.EnvironmentParameters;
 import org.guvnor.structure.repositories.Repository;
 import org.guvnor.structure.repositories.RepositoryEnvironmentConfigurations;
 import org.guvnor.structure.repositories.RepositoryService;
@@ -411,6 +412,39 @@ public class ProjectImportServiceImplTest {
     }
 
     @Test
+    public void testProjectImportWithNullCredentialsTest() {
+
+        ArgumentCaptor<RepositoryEnvironmentConfigurations> captor = ArgumentCaptor.forClass(RepositoryEnvironmentConfigurations.class);
+
+        String origin = "file:///some/path/to/fake-repo.git";
+        String username = "fakeUser";
+        String password = null;
+
+        final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
+        ImportProject importProject = mock(ImportProject.class);
+        Path rootPath = mock(Path.class);
+        org.uberfire.java.nio.file.Path convertedRootPath = mock(org.uberfire.java.nio.file.Path.class);
+        when(pathUtil.convert(any(Path.class))).thenReturn(convertedRootPath);
+        when(importProject.getCredentials()).thenReturn(new Credentials(username,
+                                                                        password));
+        when(importProject.getRoot()).thenReturn(rootPath);
+
+        when(importProject.getOrigin()).thenReturn(origin);
+
+        service.importProject(organizationalUnit,
+                              importProject);
+
+        verify(service).importProject(organizationalUnit,
+                                      origin,
+                                      username,
+                                      password);
+        verify(repoService).createRepository(any(),any(),any(),captor.capture());
+
+        assertFalse(captor.getValue().containsConfiguration(EnvironmentParameters.USER_NAME));
+        assertFalse(captor.getValue().containsConfiguration(EnvironmentParameters.PASSWORD));
+    }
+
+    @Test
     public void importProjectWithoutCredentialsTest() {
         final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
         final Repository repo = mock(Repository.class);
@@ -432,6 +466,8 @@ public class ProjectImportServiceImplTest {
                                                                        repositoryURL,
                                                                        username,
                                                                        password);
+
+
 
         verify(repoService).createRepository(same(organizationalUnit),
                                              eq(GitRepository.SCHEME.toString()),


### PR DESCRIPTION
## Description
With @pefernan found that exist the possibility that if crytp:passw contains a null value when it tries to get credentials it fail. So if any credential value is null, credentials are not set.

@ederign would you mind to review?