### PR TITLE
DROOLS-3128 Improve cheat sheet within Test Scenarios (Preview) + add vertical spaces to blank Test Report

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.css
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.css
@@ -19,6 +19,7 @@ a:hover {
 }
 
 .kie-dl-horizontal dt {
+  margin-bottom: 0.75rem;
   text-align: left;
   font-weight: normal;
   width: auto;

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingViewImpl.html
@@ -31,7 +31,6 @@
                     </dt>
                     <dd>
                         <span data-field="testResultIcon"></span>
-                        <span data-i18n-key="TEST"></span>
                         <span data-field="testResultText" style="display: inline;"></span>
                     </dd>
                     <dt>
@@ -57,8 +56,10 @@
                 <a data-field="viewAlerts">
                     <span data-i18n-key="ViewAlerts"></span></a>
 
+                <!--
                 <hr class="kie-dock__divider"/>
                 <h5 class="kie-dock__heading--section"><span data-i18n-key="ScenarioStatus"></span></h5>
+                -->
 
                 <br/>
             </div>


### PR DESCRIPTION
@danielezonca, @Rikkola, could you please take a look?

In this PR, I:

- modified the cheat sheet to be up-to-date;
- fixed vertical spaces in a blank test report;
- removed the TEST word from a blank test report;
- removed the Scenario Status header.

**This PR should be merged together with  !**

Old version can be seen here: http://file.emea.redhat.com/kkufova/DROOLS-3128-old.webm
New version can be seen here: http://file.emea.redhat.com/kkufova/DROOLS-3128-new.webm