### PR TITLE
JBPM-7790 - Process instance diagram zoom controls. Fix for standalone webapps

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/SessionScreenView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/SessionScreenView.java
@@ -23,11 +23,5 @@ public interface SessionScreenView extends IsWidget {
 
     void showScreenView(final IsWidget view);
 
-    void setScreenViewBgColor(final String color);
-
-    void setMarginTop(final int px);
-
-    void setPaddingTop(final int px);
-
     void clear();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/SessionScreenViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/SessionScreenViewImpl.java
@@ -61,27 +61,6 @@ public class SessionScreenViewImpl implements SessionScreenView {
     }
 
     @Override
-    public void setScreenViewBgColor(final String color) {
-        screenViewPanel.getElement().getStyle().setBackgroundColor(color);
-    }
-
-    @Override
-    public void setMarginTop(final int px) {
-        this.emptyViewPanel.getElement().getStyle().setMarginTop(px,
-                                                                 Style.Unit.PX);
-        this.screenViewPanel.getElement().getStyle().setMarginTop(px,
-                                                                  Style.Unit.PX);
-    }
-
-    @Override
-    public void setPaddingTop(final int px) {
-        this.emptyViewPanel.getElement().getStyle().setPaddingTop(px,
-                                                                  Style.Unit.PX);
-        this.screenViewPanel.getElement().getStyle().setPaddingTop(px,
-                                                                   Style.Unit.PX);
-    }
-
-    @Override
     public void clear() {
         this.screenViewPanel.clear();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/ScreenPanelViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/ScreenPanelViewImpl.java
@@ -16,10 +16,8 @@
 
 package org.kie.workbench.common.stunner.client.widgets.views.session;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 
-import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
@@ -27,12 +25,32 @@ import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 @Dependent
 public class ScreenPanelViewImpl implements ScreenPanelView {
 
-    private final ResizeFlowPanel panel = new ResizeFlowPanel();
+    static class SizedResizeFlowPanel extends ResizeFlowPanel {
 
-    @PostConstruct
-    public void init() {
-        panel.getElement().getStyle().setWidth(100, Style.Unit.PCT);
-        panel.getElement().getStyle().setHeight(100, Style.Unit.PCT);
+        @Override
+        public void onResize() {
+            final Widget parent = getParent();
+            if (parent != null) {
+                final int w = parent.getOffsetWidth();
+                final int h = parent.getOffsetHeight();
+                setPixelSize(w, h);
+            }
+            doSuperOnResize();
+        }
+
+        void doSuperOnResize() {
+            super.onResize();
+        }
+    }
+
+    private final ResizeFlowPanel panel;
+
+    public ScreenPanelViewImpl() {
+        this(new SizedResizeFlowPanel());
+    }
+
+    ScreenPanelViewImpl(final ResizeFlowPanel panel) {
+        this.panel = panel;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/session/ScreenPanelViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/views/session/ScreenPanelViewImplTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.client.widgets.views.session;
+
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ScreenPanelViewImplTest {
+
+    private static int WIDTH = 10;
+
+    private static int HEIGHT = 20;
+
+    @Mock
+    private Widget parent;
+
+    private ScreenPanelViewImpl.SizedResizeFlowPanel panel;
+
+    private ScreenPanelView view;
+
+    @Before
+    public void setup() {
+        this.panel = spy(new ScreenPanelViewImpl.SizedResizeFlowPanel());
+        this.view = new ScreenPanelViewImpl(panel);
+
+        doReturn(parent).when(panel).getParent();
+    }
+
+    @Test
+    public void testOnResize() {
+        when(parent.getOffsetWidth()).thenReturn(WIDTH);
+        when(parent.getOffsetHeight()).thenReturn(HEIGHT);
+
+        ((ResizeFlowPanel) view.asWidget()).onResize();
+
+        verify(panel).setPixelSize(WIDTH, HEIGHT);
+        verify(panel).doSuperOnResize();
+    }
+}


### PR DESCRIPTION
This PR fixed the DMN and Stunner _standalone_ webapps following [this](https://github.com/kiegroup/kie-wb-common/commit/5099ea6c052402cb6eda6f7ba8e69d335f70f554).

The _canvas_ needs a unbreakable chain of `RequiresResize` from AppFormer to the editor. Furthermore the size of the _canvas_ is taken from the pixel dimensions of its parent. The _standalone_ webapps had a break in pixel sizes in the `Widget` inbetween AppFormer's `PageViewImpl` (a tabs content) and Stunner's `SessionPresenterView` (the graph editor view).

Before JBPM-7790's CSS fix was merged DMN had a CSS selector for `.tab-content > div > div > div { height: 100% }` that had the same effect (but was wrong as it clearly broke JBPM console).