### PR TITLE
JBPM-8039 - It is not possible to connect nodes inside of swimlane

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
@@ -66,6 +66,10 @@ class ParentsTypeMatchPredicate implements BiPredicate<Node<? extends View<?>, ?
         final Optional<Element<?>> parentInstanceA = getParentInstance(nodeA, parentType);
         final Optional<Element<?>> parentInstanceB = getParentInstance(nodeB, parentType);
 
+        if (!parentInstanceA.isPresent() && !parentInstanceB.isPresent()) {
+            return true;
+        }
+
         return (parentInstanceA.isPresent() && parentInstanceB.isPresent())
                 && (Objects.equals(parentInstanceA.get(), parentInstanceB.get()))
                 && (hasParent(nodeA, parentInstanceA.get()) && hasParent(nodeB, parentInstanceB.get()));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
@@ -75,7 +75,7 @@ public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypes
         assertFalse(newPredicate(DefinitionC.class)
                             .test(nodeA,
                                   nodeB));
-        assertFalse(newPredicate(ParentDefinition.class)
+        assertTrue(newPredicate(ParentDefinition.class)
                            .test(nodeA,
                                  nodeC));
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
@@ -64,12 +64,10 @@ public class ParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testWithParents() {
+    public void testWithParentSubprocess() {
         assertTrue(newPredicate(ParentDefinition.class).test(nodeA, nodeB));
-        assertFalse(newPredicate(DefinitionA.class).test(nodeA, nodeB));
-        assertFalse(newPredicate(DefinitionB.class).test(nodeA, nodeB));
+        assertTrue(newPredicate(DefinitionA.class).test(nodeA, nodeB));
         assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));
-        assertFalse(newPredicate(DefinitionC.class).test(nodeA, nodeB));
         assertFalse(newPredicate(ParentDefinition.class).test(nodeA, nodeC));
         assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeC));
         assertFalse(newPredicate(ParentDefinition.class).test(nodeB, nodeC));
@@ -90,12 +88,16 @@ public class ParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
         graphHandler
                 .removeChild(parentNode, nodeA)
                 .removeChild(parentNode, nodeB);
-        assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));
+        assertTrue(newPredicate(RootDefinition.class).test(nodeA, nodeB));
 
         graphHandler.setChild(rootNode, nodeA);
         assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));
 
+        graphHandler.removeChild(rootNode, nodeA);
         graphHandler.setChild(rootNode, nodeB);
+        assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));
+
+        graphHandler.setChild(rootNode, nodeA);
         assertTrue(newPredicate(RootDefinition.class).test(nodeA, nodeB));
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
@@ -186,6 +186,6 @@ public class ConnectorParentsMatchConnectionHandlerTest extends AbstractGraphDef
                 new Class[]{ParentDefinition.class, RootDefinition.class});
 
         violations = tested.evaluate(ruleExtension, connectionContext);
-        assertViolations(violations, false);
+        assertViolations(violations, true);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandlerTest.java
@@ -165,23 +165,14 @@ public class ConnectorParentsMatchContainmentHandlerTest extends AbstractGraphDe
         assertNotNull(violations);
         assertViolations(violations, false);
 
-        //removing node b from grandparent
-        graphHandler.removeChild(grandParentNode, nodeB);
-        graphHandler.setChild(parentNode, nodeB);
-
-        //should be error now because now node b is child of parent and the target parent is the grandparent
-        violations = tested.evaluate(ruleExtension, containmentContext);
-        assertNotNull(violations);
-        assertViolations(violations, false);
-
         //now change the accepted type but set the parent as valid
         when(containmentContext.getParent()).thenReturn(parentNode);
         when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{RootDefinition.class});
 
-        //should be error now because now node b is child of parent and the target parent is the grandparent
+        //should be success now because now node b and tested node are children of not checked parent
         violations = tested.evaluate(ruleExtension, containmentContext);
         assertNotNull(violations);
-        assertViolations(violations, false);
+        assertViolations(violations, true);
 
         //set accepted type (ParentDefinition) to the same as the current parent then it should be success
         when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{GrandParentDefinition.class, ParentDefinition.class});

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/SequenceFlow.java
@@ -64,13 +64,12 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @EdgeOccurrences(role = "IntermediateEventThrowing", type = EdgeOccurrences.EdgeType.INCOMING, max = 1)
 @EdgeOccurrences(role = "IntermediateEventThrowing", type = EdgeOccurrences.EdgeType.OUTGOING, min = 1)
 @EdgeOccurrences(role = "IntermediateEventThrowing", type = EdgeOccurrences.EdgeType.OUTGOING, max = 1)
-// Sequence flows cannot exceed bounds when any of the nodes are in an embedded subprocess context.
+// Sequence flows cannot exceed bounds when any of the nodes are in an subprocess context.
 @RuleExtension(handler = ConnectorParentsMatchHandler.class,
-        typeArguments = {BPMNDiagramImpl.class, EmbeddedSubprocess.class, EventSubprocess.class,
-                MultipleInstanceSubprocess.class,
-                AdHocSubprocess.class},
-        arguments = {"Sequence flow connectors cannot exceed the embbedded subprocess' bounds. " +
-                "Both source and target nodes must be in same parent process."})
+        typeArguments = {EmbeddedSubprocess.class, EventSubprocess.class,
+                MultipleInstanceSubprocess.class, AdHocSubprocess.class},
+        arguments = {"Sequence flow connectors cannot exceed the parent's subprocess bounds. " +
+                "Both source and target nodes must be in the same subprocess."})
 @FormDefinition(
         startElement = "general",
         policy = FieldPolicy.ONLY_MARKED,


### PR DESCRIPTION
Hi @romartin, @tiagodolphine, @LuboTerifaj,

I found a regression caused by https://github.com/kiegroup/kie-wb-common/pull/2306

This is a fix and fixed tests.

In short new Embedded subprocess bounds exceeded tests was extended by https://github.com/kiegroup/kie-wb-common/pull/2306 for all types of sub-processes and BPMNDiagram, but Lane were forgotten.

But it is not possible just add Lane to this rule, because it can be a situation when you want to connect nodes from top level process with nodes inside of Swimlane and it is a valid case. Another valid case is connecting two nodes from different Swimlanes.

So, I removed BMPNDiagram from checked parents and extended rule to ignore nodes without checked parent as it was before https://github.com/kiegroup/kie-wb-common/pull/2306.

Thank you!