### PR TITLE
JBPM-6402: Stunner - Added support for profiles & implemented Ruleflow profile for BPMN

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/DMNPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/components/palette/DMNPaletteDefinitionBuilderTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.components.palette.CollapsedPaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.client.components.palette.DefaultPaletteDefinition;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
@@ -50,6 +51,9 @@ public class DMNPaletteDefinitionBuilderTest {
     private DefinitionUtils definitionUtils;
 
     @Mock
+    private DomainProfileManager profileFunctions;
+
+    @Mock
     private DefinitionsCacheRegistry definitionsRegistry;
 
     @Mock
@@ -68,6 +72,7 @@ public class DMNPaletteDefinitionBuilderTest {
     @SuppressWarnings("unchecked")
     public void setup() {
         collapsedPaletteBuilder = spy(new CollapsedPaletteDefinitionBuilder(definitionUtils,
+                                                                            profileFunctions,
                                                                             definitionsRegistry,
                                                                             translationService));
         doAnswer(new Answer() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/ChangeProfileDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/ChangeProfileDevCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.menu.dev.impl;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.kie.workbench.common.stunner.client.widgets.menu.dev.AbstractMenuDevCommand;
+import org.kie.workbench.common.stunner.client.widgets.profile.ProfileSelector;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.uberfire.client.views.pfly.modal.Bs3Modal;
+
+@Dependent
+public class ChangeProfileDevCommand extends AbstractMenuDevCommand {
+
+    private final Instance<Bs3Modal> modalFactory;
+    private final ProfileSelector profileSelector;
+
+    protected ChangeProfileDevCommand() {
+        this(null, null, null);
+    }
+
+    @Inject
+    public ChangeProfileDevCommand(final SessionManager sessionManager,
+                                   final Instance<Bs3Modal> modalFactory,
+                                   final ProfileSelector profileSelector) {
+        super(sessionManager);
+        this.modalFactory = modalFactory;
+        this.profileSelector = profileSelector;
+    }
+
+    @Override
+    public String getText() {
+        return "Change Profile";
+    }
+
+    @Override
+    public void execute() {
+        profileSelector.bind(this::getSession);
+        showModal();
+    }
+
+    private void showModal() {
+        final HTMLElement selectorView = profileSelector.getView().getElement();
+        final Bs3Modal modal = modalFactory.get();
+        modal.setFooterContent(new FlowPanel());
+        modal.setModalTitle("Choose profile");
+        modal.setContent(ElementWrapperWidget.getWidget(selectorView));
+        modal.show();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoader.java
@@ -66,7 +66,7 @@ public class DiagramLoader {
                                  final ParameterizedCommand<StunnerPreferences> callback,
                                  final ParameterizedCommand<Throwable> errorCallback) {
         final Metadata metadata = diagram.getMetadata();
-        preferencesRegistryLoader.load(metadata.getDefinitionSetId(),
+        preferencesRegistryLoader.load(metadata,
                                        callback,
                                        errorCallback);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/RequestSessionRefreshEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/RequestSessionRefreshEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.presenters.session;
+
+import org.jboss.errai.common.client.api.annotations.NonPortable;
+
+@NonPortable
+public class RequestSessionRefreshEvent {
+
+    private final String sessionId;
+
+    public RequestSessionRefreshEvent(final String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getSessionUUID() {
+        return sessionId;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/session/impl/SessionEditorPresenter.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.stunner.client.widgets.event.SessionDiagramOpene
 import org.kie.workbench.common.stunner.client.widgets.event.SessionFocusedEvent;
 import org.kie.workbench.common.stunner.client.widgets.notification.NotificationsObserver;
 import org.kie.workbench.common.stunner.client.widgets.palette.DefaultPaletteFactory;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.RequestSessionRefreshEvent;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionDiagramEditor;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionDiagramPresenter;
 import org.kie.workbench.common.stunner.client.widgets.toolbar.Toolbar;
@@ -123,6 +124,20 @@ public class SessionEditorPresenter<S extends EditorSession>
         }
     }
 
+    void onRequestSessionRefreshEvent(final @Observes RequestSessionRefreshEvent event) {
+        getSession().ifPresent(session -> {
+            if (session.getSessionUUID().equals(event.getSessionUUID())) {
+                refresh();
+            }
+        });
+    }
+
+    @Override
+    public void refresh() {
+        super.refresh();
+        getSession().ifPresent(SessionEditorPresenter::clearSelection);
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     protected Toolbar<S> newToolbar(final Annotation qualifier) {
@@ -150,5 +165,11 @@ public class SessionEditorPresenter<S extends EditorSession>
         final AbstractCanvasHandler sessionHandlerContext = (AbstractCanvasHandler) event.getCanvasHandler();
         return null != getHandler() &&
                 getHandler().equals(sessionHandlerContext);
+    }
+
+    private static void clearSelection(final EditorSession session) {
+        if (null != session.getSelectionControl()) {
+            session.getSelectionControl().clearSelection();
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/profile/ProfileSelector.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/profile/ProfileSelector.java
@@ -92,4 +92,3 @@ public class ProfileSelector extends SelectorDelegate<Profile> {
         return profileManager.getProfile(id);
     }
 }
-;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/profile/ProfileSelector.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/profile/ProfileSelector.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.profile;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import com.ait.tooling.common.api.java.util.function.Supplier;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.RequestSessionRefreshEvent;
+import org.kie.workbench.common.stunner.client.widgets.views.Selector;
+import org.kie.workbench.common.stunner.client.widgets.views.SelectorDelegate;
+import org.kie.workbench.common.stunner.client.widgets.views.SelectorImpl;
+import org.kie.workbench.common.stunner.core.api.ProfileManager;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+
+@Dependent
+public class ProfileSelector extends SelectorDelegate<Profile> {
+
+    private final SelectorImpl<Profile> selector;
+    private final ProfileManager profileManager;
+    private final Event<RequestSessionRefreshEvent> requestSessionRefreshEvent;
+
+    @Inject
+    public ProfileSelector(final SelectorImpl<Profile> selector,
+                           final ProfileManager profileManager,
+                           final Event<RequestSessionRefreshEvent> requestSessionRefreshEvent) {
+        this.selector = selector;
+        this.profileManager = profileManager;
+        this.requestSessionRefreshEvent = requestSessionRefreshEvent;
+    }
+
+    @PostConstruct
+    public void init() {
+        selector
+                .setTextProvider(Profile::getName)
+                .setValueProvider(Profile::getProfileId)
+                .setItemProvider(this::getProfile);
+    }
+
+    public ProfileSelector bind(final Supplier<AbstractSession> sessionSupplier) {
+        final AbstractSession session = sessionSupplier.get();
+        final Metadata metadata = session.getCanvasHandler().getDiagram().getMetadata();
+        final String definitionSetId = metadata.getDefinitionSetId();
+        final String profileId = metadata.getProfileId();
+        useDefinitionSet(definitionSetId);
+        useProfile(definitionSetId, profileId);
+        selector.setValueChangedCommand(() -> {
+            final Profile item = selector.getSelectedItem();
+            metadata.setProfileId(item.getProfileId());
+            requestSessionRefreshEvent.fire(new RequestSessionRefreshEvent(session.getSessionUUID()));
+        });
+        return this;
+    }
+
+    private void useDefinitionSet(final String defSetId) {
+        selector.clear();
+        profileManager
+                .getProfiles(defSetId)
+                .forEach(this::addItem);
+    }
+
+    private void useProfile(final String defSetId,
+                            final String profileId) {
+        final Profile profile = profileManager.getProfile(defSetId, profileId);
+        setSelectedItem(profile);
+    }
+
+    @Override
+    protected Selector<Profile> getDelegate() {
+        return selector;
+    }
+
+    private Profile getProfile(final String id) {
+        return profileManager.getProfile(id);
+    }
+}
+;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/Selector.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/Selector.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.views;
+
+public interface Selector<T> {
+
+    public Selector<T> addItem(T item);
+
+    public Selector<T> setSelectedItem(T item);
+
+    public T getSelectedItem();
+
+    public Selector<T> clear();
+
+    public void onValueChanged();
+
+    public SelectorView getView();
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/Selector.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/Selector.java
@@ -18,15 +18,15 @@ package org.kie.workbench.common.stunner.client.widgets.views;
 
 public interface Selector<T> {
 
-    public Selector<T> addItem(T item);
+    Selector<T> addItem(T item);
 
-    public Selector<T> setSelectedItem(T item);
+    Selector<T> setSelectedItem(T item);
 
-    public T getSelectedItem();
+    T getSelectedItem();
 
-    public Selector<T> clear();
+    Selector<T> clear();
 
-    public void onValueChanged();
+    void onValueChanged();
 
-    public SelectorView getView();
+    SelectorView getView();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorDelegate.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorDelegate.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.views;
+
+public abstract class SelectorDelegate<T> implements Selector<T> {
+
+    protected abstract Selector<T> getDelegate();
+
+    @Override
+    public Selector<T> addItem(final T item) {
+        getDelegate().addItem(item);
+        return this;
+    }
+
+    @Override
+    public Selector<T> setSelectedItem(final T item) {
+        getDelegate().setSelectedItem(item);
+        return this;
+    }
+
+    @Override
+    public T getSelectedItem() {
+        return getDelegate().getSelectedItem();
+    }
+
+    @Override
+    public Selector<T> clear() {
+        getDelegate().clear();
+        return this;
+    }
+
+    @Override
+    public void onValueChanged() {
+        getDelegate().onValueChanged();
+    }
+
+    @Override
+    public SelectorView getView() {
+        return getDelegate().getView();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorImpl.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.views;
+
+import java.util.function.Function;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.uberfire.mvp.Command;
+
+@Dependent
+public class SelectorImpl<T> implements Selector<T> {
+
+    private final SelectorView view;
+    private Function<T, String> valueProvider;
+    private Function<T, String> textProvider;
+    private Function<String, T> itemProvider;
+    private Command valueChangedCommand;
+
+    @Inject
+    public SelectorImpl(final SelectorView view) {
+        this.view = view;
+    }
+
+    @PostConstruct
+    public void init() {
+        view.init(this);
+        this.valueProvider = Object::toString;
+        this.textProvider = Object::toString;
+        this.valueChangedCommand = () -> {
+        };
+    }
+
+    public SelectorImpl<T> setTextProvider(final Function<T, String> textProvider) {
+        this.textProvider = textProvider;
+        return this;
+    }
+
+    public SelectorImpl<T> setValueProvider(final Function<T, String> valueProvider) {
+        this.valueProvider = valueProvider;
+        return this;
+    }
+
+    public SelectorImpl<T> setItemProvider(final Function<String, T> itemProvider) {
+        this.itemProvider = itemProvider;
+        return this;
+    }
+
+    public SelectorImpl<T> setValueChangedCommand(final Command valueChangedCommand) {
+        this.valueChangedCommand = valueChangedCommand;
+        return this;
+    }
+
+    @Override
+    public Selector<T> addItem(final T item) {
+        view.add(textProvider.apply(item),
+                 valueProvider.apply(item));
+        return this;
+    }
+
+    @Override
+    public Selector<T> setSelectedItem(final T item) {
+        view.setValue(valueProvider.apply(item));
+        return this;
+    }
+
+    @Override
+    public T getSelectedItem() {
+        return itemProvider.apply(view.getValue());
+    }
+
+    @Override
+    public Selector<T> clear() {
+        view.clear();
+        return this;
+    }
+
+    @Override
+    public void onValueChanged() {
+        valueChangedCommand.execute();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        view.clear();
+        valueProvider = null;
+        textProvider = null;
+        itemProvider = null;
+        valueChangedCommand = null;
+    }
+
+    @Override
+    public SelectorView getView() {
+        return view;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorView.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorView.html
@@ -1,0 +1,5 @@
+<div class="row" data-field="selector-root">
+    <div class="col-md-11">
+        <select class="form-control" data-field="selector-input"></select>
+    </div>
+</div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorView.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.views;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.Event;
+import org.jboss.errai.common.client.dom.Option;
+import org.jboss.errai.common.client.dom.Select;
+import org.jboss.errai.common.client.dom.Window;
+import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.ForEvent;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+@Dependent
+@Templated
+public class SelectorView implements IsElement {
+
+    @Inject
+    @DataField("selector-root")
+    private Div selectorContainer;
+
+    @Inject
+    @DataField("selector-input")
+    private Select selectorInput;
+
+    private Selector<?> selector;
+
+    public SelectorView init(final Selector<?> selector) {
+        this.selector = selector;
+        return this;
+    }
+
+    public SelectorView add(final String text,
+                            final String value) {
+        selectorInput.add(newOption(text, value));
+        return this;
+    }
+
+    public String getValue() {
+        return selectorInput.getValue();
+    }
+
+    public SelectorView clear() {
+        while (selectorInput.getLength() > 0) {
+            selectorInput.remove(0);
+        }
+        return this;
+    }
+
+    public SelectorView setValue(final String value) {
+        selectorInput.setValue(value);
+        return this;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        selector = null;
+    }
+
+    @EventHandler("selector-input")
+    private void onValueChanged(@ForEvent("change") final Event event) {
+        selector.onValueChanged();
+    }
+
+    private static Option newOption(final String text,
+                                    final String value) {
+        final Option option = (Option) Window.getDocument().createElement("option");
+        option.setTextContent(text);
+        option.setValue(value);
+        return option;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/presenters/diagram/impl/DiagramLoaderTest.java
@@ -75,7 +75,7 @@ public class DiagramLoaderTest {
                     = (ParameterizedCommand<StunnerPreferences>) invocation.getArguments()[1];
             callback.execute(preferences);
             return null;
-        }).when(preferencesRegistryLoader).load(eq(DS_ID),
+        }).when(preferencesRegistryLoader).load(eq(metadata),
                                                 any(ParameterizedCommand.class),
                                                 any(ParameterizedCommand.class));
         doAnswer(invocation -> {
@@ -93,7 +93,7 @@ public class DiagramLoaderTest {
         ServiceCallback<Diagram> callback = mock(ServiceCallback.class);
         tested.loadByPath(path, callback);
         verify(callback, times(1)).onSuccess(eq(diagram));
-        verify(preferencesRegistryLoader, times(1)).load(eq(DS_ID),
+        verify(preferencesRegistryLoader, times(1)).load(eq(metadata),
                                                          any(ParameterizedCommand.class),
                                                          any(ParameterizedCommand.class));
         verify(callback, never()).onError(any(ClientRuntimeError.class));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/profile/ProfileSelectorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/profile/ProfileSelectorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.profile;
+
+import java.util.Collections;
+import java.util.function.Function;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.RequestSessionRefreshEvent;
+import org.kie.workbench.common.stunner.client.widgets.views.SelectorImpl;
+import org.kie.workbench.common.stunner.core.api.ProfileManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ProfileSelectorTest {
+
+    private static final String DEF_SET_ID = "dewfSet1";
+    private static final String SESSION_UUID = "session1";
+    private static final String PROFILE_ID = "profile1";
+    private static final String PROFILE_NAME = "profileName1";
+
+    @Mock
+    private SelectorImpl<Profile> selector;
+
+    @Mock
+    private ProfileManager profileManager;
+
+    @Mock
+    private Profile profile1;
+
+    @Mock
+    private EventSourceMock<RequestSessionRefreshEvent> requestSessionRefreshEvent;
+
+    private ProfileSelector tested;
+    private AbstractSession session;
+    private Metadata metadata;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        session = mock(AbstractSession.class);
+        AbstractCanvasHandler canvasHandler = mock(AbstractCanvasHandler.class);
+        Diagram diagram = mock(Diagram.class);
+        metadata = mock(Metadata.class);
+        when(session.getSessionUUID()).thenReturn(SESSION_UUID);
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getDefinitionSetId()).thenReturn(DEF_SET_ID);
+        when(metadata.getProfileId()).thenReturn(PROFILE_ID);
+        when(selector.setItemProvider(any(Function.class))).thenReturn(selector);
+        when(selector.setTextProvider(any(Function.class))).thenReturn(selector);
+        when(selector.setValueProvider(any(Function.class))).thenReturn(selector);
+        when(selector.setValueChangedCommand(any(Command.class))).thenReturn(selector);
+        when(profileManager.getProfile(eq(DEF_SET_ID), eq(PROFILE_ID))).thenReturn(profile1);
+        when(profileManager.getProfiles(eq(DEF_SET_ID))).thenReturn(Collections.singleton(profile1));
+        when(profile1.getProfileId()).thenReturn(PROFILE_ID);
+        when(profile1.getName()).thenReturn(PROFILE_NAME);
+        tested = new ProfileSelector(selector,
+                                     profileManager,
+                                     requestSessionRefreshEvent);
+        tested.init();
+    }
+
+    @Test
+    public void testBind() {
+        when(selector.getSelectedItem()).thenReturn(profile1);
+        tested.bind(() -> session);
+        verify(selector, times(1)).clear();
+        verify(selector, times(1)).addItem(eq(profile1));
+        ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass(Command.class);
+        verify(selector, times(1)).setValueChangedCommand(commandArgumentCaptor.capture());
+        Command command = commandArgumentCaptor.getValue();
+        command.execute();
+        verify(metadata, times(1)).setProfileId(eq(PROFILE_ID));
+        ArgumentCaptor<RequestSessionRefreshEvent> eventArgumentCaptor =
+                ArgumentCaptor.forClass(RequestSessionRefreshEvent.class);
+        verify(requestSessionRefreshEvent, times(1)).fire(eventArgumentCaptor.capture());
+        RequestSessionRefreshEvent event = eventArgumentCaptor.getValue();
+        assertEquals(SESSION_UUID, event.getSessionUUID());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorDelegateTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorDelegateTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.views;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SelectorDelegateTest {
+
+    @Mock
+    private Selector delegate;
+
+    private SelectorDelegate tested;
+
+    @Before
+    public void setup() throws Exception {
+        tested = new SelectorDelegate() {
+            @Override
+            protected Selector getDelegate() {
+                return delegate;
+            }
+        };
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddItem() {
+        Object item = mock(Object.class);
+        tested.addItem(item);
+        verify(delegate, times(1)).addItem(eq(item));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSetSelecteItem() {
+        Object item = mock(Object.class);
+        tested.setSelectedItem(item);
+        verify(delegate, times(1)).setSelectedItem(eq(item));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetSelecteItem() {
+        Object item = mock(Object.class);
+        when(delegate.getSelectedItem()).thenReturn(item);
+        assertEquals(item, tested.getSelectedItem());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testClear() {
+        tested.clear();
+        verify(delegate, times(1)).clear();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnValueChanged() {
+        tested.onValueChanged();
+        verify(delegate, times(1)).onValueChanged();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetView() {
+        SelectorView view = mock(SelectorView.class);
+        when(delegate.getView()).thenReturn(view);
+        assertEquals(view, tested.getView());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorDelegateTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorDelegateTest.java
@@ -64,7 +64,6 @@ public class SelectorDelegateTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testGetSelecteItem() {
         Object item = mock(Object.class);
         when(delegate.getSelectedItem()).thenReturn(item);
@@ -72,21 +71,18 @@ public class SelectorDelegateTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testClear() {
         tested.clear();
         verify(delegate, times(1)).clear();
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testOnValueChanged() {
         tested.onValueChanged();
         verify(delegate, times(1)).onValueChanged();
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testGetView() {
         SelectorView view = mock(SelectorView.class);
         when(delegate.getView()).thenReturn(view);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/SelectorImplTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.views;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class SelectorImplTest {
+
+    @Mock
+    private SelectorView view;
+
+    @Mock
+    private Command valueChangedCommand;
+
+    private SelectorImpl<SelectorTestObject> tested;
+
+    @Before
+    public void setup() throws Exception {
+        tested = new SelectorImpl<>(view);
+        tested
+                .setTextProvider(obj -> obj.text)
+                .setValueProvider(Enum::name)
+                .setItemProvider(SelectorTestObject::valueOf)
+                .setValueChangedCommand(valueChangedCommand);
+    }
+
+    @Test
+    public void testInit() {
+        tested.init();
+        verify(view, times(1)).init(eq(tested));
+    }
+
+    @Test
+    public void testAddItem() {
+        tested.addItem(SelectorTestObject.ITEM1);
+        verify(view, times(1)).add(eq(SelectorTestObject.ITEM1.text),
+                                   eq(SelectorTestObject.ITEM1.name()));
+    }
+
+    @Test
+    public void testSetSelectedItem() {
+        tested.setSelectedItem(SelectorTestObject.ITEM1);
+        verify(view, times(1)).setValue(eq(SelectorTestObject.ITEM1.name()));
+    }
+
+    @Test
+    public void testGetSelectedItem() {
+        when(view.getValue()).thenReturn(SelectorTestObject.ITEM1.name());
+        SelectorTestObject selectedItem = tested.getSelectedItem();
+        assertEquals(SelectorTestObject.ITEM1, selectedItem);
+    }
+
+    @Test
+    public void testClear() {
+        tested.clear();
+        verify(view, times(1)).clear();
+    }
+
+    @Test
+    public void testOnValueChanged() {
+        tested.onValueChanged();
+        verify(valueChangedCommand, times(1)).execute();
+    }
+
+    @Test
+    public void testDestroy() {
+        tested.destroy();
+        verify(view, times(1)).clear();
+    }
+
+    private enum SelectorTestObject {
+        ITEM1("name1"),
+        ITEM2("name2");
+
+        private final String text;
+
+        SelectorTestObject(String text) {
+            this.text = text;
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/api/ProfileManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/api/ProfileManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.api;
+
+import java.util.Collection;
+
+import org.kie.workbench.common.stunner.core.profile.Profile;
+
+/**
+ * Entry point for handling the different Definition Set Profiles present on the context.
+ */
+public interface ProfileManager {
+
+    /**
+     * Returns all registered profiles.
+     * @return A collection of profiles
+     */
+    Collection<Profile> getAllProfiles();
+
+    /**
+     * Returns a given profiel by its identifier
+     * @return A profile with the given id, if any, otherwise the return value
+     * depends on the implementations.
+     */
+    Profile getProfile(String profileId);
+
+    /**
+     * Returns all profiles registered for a given Definition Set domain.
+     * @return A collection of profiles
+     */
+    Collection<Profile> getProfiles(String definitionSetId);
+
+    /**
+     * Returns a given profiel by its identifier and its Definition Set domain.
+     * @return A profile with the given id, if any, otherwise the return value
+     * depends on the implementations.
+     */
+    Profile getProfile(String definitionSetId, String profileId);
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/api/ProfileManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/api/ProfileManager.java
@@ -32,7 +32,7 @@ public interface ProfileManager {
     Collection<Profile> getAllProfiles();
 
     /**
-     * Returns a given profiel by its identifier
+     * Returns a given profile by its identifier
      * @return A profile with the given id, if any, otherwise the return value
      * depends on the implementations.
      */
@@ -45,7 +45,7 @@ public interface ProfileManager {
     Collection<Profile> getProfiles(String definitionSetId);
 
     /**
-     * Returns a given profiel by its identifier and its Definition Set domain.
+     * Returns a given profile by its identifier and its Definition Set domain.
      * @return A profile with the given id, if any, otherwise the return value
      * depends on the implementations.
      */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetAdapter.java
@@ -30,37 +30,37 @@ public interface DefinitionSetAdapter<T> extends PriorityAdapter {
     /**
      * Returns the definition set's identifier for a given pojo.
      */
-    String getId(final T pojo);
+    String getId(T pojo);
 
     /**
      * Returns the definition set's domain for a given pojo.
      */
-    String getDomain(final T pojo);
+    String getDomain(T pojo);
 
     /**
      * Returns the definition set's description for a given pojo.
      */
-    String getDescription(final T pojo);
+    String getDescription(T pojo);
 
     /**
      * Returns the definition set's definitions for a given pojo.
      */
-    Set<String> getDefinitions(final T pojo);
+    Set<String> getDefinitions(T pojo);
 
     /**
      * Returns the definition set's graph class for a given pojo.
      */
-    Class<? extends ElementFactory> getGraphFactoryType(final T pojo);
+    Class<? extends ElementFactory> getGraphFactoryType(T pojo);
 
     /**
      * Returns the qualifier used for this Definition Set component's implementations, if any.
      * It must return at least <code>javax.enterprise.inject.Default</code>
      * or <code>javax.enterprise.inject.Any</code>.
      */
-    Annotation getQualifier(final T pojo);
+    Annotation getQualifier(T pojo);
 
     /**
      * Returns the definition set's node id for SVG generation.
      */
-    Optional<String> getSvgNodeId(final T pojo);
+    Optional<String> getSvgNodeId(T pojo);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetRuleAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionSetRuleAdapter.java
@@ -26,5 +26,5 @@ public interface DefinitionSetRuleAdapter<T> extends PriorityAdapter {
     /**
      * Returns the definition set's rules for a given pojo.
      */
-    RuleSet getRuleSet(final T pojo);
+    RuleSet getRuleSet(T pojo);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/diagram/Metadata.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/diagram/Metadata.java
@@ -24,29 +24,33 @@ public interface Metadata extends Serializable {
 
     String getDefinitionSetId();
 
+    String getProfileId();
+
+    void setProfileId(String profileId);
+
     String getTitle();
 
-    void setTitle(final String title);
+    void setTitle(String title);
 
     String getShapeSetId();
 
-    void setShapeSetId(final String id);
+    void setShapeSetId(String id);
 
     String getCanvasRootUUID();
 
-    void setCanvasRootUUID(final String uuid);
+    void setCanvasRootUUID(String uuid);
 
     String getThumbData();
 
-    void setThumbData(final String data);
+    void setThumbData(String data);
 
     Path getPath();
 
-    void setPath(final Path path);
+    void setPath(Path path);
 
     Path getRoot();
 
-    void setRoot(final Path path);
+    void setRoot(Path path);
 
     Class<? extends Metadata> getMetadataType();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/profile/Profile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/profile/Profile.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+public interface Profile {
+
+    public String getProfileId();
+
+    public String getName();
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/profile/Profile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/profile/Profile.java
@@ -18,7 +18,7 @@ package org.kie.workbench.common.stunner.core.profile;
 
 public interface Profile {
 
-    public String getProfileId();
+    String getProfileId();
 
-    public String getName();
+    String getName();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/profile/BackendProfileManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/profile/BackendProfileManager.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.profile;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Function;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.profile.AbstractProfileManager;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+
+@ApplicationScoped
+public class BackendProfileManager extends AbstractProfileManager {
+
+    private final DefinitionUtils definitionUtils;
+    private final Instance<Profile> profileInstances;
+
+    @Inject
+    public BackendProfileManager(final DefinitionUtils definitionUtils,
+                                 final @Any Instance<Profile> profileInstances) {
+        this.definitionUtils = definitionUtils;
+        this.profileInstances = profileInstances;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        profileInstances.forEach(profileInstances::destroy);
+    }
+
+    @Override
+    protected Function<String, Annotation> getQualifier() {
+        return definitionUtils::getQualifier;
+    }
+
+    @Override
+    protected Iterable<Profile> getAllProfileInstances() {
+        return profileInstances;
+    }
+
+    @Override
+    protected Iterable<Profile> selectProfileInstances(final Annotation... qualifiers) {
+        return profileInstances.select(qualifiers);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/profile/BackendProfileManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/profile/BackendProfileManagerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.profile;
+
+import java.lang.annotation.Annotation;
+import java.util.Iterator;
+
+import javax.enterprise.inject.Instance;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.MockInstanceImpl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BackendProfileManagerTest {
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private Profile profile1;
+
+    @Mock
+    private Profile profile2;
+
+    private BackendProfileManager tested;
+    private Instance<Profile> profileInstances;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        profileInstances = spy(new MockInstanceImpl<>(profile1, profile2));
+        tested = new BackendProfileManager(definitionUtils,
+                                           profileInstances);
+    }
+
+    @Test
+    public void testDestroy() {
+        tested.destroy();
+        verify(profileInstances, times(1)).destroy(eq(profile1));
+        verify(profileInstances, times(1)).destroy(eq(profile2));
+    }
+
+    @Test
+    public void testGetQualifier() {
+        tested.getQualifier().apply("q1");
+        verify(definitionUtils, times(1)).getQualifier(eq("q1"));
+        tested.getQualifier().apply("q2");
+        verify(definitionUtils, times(1)).getQualifier(eq("q2"));
+    }
+
+    @Test
+    public void testGetAllProfileInstances() {
+        Iterable<Profile> profiles = tested.getAllProfileInstances();
+        Iterator<Profile> iterator = profiles.iterator();
+        assertEquals(profile1, iterator.next());
+        assertEquals(profile2, iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testSelectProfileInstances() {
+        Annotation qualifier = mock(Annotation.class);
+        tested.selectProfileInstances(qualifier);
+        verify(profileInstances, times(1)).select(eq(qualifier));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/profile/BackendProfileManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/profile/BackendProfileManagerTest.java
@@ -54,8 +54,7 @@ public class BackendProfileManagerTest {
     private Instance<Profile> profileInstances;
 
     @Before
-    @SuppressWarnings("unchecked")
-    public void setup() throws Exception {
+    public void setup() {
         profileInstances = spy(new MockInstanceImpl<>(profile1, profile2));
         tested = new BackendProfileManager(definitionUtils,
                                            profileInstances);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/ClientProfileManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/ClientProfileManager.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.api;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Function;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.profile.AbstractProfileManager;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+
+@ApplicationScoped
+public class ClientProfileManager extends AbstractProfileManager {
+
+    private final DefinitionUtils definitionUtils;
+    private final ManagedInstance<Profile> profileInstances;
+
+    @Inject
+    public ClientProfileManager(final DefinitionUtils definitionUtils,
+                                final @Any ManagedInstance<Profile> profileInstances) {
+        this.definitionUtils = definitionUtils;
+        this.profileInstances = profileInstances;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        profileInstances.destroyAll();
+    }
+
+    @Override
+    protected Function<String, Annotation> getQualifier() {
+        return definitionUtils::getQualifier;
+    }
+
+    @Override
+    protected Iterable<Profile> getAllProfileInstances() {
+        return profileInstances;
+    }
+
+    @Override
+    protected Iterable<Profile> selectProfileInstances(final Annotation... qualifiers) {
+        return profileInstances.select(qualifiers);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/AbstractPaletteDefinitionBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/AbstractPaletteDefinitionBuilder.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.core.client.components.palette;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -30,6 +31,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.components.palette.DefaultPaletteDefinitionProviders.DefaultItemMessageProvider;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.mvp.Command;
@@ -45,6 +47,7 @@ public abstract class AbstractPaletteDefinitionBuilder<T extends AbstractPalette
     }
 
     protected final DefinitionUtils definitionUtils;
+    protected final DomainProfileManager profileManager;
     protected final DefinitionsCacheRegistry definitionsRegistry;
     protected final StunnerTranslationService translationService;
 
@@ -54,9 +57,11 @@ public abstract class AbstractPaletteDefinitionBuilder<T extends AbstractPalette
     protected ItemMessageProvider itemMessageProvider;
 
     protected AbstractPaletteDefinitionBuilder(final DefinitionUtils definitionUtils,
+                                               final DomainProfileManager profileManager,
                                                final DefinitionsCacheRegistry definitionsRegistry,
                                                final StunnerTranslationService translationService) {
         this.definitionUtils = definitionUtils;
+        this.profileManager = profileManager;
         this.definitionsRegistry = definitionsRegistry;
         this.translationService = translationService;
         initDefaults();
@@ -113,8 +118,7 @@ public abstract class AbstractPaletteDefinitionBuilder<T extends AbstractPalette
     private void build(final Metadata metadata,
                        final Consumer<DefaultPaletteDefinition> paletteDefinitionConsumer) {
         final String definitionSetId = metadata.getDefinitionSetId();
-        final Object definitionSet = getDefinitionManager().definitionSets().getDefinitionSetById(definitionSetId);
-        final Set<String> definitions = getDefinitionManager().adapters().forDefinitionSet().getDefinitions(definitionSet);
+        final List<String> definitions = profileManager.getAllDefinitions(metadata);
         if (null != definitions) {
             final Map<String, DefaultPaletteItem> items = new LinkedHashMap<>();
             final Set<String> consumed = new HashSet<>(definitions);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilder.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.components.palette.DefaultPa
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
@@ -39,9 +40,11 @@ public class CollapsedPaletteDefinitionBuilder
 
     @Inject
     public CollapsedPaletteDefinitionBuilder(final DefinitionUtils definitionUtils,
+                                             final DomainProfileManager profileManager,
                                              final DefinitionsCacheRegistry definitionsRegistry,
                                              final StunnerTranslationService translationService) {
         super(definitionUtils,
+              profileManager,
               definitionsRegistry,
               translationService);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilder.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
@@ -104,9 +105,10 @@ public class ExpandedPaletteDefinitionBuilder
 
     @Inject
     public ExpandedPaletteDefinitionBuilder(final DefinitionUtils definitionUtils,
+                                            final DomainProfileManager profileManager,
                                             final DefinitionsCacheRegistry definitionsRegistry,
                                             final StunnerTranslationService translationService) {
-        super(definitionUtils, definitionsRegistry, translationService);
+        super(definitionUtils, profileManager, definitionsRegistry, translationService);
         initDefaults();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/preferences/StunnerPreferencesRegistryLoader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/preferences/StunnerPreferencesRegistryLoader.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.session.impl.InstanceUtils;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.preferences.StunnerPreferences;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.mvp.ParameterizedCommand;
@@ -48,9 +49,10 @@ public class StunnerPreferencesRegistryLoader {
         this.textPreferences = textPreferences;
     }
 
-    public void load(final String definitionSetId,
+    public void load(final Metadata metadata,
                      final ParameterizedCommand<StunnerPreferences> loadCompleteCallback,
                      final ParameterizedCommand<Throwable> errorCallback) {
+        final String definitionSetId = metadata.getDefinitionSetId();
         final Annotation qualifier = definitionUtils.getQualifier(definitionSetId);
         final StunnerPreferencesRegistryHolder holder = InstanceUtils.lookup(preferencesHolders,
                                                                              qualifier);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/SessionLoader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/SessionLoader.java
@@ -56,7 +56,7 @@ public class SessionLoader {
                      final ParameterizedCommand<Throwable> errorCallback) {
         final String definitionSetId = metadata.getDefinitionSetId();
         final Annotation qualifier = definitionUtils.getQualifier(definitionSetId);
-        preferencesRegistryLoader.load(definitionSetId,
+        preferencesRegistryLoader.load(metadata,
                                        prefs -> {
                                            loadInitializers(metadata,
                                                             qualifier,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/StunnerClientLogger.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/StunnerClientLogger.java
@@ -158,6 +158,7 @@ public class StunnerClientLogger {
                     final Metadata metadata = diagram.getMetadata();
                     if (null != metadata) {
                         log("Metadata defSetId = " + metadata.getDefinitionSetId());
+                        log("Metadata profileId = " + metadata.getProfileId());
                         log("Metadata shapeSetId = " + metadata.getShapeSetId());
                         log("Metadata canvas root = " + metadata.getCanvasRootUUID());
                         log("Metadata title = " + metadata.getTitle());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/api/ClientProfileManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/api/ClientProfileManagerTest.java
@@ -53,9 +53,8 @@ public class ClientProfileManagerTest {
     private ManagedInstance<Profile> profileInstances;
 
     @Before
-    @SuppressWarnings("unchecked")
-    public void setup() throws Exception {
-        profileInstances = spy(new ManagedInstanceStub<Profile>(profile1, profile2));
+    public void setup() {
+        profileInstances = spy(new ManagedInstanceStub<>(profile1, profile2));
         tested = new ClientProfileManager(definitionUtils,
                                           profileInstances);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/api/ClientProfileManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/api/ClientProfileManagerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.api;
+
+import java.lang.annotation.Annotation;
+import java.util.Iterator;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientProfileManagerTest {
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private Profile profile1;
+
+    @Mock
+    private Profile profile2;
+
+    private ClientProfileManager tested;
+    private ManagedInstance<Profile> profileInstances;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        profileInstances = spy(new ManagedInstanceStub<Profile>(profile1, profile2));
+        tested = new ClientProfileManager(definitionUtils,
+                                          profileInstances);
+    }
+
+    @Test
+    public void testGetQualifier() {
+        tested.getQualifier().apply("q1");
+        verify(definitionUtils, times(1)).getQualifier(eq("q1"));
+        tested.getQualifier().apply("q2");
+        verify(definitionUtils, times(1)).getQualifier(eq("q2"));
+    }
+
+    @Test
+    public void testGetAllProfileInstances() {
+        Iterable<Profile> profiles = tested.getAllProfileInstances();
+        Iterator<Profile> iterator = profiles.iterator();
+        assertEquals(profile1, iterator.next());
+        assertEquals(profile2, iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testSelectProfileInstances() {
+        Annotation qualifier = mock(Annotation.class);
+        tested.selectProfileInstances(qualifier);
+        verify(profileInstances, times(1)).select(eq(qualifier));
+    }
+
+    @Test
+    public void testDestroy() {
+        tested.destroy();
+        verify(profileInstances, times(1)).destroyAll();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilderTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapte
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
@@ -47,6 +48,9 @@ public class CollapsedPaletteDefinitionBuilderTest {
 
     @Mock
     private DefinitionUtils definitionUtils;
+
+    @Mock
+    private DomainProfileManager profileManager;
 
     @Mock
     private DefinitionManager definitionManager;
@@ -84,6 +88,7 @@ public class CollapsedPaletteDefinitionBuilderTest {
         when(definitionAdapter1.getTitle(eq(definition1))).thenReturn(DEF1_TITLE);
         when(definitionAdapter1.getDescription(eq(definition1))).thenReturn(DEF1_DESC);
         tested = new CollapsedPaletteDefinitionBuilder(definitionUtils,
+                                                       profileManager,
                                                        definitionsRegistry,
                                                        translationService);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilderTest.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
@@ -82,6 +83,9 @@ public class ExpandedPaletteDefinitionBuilderTest {
     private DefinitionUtils definitionUtils;
 
     @Mock
+    private DomainProfileManager profileManager;
+
+    @Mock
     private DefinitionManager definitionManager;
 
     @Mock
@@ -117,6 +121,7 @@ public class ExpandedPaletteDefinitionBuilderTest {
         when(definitionAdapter1.getTitle(eq(definition1))).thenReturn(DEF1_TITLE);
         when(definitionAdapter1.getDescription(eq(definition1))).thenReturn(DEF1_DESC);
         tested = new ExpandedPaletteDefinitionBuilder(definitionUtils,
+                                                      profileManager,
                                                       definitionsRegistry,
                                                       translationService);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactoryTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.client.components.toolbox.actions;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
@@ -33,15 +34,19 @@ import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.MorphAdapter;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
@@ -59,6 +64,12 @@ public class MorphActionsToolboxFactoryTest {
 
     @Mock
     private DefinitionManager definitionManager;
+
+    @Mock
+    private DomainProfileManager profileManager;
+
+    @Mock
+    private Predicate<String> profileFilter;
 
     @Mock
     private DefinitionUtils definitionUtils;
@@ -91,6 +102,12 @@ public class MorphActionsToolboxFactoryTest {
     private AbstractCanvasHandler canvasHandler;
 
     @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
     private Node<View, Edge> element;
 
     @Mock
@@ -107,6 +124,10 @@ public class MorphActionsToolboxFactoryTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(profileFilter.test(anyString())).thenReturn(true);
+        when(profileManager.isDefinitionIdAllowed(eq(metadata))).thenReturn(profileFilter);
         when(morphNodeAction.setMorphDefinition(any(MorphDefinition.class))).thenReturn(morphNodeAction);
         when(morphNodeAction.setTargetDefinitionId(anyString())).thenReturn(morphNodeAction);
         when(definitionManager.adapters()).thenReturn(adapters);
@@ -125,6 +146,7 @@ public class MorphActionsToolboxFactoryTest {
         when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
         when(definitionUtils.hasMorphTargets(eq(definition))).thenReturn(true);
         this.tested = new MorphActionsToolboxFactory(definitionUtils,
+                                                     profileManager,
                                                      () -> morphNodeAction,
                                                      morphNodeActionDestroyer,
                                                      () -> view,
@@ -134,9 +156,11 @@ public class MorphActionsToolboxFactoryTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testBuildToolbox() {
+        when(profileFilter.test(eq(MORPH_TARGET_ID))).thenReturn(true);
         final Optional<Toolbox<?>> toolbox =
                 tested.build(canvasHandler,
                              element);
+        verify(profileManager, times(1)).isDefinitionIdAllowed(eq(metadata));
         assertTrue(toolbox.isPresent());
         assertTrue(toolbox.get() instanceof ActionsToolbox);
         final ActionsToolbox actionsToolbox = (ActionsToolbox) toolbox.get();
@@ -156,6 +180,16 @@ public class MorphActionsToolboxFactoryTest {
                times(1)).addButton(any(Glyph.class),
                                    anyString(),
                                    any(Consumer.class));
+    }
+
+    @Test
+    public void testBuildToolboxWithProfileRestrictions() {
+        when(profileFilter.test(eq(MORPH_TARGET_ID))).thenReturn(false);
+        final Optional<Toolbox<?>> toolbox =
+                tested.build(canvasHandler,
+                             element);
+        verify(profileManager, times(1)).isDefinitionIdAllowed(eq(metadata));
+        assertFalse(toolbox.isPresent());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/preferences/StunnerPreferencesRegistryLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/preferences/StunnerPreferencesRegistryLoaderTest.java
@@ -23,6 +23,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.diagram.MetadataImpl;
 import org.kie.workbench.common.stunner.core.preferences.StunnerPreferences;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
@@ -60,6 +62,7 @@ public class StunnerPreferencesRegistryLoaderTest {
     private Annotation qualifier;
 
     private StunnerPreferencesRegistryLoader tested;
+    private Metadata metadata;
 
     @Mock
     private StunnerTextPreferences textPreferences;
@@ -67,6 +70,7 @@ public class StunnerPreferencesRegistryLoaderTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
+        metadata = new MetadataImpl.MetadataImplBuilder(DEF_SET_ID).build();
         when(definitionUtils.getQualifier(eq(DEF_SET_ID))).thenReturn(qualifier);
         preferencesHolders = spy(new ManagedInstanceStub<>(preferencesHolder));
         tested = new StunnerPreferencesRegistryLoader(definitionUtils,
@@ -86,7 +90,7 @@ public class StunnerPreferencesRegistryLoaderTest {
             return null;
         }).when(preferences).load(any(ParameterizedCommand.class),
                                   any(ParameterizedCommand.class));
-        tested.load(DEF_SET_ID,
+        tested.load(metadata,
                     loadCompleteCallback,
                     errorCallback);
         verify(preferencesHolders, times(1)).select(eq(qualifier));
@@ -110,7 +114,7 @@ public class StunnerPreferencesRegistryLoaderTest {
             }
         }).when(preferences).load(any(ParameterizedCommand.class),
                                   any(ParameterizedCommand.class));
-        tested.load(DEF_SET_ID,
+        tested.load(metadata,
                     loadCompleteCallback,
                     errorCallback);
         verify(preferencesHolders, times(1)).select(eq(qualifier));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/SessionLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/SessionLoaderTest.java
@@ -80,7 +80,7 @@ public class SessionLoaderTest {
             ParameterizedCommand<StunnerPreferences> callback = (ParameterizedCommand<StunnerPreferences>) invocation.getArguments()[1];
             callback.execute(preferences);
             return null;
-        }).when(preferencesRegistryLoader).load(eq(DEF_SET_ID),
+        }).when(preferencesRegistryLoader).load(eq(metadata),
                                                 any(ParameterizedCommand.class),
                                                 any(ParameterizedCommand.class));
         sessionLoader = new SessionLoader(definitionUtils,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/diagram/AbstractMetadata.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/diagram/AbstractMetadata.java
@@ -23,6 +23,7 @@ import org.uberfire.backend.vfs.Path;
 public abstract class AbstractMetadata implements Metadata {
 
     private String definitionSetId;
+    private String profileId;
     private String title;
     private String shapeSetId;
     private String canvasRootUUID;
@@ -50,6 +51,16 @@ public abstract class AbstractMetadata implements Metadata {
     @Override
     public String getDefinitionSetId() {
         return definitionSetId;
+    }
+
+    @Override
+    public String getProfileId() {
+        return profileId;
+    }
+
+    @Override
+    public void setProfileId(final String profileId) {
+        this.profileId = profileId;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/domain/CommonDomainLookups.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/domain/CommonDomainLookups.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.lookup.domain;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
@@ -92,6 +93,16 @@ public class CommonDomainLookups {
     public Set<String> lookupTargetNodes(final Graph<?, ? extends Node> graph,
                                          final Node<? extends Definition<Object>, ? extends Edge> sourceNode,
                                          final String edgeId) {
+        return lookupTargetNodes(graph,
+                                 sourceNode,
+                                 edgeId,
+                                 def -> true);
+    }
+
+    public Set<String> lookupTargetNodes(final Graph<?, ? extends Node> graph,
+                                         final Node<? extends Definition<Object>, ? extends Edge> sourceNode,
+                                         final String edgeId,
+                                         final Predicate<String> definitionIdsAllowedFilter) {
         final DomainLookupContext context = newContext();
         final Set<String> targetRoles =
                 new LookupTargetRoles(sourceNode,
@@ -100,7 +111,8 @@ public class CommonDomainLookups {
 
         final Set<String> allowedTargetDefinitions =
                 new LookupAllowedDefinitionsByLabels(graph,
-                                                     targetRoles)
+                                                     targetRoles,
+                                                     definitionIdsAllowedFilter)
                         .execute(context);
 
         return new FilterConnectionTargetDefinitions(edgeId, allowedTargetDefinitions).execute(context);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/AbstractProfileManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/AbstractProfileManager.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.ProfileManager;
+
+public abstract class AbstractProfileManager implements ProfileManager {
+
+    protected abstract Function<String, Annotation> getQualifier();
+
+    protected abstract Iterable<Profile> getAllProfileInstances();
+
+    protected abstract Iterable<Profile> selectProfileInstances(Annotation... qualifiers);
+
+    @Override
+    public Collection<Profile> getAllProfiles() {
+        final List<Profile> result = new ArrayList<>();
+        getAllProfileInstances().forEach(result::add);
+        return result;
+    }
+
+    @Override
+    public Profile getProfile(final String id) {
+        return null != id ?
+                getAllProfiles().stream().filter(profile -> profile.getProfileId().equals(id)).findFirst().orElse(null) :
+                null;
+    }
+
+    @Override
+    public Collection<Profile> getProfiles(final String definitionSetId) {
+        final Annotation qualifier = getQualifier().apply(definitionSetId);
+        final List<Profile> result = new ArrayList<>();
+        selectProfileInstances(qualifier).forEach(result::add);
+        result.add(getDefaultProfileInstance());
+        return result;
+    }
+
+    @Override
+    public Profile getProfile(final String definitionSetId,
+                                    final String id) {
+        final Annotation qualifier = getQualifier().apply(definitionSetId);
+        Profile profile = getProfile(id);
+        if (null == profile) {
+            profile = getDefaultDomainProfile(qualifier);
+        }
+        return profile;
+    }
+
+    private Profile getDefaultDomainProfile(final Annotation qualifier) {
+        final Iterator<Profile> domainDefaultProfile =
+                selectProfileInstances(qualifier, DefinitionManager.DEFAULT_QUALIFIER)
+                        .iterator();
+        if (domainDefaultProfile.hasNext()) {
+            return domainDefaultProfile.next();
+        }
+        return getDefaultProfileInstance();
+    }
+
+    private Profile getDefaultProfileInstance() {
+        return selectProfileInstances(DefinitionManager.DEFAULT_QUALIFIER).iterator().next();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/BindableDomainProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/BindableDomainProfile.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
+
+public class BindableDomainProfile {
+
+    public static BindableDomainProfile build(final Class<?>... types) {
+        return new BindableDomainProfile(Stream.of(types)
+                                                 .map(BindableAdapterUtils::getDefinitionId)
+                                                 .collect(Collectors.toSet()));
+    }
+
+    private final Set<String> definitionsAllowed;
+
+    BindableDomainProfile(Set<String> definitionsAllowed) {
+        this.definitionsAllowed = definitionsAllowed;
+    }
+
+    public Predicate<String> definitionAllowedFilter() {
+        return definitionsAllowed::contains;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/DomainProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/DomainProfile.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.util.function.Predicate;
+
+public interface DomainProfile extends Profile {
+
+    /**
+     * A filter for excluding domain instances from the default ones.
+     * @return A predicate that tests against a Definition's identifier.
+     * Returns <code>true</code> in case the instance is allowed, otherwise
+     * returns <code>false</code>
+     */
+    Predicate<String> definitionAllowedFilter();
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/DomainProfileManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/DomainProfileManager.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.ProfileManager;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+
+@ApplicationScoped
+public class DomainProfileManager {
+
+    private final DefinitionManager definitionManager;
+    private final ProfileManager profileManager;
+    private final FullProfile defaultProfile;
+
+    @Inject
+    public DomainProfileManager(final DefinitionManager definitionManager,
+                                final ProfileManager profileManager,
+                                final FullProfile defaultProfile) {
+        this.definitionManager = definitionManager;
+        this.profileManager = profileManager;
+        this.defaultProfile = defaultProfile;
+    }
+
+    public List<String> getAllDefinitions(final Metadata metadata) {
+        return getDefinitionsByProfile(metadata.getDefinitionSetId(),
+                                       metadata.getProfileId());
+    }
+
+    public Predicate<String> isDefinitionIdAllowed(final Metadata metadata) {
+        return getDefinitionProfile(metadata)
+                .map(DomainProfile::definitionAllowedFilter)
+                .orElse(defaultProfile.definitionAllowedFilter());
+    }
+
+    private Optional<DomainProfile> getDefinitionProfile(final Metadata metadata) {
+        return getDefinitionProfile(metadata.getDefinitionSetId(),
+                                    metadata.getProfileId());
+    }
+
+    private List<String> getDefinitionsByProfile(final String definitionSetId,
+                                                 final String profileId) {
+        final Object definitionSet = definitionManager.definitionSets().getDefinitionSetById(definitionSetId);
+        final Set<String> definitions = definitionManager.adapters().forDefinitionSet().getDefinitions(definitionSet);
+        return getDefinitionProfile(definitionSetId,
+                                    profileId)
+                .map(profile -> definitions.stream()
+                        .filter(profile.definitionAllowedFilter()))
+                .orElse(definitions.stream())
+                .collect(Collectors.toList());
+    }
+
+    private Optional<DomainProfile> getDefinitionProfile(final String definitionSetId,
+                                                         final String profileId) {
+        final Profile profile = profileManager.getProfile(definitionSetId, profileId);
+        if (profile instanceof DomainProfile) {
+            return Optional.of((DomainProfile) profile);
+        }
+        return Optional.empty();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/FullProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/profile/FullProfile.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.util.function.Predicate;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+
+@ApplicationScoped
+@Default
+public class FullProfile implements DomainProfile {
+
+    static final String ID = FullProfile.class.getName();
+
+    @Override
+    public String getProfileId() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return "Full";
+    }
+
+    @Override
+    public Predicate<String> definitionAllowedFilter() {
+        return s -> true;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/util/DefinitionUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/util/DefinitionUtils.java
@@ -219,26 +219,6 @@ public class DefinitionUtils {
         return new String[]{definitionId, baseId};
     }
 
-    public String getDefaultConnectorId(final String definitionSetId) {
-        final Object defSet = getDefinitionManager().definitionSets().getDefinitionSetById(definitionSetId);
-        if (null != defSet) {
-            final Set<String> definitions = definitionManager.adapters().forDefinitionSet().getDefinitions(defSet);
-            if (null != definitions && !definitions.isEmpty()) {
-                for (final String defId : definitions) {
-                    final Object def = definitionsRegistry.getDefinitionById(defId);
-                    if (null != def) {
-                        final Class<? extends ElementFactory> graphElement = definitionManager.adapters().forDefinition().getGraphFactoryType(def);
-                        if (isEdgeFactory(graphElement,
-                                          factoryManager.registry())) {
-                            return defId;
-                        }
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
     public boolean isAllPolicy(final MorphDefinition definition) {
         return ClonePolicy.ALL.equals(definition.getPolicy());
     }
@@ -255,6 +235,10 @@ public class DefinitionUtils {
         checkNotNull("defSetId",
                      defSetId);
         final Object ds = definitionManager.definitionSets().getDefinitionSetById(defSetId);
+        return getQualifier(ds);
+    }
+
+    private Annotation getQualifier(final Object ds) {
         return definitionManager.adapters().forDefinitionSet().getQualifier(ds);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/StunnerCoreCommon.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/resources/org/kie/workbench/common/stunner/core/StunnerCoreCommon.gwt.xml
@@ -32,6 +32,7 @@
   <source path="factory"/>
   <source path="graph"/>
   <source path="lookup"/>
+  <source path="profile"/>
   <source path="registry"/>
   <source path="resources"/>
   <source path="rule"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphInstanceBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphInstanceBuilder.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.core;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,6 +26,11 @@ import java.util.stream.Stream;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.rule.RuleSet;
+import org.kie.workbench.common.stunner.core.rule.context.EdgeCardinalityContext;
+import org.kie.workbench.common.stunner.core.rule.impl.CanConnect;
+import org.kie.workbench.common.stunner.core.rule.impl.EdgeOccurrences;
+import org.kie.workbench.common.stunner.core.rule.impl.Occurrences;
 
 /**
  * An utility class for testing scope that provides some "real" (not mocked) graph's initial
@@ -155,10 +161,10 @@ public class TestingGraphInstanceBuilder {
      * --------------------------------------------
      * |                     |                     |
      * startNode --(edge1)--> intermNode --(edge2)--> endNode
-     *                           |
-     *                        (edge3)
-     *                           |
-     *                       dockedNode
+     * |
+     * (edge3)
+     * |
+     * dockedNode
      */
     public static class TestGraph4 extends TestGraph2 {
 
@@ -253,6 +259,31 @@ public class TestingGraphInstanceBuilder {
                            result.endNode);
         result.evaluationsCount = 18;
         return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void createDefaultRulesForGraph1(RuleSet ruleSet) {
+        List rules = (List) ruleSet.getRules();
+        String def1Label = DEF1_LABELS.iterator().next();
+        String def2Label = DEF2_LABELS.iterator().next();
+        rules.add(new CanConnect("connectionFromStartToIntermediateForEdge1",
+                                 EDGE1_ID,
+                                 Collections.singletonList(new CanConnect.PermittedConnection(def1Label,
+                                                                                              def2Label))));
+        rules.add(new EdgeOccurrences("Edge1Cardinality",
+                                      EDGE1_ID,
+                                      def1Label,
+                                      EdgeCardinalityContext.Direction.OUTGOING,
+                                      -1,
+                                      -1));
+        rules.add(new Occurrences("graphCardinalityForDef1",
+                                  def1Label,
+                                  -1,
+                                  -1));
+        rules.add(new Occurrences("graphCardinalityForDef2",
+                                  def2Label,
+                                  -1,
+                                  -1));
     }
 
     private static TestGraph2 buildTestGraph2(final TestingGraphMockHandler graphTestHandler) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphMockHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphMockHandler.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core;
 
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,6 +48,7 @@ import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionS
 import org.kie.workbench.common.stunner.core.rule.RuleEvaluationContext;
 import org.kie.workbench.common.stunner.core.rule.RuleManager;
 import org.kie.workbench.common.stunner.core.rule.RuleSet;
+import org.kie.workbench.common.stunner.core.rule.RuleSetImpl;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.core.rule.RuleViolations;
 import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
@@ -59,6 +61,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyDouble;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -95,8 +98,6 @@ public class TestingGraphMockHandler {
     @Mock
     public RuleManager ruleManager;
     @Mock
-    public RuleSet ruleSet;
-    @Mock
     public MutableIndex graphIndex;
 
     public GraphFactoryImpl graphFactory;
@@ -104,6 +105,7 @@ public class TestingGraphMockHandler {
     public EdgeFactoryImpl edgeFactory;
     public GraphCommandFactory commandFactory;
     public Graph<DefinitionSet, Node> graph;
+    public RuleSet ruleSet;
 
     public TestingGraphMockHandler() {
         init();
@@ -111,6 +113,7 @@ public class TestingGraphMockHandler {
 
     @SuppressWarnings("unchecked")
     private TestingGraphMockHandler init() {
+        ruleSet = spy(new RuleSetImpl("TestingRuleSet", new ArrayList<>()));
         MockitoAnnotations.initMocks(this);
         this.graphFactory = new GraphFactoryImpl(definitionManager);
         this.nodeFactory = new NodeFactoryImpl(definitionUtils);
@@ -235,7 +238,10 @@ public class TestingGraphMockHandler {
 
     public Edge newEdge(String uuid,
                         final Optional<Object> def) {
-        final Object definition = getDefIfPresent(uuid, def);
+        final Object definition = def.isPresent() ?
+                def.get() :
+                newDef("def-" + uuid,
+                       Optional.empty());
         return newEdge(uuid, definition);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/domain/CommonDomainTargetNodeLookupTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/domain/CommonDomainTargetNodeLookupTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.lookup.domain;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
+import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
+import org.kie.workbench.common.stunner.core.rule.Rule;
+import org.kie.workbench.common.stunner.core.rule.impl.CanConnect;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommonDomainTargetNodeLookupTest {
+
+    @Mock
+    private DefinitionsCacheRegistry definitionsRegistry;
+
+    @Mock
+    private Function<String, DomainLookupsCache> cacheBuilder;
+
+    @Mock
+    private DomainLookupsCache cache;
+
+    private CommonDomainLookups tested;
+    private TestingGraphMockHandler graphTestHandler;
+    private TestingGraphInstanceBuilder.TestGraph1 graph;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        graphTestHandler = new TestingGraphMockHandler();
+        graph = TestingGraphInstanceBuilder.newGraph1(graphTestHandler);
+        TestingGraphInstanceBuilder.createDefaultRulesForGraph1(graphTestHandler.ruleSet);
+
+        when(cacheBuilder.apply(anyString())).thenReturn(cache);
+        when(cache.getRuleSet()).thenReturn(graphTestHandler.ruleSet);
+        CanConnect connectionRule = (CanConnect) ((List<Rule>) graphTestHandler.ruleSet.getRules()).get(0);
+        when(cache.getConnectionRules()).thenReturn(Collections.singletonList(connectionRule));
+        when(cache.getDefinitions(contains("label1"))).thenReturn(Arrays.asList(TestingGraphInstanceBuilder.DEF1_ID).stream().collect(Collectors.toSet()));
+        when(cache.getDefinitions(contains("label2"))).thenReturn(Arrays.asList(TestingGraphInstanceBuilder.DEF2_ID).stream().collect(Collectors.toSet()));
+        when(definitionsRegistry.getLabels(eq(TestingGraphInstanceBuilder.DEF1_ID))).thenReturn(TestingGraphInstanceBuilder.DEF1_LABELS);
+        when(definitionsRegistry.getLabels(eq(TestingGraphInstanceBuilder.DEF2_ID))).thenReturn(TestingGraphInstanceBuilder.DEF2_LABELS);
+
+        tested = new CommonDomainLookups(graphTestHandler.definitionUtils,
+                                         definitionsRegistry,
+                                         graphTestHandler.ruleManager,
+                                         cacheBuilder)
+                .setDomain("ds1");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLookupTargetNodes() {
+        Set<String> result = tested.lookupTargetNodes(graph.graph,
+                                                      graph.startNode,
+                                                      TestingGraphInstanceBuilder.EDGE1_ID);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+        assertEquals(TestingGraphInstanceBuilder.DEF2_ID, result.iterator().next());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLookupTargetNodesWithPredicate() {
+        Predicate<String> filter = TestingGraphInstanceBuilder.DEF1_ID::equals;
+        Set<String> result = tested.lookupTargetNodes(graph.graph,
+                                                      graph.startNode,
+                                                      TestingGraphInstanceBuilder.EDGE1_ID,
+                                                      filter);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/domain/CommonDomainTargetNodeLookupTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/domain/CommonDomainTargetNodeLookupTest.java
@@ -16,13 +16,13 @@
 
 package org.kie.workbench.common.stunner.core.lookup.domain;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,13 +56,11 @@ public class CommonDomainTargetNodeLookupTest {
     private DomainLookupsCache cache;
 
     private CommonDomainLookups tested;
-    private TestingGraphMockHandler graphTestHandler;
     private TestingGraphInstanceBuilder.TestGraph1 graph;
 
     @Before
-    @SuppressWarnings("unchecked")
     public void setup() throws Exception {
-        graphTestHandler = new TestingGraphMockHandler();
+        final TestingGraphMockHandler graphTestHandler = new TestingGraphMockHandler();
         graph = TestingGraphInstanceBuilder.newGraph1(graphTestHandler);
         TestingGraphInstanceBuilder.createDefaultRulesForGraph1(graphTestHandler.ruleSet);
 
@@ -70,8 +68,8 @@ public class CommonDomainTargetNodeLookupTest {
         when(cache.getRuleSet()).thenReturn(graphTestHandler.ruleSet);
         CanConnect connectionRule = (CanConnect) ((List<Rule>) graphTestHandler.ruleSet.getRules()).get(0);
         when(cache.getConnectionRules()).thenReturn(Collections.singletonList(connectionRule));
-        when(cache.getDefinitions(contains("label1"))).thenReturn(Arrays.asList(TestingGraphInstanceBuilder.DEF1_ID).stream().collect(Collectors.toSet()));
-        when(cache.getDefinitions(contains("label2"))).thenReturn(Arrays.asList(TestingGraphInstanceBuilder.DEF2_ID).stream().collect(Collectors.toSet()));
+        when(cache.getDefinitions(contains("label1"))).thenReturn(Stream.of(TestingGraphInstanceBuilder.DEF1_ID).collect(Collectors.toSet()));
+        when(cache.getDefinitions(contains("label2"))).thenReturn(Stream.of(TestingGraphInstanceBuilder.DEF2_ID).collect(Collectors.toSet()));
         when(definitionsRegistry.getLabels(eq(TestingGraphInstanceBuilder.DEF1_ID))).thenReturn(TestingGraphInstanceBuilder.DEF1_LABELS);
         when(definitionsRegistry.getLabels(eq(TestingGraphInstanceBuilder.DEF2_ID))).thenReturn(TestingGraphInstanceBuilder.DEF2_LABELS);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/domain/DomainLookupFunctionsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/lookup/domain/DomainLookupFunctionsTest.java
@@ -137,8 +137,23 @@ public class DomainLookupFunctionsTest {
         when(cache.getDefinitions(eq(ROLE2))).thenReturn(expected);
         LookupDefinitionsByLabels function = new LookupDefinitionsByLabels(new HashSet<String>(1) {{
             add(ROLE2);
-        }});
+        }},
+                                                                           id -> true);
         assertTrue(function.execute(context).contains(DEF_ID1));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLookupDefinitionsByLabelsWithFiltering() {
+        Set<String> expected = new HashSet<String>(1) {{
+            add(DEF_ID1);
+        }};
+        when(cache.getDefinitions(eq(ROLE2))).thenReturn(expected);
+        LookupDefinitionsByLabels function = new LookupDefinitionsByLabels(new HashSet<String>(1) {{
+            add(ROLE2);
+        }},
+                                                                           DEF_ID2::equals);
+        assertFalse(function.execute(context).contains(DEF_ID1));
     }
 
     @Test
@@ -150,7 +165,8 @@ public class DomainLookupFunctionsTest {
         LookupAllowedDefinitionsByLabels function = new LookupAllowedDefinitionsByLabels(graph1Instance.graph,
                                                                                          new HashSet<String>(1) {{
                                                                                              add("label1");
-                                                                                         }});
+                                                                                         }},
+                                                                                         id -> true);
         Set<String> result = function.execute(context);
         assertTrue(result.contains(TestingGraphInstanceBuilder.DEF1_ID));
         ArgumentCaptor<RuleEvaluationContext> ruleEvaluationContextCaptor = ArgumentCaptor.forClass(RuleEvaluationContext.class);
@@ -161,6 +177,21 @@ public class DomainLookupFunctionsTest {
         CardinalityContext cardinalityContext = (CardinalityContext) evaluationContext;
         assertEquals(1, cardinalityContext.getCandidateCount());
         assertEquals(CardinalityContext.Operation.ADD, cardinalityContext.getOperation().get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLookupAllowedDefinitionsByLabelsWithFiltering() {
+        when(cache.getDefinitions(eq("label1"))).thenReturn(Collections.singleton(TestingGraphInstanceBuilder.DEF1_ID));
+        when(definitionsCache.getLabels(eq(TestingGraphInstanceBuilder.DEF1_ID)))
+                .thenReturn(TestingGraphInstanceBuilder.DEF1_LABELS);
+        LookupAllowedDefinitionsByLabels function = new LookupAllowedDefinitionsByLabels(graph1Instance.graph,
+                                                                                         new HashSet<String>(1) {{
+                                                                                             add("label1");
+                                                                                         }},
+                                                                                         DEF_ID2::equals);
+        Set<String> result = function.execute(context);
+        assertTrue(result.isEmpty());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/AbstractProfileManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/AbstractProfileManagerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractProfileManagerTest {
+
+    private static final String DEF_SET_ID = "ds1";
+    private static final String PROFILE_DEFAULT_ID = "pDefault";
+    private static final String PROFILE_DOMAIN_ID = "pDomain";
+
+    @Mock
+    private Annotation domainQualifier;
+
+    @Mock
+    private Profile defaultProfile;
+
+    @Mock
+    private Profile domainProfile;
+
+    private AbstractProfileManagerStub tested;
+    private List<Profile> profiles;
+
+    @Before
+    public void setup() throws Exception {
+        when(defaultProfile.getProfileId()).thenReturn(PROFILE_DEFAULT_ID);
+        when(domainProfile.getProfileId()).thenReturn(PROFILE_DOMAIN_ID);
+        profiles = Arrays.asList(defaultProfile, domainProfile);
+        tested = new AbstractProfileManagerStub();
+    }
+
+    @Test
+    public void testGetAllProfiles() {
+        Collection<Profile> allProfiles = tested.getAllProfiles();
+        assertEquals(2, allProfiles.size());
+        assertTrue(allProfiles.contains(defaultProfile));
+        assertTrue(allProfiles.contains(domainProfile));
+    }
+
+    @Test
+    public void testGetProfileById() {
+        assertEquals(defaultProfile, tested.getProfile(PROFILE_DEFAULT_ID));
+        assertEquals(domainProfile, tested.getProfile(PROFILE_DOMAIN_ID));
+        assertNull(tested.getProfile("someOtherId"));
+    }
+
+    @Test
+    public void testGetProfilesByDomain() {
+        Collection<Profile> domainProfiles = tested.getProfiles(DEF_SET_ID);
+        assertEquals(2, domainProfiles.size());
+        assertTrue(domainProfiles.contains(defaultProfile));
+        assertTrue(domainProfiles.contains(domainProfile));
+    }
+
+    @Test
+    public void testGetProfileByDomainAndId() {
+        assertEquals(defaultProfile, tested.getProfile(DEF_SET_ID, PROFILE_DEFAULT_ID));
+        assertEquals(domainProfile, tested.getProfile(DEF_SET_ID, PROFILE_DOMAIN_ID));
+    }
+
+    private class AbstractProfileManagerStub extends AbstractProfileManager {
+
+        @Override
+        protected Function<String, Annotation> getQualifier() {
+            return AbstractProfileManagerTest.this::getQualifier;
+        }
+
+        @Override
+        protected Iterable<Profile> getAllProfileInstances() {
+            return AbstractProfileManagerTest.this.getAllProfileInstances();
+        }
+
+        @Override
+        protected Iterable<Profile> selectProfileInstances(Annotation... qualifiers) {
+            return AbstractProfileManagerTest.this.selectProfileInstances(qualifiers);
+        }
+    }
+
+    private Annotation getQualifier(String dsId) {
+        return DEF_SET_ID.equals(dsId) ? domainQualifier : null;
+    }
+
+    private Iterable<Profile> getAllProfileInstances() {
+        return profiles;
+    }
+
+    private Iterable<Profile> selectProfileInstances(Annotation... qualifiers) {
+        List<Profile> result = new ArrayList<>();
+        for (Annotation qualifier : qualifiers) {
+            if (qualifier.equals(DefinitionManager.DEFAULT_QUALIFIER)) {
+                result.add(defaultProfile);
+            } else if (qualifier.equals(domainQualifier)) {
+                result.add(domainProfile);
+            }
+        }
+        return result;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/BindableDomainProfileTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/BindableDomainProfileTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
+
+public class BindableDomainProfileTest {
+
+    @Test
+    public void testProfile() {
+        BindableDomainProfile instance = BindableDomainProfile.build(BeanType1.class,
+                                                                     BeanType2.class,
+                                                                     BeanType3.class);
+        Predicate<String> predicate = instance.definitionAllowedFilter();
+        assertTrue(predicate.test(getDefinitionId(BeanType1.class)));
+        assertTrue(predicate.test(getDefinitionId(BeanType2.class)));
+        assertTrue(predicate.test(getDefinitionId(BeanType3.class)));
+        assertFalse(predicate.test(getDefinitionId(BeanType4.class)));
+    }
+
+    private static final class BeanType1 {
+
+    }
+
+    private static final class BeanType2 {
+
+    }
+
+    private static final class BeanType3 {
+
+    }
+
+    private static final class BeanType4 {
+
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/DomainProfileManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/DomainProfileManagerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.ProfileManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetAdapter;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.registry.definition.TypeDefinitionSetRegistry;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DomainProfileManagerTest {
+
+    private static final FullProfile DEFAULT_PROFILE = new FullProfile();
+    private static final String DEF_SET_ID = "ds1";
+    private static final String DEF1 = "d1";
+    private static final String DEF2 = "d2";
+    private static final String PROFILE_DOMAIN_ID = "pDomain";
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private TypeDefinitionSetRegistry definitionSets;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private DefinitionSetAdapter definitionSetAdapter;
+
+    @Mock
+    private ProfileManager profileManager;
+
+    @Mock
+    private Object definitionSet;
+
+    @Mock
+    private Annotation domainQualifier;
+
+    @Mock
+    private DomainProfile domainProfile;
+
+    @Mock
+    private Metadata metadata;
+
+    private DomainProfileManager tested;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        when(metadata.getDefinitionSetId()).thenReturn(DEF_SET_ID);
+        when(metadata.getProfileId()).thenReturn(DEFAULT_PROFILE.getProfileId());
+        when(domainProfile.getProfileId()).thenReturn(PROFILE_DOMAIN_ID);
+        Predicate<String> domainProfileFilter = DEF1::equals;
+        when(domainProfile.definitionAllowedFilter()).thenReturn(domainProfileFilter);
+        when(definitionManager.definitionSets()).thenReturn(definitionSets);
+        when(definitionSets.getDefinitionSetById(eq(DEF_SET_ID))).thenReturn(definitionSet);
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.forDefinitionSet()).thenReturn(definitionSetAdapter);
+        when(definitionSetAdapter.getDefinitions(eq(definitionSet)))
+                .thenReturn(Arrays.asList(DEF1, DEF2).stream().collect(Collectors.toSet()));
+        when(profileManager.getProfile(eq(DEF_SET_ID), eq(DEFAULT_PROFILE.getProfileId())))
+                .thenReturn(DEFAULT_PROFILE);
+        when(profileManager.getProfile(eq(DEF_SET_ID), eq(PROFILE_DOMAIN_ID)))
+                .thenReturn(domainProfile);
+        tested = new DomainProfileManager(definitionManager,
+                                          profileManager,
+                                          DEFAULT_PROFILE);
+    }
+
+    @Test
+    public void testGetAllDefinitions() {
+        // Using the default profile
+        when(metadata.getProfileId()).thenReturn(DEFAULT_PROFILE.getProfileId());
+        List<String> allDefinitions = tested.getAllDefinitions(metadata);
+        assertEquals(2, allDefinitions.size());
+        assertTrue(allDefinitions.contains(DEF1));
+        assertTrue(allDefinitions.contains(DEF2));
+        // Using the domain profile
+        when(metadata.getProfileId()).thenReturn(PROFILE_DOMAIN_ID);
+        List<String> domainDefinitions = tested.getAllDefinitions(metadata);
+        assertEquals(1, domainDefinitions.size());
+        assertTrue(domainDefinitions.contains(DEF1));
+        assertFalse(domainDefinitions.contains(DEF2));
+    }
+
+    @Test
+    public void testIsDefinitionAllowed() {
+        // Using the default profile
+        when(metadata.getProfileId()).thenReturn(DEFAULT_PROFILE.getProfileId());
+        assertTrue(tested.isDefinitionIdAllowed(metadata).test(DEF1));
+        assertTrue(tested.isDefinitionIdAllowed(metadata).test(DEF2));
+        // Using the domain profile
+        when(metadata.getProfileId()).thenReturn(PROFILE_DOMAIN_ID);
+        assertTrue(tested.isDefinitionIdAllowed(metadata).test(DEF1));
+        assertFalse(tested.isDefinitionIdAllowed(metadata).test(DEF2));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/DomainProfileManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/DomainProfileManagerTest.java
@@ -16,11 +16,10 @@
 
 package org.kie.workbench.common.stunner.core.profile;
 
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -68,9 +67,6 @@ public class DomainProfileManagerTest {
     private Object definitionSet;
 
     @Mock
-    private Annotation domainQualifier;
-
-    @Mock
     private DomainProfile domainProfile;
 
     @Mock
@@ -91,7 +87,7 @@ public class DomainProfileManagerTest {
         when(definitionManager.adapters()).thenReturn(adapterManager);
         when(adapterManager.forDefinitionSet()).thenReturn(definitionSetAdapter);
         when(definitionSetAdapter.getDefinitions(eq(definitionSet)))
-                .thenReturn(Arrays.asList(DEF1, DEF2).stream().collect(Collectors.toSet()));
+                .thenReturn(Stream.of(DEF1, DEF2).collect(Collectors.toSet()));
         when(profileManager.getProfile(eq(DEF_SET_ID), eq(DEFAULT_PROFILE.getProfileId())))
                 .thenReturn(DEFAULT_PROFILE);
         when(profileManager.getProfile(eq(DEF_SET_ID), eq(PROFILE_DOMAIN_ID)))

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/FullProfileTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/profile/FullProfileTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.profile;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FullProfileTest {
+
+    @Test
+    public void testProfile() {
+        FullProfile profile = new FullProfile();
+        assertEquals(FullProfile.ID, profile.getProfileId());
+        assertTrue(profile.definitionAllowedFilter().test("anyBeanTypeAllowed1"));
+        assertTrue(profile.definitionAllowedFilter().test("anyBeanTypeAllowed2"));
+        assertTrue(profile.definitionAllowedFilter().test("anyBeanTypeAllowed3"));
+        assertTrue(profile.definitionAllowedFilter().test("others"));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/pom.xml
@@ -65,6 +65,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.workbench.profile</groupId>
+      <artifactId>kie-wb-common-profile-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-services-api</artifactId>
     </dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/main/java/org/kie/workbench/common/stunner/project/profile/ProjectFullProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/main/java/org/kie/workbench/common/stunner/project/profile/ProjectFullProfile.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.profile;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Specializes;
+
+import org.kie.workbench.common.profile.api.preferences.Profile;
+import org.kie.workbench.common.stunner.core.profile.FullProfile;
+
+/**
+ * Associates the Stunner profile to a workbench profile (preferences).
+ */
+@ApplicationScoped
+@Default
+@Specializes
+public class ProjectFullProfile
+        extends FullProfile
+        implements ProjectProfile {
+
+    @Override
+    public String getProjectProfileName() {
+        return Profile.FULL.getName();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/main/java/org/kie/workbench/common/stunner/project/profile/ProjectProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/main/java/org/kie/workbench/common/stunner/project/profile/ProjectProfile.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.profile;
+
+import org.kie.workbench.common.stunner.core.profile.Profile;
+
+public interface ProjectProfile extends Profile {
+
+    String getProjectProfileName();
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectAPI.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectAPI.gwt.xml
@@ -23,6 +23,7 @@
   <inherits name="org.kie.workbench.common.stunner.core.StunnerBackendApi"/>
   <inherits name="org.kie.workbench.common.stunner.core.StunnerCoreCommon"/>
 
+  <inherits name="org.kie.workbench.common.profile.ProfileAPI"/>
   <inherits name="org.guvnor.common.services.project.GuvnorProjectAPI"/>
   <inherits name='org.guvnor.common.services.GuvnorServicesAPI'/>
   <inherits name="org.kie.workbench.common.services.datamodeller.DataModellerCore"/>
@@ -30,6 +31,7 @@
   <source path="diagram"/>
   <source path="editor"/>
   <source path="factory"/>
+  <source path="profile"/>
   <source path="service"/>
 
 </module>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/test/java/org/kie/workbench/common/stunner/project/profile/ProjectFullProfileTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/src/test/java/org/kie/workbench/common/stunner/project/profile/ProjectFullProfileTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.profile;
+
+import org.junit.Test;
+import org.kie.workbench.common.profile.api.preferences.Profile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ProjectFullProfileTest {
+
+    @Test
+    public void testProfile() {
+        ProjectFullProfile profile = new ProjectFullProfile();
+        assertEquals(Profile.FULL.getName(), profile.getProjectProfileName());
+        assertTrue(profile.definitionAllowedFilter().test("anyBeanTypeAllowed1"));
+        assertTrue(profile.definitionAllowedFilter().test("anyBeanTypeAllowed2"));
+        assertTrue(profile.definitionAllowedFilter().test("anyBeanTypeAllowed3"));
+        assertTrue(profile.definitionAllowedFilter().test("others"));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/pom.xml
@@ -195,6 +195,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.workbench.profile</groupId>
+      <artifactId>kie-wb-common-profile-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-message-console-client</artifactId>
     </dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProfilePreferencesLoader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProfilePreferencesLoader.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.client.preferences;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.profile.api.preferences.ProfilePreferences;
+import org.kie.workbench.common.stunner.core.api.ProfileManager;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.profile.FullProfile;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.kie.workbench.common.stunner.project.profile.ProjectProfile;
+import org.uberfire.mvp.ParameterizedCommand;
+
+@ApplicationScoped
+public class StunnerProfilePreferencesLoader {
+
+    private final ProfileManager profileManager;
+    private final ProfilePreferences profilePreferences;
+    private final FullProfile defaultProfile;
+
+    @Inject
+    public StunnerProfilePreferencesLoader(final ProfileManager profileManager,
+                                           final ProfilePreferences profilePreferences,
+                                           final FullProfile defaultProfile) {
+        this.profileManager = profileManager;
+        this.profilePreferences = profilePreferences;
+        this.defaultProfile = defaultProfile;
+    }
+
+    public void load(final Metadata metadata,
+                     final ParameterizedCommand<Profile> loadCompleteCallback,
+                     final ParameterizedCommand<Throwable> errorCallback) {
+        profilePreferences
+                .load(profilePreferences -> {
+                    final String profileName = profilePreferences.getProfile().getName();
+                    loadCompleteCallback.execute(getProfileByPreference(metadata,
+                                                                        profileName)
+                                                         .orElse(defaultProfile));
+                }, errorCallback);
+    }
+
+    private Optional<Profile> getProfileByPreference(final Metadata metadata,
+                                                     final String profileName) {
+        return profileManager
+                .getProfiles(metadata.getDefinitionSetId())
+                .stream()
+                .filter(profile -> profile instanceof ProjectProfile)
+                .filter(profile -> ((ProjectProfile) profile).getProjectProfileName().equals(profileName))
+                .findFirst();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProjectPreferencesRegistryLoader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProjectPreferencesRegistryLoader.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.client.preferences;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Specializes;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistryHolder;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistryLoader;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerTextPreferences;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.preferences.StunnerPreferences;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.uberfire.mvp.ParameterizedCommand;
+
+@ApplicationScoped
+@Specializes
+public class StunnerProjectPreferencesRegistryLoader extends StunnerPreferencesRegistryLoader {
+
+    private final StunnerProfilePreferencesLoader profilePreferencesLoader;
+
+    @Inject
+    public StunnerProjectPreferencesRegistryLoader(final DefinitionUtils definitionUtils,
+                                                   final @Any ManagedInstance<StunnerPreferencesRegistryHolder> preferencesHolders,
+                                                   final StunnerPreferences preferences,
+                                                   final StunnerTextPreferences textPreferences,
+                                                   final StunnerProfilePreferencesLoader profilePreferencesLoader) {
+        super(definitionUtils, preferencesHolders, preferences, textPreferences);
+        this.profilePreferencesLoader = profilePreferencesLoader;
+    }
+
+    @Override
+    public void load(final Metadata metadata,
+                     final ParameterizedCommand<StunnerPreferences> loadCompleteCallback,
+                     final ParameterizedCommand<Throwable> errorCallback) {
+        super.load(metadata,
+                   preferences ->
+                           profilePreferencesLoader.load(metadata,
+                                                         profile -> {
+                                                             metadata.setProfileId(profile.getProfileId());
+                                                             loadCompleteCallback.execute(preferences);
+                                                         },
+                                                         errorCallback),
+                   errorCallback);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProfilePreferencesLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProfilePreferencesLoaderTest.java
@@ -64,7 +64,7 @@ public class StunnerProfilePreferencesLoaderTest {
 
     @Before
     @SuppressWarnings("unchecked")
-    public void setup() throws Exception {
+    public void setup() {
         when(metadata.getDefinitionSetId()).thenReturn(DEF_SET_ID);
         when(profile.getProjectProfileName()).thenReturn(org.kie.workbench.common.profile.api.preferences.Profile.PLANNER_AND_RULES.getName());
         doAnswer(invocation -> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProfilePreferencesLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProfilePreferencesLoaderTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.client.preferences;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.profile.api.preferences.ProfilePreferences;
+import org.kie.workbench.common.stunner.core.api.ProfileManager;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.profile.FullProfile;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.kie.workbench.common.stunner.project.profile.ProjectProfile;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mvp.ParameterizedCommand;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StunnerProfilePreferencesLoaderTest {
+
+    private static final String DEF_SET_ID = "ds1";
+    private static final FullProfile DEFAULT_PROFILE = new FullProfile();
+    private static final org.kie.workbench.common.profile.api.preferences.Profile PROJECT_PROFILE =
+            org.kie.workbench.common.profile.api.preferences.Profile.PLANNER_AND_RULES;
+
+    @Mock
+    private ProfileManager profileManager;
+
+    @Mock
+    private ProfilePreferences profilePreferences;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
+    private ProjectProfile profile;
+
+    private StunnerProfilePreferencesLoader tested;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        when(metadata.getDefinitionSetId()).thenReturn(DEF_SET_ID);
+        when(profile.getProjectProfileName()).thenReturn(org.kie.workbench.common.profile.api.preferences.Profile.PLANNER_AND_RULES.getName());
+        doAnswer(invocation -> {
+            ParameterizedCommand<ProfilePreferences> callback =
+                    (ParameterizedCommand<ProfilePreferences>) invocation.getArguments()[0];
+            callback.execute(profilePreferences);
+            return null;
+        }).when(profilePreferences).load(any(ParameterizedCommand.class),
+                                         any(ParameterizedCommand.class));
+        when(profilePreferences.getProfile()).thenReturn(PROJECT_PROFILE);
+        when(profileManager.getProfiles(eq(DEF_SET_ID))).thenReturn(Collections.singletonList(profile));
+        tested = new StunnerProfilePreferencesLoader(profileManager,
+                                                     profilePreferences,
+                                                     DEFAULT_PROFILE);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoad() {
+        ParameterizedCommand<Profile> loadCallback = mock(ParameterizedCommand.class);
+        ParameterizedCommand<Throwable> errorCallback = mock(ParameterizedCommand.class);
+        tested.load(metadata,
+                    loadCallback,
+                    errorCallback);
+        verify(errorCallback, never()).execute(any(Throwable.class));
+        verify(loadCallback, times(1)).execute(eq(profile));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoadDefaultProfile() {
+        when(profile.getProjectProfileName()).thenReturn(org.kie.workbench.common.profile.api.preferences.Profile.FULL.getName());
+        ParameterizedCommand<Profile> loadCallback = mock(ParameterizedCommand.class);
+        ParameterizedCommand<Throwable> errorCallback = mock(ParameterizedCommand.class);
+        tested.load(metadata,
+                    loadCallback,
+                    errorCallback);
+        verify(errorCallback, never()).execute(any(Throwable.class));
+        verify(loadCallback, times(1)).execute(eq(DEFAULT_PROFILE));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testError() {
+        final Throwable exception = mock(Throwable.class);
+        doAnswer(invocation -> {
+            ParameterizedCommand<Throwable> callback =
+                    (ParameterizedCommand<Throwable>) invocation.getArguments()[1];
+            callback.execute(exception);
+            return null;
+        }).when(profilePreferences).load(any(ParameterizedCommand.class),
+                                         any(ParameterizedCommand.class));
+        ParameterizedCommand<Profile> loadCallback = mock(ParameterizedCommand.class);
+        ParameterizedCommand<Throwable> errorCallback = mock(ParameterizedCommand.class);
+        tested.load(metadata,
+                    loadCallback,
+                    errorCallback);
+        verify(errorCallback, times(1)).execute(eq(exception));
+        verify(loadCallback, never()).execute(any(Profile.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProjectPreferencesRegistryLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProjectPreferencesRegistryLoaderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.project.client.preferences;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerPreferencesRegistryHolder;
+import org.kie.workbench.common.stunner.core.client.preferences.StunnerTextPreferences;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.diagram.MetadataImpl;
+import org.kie.workbench.common.stunner.core.preferences.StunnerPreferences;
+import org.kie.workbench.common.stunner.core.profile.Profile;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mvp.ParameterizedCommand;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StunnerProjectPreferencesRegistryLoaderTest {
+
+    private static final String PROFILE_ID = "profId1";
+    private static final String DEF_SET_ID = "ds1";
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private StunnerPreferencesRegistryHolder preferencesHolder;
+    private ManagedInstance<StunnerPreferencesRegistryHolder> preferencesHolders;
+
+    @Mock
+    private StunnerPreferences preferences;
+
+    @Mock
+    private Annotation qualifier;
+
+    private StunnerProjectPreferencesRegistryLoader tested;
+    private Metadata metadata;
+
+    @Mock
+    private StunnerProfilePreferencesLoader profilePreferencesLoader;
+
+    @Mock
+    private StunnerTextPreferences textPreferences;
+
+    @Mock
+    private Profile profile;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        metadata = new MetadataImpl.MetadataImplBuilder(DEF_SET_ID).build();
+        when(definitionUtils.getQualifier(eq(DEF_SET_ID))).thenReturn(qualifier);
+        preferencesHolders = spy(new ManagedInstanceStub<>(preferencesHolder));
+        doAnswer(invocation -> {
+            ParameterizedCommand<Profile> callback = (ParameterizedCommand<Profile>) invocation.getArguments()[1];
+            callback.execute(profile);
+            return null;
+        }).when(profilePreferencesLoader).load(eq(metadata),
+                                               any(ParameterizedCommand.class),
+                                               any(ParameterizedCommand.class));
+        when(profile.getProfileId()).thenReturn(PROFILE_ID);
+        tested = new StunnerProjectPreferencesRegistryLoader(definitionUtils,
+                                                             preferencesHolders,
+                                                             preferences,
+                                                             textPreferences,
+                                                             profilePreferencesLoader);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoad() {
+        final ParameterizedCommand<StunnerPreferences> loadCompleteCallback = mock(ParameterizedCommand.class);
+        final ParameterizedCommand<Throwable> errorCallback = mock(ParameterizedCommand.class);
+        final StunnerPreferences pre = mock(StunnerPreferences.class);
+        doAnswer(invocation -> {
+            ((ParameterizedCommand<StunnerPreferences>) invocation.getArguments()[0]).execute(pre);
+            return null;
+        }).when(preferences).load(any(ParameterizedCommand.class),
+                                  any(ParameterizedCommand.class));
+        tested.load(metadata,
+                    loadCompleteCallback,
+                    errorCallback);
+        assertEquals(PROFILE_ID, metadata.getProfileId());
+        verify(preferencesHolders, times(1)).select(eq(qualifier));
+        verify(loadCompleteCallback, times(1)).execute(eq(pre));
+        verify(errorCallback, never()).execute(any(Throwable.class));
+        verify(preferencesHolder, times(1)).set(eq(pre), eq(StunnerPreferences.class));
+        verify(preferencesHolder, times(1)).set(eq(textPreferences), eq(StunnerTextPreferences.class));
+    }
+
+    @Test
+    public void testDestroy() {
+        tested.destroy();
+        verify(preferencesHolders, times(1)).destroyAll();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProjectPreferencesRegistryLoaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/preferences/StunnerProjectPreferencesRegistryLoaderTest.java
@@ -78,7 +78,7 @@ public class StunnerProjectPreferencesRegistryLoaderTest {
 
     @Before
     @SuppressWarnings("unchecked")
-    public void setUp() throws Exception {
+    public void setUp() {
         metadata = new MetadataImpl.MetadataImplBuilder(DEF_SET_ID).build();
         when(definitionUtils.getQualifier(eq(DEF_SET_ID))).thenReturn(qualifier);
         preferencesHolders = spy(new ManagedInstanceStub<>(preferencesHolder));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfile.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.profile;
+
+import java.util.function.Predicate;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
+import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveGateway;
+import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
+import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
+import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
+import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
+import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
+import org.kie.workbench.common.stunner.core.profile.BindableDomainProfile;
+import org.kie.workbench.common.stunner.core.profile.DomainProfile;
+
+@ApplicationScoped
+@BPMN
+public class BPMNRuleFlowProfile implements DomainProfile {
+
+    static final String ID = BPMNRuleFlowProfile.class.getName();
+    private static final BindableDomainProfile domainProfile = BindableDomainProfile.build(NoneTask.class,
+                                                                                           ScriptTask.class,
+                                                                                           BusinessRuleTask.class,
+                                                                                           StartNoneEvent.class,
+                                                                                           EndNoneEvent.class,
+                                                                                           EndTerminateEvent.class,
+                                                                                           ParallelGateway.class,
+                                                                                           ExclusiveGateway.class);
+
+    @Override
+    public String getProfileId() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return "RuleFlow";
+    }
+
+    @Override
+    public Predicate<String> definitionAllowedFilter() {
+        return domainProfile.definitionAllowedFilter();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfile.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveGateway;
 import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
 import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
@@ -40,6 +41,7 @@ public class BPMNRuleFlowProfile implements DomainProfile {
     private static final BindableDomainProfile domainProfile = BindableDomainProfile.build(NoneTask.class,
                                                                                            ScriptTask.class,
                                                                                            BusinessRuleTask.class,
+                                                                                           ReusableSubprocess.class,
                                                                                            StartNoneEvent.class,
                                                                                            EndNoneEvent.class,
                                                                                            EndTerminateEvent.class,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnApi.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnApi.gwt.xml
@@ -29,6 +29,7 @@
   <source path="validation"/>
   <source path="definition"/>
   <source path="factory"/>
+  <source path="profile"/>
   <source path="forms"/>
   <source path="qualifiers"/>
   <source path="resource"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfileTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfileTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.profile;
+
+import org.junit.Test;
+import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
+import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
+import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveGateway;
+import org.kie.workbench.common.stunner.bpmn.definition.IntermediateCompensationEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.IntermediateTimerEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.Lane;
+import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
+import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
+import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
+import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
+
+public class BPMNRuleFlowProfileTest {
+
+    @Test
+    public void testProfile() {
+        BPMNRuleFlowProfile profile = new BPMNRuleFlowProfile();
+        assertEquals(BPMNRuleFlowProfile.ID, profile.getProfileId());
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(NoneTask.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(ScriptTask.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(BusinessRuleTask.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(StartNoneEvent.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(EndNoneEvent.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(EndTerminateEvent.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(ParallelGateway.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(ExclusiveGateway.class)));
+        assertFalse(profile.definitionAllowedFilter().test(getDefinitionId(UserTask.class)));
+        assertFalse(profile.definitionAllowedFilter().test(getDefinitionId(Lane.class)));
+        assertFalse(profile.definitionAllowedFilter().test(getDefinitionId(EmbeddedSubprocess.class)));
+        assertFalse(profile.definitionAllowedFilter().test(getDefinitionId(IntermediateCompensationEvent.class)));
+        assertFalse(profile.definitionAllowedFilter().test(getDefinitionId(IntermediateTimerEvent.class)));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfileTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/profile/BPMNRuleFlowProfileTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.IntermediateTimerEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.Lane;
 import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
 import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
@@ -45,6 +46,7 @@ public class BPMNRuleFlowProfileTest {
         assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(NoneTask.class)));
         assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(ScriptTask.class)));
         assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(BusinessRuleTask.class)));
+        assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(ReusableSubprocess.class)));
         assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(StartNoneEvent.class)));
         assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(EndNoneEvent.class)));
         assertTrue(profile.definitionAllowedFilter().test(getDefinitionId(EndTerminateEvent.class)));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilderTest.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -82,6 +83,9 @@ public class BPMNPaletteDefinitionBuilderTest {
 
     @Mock
     private DefinitionManager definitionManager;
+
+    @Mock
+    private DomainProfileManager profileManager;
 
     @Mock
     private AdapterManager adapterManager;
@@ -124,6 +128,7 @@ public class BPMNPaletteDefinitionBuilderTest {
         when(widAdapter.getTitle(eq(serviceTask))).thenReturn(WID_DISPLAY_NAME);
         when(widAdapter.getDescription(eq(serviceTask))).thenReturn(WID_DESC);
         ExpandedPaletteDefinitionBuilder paletteDefinitionBuilder = spy(new ExpandedPaletteDefinitionBuilder(definitionUtils,
+                                                                                                             profileManager,
                                                                                                              definitionsRegistry,
                                                                                                              translationService));
         doAnswer(invocationOnMock -> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>uberfire-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.workbench.profile</groupId>
+      <artifactId>kie-wb-common-profile-api</artifactId>
+    </dependency>
+
     <!-- Stunner. -->
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/java/org/kie/workbench/common/stunner/bpmn/project/profile/BPMNRuleFlowProjectProfile.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/java/org/kie/workbench/common/stunner/bpmn/project/profile/BPMNRuleFlowProjectProfile.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.profile;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Specializes;
+
+import org.kie.workbench.common.profile.api.preferences.Profile;
+import org.kie.workbench.common.stunner.bpmn.profile.BPMNRuleFlowProfile;
+import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
+import org.kie.workbench.common.stunner.project.profile.ProjectProfile;
+
+/**
+ * Associates the Stunner profile to a workbench profile (preferences).
+ */
+@ApplicationScoped
+@BPMN
+@Specializes
+public class BPMNRuleFlowProjectProfile
+        extends BPMNRuleFlowProfile
+        implements ProjectProfile {
+
+    @Override
+    public String getProjectProfileName() {
+        return Profile.PLANNER_AND_RULES.getName();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnProjectApi.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/StunnerBpmnProjectApi.gwt.xml
@@ -25,6 +25,7 @@
   <inherits name="org.kie.workbench.common.stunner.project.StunnerProjectAPI"/>
 
   <source path="project/factory"/>
+  <source path="project/profile"/>
   <source path="project/service"/>
 
 </module>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/test/java/org/kie/workbench/common/stunner/bpmn/project/profile/BPMNRuleFlowProjectProfileTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/test/java/org/kie/workbench/common/stunner/bpmn/project/profile/BPMNRuleFlowProjectProfileTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.profile;
+
+import org.junit.Test;
+import org.kie.workbench.common.profile.api.preferences.Profile;
+import org.kie.workbench.common.stunner.bpmn.profile.BPMNRuleFlowProfile;
+
+import static org.junit.Assert.assertEquals;
+
+public class BPMNRuleFlowProjectProfileTest {
+
+    @Test
+    public void testProfile() {
+        BPMNRuleFlowProjectProfile profile = new BPMNRuleFlowProjectProfile();
+        assertEquals(new BPMNRuleFlowProfile().getProfileId(), profile.getProfileId());
+        assertEquals(Profile.PLANNER_AND_RULES.getName(), profile.getProjectProfileName());
+    }
+}
+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/palette/CaseManagementPaletteDefinitionBuilderTest.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.stunner.cm.definition.ProcessReusableSubprocess;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.components.palette.CollapsedPaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.profile.DomainProfileManager;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
@@ -55,6 +56,9 @@ public class CaseManagementPaletteDefinitionBuilderTest {
     private DefinitionManager definitionManager;
 
     @Mock
+    private DomainProfileManager profileManager;
+
+    @Mock
     private DefinitionUtils definitionUtils;
 
     @Mock
@@ -70,6 +74,7 @@ public class CaseManagementPaletteDefinitionBuilderTest {
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         paletteDefinitionBuilder = new CollapsedPaletteDefinitionBuilder(definitionUtils,
+                                                                         profileManager,
                                                                          definitionsRegistry,
                                                                          translationService);
         tested = new CaseManagementPaletteDefinitionBuilder(paletteDefinitionBuilder,


### PR DESCRIPTION
Hey @hasys 

See https://issues.jboss.org/browse/JBPM-6402

This commit also is part of the task [JBPM-7605](https://issues.jboss.org/browse/JBPM-7605), as introduces support for generic "profiles" and the ability to switch between them. 

Also provides the concrete BPMN `RuleFlow` profile expected, and integrates the profile selection by using the profile specified on the workbench preferences.

Thanks!

