### PR TITLE
JBPM-7790: Process instance diagram zoom controls

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPage.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPage.java
@@ -25,6 +25,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import elemental2.dom.Element;
 import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Definitions;
@@ -49,6 +50,8 @@ import static org.jboss.errai.common.client.ui.ElementWrapperWidget.getWidget;
 
 @Dependent
 public class DataTypesPage extends PageImpl {
+
+    static final String DATA_TYPES_PAGE_CSS_CLASS = "data-types-page";
 
     private final DataTypeList treeList;
 
@@ -110,6 +113,12 @@ public class DataTypesPage extends PageImpl {
     @PostConstruct
     public void init() {
         dataTypeShortcuts.init(treeList);
+        setupPage();
+    }
+
+    void setupPage() {
+        final Element dataTypesPage = (Element) pageView.parentNode.parentNode;
+        dataTypesPage.classList.add(DATA_TYPES_PAGE_CSS_CLASS);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.less
@@ -113,17 +113,17 @@
 }
 
 .tab-content {
-  & > div > div > div {
-    height: 100%;
-
-    & > div {
-      height: ~"calc(100% - 30px)";
-    }
-  }
-
-  & > div > div {
+  .data-types-page {
     /* "overflow: auto" is set inline by UberFire/AppFormer since since most of editors have scroll bars.
      * However the DMN Data Types has a fixed header with internal scrollbars. */
     overflow: hidden !important;
+
+    & > div {
+      height: 100%;
+
+      & > div {
+        height: ~"calc(100% - 30px)";
+      }
+    }
   }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPageTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPageTest.java
@@ -21,6 +21,8 @@ import java.util.List;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
+import elemental2.dom.DOMTokenList;
+import elemental2.dom.Element;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -51,6 +53,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.types.DataTypesPage.DATA_TYPES_PAGE_CSS_CLASS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -121,9 +125,28 @@ public class DataTypesPageTest {
 
     @Test
     public void testInit() {
+
+        doNothing().when(page).setupPage();
+
         page.init();
 
         verify(dataTypeShortcuts).init(treeList);
+        verify(page).setupPage();
+    }
+
+    @Test
+    public void testSetupPage() {
+
+        final Element targetElement = mock(Element.class);
+
+        pageView.parentNode = mock(Element.class);
+        pageView.parentNode.parentNode = targetElement;
+
+        targetElement.classList = mock(DOMTokenList.class);
+
+        page.setupPage();
+
+        verify(targetElement.classList).add(DATA_TYPES_PAGE_CSS_CLASS);
     }
 
     @Test


### PR DESCRIPTION
This https://issues.jboss.org/browse/JBPM-7790

---

This PR fixed a collateral effect that a DMN CSS class was causing in a JBPM screen.