### PR TITLE
JBPM-8091 - Allow basic mvel expressions

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
@@ -37,7 +37,7 @@ public class SignalRef implements BPMNProperty {
 
     @Value
     @FieldValue
-    @Pattern(regexp = "^$|[a-zA-Z0-9_]+")
+    @Pattern(regexp = "^$|[a-zA-Z0-9_]+|[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[}]{1}|[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[(]{1}[a-zA-Z0-9._\",\\s]+[)]{1}[}]{1}")
     private String value;
 
     public SignalRef() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
@@ -34,6 +34,14 @@ public class SignalRefTest {
 
     private static final String VALID_REF = "validSIGNALREF0123456789_";
 
+    private static final String MVEL_EXPRESSION = "#{validSIGNALREF0123456789_mvel}";
+
+    private static final String MVEL_COMPLEX_OBJECT_EXPRESSION = "#{myObj.property}";
+
+    private static final String MVEL_INVALID_EXPRESSION = "#{.expression}";
+
+    private static final String MVEL_SYSTEM_PROPERTY = "#{System.getProperty(\"search.value\", \"default.value\")}";
+
     private Validator validator;
 
     @Before
@@ -48,6 +56,42 @@ public class SignalRefTest {
         Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
 
         assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithMvelExpression() {
+        SignalRef signalRef = new SignalRef(MVEL_EXPRESSION);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithMvelComplexObjectExpression() {
+        SignalRef signalRef = new SignalRef(MVEL_COMPLEX_OBJECT_EXPRESSION);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithMvelSystemProperty() {
+        SignalRef signalRef = new SignalRef(MVEL_SYSTEM_PROPERTY);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithMvelInvalidExpression() {
+        SignalRef signalRef = new SignalRef(MVEL_INVALID_EXPRESSION);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertFalse(validations.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
  - Not all MVEL expressions are evaluated
  - Allows basic client validation of expression
  - Complete compilation and validation delegated to runtime
  - Allows expressions like #{processVar}, #{procObj.property} and #{System.getProperty("default.value", procVar)}