### PR TITLE
DROOLS-3469 DMN xml NS definition on non-root xml elements

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNModelInstrumentedBase.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DMNModelInstrumentedBase.java
@@ -39,7 +39,10 @@ public abstract class DMNModelInstrumentedBase implements DMNDefinition {
         FEEL("feel", org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_FEEL),
         DMN("dmn", org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_DMN),
         KIE("kie", org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_KIE),
-        DEFAULT(QName.DEFAULT_NS_PREFIX, "https://github.com/kiegroup/drools/kie-dmn/");
+        DEFAULT(QName.DEFAULT_NS_PREFIX, "https://github.com/kiegroup/drools/kie-dmn/"),
+        DMNDI("dmndi", org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_DMNDI),
+        DI("di", org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_DI),
+        DC("dc", org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_DC);
 
         private String prefix;
         private String uri;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/factory/DMNDiagramFactoryImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/factory/DMNDiagramFactoryImplTest.java
@@ -101,6 +101,18 @@ public class DMNDiagramFactoryImplTest {
         assertTrue(dmnDefaultNameSpaces.containsKey(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix()));
         assertEquals(dmnDefinitions.getNamespace().getValue(),
                      dmnDefaultNameSpaces.get(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix()));
+
+        assertTrue(dmnDefaultNameSpaces.containsKey(DMNModelInstrumentedBase.Namespace.DMNDI.getPrefix()));
+        assertEquals(DMNModelInstrumentedBase.Namespace.DMNDI.getUri(),
+                     dmnDefaultNameSpaces.get(DMNModelInstrumentedBase.Namespace.DMNDI.getPrefix()));
+
+        assertTrue(dmnDefaultNameSpaces.containsKey(DMNModelInstrumentedBase.Namespace.DI.getPrefix()));
+        assertEquals(DMNModelInstrumentedBase.Namespace.DI.getUri(),
+                     dmnDefaultNameSpaces.get(DMNModelInstrumentedBase.Namespace.DI.getPrefix()));
+
+        assertTrue(dmnDefaultNameSpaces.containsKey(DMNModelInstrumentedBase.Namespace.DC.getPrefix()));
+        assertEquals(DMNModelInstrumentedBase.Namespace.DC.getUri(),
+                     dmnDefaultNameSpaces.get(DMNModelInstrumentedBase.Namespace.DC.getPrefix()));
     }
 
     @Test


### PR DESCRIPTION
/cc @manstis @jomarko @danielezonca 

Linked PR also : https://github.com/kiegroup/drools/pull/2205

The linked PR fixes the issue.
This PR additionally avoid the issue beforehand.