### PR TITLE
DROOLS-3222 Test duration should not start with zeros

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,6 @@ public class TestRunnerReportingScreen
     public TestRunnerReportingScreen() {
         //Zero argument constructor for CDI
     }
-
 
     @Inject
     public TestRunnerReportingScreen(TestRunnerReportingView view,
@@ -129,7 +128,7 @@ public class TestRunnerReportingScreen
         Long runTime = testResultMessage.getRunTime();
         Date runtime = new Date(runTime);
 
-        String milliseconds = (DateTimeFormat.getFormat("SSS").format(runtime) + " milliseconds").replaceFirst("^0+(?!$)", "");
+        String milliseconds = formatMilliseconds(DateTimeFormat.getFormat("SSS").format(runtime)) + " milliseconds";
         String seconds = DateTimeFormat.getFormat("s").format(runtime) + " seconds";
         String minutes = DateTimeFormat.getFormat("m").format(runtime) + " minutes";
 
@@ -140,6 +139,10 @@ public class TestRunnerReportingScreen
         } else {
             return minutes + " and " + seconds;
         }
+    }
+
+    String formatMilliseconds(String originalFormat) {
+        return originalFormat.replaceFirst("^0+(?!$)", "");
     }
 
     private String makeMessage(Failure failure) {

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
@@ -129,7 +129,7 @@ public class TestRunnerReportingScreen
         Long runTime = testResultMessage.getRunTime();
         Date runtime = new Date(runTime);
 
-        String milliseconds = DateTimeFormat.getFormat("SSS").format(runtime) + " milliseconds";
+        String milliseconds = (DateTimeFormat.getFormat("SSS").format(runtime) + " milliseconds").replaceFirst("^0+(?!$)", "");
         String seconds = DateTimeFormat.getFormat("s").format(runtime) + " seconds";
         String minutes = DateTimeFormat.getFormat("m").format(runtime) + " minutes";
 


### PR DESCRIPTION
@danielezonca, @Rikkola, could you please take a look?

I know this solution is not exactly perfect, but it cannot be achieved directly using `DateTimeFormat` and it is not possible to use `SimpleDateFormat` because of GWT.

Before:

![before](https://user-images.githubusercontent.com/16349113/51380509-2c69c000-1b12-11e9-8ff2-2f2fba2ab602.png)

After:

![after](https://user-images.githubusercontent.com/16349113/51380520-3390ce00-1b12-11e9-9587-aa0f7dd5704f.png)