### PR TITLE
JBPM-8098 Stunner - Canvas becomes empty after saving the diagram

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/LienzoCanvasExport.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/LienzoCanvasExport.java
@@ -67,6 +67,10 @@ public class LienzoCanvasExport implements CanvasExport<AbstractCanvasHandler> {
                                                                    canvasHandler)));
         // Set again the previous transform.
         viewport.setTransform(transform);
+
+        // Draw again the native canvas context2d (this is necessary otherwise the canvas becomes empty)
+        lienzoLayer.draw();
+
         return svgContext2D;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/LienzoCanvasExportTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/export/LienzoCanvasExportTest.java
@@ -233,6 +233,7 @@ public class LienzoCanvasExportTest {
         verify(layer, times(1)).draw(any(Context2D.class));
         ArgumentCaptor<Transform> transformArgumentCaptor = ArgumentCaptor.forClass(Transform.class);
         verify(viewport, times(2)).setTransform(transformArgumentCaptor.capture());
+        verify(layer).draw();
         List<Transform> transforms = transformArgumentCaptor.getAllValues();
         Transform t0 = transforms.get(0);
         Transform t1 = transforms.get(1);


### PR DESCRIPTION
When saving the diagram, the SVG image is generated and this process uses a Wrapped `Context2D` to generate the SVG. 
It is necessary to draw the original `Context2D` from Canvas after the SVG generation is complete, otherwise, the canvas remains empty.

@romartin I think this was removed during some refactor necessary for the infinite canvas (https://github.com/kiegroup/kie-wb-common/commit/1082e1994c9ed231384984b8bb8b9da2205b56fe#diff-22baa68f555ac85b7f154466ae47e825L76)

@LuboTerifaj 