### PR TITLE
JBPM-7834: Provide OpenShiftStartupStrategy

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-provider/src/main/java/org/guvnor/ala/openshift/access/impl/OpenShiftAccessInterfaceImpl.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-provider/src/main/java/org/guvnor/ala/openshift/access/impl/OpenShiftAccessInterfaceImpl.java
@@ -67,7 +67,7 @@ public class OpenShiftAccessInterfaceImpl implements OpenShiftAccessInterface,
 
     // package-protected for junit testing purposes (from inside the package)
     static OpenShiftConfig buildOpenShiftConfig(OpenShiftProviderConfig config) {
-        OpenShiftConfigBuilder builder = new OpenShiftConfigBuilder(OpenShiftConfig.wrap(Config.autoConfigure()));
+        OpenShiftConfigBuilder builder = new OpenShiftConfigBuilder(OpenShiftConfig.wrap(Config.autoConfigure(null)));
         /*
          * Kubernetes configuration properties; see io.fabric8.kubernetes.client.Config
          */


### PR DESCRIPTION
Fixed fabric8 client compatibility issue (https://github.com/fabric8io/kubernetes-client/commit/43f532fca44b28c4fe9c786aaf50e5d6232e5508) as result of raising fabric8 client version to 4.1.0 (Related PR: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/878) which is a pre-requisite for a larger PR (Related PR: https://github.com/kiegroup/droolsjbpm-integration/pull/1611)