### PR TITLE
JBPM-8026: Fixed wrong root path for standalone backend FS.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/BackendFileSystemBootstrap.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-backend/src/main/java/org/kie/workbench/common/stunner/backend/service/BackendFileSystemBootstrap.java
@@ -39,7 +39,7 @@ import org.uberfire.java.nio.file.Path;
 public class BackendFileSystemBootstrap {
 
     public static final String VFS_PRO = "default";
-    public static final String VFS_ROOT = "stunner";
+    public static final String VFS_ROOT = "system/stunner";
     public static final String VFS_ROOT_PATH = VFS_PRO + "://" + VFS_ROOT;
 
     private final BackendFileSystemManager backendFileSystemManager;


### PR DESCRIPTION
Hey @ederign @hasys @manstis 

See https://issues.jboss.org/browse/JBPM-8026

As @ederign hopefully pointed out, the default git repository for stunner (`stunner.git`) is being created in the wrong location. Although this module is only used in some showcases and does not affect the BC, let's put the repository where appformer expects it.

Related to https://github.com/kiegroup/drools-wb/pull/1018

Thanks!