### PR TITLE
DROOLS-3395: [DMN Designer] Two copies of node are created

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommands.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommands.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.dmn.project.client.session;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -49,8 +48,8 @@ public class DMNEditorSessionCommands extends EditorSessionCommands {
         super(commands);
     }
 
-    @PostConstruct
-    public void init() {
+    @Override
+    protected void registerCommands() {
         getCommands().register(VisitGraphSessionCommand.class)
                 .register(SwitchGridSessionCommand.class)
                 .register(ClearSessionCommand.class)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/session/EditorSessionCommands.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/session/EditorSessionCommands.java
@@ -52,6 +52,10 @@ public class EditorSessionCommands {
 
     @PostConstruct
     public void init() {
+        registerCommands();
+    }
+
+    protected void registerCommands() {
         commands.register(VisitGraphSessionCommand.class)
                 .register(SwitchGridSessionCommand.class)
                 .register(ClearSessionCommand.class)


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3395

This PR simply moves registration of commands to a method that is overridden by the DMN Editor.

This prevents Errai from invoking the `@PostConstruct` method twice.