### PR TITLE
JBPM-8013: Stunner - Diagram Editor/Viewer components are not working

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DefaultDiagramViewer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DefaultDiagramViewer.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.presenters.diagram.impl;
 
 import java.lang.annotation.Annotation;
+import java.util.Collections;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Any;
@@ -30,7 +31,11 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SingleSelection;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.zoom.ZoomControl;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElementListener;
+import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasShapeListener;
 import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistries;
+import org.kie.workbench.common.stunner.core.client.session.impl.DefaultCanvasElementListener;
+import org.kie.workbench.common.stunner.core.client.session.impl.DefaultCanvasShapeListener;
 import org.kie.workbench.common.stunner.core.client.session.impl.InstanceUtils;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -54,6 +59,8 @@ public class DefaultDiagramViewer
     private final StunnerPreferencesRegistries preferencesRegistries;
 
     private AbstractCanvas canvas;
+    private CanvasShapeListener shapeListener;
+    private CanvasElementListener elementListener;
     private AbstractCanvasHandler canvasHandler;
     private ZoomControl<AbstractCanvas> zoomControl;
     private SelectionControl<AbstractCanvasHandler, Element> selectionControl;
@@ -95,6 +102,10 @@ public class DefaultDiagramViewer
         canvasHandler = InstanceUtils.lookup(canvasHandlerInstances, qualifier);
         zoomControl = InstanceUtils.lookup(zoomControlInstances, qualifier);
         selectionControl = InstanceUtils.lookup(selectionControlInstances, qualifier);
+        shapeListener = new DefaultCanvasShapeListener(Collections.singletonList(zoomControl));
+        canvas.addRegistrationListener(shapeListener);
+        elementListener = new DefaultCanvasElementListener(Collections.singletonList(selectionControl));
+        canvasHandler.addRegistrationListener(elementListener);
     }
 
     @Override
@@ -124,6 +135,8 @@ public class DefaultDiagramViewer
         canvasHandlerInstances.destroyAll();
         canvas = null;
         canvasHandler = null;
