### PR TITLE
DROOLS-3431: [DMN Designer] Error after reopening

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorDock.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorDock.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.client.workbench.docks.UberfireDocks;
@@ -64,7 +65,11 @@ public class DecisionNavigatorDock {
         this.uberfireDock = makeUberfireDock();
     }
 
-    public void setupContent(final CanvasHandler handler) {
+    public void setupDiagram(final Diagram diagram) {
+        decisionNavigatorPresenter.setDiagram(diagram);
+    }
+
+    public void setupCanvasHandler(final CanvasHandler handler) {
         decisionNavigatorPresenter.setHandler(handler);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorPresenter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorPresenter.java
@@ -60,6 +60,8 @@ public class DecisionNavigatorPresenter {
 
     private final TranslationService translationService;
 
+    private Diagram diagram;
+
     private CanvasHandler handler;
 
     @Inject
@@ -100,6 +102,14 @@ public class DecisionNavigatorPresenter {
 
     public DecisionNavigatorTreePresenter getTreePresenter() {
         return treePresenter;
+    }
+
+    public Diagram getDiagram() {
+        return diagram;
+    }
+
+    public void setDiagram(final Diagram diagram) {
+        this.diagram = diagram;
     }
 
     public CanvasHandler getHandler() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/factories/DecisionNavigatorBaseItemFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/factories/DecisionNavigatorBaseItemFactory.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Canva
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
@@ -97,8 +98,8 @@ public class DecisionNavigatorBaseItemFactory {
 
     @SuppressWarnings("unchecked")
     String diagramUUID() {
-        final CanvasHandler canvasHandler = decisionNavigatorPresenter.getHandler();
-        final Graph<?, Node> graph = canvasHandler.getDiagram().getGraph();
+        final Diagram diagram = decisionNavigatorPresenter.getDiagram();
+        final Graph<?, Node> graph = diagram.getGraph();
 
         return StreamSupport.stream(graph.nodes().spliterator(), false)
                 .filter(n -> n.getContent() instanceof Definition)

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorDockTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorDockTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.mockito.Mock;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
@@ -80,11 +81,21 @@ public class DecisionNavigatorDockTest {
     }
 
     @Test
-    public void testSetupContent() {
+    public void testSetupDiagram() {
+
+        final Diagram diagram = mock(Diagram.class);
+
+        dock.setupDiagram(diagram);
+
+        verify(decisionNavigatorPresenter).setDiagram(diagram);
+    }
+
+    @Test
+    public void testSetupCanvasHandler() {
 
         final CanvasHandler canvasHandler = mock(CanvasHandler.class);
 
-        dock.setupContent(canvasHandler);
+        dock.setupCanvasHandler(canvasHandler);
 
         verify(decisionNavigatorPresenter).setHandler(canvasHandler);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/decision/factories/DecisionNavigatorBaseItemFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/decision/factories/DecisionNavigatorBaseItemFactoryTest.java
@@ -115,6 +115,7 @@ public class DecisionNavigatorBaseItemFactoryTest {
                                                            translationService));
 
         when(decisionNavigatorPresenter.getHandler()).thenReturn(canvasHandler);
+        when(decisionNavigatorPresenter.getDiagram()).thenReturn(diagram);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(diagram.getGraph()).thenReturn(graph);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -148,6 +148,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
 
     @Override
     protected void initialiseKieEditorForSession(final ProjectDiagram diagram) {
+        decisionNavigatorDock.setupDiagram(diagram);
         superInitialiseKieEditorForSession(diagram);
 
         kieView.getMultiPage().addPage(dataTypesPage);
@@ -186,7 +187,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         canvasHandler.ifPresent(c -> {
             final ExpressionEditorView.Presenter expressionEditor = ((DMNSession) sessionManager.getCurrentSession()).getExpressionEditor();
             expressionEditor.setToolbarStateHandler(new ProjectToolbarStateHandler(getMenuSessionItems()));
-            decisionNavigatorDock.setupContent(c);
+            decisionNavigatorDock.setupCanvasHandler(c);
             decisionNavigatorDock.open();
             dataTypesPage.reload();
         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDia
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditorTest;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEditorMenuSessionItems;
 import org.kie.workbench.common.workbench.client.PerspectiveIds;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditor;
 import org.uberfire.mocks.EventSourceMock;
@@ -47,6 +48,7 @@ import org.uberfire.mvp.impl.PathPlaceRequest;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -202,9 +204,12 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
 
         open();
 
+        final InOrder inOrder = inOrder(decisionNavigatorDock);
+        inOrder.verify(decisionNavigatorDock).setupDiagram(diagram);
+        inOrder.verify(decisionNavigatorDock).setupCanvasHandler(eq(canvasHandler));
+        inOrder.verify(decisionNavigatorDock).open();
+
         verify(expressionEditor).setToolbarStateHandler(any(ProjectToolbarStateHandler.class));
-        verify(decisionNavigatorDock).setupContent(eq(canvasHandler));
-        verify(decisionNavigatorDock).open();
         verify(dataTypesPage).reload();
         verify(layoutHelper).applyLayout(diagram);
     }
@@ -215,7 +220,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         diagramEditor.onDiagramLoad();
 
         verify(expressionEditor, never()).setToolbarStateHandler(any(ProjectToolbarStateHandler.class));
-        verify(decisionNavigatorDock, never()).setupContent(any());
+        verify(decisionNavigatorDock, never()).setupCanvasHandler(any());
         verify(decisionNavigatorDock, never()).open();
         verify(dataTypesPage, never()).reload();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -314,6 +314,7 @@ public class SessionDiagramEditorScreen implements KieEditorWrapperView.KieEdito
 
     void open(final Diagram diagram,
               final Command callback) {
+        setupDiagram(diagram);
         screenPanelView.setWidget(presenter.getView());
         layoutHelper.applyLayout(diagram);
         presenter
@@ -325,8 +326,9 @@ public class SessionDiagramEditorScreen implements KieEditorWrapperView.KieEdito
                           final ToolbarStateHandler toolbarStateHandler = new StandaloneToolbarStateHandler((DMNEditorToolbar) presenter.getToolbar());
                           final ExpressionEditorView.Presenter expressionEditor = ((DMNSession) sessionManager.getCurrentSession()).getExpressionEditor();
                           expressionEditor.setToolbarStateHandler(toolbarStateHandler);
-                          openDock(presenter.getInstance());
                           dataTypesPage.reload();
+                          setupCanvasHandler(presenter.getInstance());
+                          openDock();
                           callback.execute();
                       }));
     }
@@ -350,9 +352,16 @@ public class SessionDiagramEditorScreen implements KieEditorWrapperView.KieEdito
         destroySession();
     }
 
-    void openDock(final EditorSession session) {
+    void setupDiagram(final Diagram diagram) {
+        decisionNavigatorDock.setupDiagram(diagram);
+    }
+
+    void setupCanvasHandler(final EditorSession session) {
+        decisionNavigatorDock.setupCanvasHandler(session.getCanvasHandler());
+    }
+
+    void openDock() {
         decisionNavigatorDock.open();
-        decisionNavigatorDock.setupContent(session.getCanvasHandler());
     }
 
     void destroyDock() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
@@ -42,6 +42,7 @@ import org.kie.workbench.common.stunner.forms.client.event.RefreshFormProperties
 import org.kie.workbench.common.widgets.metadata.client.KieEditorWrapperView;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -54,6 +55,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -162,12 +164,18 @@ public class SessionDiagramEditorScreenTest {
         final Diagram diagram = mock(Diagram.class);
         final Command callback = mock(Command.class);
         final Metadata metadata = mock(Metadata.class);
+        final AbstractCanvasHandler canvasHandler = mock(AbstractCanvasHandler.class);
 
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(diagram.getMetadata()).thenReturn(metadata);
 
         editor.open(diagram, callback);
 
-        verify(editor).openDock(session);
+        final InOrder inOrder = inOrder(decisionNavigatorDock);
+        inOrder.verify(decisionNavigatorDock).setupDiagram(diagram);
+        inOrder.verify(decisionNavigatorDock).setupCanvasHandler(canvasHandler);
+        inOrder.verify(decisionNavigatorDock).open();
+
         verify(dataTypesPage).reload();
     }
 
@@ -191,10 +199,9 @@ public class SessionDiagramEditorScreenTest {
 
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
 
-        editor.openDock(session);
+        editor.openDock();
 
         verify(decisionNavigatorDock).open();
-        verify(decisionNavigatorDock).setupContent(canvasHandler);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3431

@karreiro I changed things around a bit to also set the `Diagram` on the `DecisionNavigatorPresenter`. The `Diagram` is available before the `Session` and before Stunner attempts to render the Graph (and hence trigger the `CanvasElementAddedEvent` events that lead to the undesirable behaviour reported by @jomarko).