### PR TITLE
DROOLS-3399: [DMN Designer] Data Types - Disable the global 'Save' button when edit mode is enabled

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -23,11 +23,13 @@ import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import elemental2.dom.HTMLElement;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
+import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.SmallSwitchComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.confirmation.DataTypeConfirmation;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.DataTypeConstraint;
@@ -54,6 +56,8 @@ public class DataTypeListItem {
 
     private final DataTypeConfirmation confirmation;
 
+    private final Event<DataTypeEditModeToggleEvent> editModeToggleEvent;
+
     private DataType dataType;
 
     private int level;
@@ -74,13 +78,15 @@ public class DataTypeListItem {
                             final DataTypeConstraint dataTypeConstraintComponent,
                             final SmallSwitchComponent dataTypeListComponent,
                             final DataTypeManager dataTypeManager,
-                            final DataTypeConfirmation confirmation) {
+                            final DataTypeConfirmation confirmation,
+                            final Event<DataTypeEditModeToggleEvent> editModeToggleEvent) {
         this.view = view;
         this.dataTypeSelectComponent = dataTypeSelectComponent;
         this.dataTypeConstraintComponent = dataTypeConstraintComponent;
         this.dataTypeListComponent = dataTypeListComponent;
         this.dataTypeManager = dataTypeManager;
         this.confirmation = confirmation;
+        this.editModeToggleEvent = editModeToggleEvent;
     }
 
     @PostConstruct
@@ -189,6 +195,8 @@ public class DataTypeListItem {
 
         dataTypeSelectComponent.enableEditMode();
         dataTypeConstraintComponent.enableEditMode();
+
+        editModeToggleEvent.fire(new DataTypeEditModeToggleEvent(true));
     }
 
     public void disableEditMode() {
@@ -262,6 +270,8 @@ public class DataTypeListItem {
 
         dataTypeSelectComponent.disableEditMode();
         dataTypeConstraintComponent.disableEditMode();
+
+        editModeToggleEvent.fire(new DataTypeEditModeToggleEvent(false));
     }
 
     void refreshListYesLabel() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/DataTypeEditModeToggleEvent.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/DataTypeEditModeToggleEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.common;
+
+import org.uberfire.workbench.events.UberFireEvent;
+
+public class DataTypeEditModeToggleEvent implements UberFireEvent {
+
+    private final boolean isEditModeEnabled;
+
+    public DataTypeEditModeToggleEvent(final boolean isEditModeEnabled) {
+        this.isEditModeEnabled = isEditModeEnabled;
+    }
+
+    public boolean isEditModeEnabled() {
+        return isEditModeEnabled;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
+import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.SmallSwitchComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.confirmation.DataTypeConfirmation;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.DataTypeConstraint;
@@ -36,12 +37,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.types.persistence.CreationType.ABOVE;
 import static org.kie.workbench.common.dmn.client.editors.types.persistence.CreationType.BELOW;
 import static org.kie.workbench.common.dmn.client.editors.types.persistence.CreationType.NESTED;
@@ -86,6 +90,12 @@ public class DataTypeListItemTest {
     @Mock
     private DataTypeConfirmation confirmation;
 
+    @Mock
+    private EventSourceMock<DataTypeEditModeToggleEvent> editModeToggleEvent;
+
+    @Captor
+    private ArgumentCaptor<DataTypeEditModeToggleEvent> eventArgumentCaptor;
+
     private DataTypeManager dataTypeManager;
 
     private DataTypeListItem listItem;
@@ -93,7 +103,7 @@ public class DataTypeListItemTest {
     @Before
     public void setup() {
         dataTypeManager = spy(new DataTypeManager(null, null, itemDefinitionStore, null, null, null, null, null));
-        listItem = spy(new DataTypeListItem(view, dataTypeSelectComponent, dataTypeConstraintComponent, dataTypeListComponent, dataTypeManager, confirmation));
+        listItem = spy(new DataTypeListItem(view, dataTypeSelectComponent, dataTypeConstraintComponent, dataTypeListComponent, dataTypeManager, confirmation, editModeToggleEvent));
         listItem.init(dataTypeList);
     }
 
@@ -280,6 +290,9 @@ public class DataTypeListItemTest {
         verify(view).hideKebabMenu();
         verify(dataTypeSelectComponent).enableEditMode();
         verify(dataTypeConstraintComponent).enableEditMode();
+        verify(editModeToggleEvent).fire(eventArgumentCaptor.capture());
+
+        assertTrue(eventArgumentCaptor.getValue().isEditModeEnabled());
     }
 
     @Test
@@ -297,6 +310,7 @@ public class DataTypeListItemTest {
         verify(view, never()).hideKebabMenu();
         verify(dataTypeSelectComponent, never()).enableEditMode();
         verify(dataTypeConstraintComponent, never()).enableEditMode();
+        verify(editModeToggleEvent, never()).fire(any());
     }
 
     @Test
@@ -464,6 +478,9 @@ public class DataTypeListItemTest {
         verify(listItem).refreshListYesLabel();
         verify(dataTypeSelectComponent).disableEditMode();
         verify(dataTypeConstraintComponent).disableEditMode();
+        verify(editModeToggleEvent).fire(eventArgumentCaptor.capture());
+
+        assertFalse(eventArgumentCaptor.getValue().isEditModeEnabled());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
@@ -204,6 +204,11 @@
       <artifactId>errai-data-binding</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+
     <!-- Test scope -->
     <dependency>
       <groupId>junit</groupId>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -251,6 +251,8 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
     }
 
     public void onDataTypeEditModeToggle(final @Observes DataTypeEditModeToggleEvent event) {
+        /* Delaying the 'onDataTypeEditModeToggleCallback' since external events
+         * refresh the menu widget and override this change. */
         setTimeout(getOnDataTypeEditModeToggleCallback(event), 250);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -23,6 +23,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import elemental2.dom.DomGlobal;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
@@ -30,6 +31,7 @@ import org.kie.workbench.common.dmn.client.decision.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
+import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
@@ -66,6 +68,7 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
+import org.uberfire.ext.editor.commons.client.menu.MenuItems;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnFocus;
@@ -75,6 +78,8 @@ import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.Menus;
+
+import static elemental2.dom.DomGlobal.setTimeout;
 
 @Dependent
 @DiagramEditor
@@ -243,6 +248,20 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
     @Override
     protected String getEditorIdentifier() {
         return EDITOR_ID;
+    }
+
+    public void onDataTypeEditModeToggle(final @Observes DataTypeEditModeToggleEvent event) {
+        setTimeout(getOnDataTypeEditModeToggleCallback(event), 250);
+    }
+
+    DomGlobal.SetTimeoutCallbackFn getOnDataTypeEditModeToggleCallback(final DataTypeEditModeToggleEvent event) {
+        return (e) -> {
+            if (event.isEditModeEnabled()) {
+                disableMenuItem(MenuItems.SAVE);
+            } else {
+                enableMenuItem(MenuItems.SAVE);
+            }
+        };
     }
 
     void onEditExpressionEvent(final @Observes EditExpressionEvent event) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.client.decision.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
+import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
 import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
@@ -42,6 +43,7 @@ import org.kie.workbench.common.workbench.client.PerspectiveIds;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditor;
+import org.uberfire.ext.editor.commons.client.menu.MenuItems;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
@@ -270,5 +272,31 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         diagramEditor.onDataTypePageNavTabActiveEvent(mock(DataTypePageTabActiveEvent.class));
 
         verify(multiPage).selectPage(2);
+    }
+
+    @Test
+    public void testOnDataTypeEditModeToggleWhenEditModeIsEnabled() {
+
+        final DataTypeEditModeToggleEvent editModeToggleEvent = mock(DataTypeEditModeToggleEvent.class);
+
+        doNothing().when(diagramEditor).disableMenuItem(any());
+        when(editModeToggleEvent.isEditModeEnabled()).thenReturn(true);
+
+        diagramEditor.getOnDataTypeEditModeToggleCallback(editModeToggleEvent).onInvoke();
+
+        verify(diagramEditor).disableMenuItem(MenuItems.SAVE);
+    }
+
+    @Test
+    public void testOnDataTypeEditModeToggleWhenEditModeIsNotEnabled() {
+
+        final DataTypeEditModeToggleEvent editModeToggleEvent = mock(DataTypeEditModeToggleEvent.class);
+
+        doNothing().when(diagramEditor).enableMenuItem(any());
+        when(editModeToggleEvent.isEditModeEnabled()).thenReturn(false);
+
+        diagramEditor.getOnDataTypeEditModeToggleCallback(editModeToggleEvent).onInvoke();
+
+        verify(diagramEditor).enableMenuItem(MenuItems.SAVE);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorV
 import org.kie.workbench.common.dmn.client.editors.toolbar.ToolbarStateHandler;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
+import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNEditorToolbar;
@@ -84,6 +85,7 @@ import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.MenuFactory;
+import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
 @Dependent
@@ -195,6 +197,27 @@ public class SessionDiagramEditorScreen implements KieEditorWrapperView.KieEdito
             load(name,
                  callback);
         }
+    }
+
+    public void onDataTypeEditModeToggle(final @Observes DataTypeEditModeToggleEvent editModeToggleEvent) {
+
+        if (editModeToggleEvent.isEditModeEnabled()) {
+            disableSaveMenuItem();
+        } else {
+            enableSaveMenuItem();
+        }
+    }
+
+    private void disableSaveMenuItem() {
+        getSaveMenuItem().setEnabled(false);
+    }
+
+    private void enableSaveMenuItem() {
+        getSaveMenuItem().setEnabled(true);
+    }
+
+    private MenuItem getSaveMenuItem() {
+        return getMenu().getItems().get(0);
     }
 
     private Menus makeMenuBar() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.showcase.client.screens.editor;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import com.google.gwt.user.client.ui.Widget;
@@ -27,6 +28,7 @@ import org.kie.workbench.common.dmn.client.decision.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
+import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
 import org.kie.workbench.common.dmn.showcase.client.perspectives.AuthoringPerspective;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
@@ -49,7 +51,10 @@ import org.mockito.stubbing.Answer;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditor;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
+import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.Menus;
 
+import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
@@ -225,5 +230,39 @@ public class SessionDiagramEditorScreenTest {
         editor.onDataTypePageNavTabActiveEvent(mock(DataTypePageTabActiveEvent.class));
 
         verify(multiPageEditor).selectPage(1);
+    }
+
+    @Test
+    public void testOnDataTypeEditModeToggleWhenEditModeIsEnabled() {
+
+        final DataTypeEditModeToggleEvent event = mock(DataTypeEditModeToggleEvent.class);
+        final MenuItem menuItem = mock(MenuItem.class);
+        final Menus menus = mock(Menus.class);
+        final List<MenuItem> items = singletonList(menuItem);
+
+        when(menus.getItems()).thenReturn(items);
+        when(event.isEditModeEnabled()).thenReturn(true);
+        doReturn(menus).when(editor).getMenu();
+
+        editor.onDataTypeEditModeToggle(event);
+
+        verify(menuItem).setEnabled(false);
+    }
+
+    @Test
+    public void testOnDataTypeEditModeToggleWhenEditModeIsNotEnabled() {
+
+        final DataTypeEditModeToggleEvent event = mock(DataTypeEditModeToggleEvent.class);
+        final MenuItem menuItem = mock(MenuItem.class);
+        final Menus menus = mock(Menus.class);
+        final List<MenuItem> items = singletonList(menuItem);
+
+        when(menus.getItems()).thenReturn(items);
+        when(event.isEditModeEnabled()).thenReturn(false);
+        doReturn(menus).when(editor).getMenu();
+
+        editor.onDataTypeEditModeToggle(event);
+
+        verify(menuItem).setEnabled(true);
     }
 }


### PR DESCRIPTION
See: https://issues.jboss.org/browse/DROOLS-3399

![2019-01-20 23 11 27](https://user-images.githubusercontent.com/1079279/51448991-2c83de80-1d11-11e9-9466-543dadc760ad.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/609
- https://github.com/kiegroup/kie-wb-common/pull/2411

---

There's a corner case on this PR. When the user opens two DTs on edit mode and saves the first one, the "Save" button is enabled. However, since we'll prohibit the parallel edition ([DROOLS-3015](https://issues.jboss.org/browse/DROOLS-3015)), I don't think we need to fix this here.