### PR TITLE
DROOLS-3537: [DMN Designer] Unexpected error appears when diagram is created

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/documentation/DefaultDiagramDocumentationView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/documentation/DefaultDiagramDocumentationView.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
-import javax.enterprise.inject.Specializes;
 
 import com.google.gwt.user.client.ui.Composite;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
@@ -28,7 +27,8 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 
 /**
  * Default dummy implementation of {@link DocumentationView}. To implement a {@link DocumentationView} for the domain,
- * this should be extended and annotated with {@link Specializes}. *
+ * this should be extended and annotated with the applicable discriminator qualifier for the domain. For example
+ * {@link @BPMN} or {@link @DMNEditor} etc.
  */
 @Dependent
 @Templated

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/documentation/BPMNDocumentationView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/documentation/BPMNDocumentationView.java
@@ -21,7 +21,6 @@ import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Specializes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -29,6 +28,7 @@ import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.stunner.bpmn.documentation.BPMNDocumentationService;
+import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.documentation.DefaultDiagramDocumentationView;
@@ -38,8 +38,8 @@ import org.kie.workbench.common.stunner.forms.client.event.FormFieldChanged;
 import org.uberfire.client.views.pfly.icon.PatternFlyIconType;
 import org.uberfire.client.views.pfly.widgets.Button;
 
+@BPMN
 @Dependent
-@Specializes
 @Templated
 public class BPMNDocumentationView extends DefaultDiagramDocumentationView {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditor.java
@@ -25,6 +25,7 @@ import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.bpmn.project.client.resources.BPMNClientConstants;
 import org.kie.workbench.common.stunner.bpmn.project.client.type.BPMNDiagramResourceType;
+import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
 import org.kie.workbench.common.stunner.client.widgets.popups.PopupUtil;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
@@ -77,7 +78,7 @@ public class BPMNDiagramEditor extends AbstractProjectDiagramEditor<BPMNDiagramR
 
     @Inject
     public BPMNDiagramEditor(final View view,
-                             final DocumentationView documentationView,
+                             final @BPMN DocumentationView documentationView,
                              final PlaceManager placeManager,
                              final ErrorPopupPresenter errorPopupPresenter,
                              final Event<ChangeTitleWidgetEvent> changeTitleNotificationEvent,


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3537

Further to https://github.com/kiegroup/kie-wb-common/pull/2363 whilst it is acceptable to use the `DocumentationView` _override_ specified in the JavaDocs for the BPMN editor in _standalone_ mode; when there are several Stunner-based Editors in the workbench (Business Central, that has BPMN, DMN and CM) the override affected ALL such editors. This change allows the different domains to provide their own `DocumentationView` implementation.