### PR TITLE
[7.14.x] RHPAM-1773: Can't attach Boundary Events to Service Tasks in Stunner.

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactoryTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.C
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ToolboxDomainLookups;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
@@ -115,7 +116,7 @@ public class DMNFlowActionsToolboxFactoryTest {
     public void setup() throws Exception {
         when(definitionManager.adapters()).thenReturn(adapters);
         when(adapters.forDefinition()).thenReturn(definitionAdapter);
-        when(definitionAdapter.getId(eq(allowedNodeDefinition))).thenReturn(NODE_ID);
+        when(definitionAdapter.getId(eq(allowedNodeDefinition))).thenReturn(DefinitionId.build(NODE_ID));
         createConnectorAction = new ManagedInstanceStub<>(createConnectorActionInstance);
         when(createConnectorActionInstance.setEdgeId(anyString())).thenReturn(createConnectorActionInstance);
         createNodeAction = new ManagedInstanceStub<>(createNodeActionInstance);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresScalableContainer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresScalableContainer.java
@@ -114,12 +114,10 @@ public class WiresScalableContainer extends WiresLayoutContainer {
                         .setX(x)
                         .setY(y);
                 if (null == scaleRatio) {
-                    // GWT.log("CALCULATING SCALE RATIO...");
                     final BoundingBox bb = transformableContainer.getBoundingBox();
                     final double sx = width / bb.getWidth();
                     final double sy = height / bb.getHeight();
                     scaleRatio = new Point2D(sx, sy);
-                    // GWT.log("SCALE RATIO VALUES [" + scaleRatio + "]");
                     transformableContainer.setScale(scaleRatio);
                 }
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImplTest.java
@@ -50,6 +50,7 @@ import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.impl.AbstractCompositeCommand;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
 import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -237,7 +238,7 @@ public class ResizeControlImplTest {
         when(adapterManager.forProperty()).thenReturn(propertyAdapter);
         when(adapterRegistry.getDefinitionAdapter(any(Class.class))).thenReturn(definitionAdapter);
         when(adapterRegistry.getPropertyAdapter(anyObject())).thenReturn(propertyAdapter);
-        when(definitionAdapter.getId(eq(definition))).thenReturn(DEF_ID);
+        when(definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(DEF_ID));
         when(propertyAdapter.getId(eq(wProperty))).thenReturn(W_PROPERTY_ID);
         when(propertyAdapter.getId(eq(hProperty))).thenReturn(H_PROPERTY_ID);
         when(propertyAdapter.getId(eq(rProperty))).thenReturn(R_PROPERTY_ID);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/builder/ObserverBuilderControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/builder/ObserverBuilderControlTest.java
@@ -49,6 +49,7 @@ import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetRuleAdapter;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
@@ -146,11 +147,11 @@ public class ObserverBuilderControlTest {
         AdapterManager adapters = mock(AdapterManager.class);
         DefinitionAdapter definitionAdapter = mock(DefinitionAdapter.class);
         DefinitionSetRuleAdapter rulesAdapter = mock(DefinitionSetRuleAdapter.class);
-        when(definitionAdapter.getId(any())).thenReturn("Object");
+        when(definitionAdapter.getId(any())).thenReturn(DefinitionId.build("Object"));
         when(rulesAdapter.getRuleSet(any())).thenReturn(mock(RuleSet.class));
         when(adapters.forDefinition()).thenReturn(definitionAdapter);
         when(adapters.forRules()).thenReturn(rulesAdapter);
-        when(definitionAdapter.getId(DEF)).thenReturn(DEF_ID);
+        when(definitionAdapter.getId(DEF)).thenReturn(DefinitionId.build(DEF_ID));
 
         when(clientDefinitionManager.adapters()).thenReturn(adapters);
         when(clientDefinitionManager.definitionSets()).thenReturn(mock(TypeDefinitionSetRegistry.class));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorer.java
@@ -142,7 +142,7 @@ public class TreeExplorer implements IsWidget {
     private Glyph getGlyph(final String shapeSetId,
                            final Element<org.kie.workbench.common.stunner.core.graph.content.view.View> element) {
         final Object definition = element.getContent().getDefinition();
-        final String defId = definitionUtils.getDefinitionManager().adapters().forDefinition().getId(definition);
+        final String defId = definitionUtils.getDefinitionManager().adapters().forDefinition().getId(definition).value();
         final ShapeFactory factory = shapeManager.getShapeSet(shapeSetId).getShapeFactory();
         return factory.getGlyph(defId);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerTest.java
@@ -40,6 +40,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Canva
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
@@ -156,7 +157,7 @@ public class TreeExplorerTest {
         when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
         when(definitionManager.adapters()).thenReturn(adapterManager);
         when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
-        when(definitionAdapter.getId(anyObject())).thenReturn("defId");
+        when(definitionAdapter.getId(anyObject())).thenReturn(DefinitionId.build("defId"));
         when(shapeManager.getShapeSet(eq(SHAPE_SET_ID))).thenReturn(shapeSet);
         when(shapeSet.getShapeFactory()).thenReturn(shapeFactory);
         when(shapeFactory.getGlyph(eq("defId"))).thenReturn(glyph);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapter.java
@@ -30,7 +30,7 @@ public interface DefinitionAdapter<T> extends PriorityAdapter {
     /**
      * Returns the definition's identifier for a given pojo.
      */
-    String getId(final T pojo);
+    DefinitionId getId(final T pojo);
 
     /**
      * Returns the definition's category for a given pojo.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapterWrapper.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionAdapterWrapper.java
@@ -35,7 +35,7 @@ public abstract class DefinitionAdapterWrapper<T, A extends DefinitionAdapter<T>
     }
 
     @Override
-    public String getId(final T pojo) {
+    public DefinitionId getId(final T pojo) {
         return adapter.getId(pojo);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionId.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionId.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.definition.adapter;
+
+public class DefinitionId {
+
+    public final static String DYNAMIC_ID_DELIMITER = ".";
+
+    private final String id;
+    private final int dynamicIdStartIndex;
+
+    public static DefinitionId build(final String id) {
+        return build(id, -1);
+    }
+
+    public static DefinitionId build(final String type,
+                                     final String id) {
+        final String value = generateId(type, id);
+        return build(value, type.length());
+    }
+
+    public static DefinitionId build(final String id,
+                                     final int dynamicIdStartIndex) {
+        return new DefinitionId(id, dynamicIdStartIndex);
+    }
+
+    public static String generateId(final String type,
+                                    final String id) {
+        return type + DYNAMIC_ID_DELIMITER + id;
+    }
+
+    public DefinitionId(final String id,
+                        final int dynamicIdStartIndex) {
+        this.id = id;
+        this.dynamicIdStartIndex = dynamicIdStartIndex;
+    }
+
+    public String value() {
+        return id;
+    }
+
+    public boolean isDynamic() {
+        return dynamicIdStartIndex >= 0;
+    }
+
+    public String type() {
+        return isDynamic() ?
+                id.substring(0, dynamicIdStartIndex) :
+                id;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/BindableAdapterUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/BindableAdapterUtils.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.exception.NotPojoTypeException;
 import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
 
@@ -41,7 +42,15 @@ public class BindableAdapterUtils {
 
     public static String getDynamicDefinitionId(final Class<?> type,
                                                 final String suffix) {
-        return getDefinitionId(type) + "." + suffix;
+        return getDynamicDefinitionId(getDefinitionId(type),
+                                      suffix);
+    }
+
+    public static String getDynamicDefinitionId(final String typeId,
+                                                final String suffix) {
+        return null != suffix ?
+                DefinitionId.generateId(typeId, suffix) :
+                typeId;
     }
 
     public static String getDynamicId(final Class<?> type,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionIdTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/definition/adapter/DefinitionIdTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.definition.adapter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DefinitionIdTest {
+
+    @Test
+    public void testNotDynamicDefinitionId() {
+        String input = "id1";
+        DefinitionId id = DefinitionId.build(input);
+        assertEquals(input, id.value());
+        assertFalse(id.isDynamic());
+        assertEquals(input, id.type());
+    }
+
+    @Test
+    public void testDynamicDefinitionId() {
+        String input = DefinitionId.generateId("type", "id1");
+        DefinitionId id = DefinitionId.build("type",
+                                             "id1");
+        assertEquals(input, id.value());
+        assertTrue(id.isDynamic());
+        assertEquals("type", id.type());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/bind/BackendBindableDefinitionAdapter.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.AbstractBindableDefinitionAdapter;
-import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableDefinitionAdapter;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.slf4j.Logger;
@@ -34,29 +33,14 @@ import static org.kie.workbench.common.stunner.core.backend.definition.adapter.R
 // TODO: Handle meta-properties
 // TODO: Handle i18n bundle.
 
-class BackendBindableDefinitionAdapter<T> extends AbstractBindableDefinitionAdapter<T>
+class BackendBindableDefinitionAdapter<T>
+        extends AbstractBindableDefinitionAdapter<T>
         implements BindableDefinitionAdapter<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(BackendBindableDefinitionAdapter.class);
 
     BackendBindableDefinitionAdapter(final DefinitionUtils definitionUtils) {
         super(definitionUtils);
-    }
-
-    @Override
-    public String getId(final Object pojo) {
-        final String fieldId = propertyIdFieldNames.get(pojo.getClass());
-        if (null != fieldId) {
-            try {
-                return BindableAdapterUtils.getDynamicDefinitionId(pojo.getClass(),
-                                                                   getFieldValue(pojo,
-                                                                                 fieldId));
-            } catch (IllegalAccessException e) {
-                LOG.error("Error obtaining the id for Definition " + pojo.getClass());
-            }
-            return null;
-        }
-        return getDefinitionId(pojo.getClass());
     }
 
     @Override
@@ -159,5 +143,17 @@ class BackendBindableDefinitionAdapter<T> extends AbstractBindableDefinitionAdap
                          }
                      }
                 );
+    }
+
+    @Override
+    protected String getStringFieldValue(final Object pojo,
+                                         final String fieldName) {
+        try {
+            return getFieldValue(pojo,
+                                 fieldName);
+        } catch (IllegalAccessException e) {
+            LOG.error("Error obtaining the field [" + fieldName + "] value for type [" + pojo.getClass() + "]");
+        }
+        return null;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapter.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import org.kie.workbench.common.stunner.core.backend.definition.adapter.AbstractReflectAdapter;
 import org.kie.workbench.common.stunner.core.backend.definition.adapter.ReflectionAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.HasInheritance;
 import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
@@ -51,7 +52,8 @@ import org.slf4j.LoggerFactory;
 // TODO: Handle i18n bundle.
 
 @Dependent
-public class BackendDefinitionAdapter<T> extends AbstractReflectAdapter<T>
+public class BackendDefinitionAdapter<T>
+        extends AbstractReflectAdapter<T>
         implements DefinitionAdapter<T>,
                    HasInheritance {
 
@@ -78,21 +80,21 @@ public class BackendDefinitionAdapter<T> extends AbstractReflectAdapter<T>
     }
 
     @Override
-    public String getId(final T definition) {
-        final Id id = getClassAnnotation(definition.getClass(),
-                                         Id.class);
-        if (null != id) {
+    public DefinitionId getId(final T definition) {
+        final String definitionId = getDefinitionId(definition.getClass());
+        final Id idAnn = getClassAnnotation(definition.getClass(),
+                                            Id.class);
+        if (null != idAnn) {
             try {
-
-                return BindableAdapterUtils.getDynamicDefinitionId(definition.getClass(),
-                                                                   getAnnotatedFieldValue(definition,
-                                                                                          Id.class));
+                final String value = BindableAdapterUtils.getDynamicDefinitionId(definitionId,
+                                                                                 getAnnotatedFieldValue(definition,
+                                                                                                        Id.class));
+                return DefinitionId.build(value, definitionId.length());
             } catch (Exception e) {
                 LOG.error("Error obtaining annotated id for Definition " + definition.getClass().getName());
             }
-            return null;
         }
-        return getDefinitionId(definition.getClass());
+        return DefinitionId.build(definitionId);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapterTest.java
@@ -56,7 +56,7 @@ public class BackendDefinitionAdapterTest extends AbstractBackendAdapterTest {
 
     @Test
     public void testGetId() {
-        final String id = tested.getId(instance);
+        final String id = tested.getId(instance).value();
         assertEquals(FooTestBean.class.getName(), id);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandler.java
@@ -298,12 +298,12 @@ public abstract class BaseCanvasHandler<D extends Diagram, C extends AbstractCan
         final String parentUUID = parent.getUUID();
         final String childUUID = child.getUUID();
         final Shape childShape = getCanvas().getShape(childUUID);
-        if(Objects.isNull(childShape)){
+        if (Objects.isNull(childShape)) {
             return;
         }
         if (!isCanvasRoot(parentUUID)) {
             final Shape parentShape = getCanvas().getShape(parentUUID);
-            if(Objects.isNull(parentShape)){
+            if (Objects.isNull(parentShape)) {
                 return;
             }
             getCanvas().deleteChildShape(parentShape,
@@ -442,7 +442,7 @@ public abstract class BaseCanvasHandler<D extends Diagram, C extends AbstractCan
     }
 
     protected String getDefinitionId(final Object definition) {
-        return getDefinitionManager().adapters().forDefinition().getId(definition);
+        return getDefinitionManager().adapters().forDefinition().getId(definition).value();
     }
 
     private void log(final Level level,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/AbstractElementBuilderControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/AbstractElementBuilderControl.java
@@ -239,7 +239,7 @@ public abstract class AbstractElementBuilderControl extends AbstractCanvasHandle
                             final double x,
                             final double y,
                             final CommandsCallback commandsCallback) {
-        final String defId = clientDefinitionManager.adapters().forDefinition().getId(definition);
+        final String defId = clientDefinitionManager.adapters().forDefinition().getId(definition).value();
         final String uuid = UUID.uuid();
         clientFactoryServices.newElement(uuid,
                                          defId,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/NodeBuilderControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/NodeBuilderControlImpl.java
@@ -107,7 +107,7 @@ public class NodeBuilderControlImpl
         final Connection targetConnection = request.getTargetConnection();
         if (null != node) {
             final Object nodeDef = node.getContent().getDefinition();
-            final String nodeId = clientDefinitionManager.adapters().forDefinition().getId(nodeDef);
+            final String nodeId = clientDefinitionManager.adapters().forDefinition().getId(nodeDef).value();
             final ElementBuilderControlImpl ebc = getElementBuilderControl();
             final Node<View<?>, Edge> parent = ebc.getParent(x,
                                                              y);
@@ -127,7 +127,7 @@ public class NodeBuilderControlImpl
                                            final CompositeCommand.Builder commandBuilder = new CompositeCommand.Builder().addCommands(commands);
                                            if (inEdge != null) {
                                                final Object edgeDef = inEdge.getContent().getDefinition();
-                                               final String edgeId = clientDefinitionManager.adapters().forDefinition().getId(edgeDef);
+                                               final String edgeId = clientDefinitionManager.adapters().forDefinition().getId(edgeDef).value();
                                                // The commands to batch for the edge that connects both nodes.
                                                commandBuilder.addCommand(commandFactory.addConnector(inEdge.getSourceNode(),
                                                                                                      inEdge,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilder.java
@@ -52,7 +52,7 @@ public class CollapsedPaletteDefinitionBuilder
                                             final Metadata metadata,
                                             final Function<String, DefaultPaletteItem> itemSupplier) {
         final DefinitionAdapter<Object> definitionAdapter = getDefinitionManager().adapters().forDefinition();
-        final String id = definitionAdapter.getId(definition);
+        final String id = definitionAdapter.getId(definition).value();
         final String title = definitionAdapter.getTitle(definition);
         // Notice it creates the item by using the title as for the item's tooltip property,
         // setting this an empty item title, in order to not display text once the rendered

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilder.java
@@ -116,7 +116,7 @@ public class ExpandedPaletteDefinitionBuilder
                                             final Metadata metadata,
                                             final Function<String, DefaultPaletteItem> itemSupplier) {
         final DefinitionAdapter<Object> definitionAdapter = getDefinitionManager().adapters().forDefinition();
-        final String id = definitionAdapter.getId(definition);
+        final String id = definitionAdapter.getId(definition).value();
         DefaultPaletteCategory result = null;
         DefaultPaletteCategory category = (DefaultPaletteCategory) itemSupplier.apply(categoryId);
         if (null == category) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactory.java
@@ -94,7 +94,7 @@ public class MorphActionsToolboxFactory
             final Element<? extends Definition<?>> element = (Element<? extends Definition<?>>) e;
             final Object definition = element.getContent().getDefinition();
             if (definitionUtils.hasMorphTargets(definition)) {
-                final String id = getDefinitionManager().adapters().forDefinition().getId(definition);
+                final String id = getDefinitionManager().adapters().forDefinition().getId(definition).value();
                 final MorphAdapter<Object> morphAdapter = getDefinitionManager().adapters().registry().getMorphAdapter(definition.getClass());
                 final Iterable<MorphDefinition> morphDefinitions = morphAdapter.getMorphDefinitions(definition);
                 if (null != morphDefinitions && morphDefinitions.iterator().hasNext()) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/definition/adapter/binding/ClientBindableDefinitionAdapter.java
@@ -24,12 +24,12 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.AbstractBindableDefinitionAdapter;
-import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableDefinitionAdapter;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
-class ClientBindableDefinitionAdapter extends AbstractBindableDefinitionAdapter<Object>
+class ClientBindableDefinitionAdapter
+        extends AbstractBindableDefinitionAdapter<Object>
         implements BindableDefinitionAdapter<Object> {
 
     private StunnerTranslationService translationService;
@@ -38,17 +38,6 @@ class ClientBindableDefinitionAdapter extends AbstractBindableDefinitionAdapter<
                                     StunnerTranslationService translationService) {
         super(definitionUtils);
         this.translationService = translationService;
-    }
-
-    @Override
-    public String getId(final Object pojo) {
-        final String fieldId = propertyIdFieldNames.get(pojo.getClass());
-        if (null != fieldId) {
-            return BindableAdapterUtils.getDynamicDefinitionId(pojo.getClass(),
-                                                               getProxiedValue(pojo,
-                                                                               fieldId));
-        }
-        return getDefinitionId(pojo.getClass());
     }
 
     @Override
@@ -111,6 +100,13 @@ class ClientBindableDefinitionAdapter extends AbstractBindableDefinitionAdapter<
                 .filter(name -> Objects.equals(name, propertyName))
                 .findFirst()
                 .map(prop -> getProxiedValue(pojo, prop));
+    }
+
+    @Override
+    protected String getStringFieldValue(final Object pojo,
+                                         final String fieldName) {
+        return getProxiedValue(pojo,
+                               fieldName);
     }
 
     private <T, R> R getProxiedValue(final T pojo,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/StunnerClientLogger.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/StunnerClientLogger.java
@@ -63,7 +63,7 @@ public class StunnerClientLogger {
                                      final Object def) {
         final DefinitionAdapter<Object> defAdapter =
                 definitionManager.adapters().registry().getDefinitionAdapter(def.getClass());
-        final String id = defAdapter.getId(def);
+        final String id = defAdapter.getId(def).value();
         final String category = defAdapter.getCategory(def);
         final String description = defAdapter.getDescription(def);
         final String title = defAdapter.getTitle(def);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/CollapsedPaletteDefinitionBuilderTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
@@ -78,7 +79,7 @@ public class CollapsedPaletteDefinitionBuilderTest {
         when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
         when(definitionManager.adapters()).thenReturn(adapterManager);
         when(adapterManager.forDefinition()).thenReturn(definitionAdapter1);
-        when(definitionAdapter1.getId(eq(definition1))).thenReturn(DEF1_ID);
+        when(definitionAdapter1.getId(eq(definition1))).thenReturn(DefinitionId.build(DEF1_ID));
         when(definitionAdapter1.getCategory(eq(definition1))).thenReturn(DEF1_CATEGORY);
         when(definitionAdapter1.getTitle(eq(definition1))).thenReturn(DEF1_TITLE);
         when(definitionAdapter1.getDescription(eq(definition1))).thenReturn(DEF1_DESC);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/palette/ExpandedPaletteDefinitionBuilderTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.components.palette.AbstractP
 import org.kie.workbench.common.stunner.core.client.components.palette.DefaultPaletteDefinitionBuilders.CategoryBuilder;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
@@ -111,7 +112,7 @@ public class ExpandedPaletteDefinitionBuilderTest {
         when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
         when(definitionManager.adapters()).thenReturn(adapterManager);
         when(adapterManager.forDefinition()).thenReturn(definitionAdapter1);
-        when(definitionAdapter1.getId(eq(definition1))).thenReturn(DEF1_ID);
+        when(definitionAdapter1.getId(eq(definition1))).thenReturn(DefinitionId.build(DEF1_ID));
         when(definitionAdapter1.getCategory(eq(definition1))).thenReturn(DEF1_CATEGORY);
         when(definitionAdapter1.getTitle(eq(definition1))).thenReturn(DEF1_TITLE);
         when(definitionAdapter1.getDescription(eq(definition1))).thenReturn(DEF1_DESC);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactoryTest.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.components.toolbox.Toolbox;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.MorphAdapter;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
@@ -119,7 +120,7 @@ public class MorphActionsToolboxFactoryTest {
         when(element.getUUID()).thenReturn(E_UUID);
         when(element.getContent()).thenReturn(elementContent);
         when(element.asNode()).thenReturn(element);
-        when(definitionAdapter.getId(eq(definition))).thenReturn(DEF_ID);
+        when(definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(DEF_ID));
         when(elementContent.getDefinition()).thenReturn(definition);
         when(definitionUtils.getDefinitionManager()).thenReturn(definitionManager);
         when(definitionUtils.hasMorphTargets(eq(definition))).thenReturn(true);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/AbstractBindableDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/AbstractBindableDefinitionAdapter.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -72,6 +73,21 @@ public abstract class AbstractBindableDefinitionAdapter<T> implements BindableDe
         this.propertyCategoryFieldNames = propertyCategoryFieldNames;
         this.propertyDescriptionFieldNames = propertyDescriptionFieldNames;
         this.propertyNameFields = propertyNameFields;
+    }
+
+    protected abstract String getStringFieldValue(T pojo, String fieldName);
+
+    @Override
+    public DefinitionId getId(final T pojo) {
+        final String fieldId = getIdField(pojo);
+        final String definitionId = getDefinitionId(pojo.getClass());
+        if (null != fieldId) {
+            final String id = BindableAdapterUtils.getDynamicDefinitionId(definitionId,
+                                                                          getStringFieldValue(pojo,
+                                                                                              fieldId));
+            return DefinitionId.build(id, definitionId.length());
+        }
+        return DefinitionId.build(definitionId);
     }
 
     @Override
@@ -192,5 +208,9 @@ public abstract class AbstractBindableDefinitionAdapter<T> implements BindableDe
 
     protected String getDefinitionId(final Class<?> type) {
         return BindableAdapterUtils.getDefinitionId(type);
+    }
+
+    private String getIdField(final T pojo) {
+        return getPropertyIdFieldNames().get(pojo.getClass());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapDefinitionAdapter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/adapter/bootstrap/BootstrapDefinitionAdapter.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
 import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
@@ -33,7 +34,7 @@ class BootstrapDefinitionAdapter implements DefinitionAdapter<Object> {
     }
 
     @Override
-    public String getId(final Object pojo) {
+    public DefinitionId getId(final Object pojo) {
         return getWrapped(pojo).getId(pojo);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/AbstractElementFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/AbstractElementFactory.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.factory.impl;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
@@ -31,17 +32,13 @@ public abstract class AbstractElementFactory<C, D extends Definition<C>, T exten
 
     protected abstract DefinitionManager getDefinitionManager();
 
-    protected void addLabels(final Set<String> target,
-                             final Object definition) {
-        target.add(getDefinitionId(definition));
-        target.addAll(getDefinitionLabels(definition));
-    }
-
-    protected String getDefinitionId(final Object definition) {
-        return getDefinitionManager().adapters().forDefinition().getId(definition);
-    }
-
-    protected Set<String> getDefinitionLabels(final Object definition) {
-        return getDefinitionManager().adapters().forDefinition().getLabels(definition);
+    protected void appendLabels(final Set<String> target,
+                                final Object definition) {
+        final DefinitionId id = getDefinitionManager().adapters().forDefinition().getId(definition);
+        target.add(id.value());
+        if (id.isDynamic()) {
+            target.add(id.type());
+        }
+        target.addAll(getDefinitionManager().adapters().forDefinition().getLabels(definition));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/EdgeFactoryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/EdgeFactoryImpl.java
@@ -61,8 +61,8 @@ public class EdgeFactoryImpl extends AbstractElementFactory<Object, Definition<O
             ViewConnector<Object> content = new ViewConnectorImpl<>(definition,
                                                                     buildBounds());
             edge.setContent(content);
-            addLabels(edge.getLabels(),
-                      definition);
+            appendLabels(edge.getLabels(),
+                         definition);
         }
         return edge;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/NodeFactoryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/NodeFactoryImpl.java
@@ -62,8 +62,8 @@ public class NodeFactoryImpl extends AbstractElementFactory<Object, Definition<O
         View<Object> content = new ViewImpl<>(definition,
                                               bounds);
         node.setContent(content);
-        addLabels(node.getLabels(),
-                  definition);
+        appendLabels(node.getLabels(),
+                     definition);
         return node;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/MorphNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/MorphNodeCommand.java
@@ -62,7 +62,7 @@ public final class MorphNodeCommand extends AbstractGraphCommand {
         if (!results.getType().equals(CommandResult.Type.ERROR)) {
             final DefinitionManager definitionManager = context.getDefinitionManager();
             final Object currentDef = candidate.getContent().getDefinition();
-            final String currentDefId = definitionManager.adapters().forDefinition().getId(currentDef);
+            final String currentDefId = definitionManager.adapters().forDefinition().getId(currentDef).value();
             this.oldMorphTarget = currentDefId;
             final MorphAdapter<Object> morphAdapter = context.getDefinitionManager().adapters().registry().getMorphAdapter(currentDef.getClass());
             if (null == morphAdapter) {
@@ -81,7 +81,7 @@ public final class MorphNodeCommand extends AbstractGraphCommand {
             candidate.getContent().setDefinition(newDef);
             // Update candidate roles.
             final Set<String> newLabels = new HashSet<>();
-            newLabels.add(definitionManager.adapters().forDefinition().getId(newDef));
+            newLabels.add(definitionManager.adapters().forDefinition().getId(newDef).value());
             newLabels.addAll(definitionManager.adapters().forDefinition().getLabels(newDef));
 
             candidate.getLabels().clear();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcher.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcher.java
@@ -95,7 +95,7 @@ public class FilteredParentsTypeMatcher
         @Override
         public Optional<Element<?>> apply(final Node<? extends View<?>, ? extends Edge> node,
                                           final Class<?> parentType) {
-                return getParent(node, parentType);
+            return getParent(node, parentType);
         }
 
         private Optional<Element<?>> getParent(final Node<? extends View<?>, ? extends Edge> node,
@@ -120,7 +120,8 @@ public class FilteredParentsTypeMatcher
             return candidateParent.isPresent() ?
                     Optional.ofNullable(provider.definitionManager.adapters()
                                                 .forDefinition()
-                                                .getId(candidateParent.get().getContent().getDefinition())) :
+                                                .getId(candidateParent.get().getContent().getDefinition())
+                                                .value()) :
                     Optional.empty();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
@@ -55,7 +55,7 @@ public class GraphUtils {
                 .map(Element::getContent)
                 .map(Definition::getDefinition)
                 .map(def -> Exceptions.<Set>swallow(() -> definitionManager.adapters().forDefinition().getProperties(def),
-                                               Collections.emptySet()))
+                                                    Collections.emptySet()))
                 .map(properties -> Exceptions.swallow(() -> getProperty(definitionManager, properties, id), null))
                 .orElseGet(
                         //getting by field if not found by the id (class name)
@@ -80,7 +80,6 @@ public class GraphUtils {
                 ? getPropertyByField(definitionManager, property, field.substring(index + 1))
                 : property;
     }
-
 
     public static Object getProperty(final DefinitionManager definitionManager,
                                      final Set properties,
@@ -107,15 +106,6 @@ public class GraphUtils {
             }
         });
         return count[0];
-    }
-
-    public static <T> int countDefinitions(final DefinitionManager definitionManager,
-                                           final Graph<?, ? extends Node> target,
-                                           final T definition) {
-        final String id = definitionManager.adapters().forDefinition().getId(definition);
-        return countDefinitionsById(definitionManager,
-                                    target,
-                                    id);
     }
 
     public static int countEdges(final DefinitionManager definitionManager,
@@ -165,7 +155,7 @@ public class GraphUtils {
             p = getParent((Node<? extends Definition<?>, ? extends Edge>) p);
             if (null != p) {
                 final Object definition = ((Definition) p.getContent()).getDefinition();
-                final String id = definitionManager.adapters().forDefinition().getId(definition);
+                final String id = definitionManager.adapters().forDefinition().getId(definition).value();
                 result.add(id);
             }
         }
@@ -391,7 +381,7 @@ public class GraphUtils {
         String targetId = null;
         if (element.getContent() instanceof Definition) {
             final Object definition = ((Definition) element.getContent()).getDefinition();
-            targetId = definitionManager.adapters().forDefinition().getId(definition);
+            targetId = definitionManager.adapters().forDefinition().getId(definition).value();
         } else if (element.getContent() instanceof DefinitionSet) {
             targetId = ((DefinitionSet) element.getContent()).getDefinition();
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/domain/DomainLookupFunctions.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/lookup/domain/DomainLookupFunctions.java
@@ -73,7 +73,11 @@ public class DomainLookupFunctions {
                                                       Optional.of(CardinalityContext.Operation.ADD)));
             if (isValid(outEdgeCardinalityResult)) {
                 final String defId =
-                        context.getDefinitionManager().adapters().forDefinition().getId(sourceNode.getContent().getDefinition());
+                        context.getDefinitionManager()
+                                .adapters()
+                                .forDefinition()
+                                .getId(sourceNode.getContent().getDefinition())
+                                .value();
                 return new LookupConnectionTargetRoles(edgeId, defId)
                         .execute(context);
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/DefaultDefinitionsCacheRegistry.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/DefaultDefinitionsCacheRegistry.java
@@ -91,7 +91,7 @@ public class DefaultDefinitionsCacheRegistry
     public boolean remove(final Object instance) {
         final Class<?> type = instance.getClass();
         final DefinitionAdapter<Object> adapter = getAdapter(type);
-        final String id = adapter.getId(instance);
+        final String id = adapter.getId(instance).value();
         definitionsByType.remove(type.getName());
         return null != definitionsById.remove(id);
     }
@@ -100,7 +100,7 @@ public class DefaultDefinitionsCacheRegistry
     public boolean contains(final Object instance) {
         final Class<?> type = instance.getClass();
         final DefinitionAdapter<Object> adapter = getAdapter(type);
-        final String id = adapter.getId(instance);
+        final String id = adapter.getId(instance).value();
         return definitionsById.containsKey(id);
     }
 
@@ -124,7 +124,7 @@ public class DefaultDefinitionsCacheRegistry
     private DefinitionHolder registerInstance(final Object instance) {
         final Class<?> type = instance.getClass();
         final DefinitionAdapter<Object> adapter = getAdapter(type);
-        final String id = adapter.getId(instance);
+        final String id = adapter.getId(instance).value();
         final Set<String> labels = adapter.getLabels(instance);
         final DefinitionHolder holder = new DefinitionHolder(instance,
                                                              labels);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/DefinitionMapRegistry.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/DefinitionMapRegistry.java
@@ -42,7 +42,7 @@ public class DefinitionMapRegistry<T> extends AbstractDynamicRegistryWrapper<T, 
                                   final Map<String, T> map) {
         super(
                 new MapRegistry<T>(
-                        item -> null != item ? adapterManager.forDefinition().getId(item) : null,
+                        item -> null != item ? adapterManager.forDefinition().getId(item).value() : null,
                         map)
         );
         this.adapterManager = adapterManager;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/AbstractParentsMatchHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/AbstractParentsMatchHandler.java
@@ -56,7 +56,7 @@ public abstract class AbstractParentsMatchHandler<T extends AbstractParentsMatch
         final Object content = edge.getContent();
         if (content instanceof Definition) {
             final Definition holder = (Definition) content;
-            return Optional.of(definitionManager.adapters().forDefinition().getId(holder.getDefinition()));
+            return Optional.of(definitionManager.adapters().forDefinition().getId(holder.getDefinition()).value());
         }
         return Optional.empty();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/handler/impl/GraphEvaluationHandlerUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/handler/impl/GraphEvaluationHandlerUtils.java
@@ -55,7 +55,7 @@ public class GraphEvaluationHandlerUtils {
     }
 
     public String getDefinitionId(final Object definition) {
-        return definitionManager.adapters().forDefinition().getId(definition);
+        return definitionManager.adapters().forDefinition().getId(definition).value();
     }
 
     public Set<String> getParentIds(final Graph<? extends DefinitionSet, ? extends Node> graph,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/util/ClassUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/util/ClassUtils.java
@@ -58,6 +58,10 @@ public class ClassUtils {
         return instance.getClass().getName().equals(type.getName());
     }
 
+    public static String getName(Class<?> type) {
+        return type.getName();
+    }
+
     public boolean isPrimitiveClass(Class<?> type) {
         return type.isPrimitive() || WRAPPER_MAP.containsKey(type);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/util/DefinitionUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/util/DefinitionUtils.java
@@ -205,7 +205,7 @@ public class DefinitionUtils {
     public <T> String[] getDefinitionIds(final T definition) {
         final Class<?> type = definition.getClass();
         final DefinitionAdapter<Object> definitionAdapter = definitionManager.adapters().registry().getDefinitionAdapter(type);
-        final String definitionId = definitionAdapter.getId(definition);
+        final String definitionId = definitionAdapter.getId(definition).value();
         String baseId = null;
         if (definitionAdapter instanceof HasInheritance) {
             baseId = ((HasInheritance) definitionAdapter).getBaseType(type);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/AbstractGraphDefinitionTypesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/AbstractGraphDefinitionTypesTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.core;
 
 import java.util.Optional;
 
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.graph.Node;
 
 import static org.mockito.Matchers.eq;
@@ -76,11 +77,11 @@ public class AbstractGraphDefinitionTypesTest {
         this.definitionA = new DefinitionA();
         this.definitionB = new DefinitionB();
         this.definitionC = new DefinitionC();
-        when(graphHandler.definitionAdapter.getId(eq(rootDefinition))).thenReturn(DEF_ROOT_ID);
-        when(graphHandler.definitionAdapter.getId(eq(parentDefinition))).thenReturn(DEF_PARENT_ID);
-        when(graphHandler.definitionAdapter.getId(eq(definitionA))).thenReturn(DEF_A_ID);
-        when(graphHandler.definitionAdapter.getId(eq(definitionB))).thenReturn(DEF_B_ID);
-        when(graphHandler.definitionAdapter.getId(eq(definitionC))).thenReturn(DEF_C_ID);
+        when(graphHandler.definitionAdapter.getId(eq(rootDefinition))).thenReturn(DefinitionId.build(DEF_ROOT_ID));
+        when(graphHandler.definitionAdapter.getId(eq(parentDefinition))).thenReturn(DefinitionId.build(DEF_PARENT_ID));
+        when(graphHandler.definitionAdapter.getId(eq(definitionA))).thenReturn(DefinitionId.build(DEF_A_ID));
+        when(graphHandler.definitionAdapter.getId(eq(definitionB))).thenReturn(DefinitionId.build(DEF_B_ID));
+        when(graphHandler.definitionAdapter.getId(eq(definitionC))).thenReturn(DefinitionId.build(DEF_C_ID));
         this.rootNode = newViewNode(ROOT_UUID,
                                     rootDefinition,
                                     0,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphMockHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphMockHandler.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionSetRuleAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
 import org.kie.workbench.common.stunner.core.factory.impl.EdgeFactoryImpl;
@@ -137,6 +138,21 @@ public class TestingGraphMockHandler {
         return this;
     }
 
+    public Object getDefIfPresent(final String id,
+                                  final Optional<Object> actual) {
+        Object definition = null;
+        if (actual.isPresent()) {
+            definition = actual.get();
+            if (null == definitionAdapter.getId(definition)) {
+                when(definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(id));
+            }
+        } else {
+            definition = newDef("def-" + id,
+                                Optional.empty());
+        }
+        return definition;
+    }
+
     public Object newDef(final String id,
                          final Optional<Set<String>> labels) {
         final Object def = mock(Object.class);
@@ -149,7 +165,7 @@ public class TestingGraphMockHandler {
     public void mockDefAttributes(final Object def,
                                   final String id,
                                   final Optional<Set<String>> labels) {
-        when(definitionAdapter.getId(def)).thenReturn(id);
+        when(definitionAdapter.getId(def)).thenReturn(DefinitionId.build(id));
         if (labels.isPresent()) {
             when(definitionAdapter.getLabels(def)).thenReturn(labels.get());
         }
@@ -183,10 +199,7 @@ public class TestingGraphMockHandler {
                             final double y,
                             final double w,
                             final double h) {
-        final Object definition = def.isPresent() ?
-                def.get() :
-                newDef("def-" + uuid,
-                       Optional.empty());
+        final Object definition = getDefIfPresent(uuid, def);
         when(definitionUtils.buildBounds(eq(definition),
                                          anyDouble(),
                                          anyDouble()))
@@ -222,12 +235,7 @@ public class TestingGraphMockHandler {
 
     public Edge newEdge(String uuid,
                         final Optional<Object> def) {
-        final Object definition = def.isPresent() ?
-                def.get() :
-                newDef("def-" + uuid,
-                       Optional.empty());
-
-
+        final Object definition = getDefIfPresent(uuid, def);
         return newEdge(uuid, definition);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/AbstractBindableDefinitionAdapterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/definition/adapter/binding/AbstractBindableDefinitionAdapterTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.definition.adapter.binding;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
+import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDynamicDefinitionId;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractBindableDefinitionAdapterTest {
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private AbstractBindableDefinitionAdapter delegate;
+
+    private final Map<Class, String> propertyIdFieldNames = new HashMap<>();
+    private final Map<Class, Class> baseTypes = new HashMap<>();
+
+    private AbstractBindableDefinitionAdapterStub testeed;
+    private SomePojo pojo;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws Exception {
+        pojo = new SomePojo();
+        testeed = new AbstractBindableDefinitionAdapterStub(definitionUtils);
+        testeed.setBindings(mock(Map.class),
+                            baseTypes,
+                            mock(Map.class),
+                            mock(Map.class),
+                            mock(Map.class),
+                            propertyIdFieldNames,
+                            mock(Map.class),
+                            mock(Map.class),
+                            mock(Map.class),
+                            mock(Map.class),
+                            mock(Map.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetId() {
+        DefinitionId id = testeed.getId(pojo);
+        assertEquals(getDefinitionId(SomePojo.class), id.value());
+        assertEquals(getDefinitionId(SomePojo.class), id.type());
+        assertFalse(id.isDynamic());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetIdWhenDynamic() {
+        String idFieldName = "theIdField";
+        String idFieldValue = "theIdFieldValue";
+        propertyIdFieldNames.put(SomePojo.class, idFieldName);
+        when(delegate.getStringFieldValue(eq(pojo), eq(idFieldName))).thenReturn(idFieldValue);
+        DefinitionId id = testeed.getId(pojo);
+        assertEquals(getDynamicDefinitionId(SomePojo.class, idFieldValue), id.value());
+        assertEquals(getDefinitionId(SomePojo.class), id.type());
+        assertTrue(id.isDynamic());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetBaseType() {
+        String somePojoClassId = getDefinitionId(SomeBasePojo.class);
+        baseTypes.put(SomePojo.class, SomeBasePojo.class);
+        assertEquals(somePojoClassId, testeed.getBaseType(SomePojo.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetTypes() {
+        String somePojoClassId = getDefinitionId(SomeBasePojo.class);
+        String pojoClassId = getDefinitionId(SomePojo.class);
+        String[] types = testeed.getTypes(somePojoClassId);
+        assertNull(types);
+        baseTypes.put(SomePojo.class, SomeBasePojo.class);
+        types = testeed.getTypes(somePojoClassId);
+        assertEquals(1, types.length);
+        assertEquals(pojoClassId, types[0]);
+    }
+
+    private static class SomePojo {
+
+    }
+
+    private static class SomeBasePojo {
+
+    }
+
+    private class AbstractBindableDefinitionAdapterStub<T> extends AbstractBindableDefinitionAdapter<T> {
+
+        public AbstractBindableDefinitionAdapterStub(final DefinitionUtils definitionUtils) {
+            super(definitionUtils);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected Set<?> getBindProperties(T pojo) {
+            return delegate.getBindProperties(pojo);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected String getStringFieldValue(T pojo, String fieldName) {
+            return delegate.getStringFieldValue(pojo, fieldName);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public String getCategory(T pojo) {
+            return delegate.getCategory(pojo);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public String getTitle(T pojo) {
+            return delegate.getTitle(pojo);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public String getDescription(T pojo) {
+            return delegate.getDescription(pojo);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Set<String> getLabels(T pojo) {
+            return delegate.getLabels(pojo);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Set<?> getPropertySets(T pojo) {
+            return delegate.getPropertySets(pojo);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Optional<?> getProperty(T pojo, String propertyName) {
+            return delegate.getProperty(pojo, propertyName);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Optional<String> getNameField(T pojo) {
+            return delegate.getNameField(pojo);
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/factory/impl/EdgeFactoryImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/factory/impl/EdgeFactoryImplTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.factory.graph.EdgeFactory;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -62,7 +63,7 @@ public class EdgeFactoryImplTest {
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         this.testingkHelper = new TestingGraphMockHandler();
-        when(testingkHelper.definitionAdapter.getId(eq(definition))).thenReturn(ID);
+        when(testingkHelper.definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(ID));
         when(testingkHelper.definitionAdapter.getLabels(eq(definition))).thenReturn(LABELS);
         this.tested = new EdgeFactoryImpl(testingkHelper.definitionManager);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/factory/impl/NodeFactoryImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/factory/impl/NodeFactoryImplTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -46,7 +47,8 @@ import static org.mockito.Mockito.when;
 public class NodeFactoryImplTest {
 
     public static final String UUID = "uuid1";
-    public static final String ID = "defId";
+    public static final String DEF_TYPE_ID = "defType";
+    public static final String DEF_ID = "defId";
     public static final Set<String> LABELS = Arrays.asList("label1",
                                                            "label2").stream().collect(Collectors.toSet());
     public static final Bounds BOUNDS = new BoundsImpl(new BoundImpl(10d,
@@ -67,7 +69,6 @@ public class NodeFactoryImplTest {
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         this.testingkHelper = new TestingGraphMockHandler();
-        when(testingkHelper.definitionAdapter.getId(eq(definition))).thenReturn(ID);
         when(testingkHelper.definitionAdapter.getLabels(eq(definition))).thenReturn(LABELS);
         when(definitionUtils.getDefinitionManager()).thenReturn(testingkHelper.definitionManager);
         when(definitionUtils.buildBounds(eq(definition),
@@ -84,6 +85,7 @@ public class NodeFactoryImplTest {
 
     @Test
     public void testBuild() {
+        when(testingkHelper.definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(DEF_ID));
         final Node<Definition<Object>, Edge> node = tested.build(UUID,
                                                                  definition);
         assertNotNull(node);
@@ -91,7 +93,24 @@ public class NodeFactoryImplTest {
                      node.getUUID());
         assertEquals(3,
                      node.getLabels().size());
-        assertTrue(node.getLabels().contains(ID));
+        assertTrue(node.getLabels().contains(DEF_ID));
+        assertTrue(node.getLabels().contains("label1"));
+        assertTrue(node.getLabels().contains("label2"));
+    }
+
+    @Test
+    public void testBuildDynamicDefinition() {
+        when(testingkHelper.definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(DEF_TYPE_ID,
+                                                                                                   DEF_ID));
+        final Node<Definition<Object>, Edge> node = tested.build(UUID,
+                                                                 definition);
+        assertNotNull(node);
+        assertEquals(UUID,
+                     node.getUUID());
+        assertEquals(4,
+                     node.getLabels().size());
+        assertTrue(node.getLabels().contains(DefinitionId.generateId(DEF_TYPE_ID, DEF_ID)));
+        assertTrue(node.getLabels().contains(DEF_TYPE_ID));
         assertTrue(node.getLabels().contains("label1"));
         assertTrue(node.getLabels().contains("label2"));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/MorphNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/MorphNodeCommandTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.MorphAdapter;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -83,11 +84,11 @@ public class MorphNodeCommandTest extends AbstractGraphCommandTest {
         when(content.getDefinition()).thenReturn(CURRENT_DEFINITION);
         when(adapterRegistry.getMorphAdapter(any(Class.class))).thenReturn(morphAdaptor);
 
-        when(definitionAdapter.getId(CURRENT_DEFINITION)).thenReturn(CURRENT_DEFINITION_ID);
+        when(definitionAdapter.getId(CURRENT_DEFINITION)).thenReturn(DefinitionId.build(CURRENT_DEFINITION_ID));
         when(definitionAdapter.getLabels(CURRENT_DEFINITION)).thenReturn(Collections.emptySet());
         when(morphAdaptor.morph(CURRENT_DEFINITION, morphDefinition, CURRENT_DEFINITION_ID)).thenReturn(NEW_DEFINITION);
 
-        when(definitionAdapter.getId(NEW_DEFINITION)).thenReturn(NEW_DEFINITION_ID);
+        when(definitionAdapter.getId(NEW_DEFINITION)).thenReturn(DefinitionId.build(NEW_DEFINITION_ID));
         when(definitionAdapter.getLabels(NEW_DEFINITION)).thenReturn(Collections.singleton(NEW_DEFINITION_LABEL));
         when(morphAdaptor.morph(NEW_DEFINITION, morphDefinition, CURRENT_DEFINITION_ID)).thenReturn(CURRENT_DEFINITION);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPropertyValueCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPropertyValueCommandTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.exception.BadCommandArgumentsException;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
@@ -71,7 +72,7 @@ public class UpdateElementPropertyValueCommandTest extends AbstractGraphCommandT
             add(property);
         }};
         when(definitionAdapter.getProperties(eq(definition))).thenReturn(properties);
-        when(definitionAdapter.getId(eq(definition))).thenReturn(DEF_ID);
+        when(definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(DEF_ID));
         when(propertyAdapter.getId(eq(property))).thenReturn(PROPERTY_ID);
         when(propertyAdapter.getValue(eq(property))).thenReturn(PROPERTY_OLD_VALUE);
         when(graphIndex.getNode(eq(UUID))).thenReturn(candidate);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.AbstractGraphDefinitionTypesTest;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -64,9 +65,9 @@ public class ConnectorParentsMatchConnectionHandlerTest extends AbstractGraphDef
     public void setup() throws Exception {
         super.setup();
         this.graph = graphHandler.graph;
+        when(graphHandler.definitionAdapter.getId(eq(connectorDef))).thenReturn(DefinitionId.build(DEF_EDGE_ID));
         this.connector = graphHandler.newEdge(EDGE_UUID,
                                               Optional.of(connectorDef));
-        when(graphHandler.definitionAdapter.getId(eq(connectorDef))).thenReturn(DEF_EDGE_ID);
         when(connectionContext.getGraph()).thenReturn(graph);
         when(connectionContext.getConnector()).thenReturn(connector);
         when(ruleExtension.getId()).thenReturn(DEF_EDGE_ID);
@@ -100,7 +101,7 @@ public class ConnectorParentsMatchConnectionHandlerTest extends AbstractGraphDef
         when(ruleExtension.getId()).thenReturn("anyOtherId");
         when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{ParentDefinition.class});
         assertFalse(tested.accepts(ruleExtension,
-                                  connectionContext));
+                                   connectionContext));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchContainmentHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.AbstractGraphDefinitionTypesTest;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
@@ -70,7 +71,7 @@ public class ConnectorParentsMatchContainmentHandlerTest extends AbstractGraphDe
     public void setup() throws Exception {
         super.setup();
         this.graph = graphHandler.graph;
-        when(graphHandler.definitionAdapter.getId(eq(connectorDef))).thenReturn(DEF_EDGE_ID);
+        when(graphHandler.definitionAdapter.getId(eq(connectorDef))).thenReturn(DefinitionId.build(DEF_EDGE_ID));
         this.connector = graphHandler.newEdge(EDGE_UUID,
                                               Optional.of(connectorDef));
         when(containmentContext.getGraph()).thenReturn(graph);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/AbstractGraphRuleHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/AbstractGraphRuleHandlerTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -96,7 +97,7 @@ public abstract class AbstractGraphRuleHandlerTest {
         when(element.getContent()).thenReturn(elementContent);
         when(element.getLabels()).thenReturn(DEFINITION_LABELS);
         when(elementContent.getDefinition()).thenReturn(elementDefinition);
-        when(definitionAdapter.getId(eq(elementDefinition))).thenReturn(DEFINITION_ID);
+        when(definitionAdapter.getId(eq(elementDefinition))).thenReturn(DefinitionId.build(DEFINITION_ID));
         when(definitionAdapter.getLabels(eq(elementDefinition))).thenReturn(DEFINITION_LABELS);
         when(candidate.getContent()).thenReturn(candidateContent);
         when(candidate.getLabels()).thenReturn(CANDIDATE_LABELS);
@@ -104,9 +105,9 @@ public abstract class AbstractGraphRuleHandlerTest {
         when(parent.getContent()).thenReturn(parentContent);
         when(parent.getLabels()).thenReturn(PARENT_LABELS);
         when(parentContent.getDefinition()).thenReturn(parentDefinition);
-        when(definitionAdapter.getId(eq(candidateDefinition))).thenReturn(CANDIDATE_ID);
+        when(definitionAdapter.getId(eq(candidateDefinition))).thenReturn(DefinitionId.build(CANDIDATE_ID));
         when(definitionAdapter.getLabels(eq(candidateDefinition))).thenReturn(CANDIDATE_LABELS);
-        when(definitionAdapter.getId(eq(parentDefinition))).thenReturn(PARENT_ID);
+        when(definitionAdapter.getId(eq(parentDefinition))).thenReturn(DefinitionId.build(PARENT_ID));
         when(definitionAdapter.getLabels(eq(parentDefinition))).thenReturn(PARENT_LABELS);
     }
 
@@ -118,7 +119,7 @@ public abstract class AbstractGraphRuleHandlerTest {
         Object d = mock(Object.class);
         when(e.getContent()).thenReturn(v);
         when(v.getDefinition()).thenReturn(d);
-        when(definitionAdapter.getId(eq(d))).thenReturn(id);
+        when(definitionAdapter.getId(eq(d))).thenReturn(DefinitionId.build(id));
         when(definitionAdapter.getLabels(eq(d))).thenReturn(labels);
         when(e.getLabels()).thenReturn(labels);
         return e;
@@ -132,7 +133,7 @@ public abstract class AbstractGraphRuleHandlerTest {
         Object d = mock(Object.class);
         when(e.getContent()).thenReturn(v);
         when(v.getDefinition()).thenReturn(d);
-        when(definitionAdapter.getId(eq(d))).thenReturn(id);
+        when(definitionAdapter.getId(eq(d))).thenReturn(DefinitionId.build(id));
         when(definitionAdapter.getLabels(eq(d))).thenReturn(labels);
         when(e.getLabels()).thenReturn(labels);
         return e;
@@ -146,7 +147,7 @@ public abstract class AbstractGraphRuleHandlerTest {
         Object d = mock(Object.class);
         when(e.getContent()).thenReturn(v);
         when(v.getDefinition()).thenReturn(d);
-        when(definitionAdapter.getId(eq(d))).thenReturn(id);
+        when(definitionAdapter.getId(eq(d))).thenReturn(DefinitionId.build(id));
         when(definitionAdapter.getLabels(eq(d))).thenReturn(labels);
         when(e.getLabels()).thenReturn(labels);
         return e;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/ConnectorCardinalityEvaluationHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/ConnectorCardinalityEvaluationHandlerTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
@@ -99,7 +100,7 @@ public class ConnectorCardinalityEvaluationHandlerTest extends AbstractGraphRule
         when(edge.getContent()).thenReturn(edgeContent);
         when(edge.getLabels()).thenReturn(edgeLabels);
         when(edgeContent.getDefinition()).thenReturn(edgeDefinition);
-        when(definitionAdapter.getId(eq(edgeDefinition))).thenReturn(EDGE_ID);
+        when(definitionAdapter.getId(eq(edgeDefinition))).thenReturn(DefinitionId.build(EDGE_ID));
         tested = new ConnectorCardinalityEvaluationHandler(evalUtils,
                                                            new EdgeCardinalityEvaluationHandler());
     }
@@ -114,7 +115,7 @@ public class ConnectorCardinalityEvaluationHandlerTest extends AbstractGraphRule
         assertFalse(tested.accepts(RULE_IN_NO_LIMIT,
                                    context));
         when(context.getDirection()).thenReturn(EdgeCardinalityContext.Direction.INCOMING);
-        when(definitionAdapter.getId(eq(edgeDefinition))).thenReturn("anotherId");
+        when(definitionAdapter.getId(eq(edgeDefinition))).thenReturn(DefinitionId.build("anotherId"));
         assertFalse(tested.accepts(RULE_IN_NO_LIMIT,
                                    context));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/GraphConnectionEvaluationHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/GraphConnectionEvaluationHandlerTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
@@ -80,7 +81,7 @@ public class GraphConnectionEvaluationHandlerTest extends AbstractGraphRuleHandl
         when(edge.getContent()).thenReturn(edgeContent);
         when(edge.getLabels()).thenReturn(edgeLabels);
         when(edgeContent.getDefinition()).thenReturn(edgeDefinition);
-        when(definitionAdapter.getId(eq(edgeDefinition))).thenReturn(EDGE_ID);
+        when(definitionAdapter.getId(eq(edgeDefinition))).thenReturn(DefinitionId.build(EDGE_ID));
         when(context.getConnector()).thenReturn(edge);
         when(context.getSource()).thenReturn(Optional.of(parent));
         when(context.getTarget()).thenReturn(Optional.of(candidate));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilder.java
@@ -272,7 +272,7 @@ public class BPMNPaletteDefinitionBuilder
                 } else {
                     subcategoryGroup = (DefaultPaletteGroup) subcategoryGroupOp.get();
                 }
-                final String defId = adapter.getId(serviceTask);
+                final String defId = adapter.getId(serviceTask).value();
                 final String title = adapter.getTitle(serviceTask);
                 final String description = adapter.getDescription(serviceTask);
                 final DefaultPaletteItem item =

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/palette/BPMNPaletteDefinitionBuilderTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.stunner.core.client.components.palette.DefaultPa
 import org.kie.workbench.common.stunner.core.client.components.palette.ExpandedPaletteDefinitionBuilder;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
 import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
 import org.kie.workbench.common.stunner.core.registry.impl.DefinitionsCacheRegistry;
@@ -118,7 +119,7 @@ public class BPMNPaletteDefinitionBuilderTest {
         when(definitionManager.adapters()).thenReturn(adapterManager);
         when(adapterManager.registry()).thenReturn(adapterRegistry);
         when(adapterRegistry.getDefinitionAdapter(any(Class.class))).thenReturn(widAdapter);
-        when(widAdapter.getId(eq(serviceTask))).thenReturn(WID_NAME);
+        when(widAdapter.getId(eq(serviceTask))).thenReturn(DefinitionId.build(WID_NAME));
         when(widAdapter.getCategory(eq(serviceTask))).thenReturn(WID_CAT);
         when(widAdapter.getTitle(eq(serviceTask))).thenReturn(WID_DISPLAY_NAME);
         when(widAdapter.getDescription(eq(serviceTask))).thenReturn(WID_DESC);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/factory/CaseGraphFactoryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/factory/CaseGraphFactoryImpl.java
@@ -88,7 +88,7 @@ public class CaseGraphFactoryImpl extends BPMNGraphFactoryImpl {
                 definitionManager.adapters().registry().getDefinitionAdapter(milestone.getClass());
 
         final Node<View<ServiceTask>, Edge> firstElement =
-                (Node<View<ServiceTask>, Edge>) factoryManager.newElement(UUID.uuid(), adapter.getId(milestone));
+                (Node<View<ServiceTask>, Edge>) factoryManager.newElement(UUID.uuid(), adapter.getId(milestone).value());
 
         final AdHoc adHoc = diagramNode.getContent().getDefinition().getDiagramSet().getAdHoc();
         final String adHocPropertyId = definitionManager.adapters().forProperty().getId(adHoc);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/factory/CaseGraphFactoryImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/factory/CaseGraphFactoryImplTest.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandManager;
@@ -129,7 +130,7 @@ public class CaseGraphFactoryImplTest {
         when(definitionManager.adapters()).thenReturn(adapters);
         when(adapters.registry()).thenReturn(registry);
         when(registry.getDefinitionAdapter(ServiceTask.class)).thenReturn(adapter);
-        when(adapter.getId(milestone)).thenReturn(MILESTONE_ID);
+        when(adapter.getId(milestone)).thenReturn(DefinitionId.build(MILESTONE_ID));
         when(factoryManager.newElement(anyString(),
                                        eq(BPMNDiagramImpl.class))).thenReturn(diagramNode);
         when(factoryManager.newElement(anyString(),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeFactoryTest.java
@@ -56,6 +56,7 @@ import org.kie.workbench.common.stunner.core.client.shape.impl.AbstractElementSh
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.shapes.client.BasicConnectorShape;
@@ -164,9 +165,9 @@ public class CaseManagementShapeFactoryTest {
     @SuppressWarnings("unchecked")
     public void setup() {
         final PictureShapeView pictureShapeView = new PictureShapeView(new MultiPath().rect(0,
-                                                                                      0,
-                                                                                      10,
-                                                                                      10));
+                                                                                            0,
+                                                                                            10,
+                                                                                            10));
 
         this.stageShape = new SVGPrimitiveShape(new Rectangle(0.0d, 0.0d));
         this.taskShape = new SVGPrimitiveShape(new Rectangle(0.0d, 0.0d));
@@ -365,7 +366,7 @@ public class CaseManagementShapeFactoryTest {
     @SuppressWarnings("unchecked")
     private void assertShapeConstruction(final BPMNDefinition definition,
                                          final Consumer<Shape> o) {
-        when(definitionAdapter.getId(eq(definition))).thenReturn(definition.getClass().getName());
+        when(definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(definition.getClass().getName()));
 
         final Shape<? extends ShapeView> shape = factory.newShape(definition);
         assertNotNull(shape);


### PR DESCRIPTION
Hey @hasys 

This is the fix for the blocker issue - https://issues.jboss.org/browse/RHPAM-1773

It fixes the docking issues with Service Tasks, now it's possible to do it as well as with other tasks.

PS: The change/fix is really small, but it was necessary to refactor the return type for method `DefinitionAdapter#getId`, from `Strung` to `DefintionId`,which is a new type that allows "dynamic" ids (eg: service tasks). So this is while a few files are changed but due to the refactor on the API.

Thanks!