+        shapeListener = null;
+        elementListener = null;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoader.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.presenters.diagram.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistryLoader;
+import org.kie.workbench.common.stunner.core.client.service.ClientDiagramService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.preferences.StunnerPreferences;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.mvp.ParameterizedCommand;
+
+@ApplicationScoped
+public class DiagramLoader {
+
+    private final ClientDiagramService clientDiagramServices;
+    private final StunnerPreferencesRegistryLoader preferencesRegistryLoader;
+
+    @Inject
+    public DiagramLoader(final ClientDiagramService clientDiagramServices,
+                         final StunnerPreferencesRegistryLoader preferencesRegistryLoader) {
+        this.clientDiagramServices = clientDiagramServices;
+        this.preferencesRegistryLoader = preferencesRegistryLoader;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void loadByPath(final Path path,
+                           final ServiceCallback<Diagram> callback) {
+        clientDiagramServices.getByPath(path,
+                                        new ServiceCallback<Diagram<Graph, Metadata>>() {
+                                            @Override
+                                            public void onSuccess(final Diagram<Graph, Metadata> diagram) {
+                                                loadPreferences(diagram,
+                                                                prefs -> callback.onSuccess(diagram),
+                                                                error -> callback.onError(new ClientRuntimeError(error)));
+                                            }
+
+                                            @Override
+                                            public void onError(final ClientRuntimeError error) {
+                                                callback.onError(error);
+                                            }
+                                        });
+    }
+
+    private void loadPreferences(final Diagram<Graph, Metadata> diagram,
+                                 final ParameterizedCommand<StunnerPreferences> callback,
+                                 final ParameterizedCommand<Throwable> errorCallback) {
+        final Metadata metadata = diagram.getMetadata();
+        preferencesRegistryLoader.load(metadata.getDefinitionSetId(),
+                                       callback,
+                                       errorCallback);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoaderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.presenters.diagram.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistryLoader;
+import org.kie.workbench.common.stunner.core.client.service.ClientDiagramService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.preferences.StunnerPreferences;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.mvp.ParameterizedCommand;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiagramLoaderTest {
+
+    private static final String DS_ID = "ds1";
+
+    @Mock
+    private ClientDiagramService clientDiagramServices;
+
+    @Mock
+    private StunnerPreferencesRegistryLoader preferencesRegistryLoader;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
+    private StunnerPreferences preferences;
+
+    @Mock
+    private Path path;
+
+    private DiagramLoader tested;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getDefinitionSetId()).thenReturn(DS_ID);
+        doAnswer(invocation -> {
+            ParameterizedCommand<StunnerPreferences> callback
+                    = (ParameterizedCommand<StunnerPreferences>) invocation.getArguments()[1];
+            callback.execute(preferences);
+            return null;
+        }).when(preferencesRegistryLoader).load(eq(DS_ID),
+                                                any(ParameterizedCommand.class),
+                                                any(ParameterizedCommand.class));
+        doAnswer(invocation -> {
+            ServiceCallback<Diagram> argCallback = (ServiceCallback<Diagram>) invocation.getArguments()[1];
+            argCallback.onSuccess(diagram);
+            return null;
+        }).when(clientDiagramServices).getByPath(eq(path), any(ServiceCallback.class));
+        tested = new DiagramLoader(clientDiagramServices,
+                                   preferencesRegistryLoader);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoadByPah() {
+        ServiceCallback<Diagram> callback = mock(ServiceCallback.class);
+        tested.loadByPath(path, callback);
+        verify(callback, times(1)).onSuccess(eq(diagram));
+        verify(preferencesRegistryLoader, times(1)).load(eq(DS_ID),
+                                                         any(ParameterizedCommand.class),
+                                                         any(ParameterizedCommand.class));
+        verify(callback, never()).onError(any(ClientRuntimeError.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/preferences/StunnerPreferencesRegistryLoader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/preferences/StunnerPreferencesRegistryLoader.java
@@ -56,8 +56,8 @@ public class StunnerPreferencesRegistryLoader {
                                                                              qualifier);
         preferences.load(prefs -> {
                              holder.set(prefs, StunnerPreferences.class);
-                             loadCompleteCallback.execute(prefs);
                              holder.set(textPreferences, StunnerTextPreferences.class);
+                             loadCompleteCallback.execute(prefs);
                          },
                          errorCallback);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultCanvasElementListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultCanvasElementListener.java
@@ -53,6 +53,10 @@ public class DefaultCanvasElementListener implements CanvasElementListener {
         onClear();
     }
 
+    public Iterable<CanvasControl<AbstractCanvasHandler>> getCanvasControls() {
+        return canvasControls;
+    }
+
     private void onRegisterElement(final Element element) {
         onElementRegistration(element,
                               true,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultCanvasShapeListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultCanvasShapeListener.java
@@ -45,6 +45,10 @@ public class DefaultCanvasShapeListener implements CanvasShapeListener {
         onClear();
     }
 
+    public Iterable<CanvasControl<AbstractCanvas>> getCanvasControls() {
+        return canvasControls;
+    }
+
     private void onRegisterShape(final Shape shape) {
         onShapeRegistration(shape,
                             true);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/DiagramPresenterScreen.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/DiagramPresenterScreen.java
@@ -60,7 +60,7 @@ public class DiagramPresenterScreen {
     public static final String DIAGRAM_NAME = "evaluation2";
 
     @Inject
-    private ShowcaseDiagramService diagramLoader;
+    private ShowcaseDiagramService diagramService;
 
     @Inject
     private ManagedInstance<DiagramViewer<Diagram, AbstractCanvasHandler>> diagramViewers;
@@ -85,55 +85,55 @@ public class DiagramPresenterScreen {
 
     private Menus makeMenuBar() {
         return MenuFactory
-                .newTopLevelMenu("View " + DIAGRAM_NAME)
-                .respondsWith(this::show)
+                .newTopLevelMenu("View process: " + DIAGRAM_NAME)
+                .respondsWith(this::viewProcess)
                 .endMenu()
-                .newTopLevelMenu("Edit " + DIAGRAM_NAME)
-                .respondsWith(this::edit)
+                .newTopLevelMenu("Edit process: " + DIAGRAM_NAME)
+                .respondsWith(this::editProcess)
                 .endMenu()
                 .build();
     }
 
-    private void show() {
+    private void viewProcess() {
         Logger.getLogger("org.kie.workbench.common.stunner").setLevel(Level.FINE);
         BusyPopup.showMessage("Loading");
         destroy();
-        diagramLoader.loadByName(DIAGRAM_NAME,
-                                 new ServiceCallback<Diagram>() {
-                                     @Override
-                                     public void onSuccess(final Diagram diagram) {
-                                         diagramViewer = diagramViewers.get();
-                                         screenPanelView.setWidget(diagramViewer.getView());
-                                         diagramViewer.open(diagram,
-                                                            new ScreenViewerCallback());
-                                     }
+        diagramService.loadByName(DIAGRAM_NAME,
+                                  new ServiceCallback<Diagram>() {
+                                      @Override
+                                      public void onSuccess(final Diagram diagram) {
+                                          diagramViewer = diagramViewers.get();
+                                          screenPanelView.setWidget(diagramViewer.getView());
+                                          diagramViewer.open(diagram,
+                                                             new ScreenViewerCallback());
+                                      }
 
-                                     @Override
-                                     public void onError(final ClientRuntimeError error) {
-                                         showError(error);
-                                     }
-                                 });
+                                      @Override
+                                      public void onError(final ClientRuntimeError error) {
+                                          showError(error);
+                                      }
+                                  });
     }
 
-    private void edit() {
+    private void editProcess() {
         Logger.getLogger("org.kie.workbench.common.stunner").setLevel(Level.FINE);
         BusyPopup.showMessage("Loading");
         destroy();
-        diagramLoader.loadByName(DIAGRAM_NAME,
-                                 new ServiceCallback<Diagram>() {
-                                     @Override
-                                     public void onSuccess(final Diagram diagram) {
-                                         diagramEditor = diagramEditors.get();
-                                         screenPanelView.setWidget(diagramEditor.getView());
-                                         diagramEditor.open(diagram,
-                                                            new ScreenViewerCallback());
-                                     }
+        diagramService.loadByName(DIAGRAM_NAME,
+                                  new ServiceCallback<Diagram>() {
+                                      @Override
+                                      public void onSuccess(final Diagram diagram) {
+                                          diagramEditor = diagramEditors.get();
+                                          screenPanelView.setWidget(diagramEditor.getView());
+                                          diagramEditor.open(diagram,
+                                                             new ScreenViewerCallback());
+                                      }
 
-                                     @Override
-                                     public void onError(ClientRuntimeError error) {
-                                         showError(error);
-                                     }
-                                 });
+                                      @Override
+                                      public void onError(ClientRuntimeError error) {
+                                          showError(error);
+                                      }
+                                  });
     }
 
     @OnOpen

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/ShowcaseDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/ShowcaseDiagramService.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.standalone.client.screens;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.client.widgets.presenters.diagram.impl.DiagramLoader;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasExport;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
@@ -38,17 +39,15 @@ import org.uberfire.backend.vfs.Path;
 @ApplicationScoped
 public class ShowcaseDiagramService {
 
+    private final DiagramLoader diagramLoader;
     private final ClientDiagramServiceImpl clientDiagramServices;
     private final CanvasExport<AbstractCanvasHandler> canvasExport;
 
-    protected ShowcaseDiagramService() {
-        this(null,
-             null);
-    }
-
     @Inject
-    public ShowcaseDiagramService(final ClientDiagramServiceImpl clientDiagramServices,
+    public ShowcaseDiagramService(final DiagramLoader diagramLoader,
+                                  final ClientDiagramServiceImpl clientDiagramServices,
                                   final CanvasExport<AbstractCanvasHandler> canvasExport) {
+        this.diagramLoader = diagramLoader;
         this.clientDiagramServices = clientDiagramServices;
         this.canvasExport = canvasExport;
     }
@@ -77,18 +76,7 @@ public class ShowcaseDiagramService {
     @SuppressWarnings("unchecked")
     public void loadByPath(final Path path,
                            final ServiceCallback<Diagram> callback) {
-        clientDiagramServices.getByPath(path,
-                                        new ServiceCallback<Diagram<Graph, Metadata>>() {
-                                            @Override
-                                            public void onSuccess(final Diagram<Graph, Metadata> diagram) {
-                                                callback.onSuccess(diagram);
-                                            }
-
-                                            @Override
-                                            public void onError(final ClientRuntimeError error) {
-                                                callback.onError(error);
-                                            }
-                                        });
+        diagramLoader.loadByPath(path, callback);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Hey @hasys @nmirasch @cristianonicolai @krisv 

Some background - From the console perspective they are considering to move from the actual SVG image used for the process to a real canvas (Stunner). IMO that's great for several reasons: Stunner already provides editor/viewer components, it's much more powerful on the UI and because of they can use the Stunner API as well. So I recommended to @nmirasch to give it a quick try to the Stunner's `DiagramViewer` component, which allows to display a process in a canvas and use the api to manage the shapes, etc. 

But I noticed there were a few bugs on the `DiagramViewer` and `DiagramEditor` types, which were easy to fix and I just created the ticket [JBPM-8013](https://issues.jboss.org/browse/JBPM-8013) and this PR which provides the fixes:

**Important note**: The workbench distributions, when stunner is provided as a kie editor, are not using neither the `DiagramViewer` nor `DiagramEditor` types , so this fixes should not affect the product releases. Anyway once third parties (as the console) needs this, it's actually broken. So this is not really testeable from the UI in the generated WARs. @hasys @nmirasch you can run the `showcase-standalone` to test it, on the home page there exist two buttons, _edit evaluation2_ and _view evaluation2_, which opens the _evaluation2_ process in both modes. 


See here the _view_ and _edit_ buttons on the showcase:
![screenshot from 2018-12-01 03-13-27](https://user-images.githubusercontent.com/4602417/49322363-1591ee80-f50f-11e8-8bde-eaa02f4e0844.png)



And see here the _evaluation2_ process displayed on read mode:
![screenshot from 2018-12-01 03-13-47](https://user-images.githubusercontent.com/4602417/49322370-2478a100-f50f-11e8-80a0-b054247733c7.png)

@nmirasch @cristianonicolai Once this is fixed (you can even cherry-pick it) you'll be able to add an Stunner widget anywhere and use its API to handle the states, shapes, colors, etc. You can find a simple usage example in `DiagramPresenterScreen` (inside this PR).  

Thanks!