### PR TITLE
JBPM-8157: Stunner - Documentation page produces an error when a process with a UserTask is being opened

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/documentation/ClientBPMNDocumentationService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/documentation/ClientBPMNDocumentationService.java
@@ -304,7 +304,12 @@ public class ClientBPMNDocumentationService implements BPMNDocumentationService 
         final Set<?> properties = definitionManager.adapters().forDefinition().getProperties(definition);
         return properties.stream()
                 .filter(prop -> !ignoredPropertiesIds.containsKey(propertyAdapter.getId(prop)))
+                .filter(prop -> isNotEmpty(propertyAdapter.getCaption(prop)))
                 .collect(Collectors.toMap(propertyAdapter::getCaption, this::getElementValue));
+    }
+
+    private static boolean isNotEmpty(String value) {
+        return null != value && value.trim().length() > 0;
     }
 
     private String getElementValue(Object prop) {


### PR DESCRIPTION
Hey @hasys  @wmedvede 

This is a quick fix for [JBPM-8157](https://issues.jboss.org/browse/JBPM-8157). 

I have reassigned the ticket to @tiagodolphine , because I'm not really sure if that's the right fix and also because there are still missing the tests, but at least this commit fixes this bug, which is urgent, as it's being produced lot of times and really on the initial authoring stages... 

So for now, if you agree, let's commit this fix and let @tiagodolphine check and test it properly once he's back. WDYT?  

Thanks!