### PR TITLE
[Stunner] Use try with resources. Ensure XMLEncoder is flushed before Stream is closed

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/service/XMLEncoderDiagramMetadataMarshaller.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/main/java/org/kie/workbench/common/stunner/core/backend/service/XMLEncoderDiagramMetadataMarshaller.java
@@ -41,11 +41,11 @@ public class XMLEncoderDiagramMetadataMarshaller implements DiagramMetadataMarsh
 
     @Override
     public String marshall(final Metadata metadata) throws IOException {
-        try (final ByteArrayOutputStream os = new ByteArrayOutputStream();
-             final XMLEncoder encoder = new XMLEncoder(os)) {
-            encoder.writeObject(metadata);
-            String raw = os.toString(CHARSET);
-            return raw;
-        }
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        XMLEncoder encoder = new XMLEncoder(os);
+        encoder.writeObject(metadata);
+        encoder.close();
+        String raw = os.toString(CHARSET);
+        return raw;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/service/XMLEncoderDiagramMetadataMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/service/XMLEncoderDiagramMetadataMarshallerTest.java
@@ -26,7 +26,9 @@ import org.kie.workbench.common.stunner.core.diagram.MetadataImpl;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class XMLEncoderDiagramMetadataMarshallerTest {
@@ -50,6 +52,9 @@ public class XMLEncoderDiagramMetadataMarshallerTest {
         metadata.setTitle("title1");
         String result = tested.marshall(metadata);
         assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertTrue(result.contains("<java"));
+        assertTrue(result.contains("</java>"));
     }
 
     @Test


### PR DESCRIPTION
Further to https://github.com/kiegroup/kie-wb-common/pull/2406 this PR ensures the `XMLEncoder` is flushed to the `OutputStream` before the stream is closed (by the try with resources block)