### PR TITLE
JBPM-8069 Stunner - it is not possible to move in/out of swimlane connected node

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
@@ -57,12 +57,17 @@ class ParentsTypeMatchPredicate implements BiPredicate<Node<? extends View<?>, ?
     public boolean test(final Node<? extends View<?>, ? extends Edge> nodeA,
                         final Node<? extends View<?>, ? extends Edge> nodeB) {
 
-        checkNotNull("nodeA", nodeA);
         checkNotNull("nodeB", nodeB);
+        checkNotNull("nodeA", nodeA);
+
+        if (Objects.isNull(parentType)) {
+            return true;
+        }
+
         final Element<?> parentInstanceA = getParentInstance(nodeA, parentType).orElse(null);
         final Element<?> parentInstanceB = getParentInstance(nodeB, parentType).orElse(null);
 
-        if (Objects.nonNull(parentType) && (Objects.isNull(parentInstanceA) || Objects.isNull(parentInstanceB))) {
+        if (Objects.isNull(parentInstanceA) || Objects.isNull(parentInstanceB)) {
             return false;
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatchPredicate.java
@@ -39,14 +39,10 @@ class ParentsTypeMatchPredicate implements BiPredicate<Node<? extends View<?>, ?
     private Class<?> parentType;
 
     ParentsTypeMatchPredicate(final BiFunction<Node<? extends View<?>, ? extends Edge>, Class<?>, Optional<Element<?>>> parentProvider,
-                              final BiPredicate<Node<?, ? extends Edge>, Element<?>> hasParentPredicate) {
+                              final BiPredicate<Node<?, ? extends Edge>, Element<?>> hasParentPredicate, final Class<?> parentType) {
         this.parentProvider = parentProvider;
         this.hasParentPredicate = hasParentPredicate;
-    }
-
-    public ParentsTypeMatchPredicate forParentType(final Class<?> parentType) {
         this.parentType = parentType;
-        return this;
     }
 
     /**
@@ -63,16 +59,15 @@ class ParentsTypeMatchPredicate implements BiPredicate<Node<? extends View<?>, ?
 
         checkNotNull("nodeA", nodeA);
         checkNotNull("nodeB", nodeB);
-        final Optional<Element<?>> parentInstanceA = getParentInstance(nodeA, parentType);
-        final Optional<Element<?>> parentInstanceB = getParentInstance(nodeB, parentType);
+        final Element<?> parentInstanceA = getParentInstance(nodeA, parentType).orElse(null);
+        final Element<?> parentInstanceB = getParentInstance(nodeB, parentType).orElse(null);
 
-        if (!parentInstanceA.isPresent() && !parentInstanceB.isPresent()) {
-            return true;
+        if (Objects.nonNull(parentType) && (Objects.isNull(parentInstanceA) || Objects.isNull(parentInstanceB))) {
+            return false;
         }
 
-        return (parentInstanceA.isPresent() && parentInstanceB.isPresent())
-                && (Objects.equals(parentInstanceA.get(), parentInstanceB.get()))
-                && (hasParent(nodeA, parentInstanceA.get()) && hasParent(nodeB, parentInstanceB.get()));
+        return Objects.equals(parentInstanceA, parentInstanceB)
+                && (hasParent(nodeA, parentInstanceA) && hasParent(nodeB, parentInstanceB));
     }
 
     private Optional<Element<?>> getParentInstance(final Node<? extends View<?>, ? extends Edge> node,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcher.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcher.java
@@ -37,14 +37,10 @@ public class ParentsTypeMatcher
 
     private final ParentsTypeMatchPredicate parentsTypeMatch;
 
-    public ParentsTypeMatcher(final DefinitionManager definitionManager) {
+    public ParentsTypeMatcher(final DefinitionManager definitionManager, final Class<?> parentType) {
         this.parentsTypeMatch = new ParentsTypeMatchPredicate(new ParentByDefinitionIdProvider(definitionManager),
-                                                              new GraphUtils.HasParentPredicate());
-    }
-
-    public ParentsTypeMatcher forParentType(final Class<?> parentType) {
-        this.parentsTypeMatch.forParentType(parentType);
-        return this;
+                                                              new GraphUtils.HasParentPredicate(),
+                                                              parentType);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/AbstractParentsMatchHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/AbstractParentsMatchHandler.java
@@ -33,16 +33,22 @@ import org.kie.workbench.common.stunner.core.rule.violations.RuleViolationImpl;
 public abstract class AbstractParentsMatchHandler<T extends AbstractParentsMatchHandler, C extends RuleEvaluationContext>
         extends RuleExtensionHandler<T, C> {
 
-    public static Class<?> getParentType(final RuleExtension rule, Element<? extends Definition> parent) {
+    /**
+     * Returns the match parent type that matches the {@link RuleExtension#getTypeArguments()} considering the given parents.
+     * @param rule
+     * @param parent
+     * @return
+     */
+    public static Optional<Class<?>> getParentType(final RuleExtension rule, Element<? extends Definition>... parent) {
         final Class<?>[] typeArguments = rule.getTypeArguments();
-        final Class parentDefinitionClass = Objects.nonNull(parent)
-                && Objects.nonNull(parent.getContent())
-                && Objects.nonNull(parent.getContent().getDefinition()) ? parent.getContent().getDefinition().getClass() :
-                null;
-        return Stream.of(typeArguments)
-                .filter(clazz -> Objects.equals(clazz, parentDefinitionClass))
+        return Stream.of(parent)
+                .filter(Objects::nonNull)
+                .map(Element::getContent)
+                .map(Definition::getDefinition)
+                .map(Object::getClass)
+                .filter(parentClass -> Stream.of(typeArguments).anyMatch(type -> Objects.equals(type, parentClass)))
                 .findFirst()
-                .orElse(null);
+                .map(c -> (Class<?>) c);
     }
 
     public static boolean hasParentType(final RuleExtension rule) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandler.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.stunner.core.rule.ext.impl;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -119,18 +118,11 @@ public class ConnectorParentsMatchConnectionHandler
         if (sourceNode.isPresent() && targetNode.isPresent()) {
             final Node<? extends View<?>, ? extends Edge> source = sourceNode.get();
             final Node<? extends View<?>, ? extends Edge> target = targetNode.get();
+            final Element<? extends Definition> parentTarget = (Element<? extends Definition>) GraphUtils.getParent(target);
+            final Element<? extends Definition> parentSource = (Element<? extends Definition>) GraphUtils.getParent(source);
+            final Optional<Class<?>> parentType = getParentType(rule, parentTarget, parentSource);
 
-            //source parent
-            final Optional<? extends Element<? extends Definition>> sourceParent =
-                    Optional.ofNullable((Element<? extends Definition>) GraphUtils.getParent(source));
-            final Class<?> parentTypeForSource = getParentType(rule, sourceParent.orElse(null));
-            //target parent
-            final Optional<? extends Element<? extends Definition>> targetParent =
-                    Optional.ofNullable((Element<? extends Definition>) GraphUtils.getParent(target));
-            final Class<?> parentTypeForTarget = getParentType(rule, targetParent.orElse(null));
-
-            isValid = new ParentsTypeMatcher(definitionManager)
-                    .forParentType(Objects.nonNull(parentTypeForSource) ? parentTypeForSource : parentTypeForTarget)
+            isValid = new ParentsTypeMatcher(definitionManager, parentType.orElse(null))
                     .test(source, target);
         }
         if (!isValid) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
@@ -116,9 +116,8 @@ public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypes
     @SuppressWarnings("unchecked")
     public void testWithParentAndNoParentType() {
 
-        assertTrue(newPredicate(RootDefinition.class)
-                           .test(nodeA,
-                                 nodeC));
+        assertTrue(newPredicate(RootDefinition.class).test(nodeA,
+                                                           nodeC));
 
         assertFalse(newPredicate(DefinitionB.class)
                             .test(nodeA,
@@ -127,6 +126,14 @@ public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypes
         assertTrue(newPredicate(null)
                            .test(nodeA,
                                  nodeC));
+
+        assertFalse(newPredicate(RootDefinition.class)
+                            .test(nodeA,
+                                  nodeB));
+
+        assertTrue(newPredicate(null)
+                           .test(nodeA,
+                                 nodeB));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/FilteredParentsTypeMatcherTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.graph.util;
 
+import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,10 +77,9 @@ public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypes
         assertFalse(newPredicate(DefinitionC.class)
                             .test(nodeA,
                                   nodeB));
-        assertTrue(newPredicate(ParentDefinition.class)
-                           .test(nodeA,
-                                 nodeC));
-
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(nodeA,
+                                  nodeC));
         assertTrue(newPredicate(RootDefinition.class)
                            .test(nodeA,
                                  nodeC));
@@ -95,6 +96,7 @@ public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypes
         assertFalse(newPredicate(RootDefinition.class)
                             .test(nodeA,
                                   nodeB));
+
         assertFalse(newPredicate(ParentDefinition.class)
                             .test(nodeA,
                                   nodeB));
@@ -105,6 +107,26 @@ public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypes
         assertTrue(newPredicate(RootDefinition.class)
                            .test(nodeA,
                                  nodeB));
+        assertFalse(newPredicate(ParentDefinition.class)
+                            .test(nodeA,
+                                  nodeB));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithParentAndNoParentType() {
+
+        assertTrue(newPredicate(RootDefinition.class)
+                           .test(nodeA,
+                                 nodeC));
+
+        assertFalse(newPredicate(DefinitionB.class)
+                            .test(nodeA,
+                                  nodeC));
+
+        assertTrue(newPredicate(null)
+                           .test(nodeA,
+                                 nodeC));
     }
 
     @Test
@@ -124,7 +146,7 @@ public class FilteredParentsTypeMatcherTest extends AbstractGraphDefinitionTypes
     private FilteredParentsTypeMatcher newPredicate(final Class<?> parentType) {
         return new FilteredParentsTypeMatcher(graphHandler.definitionManager,
                                               rootNode,
-                                              nodeA)
-                .forParentType(parentType);
+                                              nodeA,
+                                              Optional.ofNullable(parentType));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
@@ -34,8 +34,7 @@ public class ParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
     }
 
     private ParentsTypeMatcher newPredicate(final Class<?> parentType) {
-        return new ParentsTypeMatcher(graphHandler.definitionManager)
-                .forParentType(parentType);
+        return new ParentsTypeMatcher(graphHandler.definitionManager, parentType);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -66,7 +65,7 @@ public class ParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
     @SuppressWarnings("unchecked")
     public void testWithParentSubprocess() {
         assertTrue(newPredicate(ParentDefinition.class).test(nodeA, nodeB));
-        assertTrue(newPredicate(DefinitionA.class).test(nodeA, nodeB));
+        assertFalse(newPredicate(DefinitionA.class).test(nodeA, nodeB));
         assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));
         assertFalse(newPredicate(ParentDefinition.class).test(nodeA, nodeC));
         assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeC));
@@ -88,7 +87,7 @@ public class ParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
         graphHandler
                 .removeChild(parentNode, nodeA)
                 .removeChild(parentNode, nodeB);
-        assertTrue(newPredicate(RootDefinition.class).test(nodeA, nodeB));
+        assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));
 
         graphHandler.setChild(rootNode, nodeA);
         assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ParentsTypeMatcherTest.java
@@ -109,4 +109,13 @@ public class ParentsTypeMatcherTest extends AbstractGraphDefinitionTypesTest {
         graphHandler.setChild(rootNode, nodeA);
         assertTrue(newPredicate(RootDefinition.class).test(nodeA, nodeC));
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWithParentAndNoParentType() {
+        assertTrue(newPredicate(null).test(nodeA, nodeC));
+        assertFalse(newPredicate(DefinitionB.class).test(nodeA, nodeC));
+        assertTrue(newPredicate(null).test(nodeA, nodeB));
+        assertFalse(newPredicate(RootDefinition.class).test(nodeA, nodeB));
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
@@ -117,6 +117,17 @@ public class ConnectorParentsMatchConnectionHandlerTest extends AbstractGraphDef
 
     @Test
     @SuppressWarnings("unchecked")
+    public void testNoParentDefinition() {
+        when(connectionContext.getSource()).thenReturn(Optional.of(nodeA));
+        when(connectionContext.getTarget()).thenReturn(Optional.of(nodeC));
+        when(ruleExtension.getTypeArguments()).thenReturn(new Class[]{});
+        final RuleViolations violations = tested.evaluate(ruleExtension, connectionContext);
+        assertNotNull(violations);
+        assertViolations(violations, true);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void testEvaluateParentDefinition() {
         assertEvalSuccess(Optional.of(nodeA),
                           Optional.of(nodeB));
@@ -187,6 +198,6 @@ public class ConnectorParentsMatchConnectionHandlerTest extends AbstractGraphDef
                 new Class[]{ParentDefinition.class, RootDefinition.class});
 
         violations = tested.evaluate(ruleExtension, connectionContext);
-        assertViolations(violations, false);
+        assertViolations(violations, true);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/ext/impl/ConnectorParentsMatchConnectionHandlerTest.java
@@ -187,6 +187,6 @@ public class ConnectorParentsMatchConnectionHandlerTest extends AbstractGraphDef
                 new Class[]{ParentDefinition.class, RootDefinition.class});
 
         violations = tested.evaluate(ruleExtension, connectionContext);
-        assertViolations(violations, true);
+        assertViolations(violations, false);
     }
 }


### PR DESCRIPTION
Now If you have connected node you can move it outside of swimlane (or bring it inside of any swimlane).
This should not be possible with subprocesses, that should be validated as well.

I made some modifications now it seems to be working better, however, I think this part deserves a refactoring in the future to make it more simple and clear, now it is quite complicated to follow and debug the rules evaluation for this case. 

@romartin 
@hasys 