### PR TITLE
DROOLS-2262: [DMN Designer] DRD Grid Column width is not preserved

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasComponentWidths.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasComponentWidths.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition;
+
+import java.util.List;
+
+public interface HasComponentWidths {
+
+    List<Double> getComponentWidths();
+
+    int getRequiredComponentWidthCount();
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasComponentWidths.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasComponentWidths.java
@@ -18,9 +18,20 @@ package org.kie.workbench.common.dmn.api.definition;
 
 import java.util.List;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+
 public interface HasComponentWidths {
 
+    /**
+     * Gets a list of the widths of the different components. A component is considered
+     * a column used to visually represent a Boxed {@link Expression} Grid in the editor.
+     * @return
+     */
     List<Double> getComponentWidths();
 
+    /**
+     * Returns the expected number of components to correctly represent an {@link Expression} in the editor.
+     * @return
+     */
     int getRequiredComponentWidthCount();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/HasExpression.java
@@ -33,4 +33,21 @@ public interface HasExpression {
     default boolean isClearSupported() {
         return true;
     }
+
+    HasExpression NOP = new HasExpression() {
+        @Override
+        public Expression getExpression() {
+            return null;
+        }
+
+        @Override
+        public void setExpression(final Expression expression) {
+
+        }
+
+        @Override
+        public DMNModelInstrumentedBase asDMNModelInstrumentedBase() {
+            return null;
+        }
+    };
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Context.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Context.java
@@ -30,6 +30,8 @@ import static org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRef
 @Portable
 public class Context extends Expression {
 
+    private static final int STATIC_COLUMNS = 3;
+
     private List<ContextEntry> contextEntry;
 
     public Context() {
@@ -61,6 +63,11 @@ public class Context extends Expression {
         hasTypeRefs.addAll(getFlatHasTypeRefs(getContextEntry()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public int getRequiredComponentWidthCount() {
+        return STATIC_COLUMNS;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Context.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Context.java
@@ -90,6 +90,9 @@ public class Context extends Expression {
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
+        if (componentWidths != null ? !componentWidths.equals(that.componentWidths) : that.componentWidths != null) {
+            return false;
+        }
         return contextEntry != null ? contextEntry.equals(that.contextEntry) : that.contextEntry == null;
     }
 
@@ -98,6 +101,7 @@ public class Context extends Expression {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          description != null ? description.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
+                                         componentWidths != null ? componentWidths.hashCode() : 0,
                                          contextEntry != null ? contextEntry.hashCode() : 0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTable.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTable.java
@@ -30,6 +30,8 @@ import static org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRef
 @Portable
 public class DecisionTable extends Expression {
 
+    private static final int STATIC_COLUMNS = 2;
+
     private List<InputClause> input;
     private List<OutputClause> output;
     private List<DecisionRule> rule;
@@ -144,6 +146,11 @@ public class DecisionTable extends Expression {
         hasTypeRefs.addAll(getFlatHasTypeRefs(getRule()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public int getRequiredComponentWidthCount() {
+        return getInput().size() + getOutput().size() + STATIC_COLUMNS;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTable.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTable.java
@@ -173,6 +173,9 @@ public class DecisionTable extends Expression {
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
+        if (componentWidths != null ? !componentWidths.equals(that.componentWidths) : that.componentWidths != null) {
+            return false;
+        }
         if (input != null ? !input.equals(that.input) : that.input != null) {
             return false;
         }
@@ -199,6 +202,7 @@ public class DecisionTable extends Expression {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          description != null ? description.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
+                                         componentWidths != null ? componentWidths.hashCode() : 0,
                                          input != null ? input.hashCode() : 0,
                                          output != null ? output.hashCode() : 0,
                                          rule != null ? rule.hashCode() : 0,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Expression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Expression.java
@@ -17,7 +17,9 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
@@ -25,9 +27,12 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 
 import static java.util.Collections.singletonList;
 
-public abstract class Expression extends DMNElement implements HasTypeRef {
+public abstract class Expression extends DMNElement implements HasTypeRef,
+                                                               HasComponentWidths {
 
     protected QName typeRef;
+
+    protected java.util.List<Double> componentWidths = new ArrayList<>();
 
     public Expression() {
     }
@@ -52,6 +57,16 @@ public abstract class Expression extends DMNElement implements HasTypeRef {
     @Override
     public void setTypeRef(final QName typeRef) {
         this.typeRef = typeRef;
+    }
+
+    @Override
+    public java.util.List<Double> getComponentWidths() {
+        final int requiredComponentWidthCount = getRequiredComponentWidthCount();
+        if (componentWidths.size() != requiredComponentWidthCount) {
+            componentWidths = new ArrayList<>(requiredComponentWidthCount);
+            IntStream.range(0, requiredComponentWidthCount).forEach(i -> componentWidths.add(null));
+        }
+        return componentWidths;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
@@ -127,6 +127,9 @@ public class FunctionDefinition extends Expression implements HasExpression {
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
+        if (componentWidths != null ? !componentWidths.equals(that.componentWidths) : that.componentWidths != null) {
+            return false;
+        }
         if (expression != null ? !expression.equals(that.expression) : that.expression != null) {
             return false;
         }
@@ -138,6 +141,7 @@ public class FunctionDefinition extends Expression implements HasExpression {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          description != null ? description.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
+                                         componentWidths != null ? componentWidths.hashCode() : 0,
                                          expression != null ? expression.hashCode() : 0,
                                          formalParameter != null ? formalParameter.hashCode() : 0);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinition.java
@@ -32,6 +32,8 @@ import static org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRef
 @Portable
 public class FunctionDefinition extends Expression implements HasExpression {
 
+    private static final int STATIC_COLUMNS = 2;
+
     private Expression expression;
 
     private Kind kind = Kind.FEEL; // same default as per DMN spec.
@@ -98,6 +100,11 @@ public class FunctionDefinition extends Expression implements HasExpression {
         hasTypeRefs.addAll(getFlatHasTypeRefs(getFormalParameter()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public int getRequiredComponentWidthCount() {
+        return STATIC_COLUMNS;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClauseUnaryTests.java
@@ -47,9 +47,9 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Bindable
 @PropertySet
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
-    defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-    i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests"),
-    startElement = "text")
+        defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests"),
+        startElement = "text")
 public class InputClauseUnaryTests extends DMNModelInstrumentedBase implements IsUnaryTests,
                                                                                DMNPropertySet {
 
@@ -61,12 +61,12 @@ public class InputClauseUnaryTests extends DMNModelInstrumentedBase implements I
 
     @Property
     @FormField(afterElement = "text",
-        labelKey = "constraintType",
-        type = ListBoxFieldType.class,
-        settings = {@FieldParam(name = "addEmptyOption", value = "expression")})
+            labelKey = "constraintType",
+            type = ListBoxFieldType.class,
+            settings = {@FieldParam(name = "addEmptyOption", value = "expression")})
     @SelectorDataProvider(
-        type = SelectorDataProvider.ProviderType.CLIENT,
-        className = "org.kie.workbench.common.dmn.api.property.dmn.dataproviders.ConstraintTypeDataProvider")
+            type = SelectorDataProvider.ProviderType.CLIENT,
+            className = "org.kie.workbench.common.dmn.api.property.dmn.dataproviders.ConstraintTypeDataProvider")
     protected ConstraintTypeProperty constraintTypeProperty;
 
     public InputClauseUnaryTests() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Invocation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Invocation.java
@@ -32,6 +32,8 @@ import static org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRef
 @Portable
 public class Invocation extends Expression implements HasExpression {
 
+    private static final int STATIC_COLUMNS = 3;
+
     private Expression expression;
     private List<Binding> binding;
 
@@ -86,6 +88,11 @@ public class Invocation extends Expression implements HasExpression {
         hasTypeRefs.addAll(getFlatHasTypeRefs(getBinding()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public int getRequiredComponentWidthCount() {
+        return STATIC_COLUMNS;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Invocation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Invocation.java
@@ -115,6 +115,9 @@ public class Invocation extends Expression implements HasExpression {
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
+        if (componentWidths != null ? !componentWidths.equals(that.componentWidths) : that.componentWidths != null) {
+            return false;
+        }
         if (expression != null ? !expression.equals(that.expression) : that.expression != null) {
             return false;
         }
@@ -126,6 +129,7 @@ public class Invocation extends Expression implements HasExpression {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          description != null ? description.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
+                                         componentWidths != null ? componentWidths.hashCode() : 0,
                                          expression != null ? expression.hashCode() : 0,
                                          binding != null ? binding.hashCode() : 0);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/List.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/List.java
@@ -92,6 +92,9 @@ public class List extends Expression {
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
+        if (componentWidths != null ? !componentWidths.equals(that.componentWidths) : that.componentWidths != null) {
+            return false;
+        }
         return expression != null ? expression.equals(that.expression) : that.expression == null;
     }
 
@@ -100,6 +103,7 @@ public class List extends Expression {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          description != null ? description.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
+                                         componentWidths != null ? componentWidths.hashCode() : 0,
                                          expression != null ? expression.hashCode() : 0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/List.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/List.java
@@ -29,6 +29,8 @@ import static org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRef
 @Portable
 public class List extends Expression {
 
+    private static final int STATIC_COLUMNS = 1;
+
     private java.util.List<Expression> expression;
 
     public List() {
@@ -63,6 +65,11 @@ public class List extends Expression {
         hasTypeRefs.addAll(getFlatHasTypeRefs(getExpression()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public int getRequiredComponentWidthCount() {
+        return getExpression().size() + STATIC_COLUMNS;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
@@ -170,6 +170,9 @@ public class LiteralExpression extends Expression implements IsLiteralExpression
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
+        if (componentWidths != null ? !componentWidths.equals(that.componentWidths) : that.componentWidths != null) {
+            return false;
+        }
         if (text != null ? !text.equals(that.text) : that.text != null) {
             return false;
         }
@@ -184,6 +187,7 @@ public class LiteralExpression extends Expression implements IsLiteralExpression
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          description != null ? description.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
+                                         componentWidths != null ? componentWidths.hashCode() : 0,
                                          text != null ? text.hashCode() : 0,
                                          importedValues != null ? importedValues.hashCode() : 0,
                                          expressionLanguage != null ? expressionLanguage.hashCode() : 0);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpression.java
@@ -50,6 +50,8 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 public class LiteralExpression extends Expression implements IsLiteralExpression,
                                                              DomainObject {
 
+    private static final int STATIC_COLUMNS = 1;
+
     @Category
     private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
 
@@ -141,6 +143,11 @@ public class LiteralExpression extends Expression implements IsLiteralExpression
     @Override
     public String getDomainObjectNameTranslationKey() {
         return DMNAPIConstants.LiteralExpression_DomainObjectName;
+    }
+
+    @Override
+    public int getRequiredComponentWidthCount() {
+        return STATIC_COLUMNS;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Relation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Relation.java
@@ -104,6 +104,9 @@ public class Relation extends Expression {
         if (typeRef != null ? !typeRef.equals(that.typeRef) : that.typeRef != null) {
             return false;
         }
+        if (componentWidths != null ? !componentWidths.equals(that.componentWidths) : that.componentWidths != null) {
+            return false;
+        }
         if (column != null ? !column.equals(that.column) : that.column != null) {
             return false;
         }
@@ -115,6 +118,7 @@ public class Relation extends Expression {
         return HashUtil.combineHashCodes(id != null ? id.hashCode() : 0,
                                          description != null ? description.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0,
+                                         componentWidths != null ? componentWidths.hashCode() : 0,
                                          column != null ? column.hashCode() : 0,
                                          row != null ? row.hashCode() : 0);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Relation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/Relation.java
@@ -29,6 +29,8 @@ import static org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRef
 @Portable
 public class Relation extends Expression {
 
+    public static final int STATIC_COLUMNS = 1;
+
     private java.util.List<InformationItem> column;
     private java.util.List<List> row;
 
@@ -75,6 +77,11 @@ public class Relation extends Expression {
         hasTypeRefs.addAll(getFlatHasTypeRefs(getRow()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public int getRequiredComponentWidthCount() {
+        return getColumn().size() + STATIC_COLUMNS;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/UnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/v1_1/UnaryTests.java
@@ -44,8 +44,8 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Bindable
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
-    defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-    startElement = "id")
+        defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
+        startElement = "id")
 public class UnaryTests extends DMNElement implements IsUnaryTests,
                                                       DomainObject {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/BindingTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/BindingTest.java
@@ -78,7 +78,6 @@ public class BindingTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final Expression expression = mock(Expression.class);
         final InformationItem parameter = mock(InformationItem.class);
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModelTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/BusinessKnowledgeModelTest.java
@@ -31,7 +31,6 @@ public class BusinessKnowledgeModelTest {
 
     @Test
     public void testConstructor() {
-
         final Id id = mock(Id.class);
         final Description description = mock(Description.class);
         final Name name = mock(Name.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ConstraintTypeTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ConstraintTypeTest.java
@@ -24,28 +24,28 @@ public class ConstraintTypeTest {
 
     @Test
     public void testEnumerationString() {
-        testFromString(ConstraintType.ENUMERATION,"enumeration");
-        testFromString(ConstraintType.ENUMERATION,"Enumeration");
-        testFromString(ConstraintType.ENUMERATION,"ENUMERATION");
+        testFromString(ConstraintType.ENUMERATION, "enumeration");
+        testFromString(ConstraintType.ENUMERATION, "Enumeration");
+        testFromString(ConstraintType.ENUMERATION, "ENUMERATION");
     }
 
     @Test
     public void testExpressionString() {
-        testFromString(ConstraintType.EXPRESSION,"expression");
-        testFromString(ConstraintType.EXPRESSION,"Expression");
-        testFromString(ConstraintType.EXPRESSION,"EXPRESSION");
+        testFromString(ConstraintType.EXPRESSION, "expression");
+        testFromString(ConstraintType.EXPRESSION, "Expression");
+        testFromString(ConstraintType.EXPRESSION, "EXPRESSION");
     }
 
     @Test
     public void testRangeString() {
-        testFromString(ConstraintType.RANGE,"range");
-        testFromString(ConstraintType.RANGE,"Range");
-        testFromString(ConstraintType.RANGE,"RANGE");
+        testFromString(ConstraintType.RANGE, "range");
+        testFromString(ConstraintType.RANGE, "Range");
+        testFromString(ConstraintType.RANGE, "RANGE");
     }
 
     @Test
     public void testUnknownString() {
-        testFromString(null,"unknownvalue");
+        testFromString(null, "unknownvalue");
     }
 
     private void testFromString(ConstraintType expected, String value) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextEntryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextEntryTest.java
@@ -47,7 +47,6 @@ public class ContextEntryTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final Expression expression = mock(Expression.class);
         final InformationItem variable = mock(InformationItem.class);
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,5 +64,12 @@ public class ContextTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(context, hasTypeRef1, hasTypeRef2);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(context.getRequiredComponentWidthCount(),
+                     context.getComponentWidths().size());
+        context.getComponentWidths().forEach(Assert::assertNull);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ContextTest.java
@@ -48,7 +48,6 @@ public class ContextTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final ContextEntry contextEntry1 = mock(ContextEntry.class);
         final ContextEntry contextEntry2 = mock(ContextEntry.class);
         final List<ContextEntry> contextEntry = asList(contextEntry1, contextEntry2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionRuleTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionRuleTest.java
@@ -47,7 +47,6 @@ public class DecisionRuleTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final LiteralExpression literalExpression1 = mock(LiteralExpression.class);
         final LiteralExpression literalExpression2 = mock(LiteralExpression.class);
         final List<LiteralExpression> outputEntry = asList(literalExpression1, literalExpression2);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTableTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTableTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,5 +78,12 @@ public class DecisionTableTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(decisionTable, hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4, hasTypeRef5, hasTypeRef6);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(decisionTable.getRequiredComponentWidthCount(),
+                     decisionTable.getComponentWidths().size());
+        decisionTable.getComponentWidths().forEach(Assert::assertNull);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTableTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTableTest.java
@@ -54,7 +54,6 @@ public class DecisionTableTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final List<InputClause> inputClauses = asList(mock(InputClause.class), mock(InputClause.class));
         final List<OutputClause> outputClauses = asList(mock(OutputClause.class), mock(OutputClause.class));
         final List<DecisionRule> decisionRules = asList(mock(DecisionRule.class), mock(DecisionRule.class));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/DecisionTest.java
@@ -33,7 +33,6 @@ public class DecisionTest {
 
     @Test
     public void testConstructor() {
-
         final Id id = mock(Id.class);
         final Description description = mock(Description.class);
         final Name name = mock(Name.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ExpressionTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
@@ -33,6 +34,10 @@ public class ExpressionTest {
     @Before
     public void setup() {
         this.expression = spy(new Expression() {
+            @Override
+            public int getRequiredComponentWidthCount() {
+                return 1;
+            }
         });
     }
 
@@ -43,5 +48,12 @@ public class ExpressionTest {
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(expression);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(expression.getRequiredComponentWidthCount(),
+                     expression.getComponentWidths().size());
+        expression.getComponentWidths().forEach(Assert::assertNull);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ExpressionTest.java
@@ -25,7 +25,6 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.spy;
 
 public class ExpressionTest {
 
@@ -33,17 +32,16 @@ public class ExpressionTest {
 
     @Before
     public void setup() {
-        this.expression = spy(new Expression() {
+        this.expression = new Expression() {
             @Override
             public int getRequiredComponentWidthCount() {
                 return 1;
             }
-        });
+        };
     }
 
     @Test
     public void testGetHasTypeRefs() {
-
         final List<HasTypeRef> actualHasTypeRefs = expression.getHasTypeRefs();
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(expression);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinitionTest.java
@@ -48,7 +48,6 @@ public class FunctionDefinitionTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final Expression expression = mock(Expression.class);
         final InformationItem informationItem1 = mock(InformationItem.class);
         final InformationItem informationItem2 = mock(InformationItem.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/FunctionDefinitionTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,5 +69,12 @@ public class FunctionDefinitionTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(functionDefinition, hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(functionDefinition.getRequiredComponentWidthCount(),
+                     functionDefinition.getComponentWidths().size());
+        functionDefinition.getComponentWidths().forEach(Assert::assertNull);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItemPrimaryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InformationItemPrimaryTest.java
@@ -38,7 +38,6 @@ public class InformationItemPrimaryTest {
 
     @Test
     public void testTypeRefHolderWrapsTypeRef() {
-
         final QName typeRef = informationItemPrimary.getTypeRef();
         final QNameHolder typeRefHolder = informationItemPrimary.getTypeRefHolder();
 
@@ -47,7 +46,6 @@ public class InformationItemPrimaryTest {
 
     @Test
     public void testTypeRefHolderWrapsTypeRefAfterSettingTypeRef() {
-
         final QName typeRef = new QName();
 
         informationItemPrimary.setTypeRef(typeRef);
@@ -60,7 +58,6 @@ public class InformationItemPrimaryTest {
 
     @Test
     public void testTypeRefHolderWrapsTYpeRefAfterSettingTypeRefHolder() {
-
         final QName typeRef = informationItemPrimary.getTypeRef();
         final QNameHolder typeRefHolder = new QNameHolder();
 
@@ -71,7 +68,6 @@ public class InformationItemPrimaryTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final List<HasTypeRef> actualHasTypeRefs = informationItemPrimary.getHasTypeRefs();
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(informationItemPrimary);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputClauseTest.java
@@ -47,7 +47,6 @@ public class InputClauseTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final LiteralExpression literalExpression = mock(LiteralExpression.class);
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);
         final HasTypeRef hasTypeRef2 = mock(HasTypeRef.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InputDataTest.java
@@ -31,7 +31,6 @@ public class InputDataTest {
 
     @Test
     public void testConstructor() {
-
         final Id id = mock(Id.class);
         final Description description = mock(Description.class);
         final Name name = mock(Name.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InvocationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InvocationTest.java
@@ -48,7 +48,6 @@ public class InvocationTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final Expression expression = mock(Expression.class);
         final List<Binding> binding = asList(mock(Binding.class), mock(Binding.class));
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InvocationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/InvocationTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,5 +67,12 @@ public class InvocationTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(invocation, hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(invocation.getRequiredComponentWidthCount(),
+                     invocation.getComponentWidths().size());
+        invocation.getComponentWidths().forEach(Assert::assertNull);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ItemDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ItemDefinitionTest.java
@@ -36,7 +36,6 @@ public class ItemDefinitionTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final List<HasTypeRef> actualHasTypeRefs = itemDefinition.getHasTypeRefs();
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(itemDefinition);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ListTest.java
@@ -48,7 +48,6 @@ public class ListTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final List<Expression> expression = asList(mock(Expression.class), mock(Expression.class));
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);
         final HasTypeRef hasTypeRef2 = mock(HasTypeRef.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/ListTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,5 +62,12 @@ public class ListTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(list, hasTypeRef1, hasTypeRef2);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(list.getRequiredComponentWidthCount(),
+                     list.getComponentWidths().size());
+        list.getComponentWidths().forEach(Assert::assertNull);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpressionTest.java
@@ -20,12 +20,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRefHelper;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.spy;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({HasTypeRefHelper.class})
@@ -35,7 +36,15 @@ public class LiteralExpressionTest {
 
     @Before
     public void setup() {
-        this.literalExpression = spy(new LiteralExpression());
+        this.literalExpression = new LiteralExpression();
+    }
+
+    @Test
+    public void testGetHasTypeRefs() {
+        final java.util.List<HasTypeRef> actualHasTypeRefs = literalExpression.getHasTypeRefs();
+        final java.util.List<HasTypeRef> expectedHasTypeRefs = singletonList(literalExpression);
+
+        assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/LiteralExpressionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.v1_1;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRefHelper;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({HasTypeRefHelper.class})
+public class LiteralExpressionTest {
+
+    private LiteralExpression literalExpression;
+
+    @Before
+    public void setup() {
+        this.literalExpression = spy(new LiteralExpression());
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(literalExpression.getRequiredComponentWidthCount(),
+                     literalExpression.getComponentWidths().size());
+        literalExpression.getComponentWidths().forEach(Assert::assertNull);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClauseLiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClauseLiteralExpressionTest.java
@@ -36,7 +36,6 @@ public class OutputClauseLiteralExpressionTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final List<HasTypeRef> actualHasTypeRefs = outputClauseLiteralExpression.getHasTypeRefs();
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(outputClauseLiteralExpression);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/OutputClauseTest.java
@@ -47,7 +47,6 @@ public class OutputClauseTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final OutputClauseLiteralExpression outputClauseLiteralExpression = mock(OutputClauseLiteralExpression.class);
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);
         final HasTypeRef hasTypeRef2 = mock(HasTypeRef.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/RelationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/RelationTest.java
@@ -48,7 +48,6 @@ public class RelationTest {
 
     @Test
     public void testGetHasTypeRefs() {
-
         final List<InformationItem> column = asList(mock(InformationItem.class), mock(InformationItem.class));
         final List<org.kie.workbench.common.dmn.api.definition.v1_1.List> row = asList(mock(org.kie.workbench.common.dmn.api.definition.v1_1.List.class), mock(org.kie.workbench.common.dmn.api.definition.v1_1.List.class));
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/RelationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/v1_1/RelationTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.v1_1;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,5 +67,12 @@ public class RelationTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(relation, hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testComponentWidths() {
+        assertEquals(relation.getRequiredComponentWidthCount(),
+                     relation.getComponentWidths().size());
+        relation.getComponentWidths().forEach(Assert::assertNull);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverter.java
@@ -16,18 +16,25 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Binding;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 
 public class BindingPropertyConverter {
 
-    public static Binding wbFromDMN(final org.kie.dmn.model.api.Binding dmn) {
+    public static Binding wbFromDMN(final org.kie.dmn.model.api.Binding dmn,
+                                    final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         if (dmn == null) {
             return null;
         }
         InformationItem convertedParameter = InformationItemPropertyConverter.wbFromDMN(dmn.getParameter());
-        Expression convertedExpression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
+        Expression convertedExpression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression(),
+                                                                               hasComponentWidthsConsumer);
 
         Binding result = new Binding();
         if (convertedParameter != null) {
@@ -41,13 +48,15 @@ public class BindingPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.api.Binding dmnFromWB(final Binding wb) {
+    public static org.kie.dmn.model.api.Binding dmnFromWB(final Binding wb,
+                                                          final Consumer<ComponentWidths> componentWidthsConsumer) {
         if (wb == null) {
             return null;
         }
         org.kie.dmn.model.api.Binding result = new org.kie.dmn.model.v1_2.TBinding();
         org.kie.dmn.model.api.InformationItem convertedParameter = InformationItemPropertyConverter.dmnFromWB(wb.getParameter());
-        org.kie.dmn.model.api.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        org.kie.dmn.model.api.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
+                                                                                                     componentWidthsConsumer);
 
         if (convertedParameter != null) {
             convertedParameter.setParent(result);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
@@ -17,7 +17,10 @@
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionService;
@@ -31,6 +34,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -46,7 +50,8 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
     }
 
     @Override
-    public Node<View<BusinessKnowledgeModel>, ?> nodeFromDMN(final org.kie.dmn.model.api.BusinessKnowledgeModel dmn) {
+    public Node<View<BusinessKnowledgeModel>, ?> nodeFromDMN(final org.kie.dmn.model.api.BusinessKnowledgeModel dmn,
+                                                             final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         @SuppressWarnings("unchecked")
         Node<View<BusinessKnowledgeModel>, ?> node = (Node<View<BusinessKnowledgeModel>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                                        BusinessKnowledgeModel.class).asNode();
@@ -54,7 +59,8 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         Name name = new Name(dmn.getName());
         InformationItemPrimary informationItem = InformationItemPrimaryPropertyConverter.wbFromDMN(dmn.getVariable());
-        FunctionDefinition functionDefinition = FunctionDefinitionPropertyConverter.wbFromDMN(dmn.getEncapsulatedLogic());
+        FunctionDefinition functionDefinition = FunctionDefinitionPropertyConverter.wbFromDMN(dmn.getEncapsulatedLogic(),
+                                                                                              hasComponentWidthsConsumer);
         BusinessKnowledgeModel bkm = new BusinessKnowledgeModel(id,
                                                                 description,
                                                                 name,
@@ -76,7 +82,8 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
     }
 
     @Override
-    public org.kie.dmn.model.api.BusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node) {
+    public org.kie.dmn.model.api.BusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node,
+                                                                    final Consumer<ComponentWidths> componentWidthsConsumer) {
         BusinessKnowledgeModel source = node.getContent().getDefinition();
         org.kie.dmn.model.api.BusinessKnowledgeModel result = new org.kie.dmn.model.v1_2.TBusinessKnowledgeModel();
         result.setId(source.getId().getValue());
@@ -87,7 +94,8 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
             variable.setParent(result);
         }
         result.setVariable(variable);
-        org.kie.dmn.model.api.FunctionDefinition functionDefinition = FunctionDefinitionPropertyConverter.dmnFromWB(source.getEncapsulatedLogic());
+        org.kie.dmn.model.api.FunctionDefinition functionDefinition = FunctionDefinitionPropertyConverter.dmnFromWB(source.getEncapsulatedLogic(),
+                                                                                                                    componentWidthsConsumer);
         if (functionDefinition != null) {
             functionDefinition.setParent(result);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
@@ -16,15 +16,22 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ContextEntry;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 
 public class ContextEntryPropertyConverter {
 
-    public static ContextEntry wbFromDMN(final org.kie.dmn.model.api.ContextEntry dmn) {
+    public static ContextEntry wbFromDMN(final org.kie.dmn.model.api.ContextEntry dmn,
+                                         final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         InformationItem variable = InformationItemPropertyConverter.wbFromDMN(dmn.getVariable());
-        Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
+        Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression(),
+                                                                      hasComponentWidthsConsumer);
 
         ContextEntry result = new ContextEntry();
         if (variable != null) {
@@ -38,14 +45,16 @@ public class ContextEntryPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.api.ContextEntry dmnFromWB(final ContextEntry wb) {
+    public static org.kie.dmn.model.api.ContextEntry dmnFromWB(final ContextEntry wb,
+                                                               final Consumer<ComponentWidths> componentWidthsConsumer) {
         org.kie.dmn.model.api.ContextEntry result = new org.kie.dmn.model.v1_2.TContextEntry();
 
         org.kie.dmn.model.api.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
         if (variable != null) {
             variable.setParent(result);
         }
-        org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
+                                                                                            componentWidthsConsumer);
         if (expression != null) {
             expression.setParent(result);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
@@ -17,7 +17,10 @@
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
@@ -35,6 +38,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.Question;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -51,7 +55,8 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.De
     }
 
     @Override
-    public Node<View<Decision>, ?> nodeFromDMN(final org.kie.dmn.model.api.Decision dmn) {
+    public Node<View<Decision>, ?> nodeFromDMN(final org.kie.dmn.model.api.Decision dmn,
+                                               final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         @SuppressWarnings("unchecked")
         Node<View<Decision>, ?> node = (Node<View<Decision>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                            Decision.class).asNode();
@@ -59,7 +64,8 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.De
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         Name name = new Name(dmn.getName());
         InformationItemPrimary informationItem = InformationItemPrimaryPropertyConverter.wbFromDMN(dmn.getVariable());
-        Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
+        Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression(),
+                                                                      hasComponentWidthsConsumer);
         Decision decision = new Decision(id,
                                          description,
                                          name,
@@ -85,7 +91,8 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.De
     }
 
     @Override
-    public org.kie.dmn.model.api.Decision dmnFromNode(final Node<View<Decision>, ?> node) {
+    public org.kie.dmn.model.api.Decision dmnFromNode(final Node<View<Decision>, ?> node,
+                                                      final Consumer<ComponentWidths> componentWidthsConsumer) {
         Decision source = node.getContent().getDefinition();
         org.kie.dmn.model.api.Decision d = new org.kie.dmn.model.v1_2.TDecision();
         d.setId(source.getId().getValue());
@@ -96,7 +103,8 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.De
             variable.setParent(d);
         }
         d.setVariable(variable);
-        org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(source.getExpression());
+        org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(source.getExpression(),
+                                                                                            componentWidthsConsumer);
         if (expression != null) {
             expression.setParent(d);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionServiceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionServiceConverter.java
@@ -19,8 +19,11 @@ package org.kie.workbench.common.dmn.backend.definition.v1_1;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNElementReference;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
@@ -35,6 +38,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -51,7 +55,8 @@ public class DecisionServiceConverter implements NodeConverter<org.kie.dmn.model
     }
 
     @Override
-    public Node<View<DecisionService>, ?> nodeFromDMN(final org.kie.dmn.model.api.DecisionService dmn) {
+    public Node<View<DecisionService>, ?> nodeFromDMN(final org.kie.dmn.model.api.DecisionService dmn,
+                                                      final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         @SuppressWarnings("unchecked")
         Node<View<DecisionService>, ?> node = (Node<View<DecisionService>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                          DecisionService.class).asNode();
@@ -86,7 +91,8 @@ public class DecisionServiceConverter implements NodeConverter<org.kie.dmn.model
 
     @Override
     @SuppressWarnings("unchecked")
-    public org.kie.dmn.model.api.DecisionService dmnFromNode(Node<View<DecisionService>, ?> node) {
+    public org.kie.dmn.model.api.DecisionService dmnFromNode(final Node<View<DecisionService>, ?> node,
+                                                             final Consumer<ComponentWidths> componentWidthsConsumer) {
         DecisionService source = node.getContent().getDefinition();
         org.kie.dmn.model.api.DecisionService ds = new org.kie.dmn.model.v1_2.TDecisionService();
         ds.setId(source.getId().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
@@ -16,6 +16,14 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.xml.namespace.QName;
+
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
@@ -24,29 +32,58 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
 import org.kie.workbench.common.dmn.api.definition.v1_1.List;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 
 public class ExpressionPropertyConverter {
 
-    public static Expression wbFromDMN(final org.kie.dmn.model.api.Expression dmn) {
+    public static Expression wbFromDMN(final org.kie.dmn.model.api.Expression dmn,
+                                       final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         if (dmn instanceof org.kie.dmn.model.api.LiteralExpression) {
-            return LiteralExpressionPropertyConverter.wbFromDMN((org.kie.dmn.model.api.LiteralExpression) dmn);
+            final LiteralExpression e = LiteralExpressionPropertyConverter.wbFromDMN((org.kie.dmn.model.api.LiteralExpression) dmn);
+            hasComponentWidthsConsumer.accept(dmn.getId(),
+                                              e);
+            return e;
         } else if (dmn instanceof org.kie.dmn.model.api.Context) {
-            return ContextPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Context) dmn);
+            final Context e = ContextPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Context) dmn,
+                                                                 hasComponentWidthsConsumer);
+            hasComponentWidthsConsumer.accept(dmn.getId(),
+                                              e);
+            return e;
         } else if (dmn instanceof org.kie.dmn.model.api.Relation) {
-            return RelationPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Relation) dmn);
+            final Relation e = RelationPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Relation) dmn,
+                                                                   hasComponentWidthsConsumer);
+            hasComponentWidthsConsumer.accept(dmn.getId(),
+                                              e);
+            return e;
         } else if (dmn instanceof org.kie.dmn.model.api.List) {
-            return ListPropertyConverter.wbFromDMN((org.kie.dmn.model.api.List) dmn);
+            final List e = ListPropertyConverter.wbFromDMN((org.kie.dmn.model.api.List) dmn,
+                                                           hasComponentWidthsConsumer);
+            hasComponentWidthsConsumer.accept(dmn.getId(),
+                                              e);
+            return e;
         } else if (dmn instanceof org.kie.dmn.model.api.Invocation) {
-            return InvocationPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Invocation) dmn);
+            final Invocation e = InvocationPropertyConverter.wbFromDMN((org.kie.dmn.model.api.Invocation) dmn,
+                                                                       hasComponentWidthsConsumer);
+            hasComponentWidthsConsumer.accept(dmn.getId(),
+                                              e);
+            return e;
         } else if (dmn instanceof org.kie.dmn.model.api.FunctionDefinition) {
-            return FunctionDefinitionPropertyConverter.wbFromDMN((org.kie.dmn.model.api.FunctionDefinition) dmn);
+            final FunctionDefinition e = FunctionDefinitionPropertyConverter.wbFromDMN((org.kie.dmn.model.api.FunctionDefinition) dmn,
+                                                                                       hasComponentWidthsConsumer);
+            hasComponentWidthsConsumer.accept(dmn.getId(),
+                                              e);
+            return e;
         } else if (dmn instanceof org.kie.dmn.model.api.DecisionTable) {
-            return DecisionTablePropertyConverter.wbFromDMN((org.kie.dmn.model.api.DecisionTable) dmn);
+            final DecisionTable e = DecisionTablePropertyConverter.wbFromDMN((org.kie.dmn.model.api.DecisionTable) dmn);
+            hasComponentWidthsConsumer.accept(dmn.getId(),
+                                              e);
+            return e;
         }
         return null;
     }
 
-    public static org.kie.dmn.model.api.Expression dmnFromWB(final Expression wb) {
+    public static org.kie.dmn.model.api.Expression dmnFromWB(final Expression wb,
+                                                             final Consumer<ComponentWidths> componentWidthsConsumer) {
         // SPECIAL CASE: to represent a partially edited DMN file.
         // reference above.
         if (wb == null) {
@@ -54,18 +91,31 @@ public class ExpressionPropertyConverter {
             return mockedExpression;
         }
 
+        final String uuid = wb.getId().getValue();
+        if (Objects.nonNull(uuid)) {
+            final ComponentWidths componentWidths = new ComponentWidths();
+            componentWidths.setDmnElementRef(new QName(uuid));
+            componentWidths.setWidths(new ArrayList<>(wb.getComponentWidths()));
+            componentWidthsConsumer.accept(componentWidths);
+        }
+
         if (wb instanceof LiteralExpression) {
             return LiteralExpressionPropertyConverter.dmnFromWB((LiteralExpression) wb);
         } else if (wb instanceof Context) {
-            return ContextPropertyConverter.dmnFromWB((Context) wb);
+            return ContextPropertyConverter.dmnFromWB((Context) wb,
+                                                      componentWidthsConsumer);
         } else if (wb instanceof Relation) {
-            return RelationPropertyConverter.dmnFromWB((Relation) wb);
+            return RelationPropertyConverter.dmnFromWB((Relation) wb,
+                                                       componentWidthsConsumer);
         } else if (wb instanceof List) {
-            return ListPropertyConverter.dmnFromWB((List) wb);
+            return ListPropertyConverter.dmnFromWB((List) wb,
+                                                   componentWidthsConsumer);
         } else if (wb instanceof Invocation) {
-            return InvocationPropertyConverter.dmnFromWB((Invocation) wb);
+            return InvocationPropertyConverter.dmnFromWB((Invocation) wb,
+                                                         componentWidthsConsumer);
         } else if (wb instanceof FunctionDefinition) {
-            return FunctionDefinitionPropertyConverter.dmnFromWB((FunctionDefinition) wb);
+            return FunctionDefinitionPropertyConverter.dmnFromWB((FunctionDefinition) wb,
+                                                                 componentWidthsConsumer);
         } else if (wb instanceof DecisionTable) {
             return DecisionTablePropertyConverter.dmnFromWB((DecisionTable) wb);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverter.java
@@ -16,7 +16,11 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
 import org.kie.dmn.model.api.FunctionKind;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
 import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition.Kind;
@@ -24,17 +28,20 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 
 public class FunctionDefinitionPropertyConverter {
 
-    public static FunctionDefinition wbFromDMN(final org.kie.dmn.model.api.FunctionDefinition dmn) {
+    public static FunctionDefinition wbFromDMN(final org.kie.dmn.model.api.FunctionDefinition dmn,
+                                               final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         if (dmn == null) {
             return null;
         }
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef(), dmn);
-        Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
+        Expression expression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression(),
+                                                                      hasComponentWidthsConsumer);
         FunctionDefinition result = new FunctionDefinition(id,
                                                            description,
                                                            typeRef,
@@ -70,7 +77,8 @@ public class FunctionDefinitionPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.api.FunctionDefinition dmnFromWB(final FunctionDefinition wb) {
+    public static org.kie.dmn.model.api.FunctionDefinition dmnFromWB(final FunctionDefinition wb,
+                                                                     final Consumer<ComponentWidths> componentWidthsConsumer) {
         if (wb == null) {
             return null;
         }
@@ -79,7 +87,8 @@ public class FunctionDefinitionPropertyConverter {
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
-        result.setExpression(ExpressionPropertyConverter.dmnFromWB(wb.getExpression()));
+        result.setExpression(ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
+                                                                   componentWidthsConsumer));
 
         Kind kind = wb.getKind();
         switch (kind) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
@@ -16,6 +16,10 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
@@ -24,6 +28,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
@@ -38,7 +43,8 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.api.I
     }
 
     @Override
-    public Node<View<InputData>, ?> nodeFromDMN(final org.kie.dmn.model.api.InputData dmn) {
+    public Node<View<InputData>, ?> nodeFromDMN(final org.kie.dmn.model.api.InputData dmn,
+                                                final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         @SuppressWarnings("unchecked")
         Node<View<InputData>, ?> node = (Node<View<InputData>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                              InputData.class).asNode();
@@ -63,7 +69,8 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.api.I
     }
 
     @Override
-    public org.kie.dmn.model.api.InputData dmnFromNode(final Node<View<InputData>, ?> node) {
+    public org.kie.dmn.model.api.InputData dmnFromNode(final Node<View<InputData>, ?> node,
+                                                       final Consumer<ComponentWidths> componentWidthsConsumer) {
         InputData source = node.getContent().getDefinition();
         org.kie.dmn.model.api.InputData result = new org.kie.dmn.model.v1_2.TInputData();
         result.setId(source.getId().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverter.java
@@ -16,16 +16,22 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Binding;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 
 public class InvocationPropertyConverter {
 
-    public static Invocation wbFromDMN(final org.kie.dmn.model.api.Invocation dmn) {
+    public static Invocation wbFromDMN(final org.kie.dmn.model.api.Invocation dmn,
+                                       final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         if (dmn == null) {
             return null;
         }
@@ -38,14 +44,16 @@ public class InvocationPropertyConverter {
         result.setDescription(description);
         result.setTypeRef(typeRef);
 
-        Expression convertedExpression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression());
+        Expression convertedExpression = ExpressionPropertyConverter.wbFromDMN(dmn.getExpression(),
+                                                                               hasComponentWidthsConsumer);
         result.setExpression(convertedExpression);
         if (convertedExpression != null) {
             convertedExpression.setParent(result);
         }
 
         for (org.kie.dmn.model.api.Binding b : dmn.getBinding()) {
-            Binding bConverted = BindingPropertyConverter.wbFromDMN(b);
+            Binding bConverted = BindingPropertyConverter.wbFromDMN(b,
+                                                                    hasComponentWidthsConsumer);
             if (bConverted != null) {
                 bConverted.setParent(result);
             }
@@ -55,7 +63,8 @@ public class InvocationPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.api.Invocation dmnFromWB(final Invocation wb) {
+    public static org.kie.dmn.model.api.Invocation dmnFromWB(final Invocation wb,
+                                                             final Consumer<ComponentWidths> componentWidthsConsumer) {
         if (wb == null) {
             return null;
         }
@@ -65,14 +74,16 @@ public class InvocationPropertyConverter {
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
 
-        org.kie.dmn.model.api.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression());
+        org.kie.dmn.model.api.Expression convertedExpression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
+                                                                                                     componentWidthsConsumer);
         if (convertedExpression != null) {
             convertedExpression.setParent(result);
         }
         result.setExpression(convertedExpression);
 
         for (Binding b : wb.getBinding()) {
-            org.kie.dmn.model.api.Binding bConverted = BindingPropertyConverter.dmnFromWB(b);
+            org.kie.dmn.model.api.Binding bConverted = BindingPropertyConverter.dmnFromWB(b,
+                                                                                          componentWidthsConsumer);
             if (bConverted != null) {
                 bConverted.setParent(result);
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
@@ -17,7 +17,10 @@
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
@@ -30,6 +33,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.KnowledgeSourceType;
 import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -45,7 +49,8 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
     }
 
     @Override
-    public Node<View<KnowledgeSource>, ?> nodeFromDMN(final org.kie.dmn.model.api.KnowledgeSource dmn) {
+    public Node<View<KnowledgeSource>, ?> nodeFromDMN(final org.kie.dmn.model.api.KnowledgeSource dmn,
+                                                      final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         @SuppressWarnings("unchecked")
         Node<View<KnowledgeSource>, ?> node = (Node<View<KnowledgeSource>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                          KnowledgeSource.class).asNode();
@@ -67,7 +72,8 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
     }
 
     @Override
-    public org.kie.dmn.model.api.KnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node) {
+    public org.kie.dmn.model.api.KnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node,
+                                                             final Consumer<ComponentWidths> componentWidthsConsumer) {
         KnowledgeSource source = node.getContent().getDefinition();
         org.kie.dmn.model.api.KnowledgeSource result = new org.kie.dmn.model.v1_2.TKnowledgeSource();
         result.setId(source.getId().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverter.java
@@ -17,23 +17,29 @@
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
 import java.util.ArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.List;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 
 public class ListPropertyConverter {
 
-    public static List wbFromDMN(final org.kie.dmn.model.api.List dmn) {
+    public static List wbFromDMN(final org.kie.dmn.model.api.List dmn,
+                                 final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         Id id = new Id(dmn.getId());
         Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         QName typeRef = QNamePropertyConverter.wbFromDMN(dmn.getTypeRef(), dmn);
 
         java.util.List<Expression> expression = new ArrayList<>();
         for (org.kie.dmn.model.api.Expression e : dmn.getExpression()) {
-            Expression eConverted = ExpressionPropertyConverter.wbFromDMN(e);
+            Expression eConverted = ExpressionPropertyConverter.wbFromDMN(e,
+                                                                          hasComponentWidthsConsumer);
             expression.add(eConverted);
         }
 
@@ -46,7 +52,8 @@ public class ListPropertyConverter {
         return result;
     }
 
-    public static org.kie.dmn.model.api.List dmnFromWB(final List wb) {
+    public static org.kie.dmn.model.api.List dmnFromWB(final List wb,
+                                                       final Consumer<ComponentWidths> componentWidthsConsumer) {
         org.kie.dmn.model.api.List result = new org.kie.dmn.model.v1_2.TList();
         result.setId(wb.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
@@ -54,7 +61,8 @@ public class ListPropertyConverter {
                                             result::setTypeRef);
 
         for (Expression e : wb.getExpression()) {
-            org.kie.dmn.model.api.Expression eConverted = ExpressionPropertyConverter.dmnFromWB(e);
+            org.kie.dmn.model.api.Expression eConverted = ExpressionPropertyConverter.dmnFromWB(e,
+                                                                                                componentWidthsConsumer);
             if (eConverted != null) {
                 eConverted.setParent(result);
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/NodeConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/NodeConverter.java
@@ -16,12 +16,19 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 interface NodeConverter<D extends org.kie.dmn.model.api.DMNModelInstrumentedBase, W extends org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase> {
 
-    Node<View<W>, ?> nodeFromDMN(final D source);
+    Node<View<W>, ?> nodeFromDMN(final D source,
+                                 final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer);
 
-    D dmnFromNode(final Node<View<W>, ?> source);
+    D dmnFromNode(final Node<View<W>, ?> source,
+                  final Consumer<ComponentWidths> componentWidthsConsumer);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
@@ -16,6 +16,10 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
 import org.kie.workbench.common.dmn.api.property.dimensions.GeneralRectangleDimensionsSet;
@@ -24,6 +28,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.dmn.api.property.dmn.TextFormat;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
@@ -38,7 +43,8 @@ public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.
     }
 
     @Override
-    public Node<View<TextAnnotation>, ?> nodeFromDMN(final org.kie.dmn.model.api.TextAnnotation dmn) {
+    public Node<View<TextAnnotation>, ?> nodeFromDMN(final org.kie.dmn.model.api.TextAnnotation dmn,
+                                                     final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer) {
         @SuppressWarnings("unchecked")
         Node<View<TextAnnotation>, ?> node = (Node<View<TextAnnotation>, ?>) factoryManager.newElement(dmn.getId(),
                                                                                                        TextAnnotation.class).asNode();
@@ -58,7 +64,8 @@ public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.
     }
 
     @Override
-    public org.kie.dmn.model.api.TextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node) {
+    public org.kie.dmn.model.api.TextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node,
+                                                            final Consumer<ComponentWidths> componentWidthsConsumer) {
         TextAnnotation source = node.getContent().getDefinition();
         org.kie.dmn.model.api.TextAnnotation result = new org.kie.dmn.model.v1_2.TTextAnnotation();
         result.setId(source.getId().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/ComponentWidths.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/ComponentWidths.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1.dd;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+
+@XStreamAlias("ComponentWidths")
+public class ComponentWidths extends KieDMNModelInstrumentedBase {
+
+    @XStreamAsAttribute
+    private QName dmnElementRef;
+
+    @XStreamImplicit
+    private List<Double> widths;
+
+    public ComponentWidths() {
+        this.widths = new ArrayList<>();
+    }
+
+    public QName getDmnElementRef() {
+        return dmnElementRef;
+    }
+
+    public void setDmnElementRef(final QName value) {
+        this.dmnElementRef = value;
+    }
+
+    public List<Double> getWidths() {
+        return widths;
+    }
+
+    public void setWidths(final List<Double> widths) {
+        this.widths = widths;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/ComponentWidthsConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/ComponentWidthsConverter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1.dd;
+
+import java.util.Objects;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.kie.dmn.backend.marshalling.v1_2.xstream.DMNModelInstrumentedBaseConverter;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+
+import static org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDIExtensionsRegister.COMPONENT_WIDTH_ALIAS;
+
+public class ComponentWidthsConverter extends DMNModelInstrumentedBaseConverter {
+
+    public ComponentWidthsConverter(final XStream xstream) {
+        super(xstream);
+    }
+
+    @Override
+    protected void assignChildElement(final Object parent,
+                                      final String nodeName,
+                                      final Object child) {
+        super.assignChildElement(parent, nodeName, child);
+
+        final ComponentWidths componentWidths = (ComponentWidths) parent;
+
+        componentWidths.getWidths().add((Double) child);
+    }
+
+    @Override
+    protected void assignAttributes(final HierarchicalStreamReader reader,
+                                    final Object parent) {
+        super.assignAttributes(reader, parent);
+
+        final ComponentWidths componentWidths = (ComponentWidths) parent;
+
+        componentWidths.setDmnElementRef(new QName(reader.getAttribute("dmnElementRef")));
+    }
+
+    @Override
+    protected void writeChildren(final HierarchicalStreamWriter writer,
+                                 final MarshallingContext context,
+                                 final Object parent) {
+        super.writeChildren(writer, context, parent);
+
+        final ComponentWidths componentWidths = (ComponentWidths) parent;
+
+        componentWidths.getWidths().forEach(width -> {
+            if (Objects.nonNull(width)) {
+                writeChildrenNode(writer,
+                                  context,
+                                  width,
+                                  COMPONENT_WIDTH_ALIAS);
+            }
+        });
+    }
+
+    @Override
+    protected void writeAttributes(final HierarchicalStreamWriter writer,
+                                   final Object parent) {
+        super.writeAttributes(writer, parent);
+
+        final ComponentWidths componentWidths = (ComponentWidths) parent;
+
+        writer.addAttribute("dmnElementRef", componentWidths.getDmnElementRef().toString());
+    }
+
+    @Override
+    protected DMNModelInstrumentedBase createModelObject() {
+        return new ComponentWidths();
+    }
+
+    @Override
+    public boolean canConvert(final Class clazz) {
+        return clazz.equals(ComponentWidths.class);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/ComponentsWidthsExtension.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/ComponentsWidthsExtension.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1.dd;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+@XStreamAlias("ComponentsWidthsExtension")
+public class ComponentsWidthsExtension {
+
+    @XStreamImplicit
+    private List<ComponentWidths> widths;
+
+    public ComponentsWidthsExtension() {
+        this.widths = new ArrayList<>();
+    }
+
+    public List<ComponentWidths> getComponentsWidths() {
+        return widths;
+    }
+
+    public void setComponentsWidths(final List<ComponentWidths> widths) {
+        this.widths = widths;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegister.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegister.java
@@ -20,6 +20,8 @@ import javax.xml.namespace.QName;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.QNameMap;
 import org.kie.dmn.api.marshalling.DMNExtensionRegister;
+import org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_2.TDefinitions;
 
 import static org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace.KIE;
 
@@ -43,17 +45,22 @@ public class DMNDIExtensionsRegister implements DMNExtensionRegister {
     @Override
     public void beforeMarshal(final Object o,
                               final QNameMap qmap) {
-        qmap.registerMapping(new QName(KIE.getUri(),
-                                       COMPONENTS_WIDTHS_EXTENSION_ALIAS,
-                                       KIE.getPrefix()),
-                             COMPONENTS_WIDTHS_EXTENSION_ALIAS);
-        qmap.registerMapping(new QName(KIE.getUri(),
-                                       COMPONENT_WIDTHS_ALIAS,
-                                       KIE.getPrefix()),
-                             COMPONENT_WIDTHS_ALIAS);
-        qmap.registerMapping(new QName(KIE.getUri(),
-                                       COMPONENT_WIDTH_ALIAS,
-                                       KIE.getPrefix()),
-                             COMPONENT_WIDTH_ALIAS);
+        if (o instanceof TDefinitions) {
+            final TDefinitions tDefinitions = (TDefinitions) o;
+            final String prefix = tDefinitions.getPrefixForNamespaceURI(KieDMNModelInstrumentedBase.URI_KIE).orElse("kie");
+
+            qmap.registerMapping(new QName(KIE.getUri(),
+                                           COMPONENTS_WIDTHS_EXTENSION_ALIAS,
+                                           prefix),
+                                 COMPONENTS_WIDTHS_EXTENSION_ALIAS);
+            qmap.registerMapping(new QName(KIE.getUri(),
+                                           COMPONENT_WIDTHS_ALIAS,
+                                           prefix),
+                                 COMPONENT_WIDTHS_ALIAS);
+            qmap.registerMapping(new QName(KIE.getUri(),
+                                           COMPONENT_WIDTH_ALIAS,
+                                           prefix),
+                                 COMPONENT_WIDTH_ALIAS);
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegister.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegister.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1.dd;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.QNameMap;
+import org.kie.dmn.api.marshalling.DMNExtensionRegister;
+
+import static org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace.KIE;
+
+public class DMNDIExtensionsRegister implements DMNExtensionRegister {
+
+    static final String COMPONENTS_WIDTHS_EXTENSION_ALIAS = "ComponentsWidthsExtension";
+
+    static final String COMPONENT_WIDTHS_ALIAS = "ComponentWidths";
+
+    static final String COMPONENT_WIDTH_ALIAS = "width";
+
+    @Override
+    public void registerExtensionConverters(final XStream xStream) {
+        xStream.processAnnotations(ComponentsWidthsExtension.class);
+        xStream.processAnnotations(ComponentWidths.class);
+        xStream.alias(COMPONENT_WIDTH_ALIAS, Double.class);
+
+        xStream.registerConverter(new ComponentWidthsConverter(xStream));
+    }
+
+    @Override
+    public void beforeMarshal(final Object o,
+                              final QNameMap qmap) {
+        qmap.registerMapping(new QName(KIE.getUri(),
+                                       COMPONENTS_WIDTHS_EXTENSION_ALIAS,
+                                       KIE.getPrefix()),
+                             COMPONENTS_WIDTHS_EXTENSION_ALIAS);
+        qmap.registerMapping(new QName(KIE.getUri(),
+                                       COMPONENT_WIDTHS_ALIAS,
+                                       KIE.getPrefix()),
+                             COMPONENT_WIDTHS_ALIAS);
+        qmap.registerMapping(new QName(KIE.getUri(),
+                                       COMPONENT_WIDTH_ALIAS,
+                                       KIE.getPrefix()),
+                             COMPONENT_WIDTH_ALIAS);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegister.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegister.java
@@ -47,7 +47,7 @@ public class DMNDIExtensionsRegister implements DMNExtensionRegister {
                               final QNameMap qmap) {
         if (o instanceof TDefinitions) {
             final TDefinitions tDefinitions = (TDefinitions) o;
-            final String prefix = tDefinitions.getPrefixForNamespaceURI(KieDMNModelInstrumentedBase.URI_KIE).orElse("kie");
+            final String prefix = tDefinitions.getPrefixForNamespaceURI(KieDMNModelInstrumentedBase.URI_KIE).orElse(KIE.getPrefix());
 
             qmap.registerMapping(new QName(KIE.getUri(),
                                            COMPONENTS_WIDTHS_EXTENSION_ALIAS,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -1873,6 +1873,12 @@ public class DMNMarshallerTest {
                                                 final Expression expression) {
         final Node<View, ?> decisionNode = nodeOfDefinition(unmarshalledGraph.nodes().iterator(), Decision.class);
         final Expression decisionNodeExpression = ((Decision) decisionNode.getContent().getDefinition()).getExpression();
+
+        // The process of marshalling an Expression that has been programmatically instantiated (vs created in the UI)
+        // leads to the _source_ Expression ComponentWidths being initialised. Therefore to ensure a like-for-like equality
+        // comparison ensure the unmarshalled _target_ Expression has had it's ComponentWidths initialised too.
+        decisionNodeExpression.getComponentWidths();
+        ((Context) decisionNodeExpression).getContextEntry().get(0).getExpression().getComponentWidths();
         assertThat(decisionNodeExpression).isEqualTo(expression);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Scanner;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -83,6 +84,7 @@ import org.kie.dmn.model.v1_2.TDecision;
 import org.kie.dmn.model.v1_2.TInputData;
 import org.kie.dmn.model.v1_2.TTextAnnotation;
 import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Association;
 import org.kie.workbench.common.dmn.api.definition.v1_1.AuthorityRequirement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
@@ -1703,6 +1705,8 @@ public class DMNMarshallerTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testStunnerConstellationButtonCausingPoint2DbeingNull() throws IOException {
+        final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer = (uuid, hcw) -> {/*NOP*/};
+
         Diagram diagram = applicationFactoryManager.newDiagram("testDiagram",
                                                                BindableAdapterUtils.getDefinitionSetId(DMNDefinitionSet.class),
                                                                null);
@@ -1710,14 +1714,16 @@ public class DMNMarshallerTest {
         Node diagramRoot = DMNMarshaller.findDMNDiagramRoot(g);
         testAugmentWithNSPrefixes(((DMNDiagram) ((View<?>) diagramRoot.getContent()).getDefinition()).getDefinitions());
 
-        org.kie.dmn.model.api.InputData dmnInputData = (org.kie.dmn.model.api.InputData) new TInputData();
+        org.kie.dmn.model.api.InputData dmnInputData = new TInputData();
         dmnInputData.setId("inputDataID");
         dmnInputData.setName(dmnInputData.getId());
-        Node inputDataNode = new InputDataConverter(applicationFactoryManager).nodeFromDMN(dmnInputData);
-        org.kie.dmn.model.api.Decision dmnDecision = (org.kie.dmn.model.api.Decision) new TDecision();
+        Node inputDataNode = new InputDataConverter(applicationFactoryManager).nodeFromDMN(dmnInputData,
+                                                                                           hasComponentWidthsConsumer);
+        org.kie.dmn.model.api.Decision dmnDecision = new TDecision();
         dmnDecision.setId("decisionID");
         dmnDecision.setName(dmnDecision.getId());
-        Node decisionNode = new DecisionConverter(applicationFactoryManager).nodeFromDMN(dmnDecision);
+        Node decisionNode = new DecisionConverter(applicationFactoryManager).nodeFromDMN(dmnDecision,
+                                                                                         hasComponentWidthsConsumer);
         g.addNode(inputDataNode);
         g.addNode(decisionNode);
         View content = (View) decisionNode.getContent();
@@ -1760,6 +1766,8 @@ public class DMNMarshallerTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testAssociationEdgeDMNDI() throws IOException {
+        final BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer = (uuid, hcw) -> {/*NOP*/};
+
         Diagram diagram = applicationFactoryManager.newDiagram("testDiagram",
                                                                BindableAdapterUtils.getDefinitionSetId(DMNDefinitionSet.class),
                                                                null);
@@ -1770,10 +1778,12 @@ public class DMNMarshallerTest {
         org.kie.dmn.model.api.InputData dmnInputData = new TInputData();
         dmnInputData.setId("inputDataID");
         dmnInputData.setName(dmnInputData.getId());
-        Node inputDataNode = new InputDataConverter(applicationFactoryManager).nodeFromDMN(dmnInputData);
+        Node inputDataNode = new InputDataConverter(applicationFactoryManager).nodeFromDMN(dmnInputData,
+                                                                                           hasComponentWidthsConsumer);
         org.kie.dmn.model.api.TextAnnotation dmnTextAnnotation = new TTextAnnotation();
         dmnTextAnnotation.setId("textAnnotationID");
-        Node textAnnotationNode = new TextAnnotationConverter(applicationFactoryManager).nodeFromDMN(dmnTextAnnotation);
+        Node textAnnotationNode = new TextAnnotationConverter(applicationFactoryManager).nodeFromDMN(dmnTextAnnotation,
+                                                                                                     hasComponentWidthsConsumer);
         g.addNode(inputDataNode);
         g.addNode(textAnnotationNode);
         View content = (View) textAnnotationNode.getContent();
@@ -1803,6 +1813,30 @@ public class DMNMarshallerTest {
         assertThat(dmnDefinitions.getDMNDI().getDMNDiagram().get(0).getDMNDiagramElement().stream().filter(DMNEdge.class::isInstance).count()).isEqualTo(1);
         DMNEdge dmndiEdge = findEdgeByDMNI(dmnDefinitions.getDMNDI().getDMNDiagram().get(0), associationID);
         assertThat(dmndiEdge.getWaypoint()).hasSize(2);
+    }
+
+    @Test
+    public void test_ExpressionComponentWidthPersistence() throws IOException {
+        roundTripUnmarshalThenMarshalUnmarshal(this.getClass().getResourceAsStream("/DROOLS-2262.dmn"),
+                                               this::checkComponentWidths);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void checkComponentWidths(Graph<?, Node<?, ?>> graph) {
+        final Node<?, ?> node = graph.getNode("_37883BDC-DB54-4925-B539-A0F19B1DDE41");
+        assertThat(node).isNotNull();
+        assertNodeContentDefinitionIs(node, Decision.class);
+
+        final Decision definition = ((View<Decision>) node.getContent()).getDefinition();
+        assertThat(definition.getExpression()).isNotNull();
+
+        final HasComponentWidths expression = definition.getExpression();
+        final List<Double> componentWidths = expression.getComponentWidths();
+        assertThat(componentWidths.size()).isEqualTo(expression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.get(0)).isEqualTo(50.0);
+        assertThat(componentWidths.get(1)).isEqualTo(150.0);
+        assertThat(componentWidths.get(2)).isEqualTo(200.0);
+        assertThat(componentWidths.get(3)).isEqualTo(250.0);
     }
 
     private static void testAugmentWithNSPrefixes(org.kie.workbench.common.dmn.api.definition.v1_1.Definitions definitions) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BindingPropertyConverterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TBinding;
+import org.kie.dmn.model.v1_2.TInformationItem;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Binding;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BindingPropertyConverterTest {
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    @Test
+    public void testWBFromDMN() {
+        final org.kie.dmn.model.api.Binding dmn = new TBinding();
+        final org.kie.dmn.model.api.InformationItem informationItem = new TInformationItem();
+        dmn.setParameter(informationItem);
+
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        literalExpression.setId(EXPRESSION_UUID);
+
+        dmn.setExpression(literalExpression);
+
+        final Binding wb = BindingPropertyConverter.wbFromDMN(dmn, hasComponentWidthsConsumer);
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getParameter()).isNotNull();
+        assertThat(wb.getExpression()).isNotNull();
+        assertThat(wb.getExpression().getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getExpression());
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final Binding wb = new Binding();
+        final InformationItem informationItem = new InformationItem();
+        wb.setParameter(informationItem);
+
+        final LiteralExpression literalExpression = new LiteralExpression();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+
+        wb.setExpression(literalExpression);
+
+        final org.kie.dmn.model.api.Binding dmn = BindingPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getParameter()).isNotNull();
+        assertThat(dmn.getExpression()).isNotNull();
+        assertThat(dmn.getExpression().getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverterTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TBusinessKnowledgeModel;
+import org.kie.dmn.model.v1_2.TFunctionDefinition;
+import org.kie.dmn.model.v1_2.TInformationItem;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
+import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.kie.workbench.common.stunner.core.util.UUID;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BusinessKnowledgeModelConverterTest {
+
+    private static final String DECISION_UUID = "d-uuid";
+
+    private static final String DECISION_NAME = "d-name";
+
+    private static final String DECISION_DESCRIPTION = "d-description";
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Mock
+    private FactoryManager factoryManager;
+
+    @Mock
+    private Element element;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    private BusinessKnowledgeModelConverter converter;
+
+    @Before
+    public void setup() {
+        this.converter = new BusinessKnowledgeModelConverter(factoryManager);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWBFromDMN() {
+        final Node<View<BusinessKnowledgeModel>, ?> factoryNode = new NodeImpl<>(UUID.uuid());
+        final View<BusinessKnowledgeModel> view = new ViewImpl<>(new BusinessKnowledgeModel(), Bounds.create());
+        factoryNode.setContent(view);
+
+        when(factoryManager.newElement(anyString(), eq(BusinessKnowledgeModel.class))).thenReturn(element);
+        when(element.asNode()).thenReturn(factoryNode);
+
+        final org.kie.dmn.model.api.BusinessKnowledgeModel dmn = new TBusinessKnowledgeModel();
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        final org.kie.dmn.model.api.InformationItem informationItem = new TInformationItem();
+        final org.kie.dmn.model.api.FunctionDefinition functionDefinition = new TFunctionDefinition();
+        literalExpression.setId(EXPRESSION_UUID);
+        functionDefinition.setExpression(literalExpression);
+
+        dmn.setId(DECISION_UUID);
+        dmn.setName(DECISION_NAME);
+        dmn.setDescription(DECISION_DESCRIPTION);
+        dmn.setVariable(informationItem);
+        dmn.setEncapsulatedLogic(functionDefinition);
+
+        final Node<View<BusinessKnowledgeModel>, ?> node = converter.nodeFromDMN(dmn, hasComponentWidthsConsumer);
+        final BusinessKnowledgeModel wb = node.getContent().getDefinition();
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getId()).isNotNull();
+        assertThat(wb.getId().getValue()).isEqualTo(DECISION_UUID);
+        assertThat(wb.getName()).isNotNull();
+        assertThat(wb.getName().getValue()).isEqualTo(DECISION_NAME);
+        assertThat(wb.getDescription()).isNotNull();
+        assertThat(wb.getDescription().getValue()).isEqualTo(DECISION_DESCRIPTION);
+        assertThat(wb.getVariable()).isNotNull();
+        assertThat(wb.getEncapsulatedLogic()).isNotNull();
+        assertThat(wb.getEncapsulatedLogic().getExpression()).isNotNull();
+        assertThat(wb.getEncapsulatedLogic().getExpression().getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getEncapsulatedLogic().getExpression());
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final BusinessKnowledgeModel wb = new BusinessKnowledgeModel();
+        final LiteralExpression literalExpression = new LiteralExpression();
+        final InformationItemPrimary informationItem = new InformationItemPrimary();
+        final FunctionDefinition functionDefinition = new FunctionDefinition();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+        functionDefinition.setExpression(literalExpression);
+
+        wb.getId().setValue(DECISION_UUID);
+        wb.getName().setValue(DECISION_NAME);
+        wb.getDescription().setValue(DECISION_DESCRIPTION);
+        wb.setVariable(informationItem);
+        wb.setEncapsulatedLogic(functionDefinition);
+
+        final Node<View<BusinessKnowledgeModel>, ?> node = new NodeImpl<>(UUID.uuid());
+        final View<BusinessKnowledgeModel> view = new ViewImpl<>(wb, Bounds.create());
+        node.setContent(view);
+
+        final org.kie.dmn.model.api.BusinessKnowledgeModel dmn = converter.dmnFromNode(node, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getId()).isNotNull();
+        assertThat(dmn.getId()).isEqualTo(DECISION_UUID);
+        assertThat(dmn.getName()).isNotNull();
+        assertThat(dmn.getName()).isEqualTo(DECISION_NAME);
+        assertThat(dmn.getDescription()).isNotNull();
+        assertThat(dmn.getDescription()).isEqualTo(DECISION_DESCRIPTION);
+        assertThat(dmn.getVariable()).isNotNull();
+        assertThat(dmn.getEncapsulatedLogic()).isNotNull();
+        assertThat(dmn.getEncapsulatedLogic().getExpression()).isNotNull();
+        assertThat(dmn.getEncapsulatedLogic().getExpression().getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TContextEntry;
+import org.kie.dmn.model.v1_2.TInformationItem;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.ContextEntry;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContextEntryPropertyConverterTest {
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    @Test
+    public void testWBFromDMN() {
+        final org.kie.dmn.model.api.ContextEntry dmn = new TContextEntry();
+        final org.kie.dmn.model.api.InformationItem informationItem = new TInformationItem();
+        dmn.setVariable(informationItem);
+
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        literalExpression.setId(EXPRESSION_UUID);
+
+        dmn.setExpression(literalExpression);
+
+        final ContextEntry wb = ContextEntryPropertyConverter.wbFromDMN(dmn, hasComponentWidthsConsumer);
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getVariable()).isNotNull();
+        assertThat(wb.getExpression()).isNotNull();
+        assertThat(wb.getExpression().getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getExpression());
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final ContextEntry wb = new ContextEntry();
+        final InformationItem informationItem = new InformationItem();
+        wb.setVariable(informationItem);
+
+        final LiteralExpression literalExpression = new LiteralExpression();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+
+        wb.setExpression(literalExpression);
+
+        final org.kie.dmn.model.api.ContextEntry dmn = ContextEntryPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getVariable()).isNotNull();
+        assertThat(dmn.getExpression()).isNotNull();
+        assertThat(dmn.getExpression().getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverterTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TDecision;
+import org.kie.dmn.model.v1_2.TInformationItem;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.kie.workbench.common.stunner.core.util.UUID;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DecisionConverterTest {
+
+    private static final String DECISION_UUID = "d-uuid";
+
+    private static final String DECISION_NAME = "d-name";
+
+    private static final String DECISION_DESCRIPTION = "d-description";
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Mock
+    private FactoryManager factoryManager;
+
+    @Mock
+    private Element element;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    private DecisionConverter converter;
+
+    @Before
+    public void setup() {
+        this.converter = new DecisionConverter(factoryManager);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWBFromDMN() {
+        final Node<View<Decision>, ?> factoryNode = new NodeImpl<>(UUID.uuid());
+        final View<Decision> view = new ViewImpl<>(new Decision(), Bounds.create());
+        factoryNode.setContent(view);
+
+        when(factoryManager.newElement(anyString(), eq(Decision.class))).thenReturn(element);
+        when(element.asNode()).thenReturn(factoryNode);
+
+        final org.kie.dmn.model.api.Decision dmn = new TDecision();
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        final org.kie.dmn.model.api.InformationItem informationItem = new TInformationItem();
+        literalExpression.setId(EXPRESSION_UUID);
+
+        dmn.setId(DECISION_UUID);
+        dmn.setName(DECISION_NAME);
+        dmn.setDescription(DECISION_DESCRIPTION);
+        dmn.setVariable(informationItem);
+        dmn.setExpression(literalExpression);
+
+        final Node<View<Decision>, ?> node = converter.nodeFromDMN(dmn, hasComponentWidthsConsumer);
+        final Decision wb = node.getContent().getDefinition();
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getId()).isNotNull();
+        assertThat(wb.getId().getValue()).isEqualTo(DECISION_UUID);
+        assertThat(wb.getName()).isNotNull();
+        assertThat(wb.getName().getValue()).isEqualTo(DECISION_NAME);
+        assertThat(wb.getDescription()).isNotNull();
+        assertThat(wb.getDescription().getValue()).isEqualTo(DECISION_DESCRIPTION);
+        assertThat(wb.getVariable()).isNotNull();
+        assertThat(wb.getExpression()).isNotNull();
+        assertThat(wb.getExpression().getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getExpression());
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final Decision wb = new Decision();
+        final LiteralExpression literalExpression = new LiteralExpression();
+        final InformationItemPrimary informationItem = new InformationItemPrimary();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+
+        wb.getId().setValue(DECISION_UUID);
+        wb.getName().setValue(DECISION_NAME);
+        wb.getDescription().setValue(DECISION_DESCRIPTION);
+        wb.setVariable(informationItem);
+        wb.setExpression(literalExpression);
+
+        final Node<View<Decision>, ?> node = new NodeImpl<>(UUID.uuid());
+        final View<Decision> view = new ViewImpl<>(wb, Bounds.create());
+        node.setContent(view);
+
+        final org.kie.dmn.model.api.Decision dmn = converter.dmnFromNode(node, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getId()).isNotNull();
+        assertThat(dmn.getId()).isEqualTo(DECISION_UUID);
+        assertThat(dmn.getName()).isNotNull();
+        assertThat(dmn.getName()).isEqualTo(DECISION_NAME);
+        assertThat(dmn.getDescription()).isNotNull();
+        assertThat(dmn.getDescription()).isEqualTo(DECISION_DESCRIPTION);
+        assertThat(dmn.getVariable()).isNotNull();
+        assertThat(dmn.getExpression()).isNotNull();
+        assertThat(dmn.getExpression().getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverterTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TContext;
+import org.kie.dmn.model.v1_2.TDecisionTable;
+import org.kie.dmn.model.v1_2.TFunctionDefinition;
+import org.kie.dmn.model.v1_2.TInvocation;
+import org.kie.dmn.model.v1_2.TList;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.dmn.model.v1_2.TRelation;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExpressionPropertyConverterTest {
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    @Test
+    public void testWBFromDMN_LiteralExpressionConversion() {
+        final org.kie.dmn.model.api.LiteralExpression dmn = new TLiteralExpression();
+        dmn.setId(EXPRESSION_UUID);
+
+        assertWBFromDMNConversion(dmn, LiteralExpression.class);
+    }
+
+    private void assertWBFromDMNConversion(final org.kie.dmn.model.api.Expression dmn,
+                                           final Class wbClass) {
+        final Expression wb = ExpressionPropertyConverter.wbFromDMN(dmn, hasComponentWidthsConsumer);
+        assertThat(wb).isInstanceOf(wbClass);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb);
+    }
+
+    @Test
+    public void testDMNFromWB_LiteralExpressionConversion() {
+        final LiteralExpression wb = new LiteralExpression();
+        final List<Double> wbComponentWidths = wb.getComponentWidths();
+        wbComponentWidths.set(0, 200.0);
+        wb.getId().setValue(EXPRESSION_UUID);
+
+        assertDMNFromWBConversion(wb, TLiteralExpression.class, 200.0);
+    }
+
+    private void assertDMNFromWBConversion(final Expression wb,
+                                           final Class dmnClass,
+                                           final double... expectedComponentWidths) {
+        final org.kie.dmn.model.api.Expression dmn = ExpressionPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+        assertThat(dmn).isInstanceOf(dmnClass);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+
+        final List<Double> widths = componentWidths.getWidths();
+        assertThat(widths.size()).isEqualTo(wb.getRequiredComponentWidthCount());
+        assertThat(widths.size()).isEqualTo(expectedComponentWidths.length);
+
+        IntStream.range(0, expectedComponentWidths.length).forEach(i -> assertThat(widths.get(i)).isEqualTo(expectedComponentWidths[i]));
+    }
+
+    @Test
+    public void testWBFromDMN_ContextConversion() {
+        final org.kie.dmn.model.api.Context dmn = new TContext();
+        dmn.setId(EXPRESSION_UUID);
+
+        assertWBFromDMNConversion(dmn, Context.class);
+    }
+
+    @Test
+    public void testDMNFromWB_ContextConversion() {
+        final Context wb = new Context();
+        final List<Double> wbComponentWidths = wb.getComponentWidths();
+        wbComponentWidths.set(0, 100.0);
+        wbComponentWidths.set(1, 200.0);
+        wbComponentWidths.set(2, 300.0);
+        wb.getId().setValue(EXPRESSION_UUID);
+
+        assertDMNFromWBConversion(wb, TContext.class, 100.0, 200.0, 300.0);
+    }
+
+    @Test
+    public void testWBFromDMN_RelationConversion() {
+        final org.kie.dmn.model.api.Relation dmn = new TRelation();
+        dmn.setId(EXPRESSION_UUID);
+
+        assertWBFromDMNConversion(dmn, Relation.class);
+    }
+
+    @Test
+    public void testDMNFromWB_RelationConversion() {
+        final Relation wb = new Relation();
+        final List<Double> wbComponentWidths = wb.getComponentWidths();
+        wbComponentWidths.set(0, 200.0);
+        wb.getId().setValue(EXPRESSION_UUID);
+
+        assertDMNFromWBConversion(wb, TRelation.class, 200.0);
+    }
+
+    @Test
+    public void testWBFromDMN_ListConversion() {
+        final org.kie.dmn.model.api.List dmn = new TList();
+        dmn.setId(EXPRESSION_UUID);
+
+        assertWBFromDMNConversion(dmn, org.kie.workbench.common.dmn.api.definition.v1_1.List.class);
+    }
+
+    @Test
+    public void testDMNFromWB_ListConversion() {
+        final org.kie.workbench.common.dmn.api.definition.v1_1.List wb = new org.kie.workbench.common.dmn.api.definition.v1_1.List();
+        final List<Double> wbComponentWidths = wb.getComponentWidths();
+        wbComponentWidths.set(0, 200.0);
+        wb.getId().setValue(EXPRESSION_UUID);
+
+        assertDMNFromWBConversion(wb, TList.class, 200.0);
+    }
+
+    @Test
+    public void testWBFromDMN_InvocationConversion() {
+        final org.kie.dmn.model.api.Invocation dmn = new TInvocation();
+        dmn.setId(EXPRESSION_UUID);
+
+        assertWBFromDMNConversion(dmn, Invocation.class);
+    }
+
+    @Test
+    public void testDMNFromWB_InvocationConversion() {
+        final Invocation wb = new Invocation();
+        final List<Double> wbComponentWidths = wb.getComponentWidths();
+        wbComponentWidths.set(0, 100.0);
+        wbComponentWidths.set(1, 200.0);
+        wbComponentWidths.set(2, 300.0);
+        wb.getId().setValue(EXPRESSION_UUID);
+
+        assertDMNFromWBConversion(wb, TInvocation.class, 100.0, 200.0, 300.0);
+    }
+
+    @Test
+    public void testWBFromDMN_FunctionDefinitionConversion() {
+        final org.kie.dmn.model.api.FunctionDefinition dmn = new TFunctionDefinition();
+        dmn.setId(EXPRESSION_UUID);
+
+        assertWBFromDMNConversion(dmn, FunctionDefinition.class);
+    }
+
+    @Test
+    public void testDMNFromWB_FunctionDefinitionConversion() {
+        final FunctionDefinition wb = new FunctionDefinition();
+        final List<Double> wbComponentWidths = wb.getComponentWidths();
+        wbComponentWidths.set(0, 100.0);
+        wbComponentWidths.set(1, 200.0);
+        wb.getId().setValue(EXPRESSION_UUID);
+
+        assertDMNFromWBConversion(wb, TFunctionDefinition.class, 100.0, 200.0);
+    }
+
+    @Test
+    public void testWBFromDMN_DecisionTableConversion() {
+        final org.kie.dmn.model.api.DecisionTable dmn = new TDecisionTable();
+        dmn.setId(EXPRESSION_UUID);
+
+        assertWBFromDMNConversion(dmn, DecisionTable.class);
+    }
+
+    @Test
+    public void testDMNFromWB_DecisionTableConversion() {
+        final DecisionTable wb = new DecisionTable();
+        final List<Double> wbComponentWidths = wb.getComponentWidths();
+        wbComponentWidths.set(0, 100.0);
+        wbComponentWidths.set(1, 200.0);
+        wb.getId().setValue(EXPRESSION_UUID);
+
+        assertDMNFromWBConversion(wb, TDecisionTable.class, 100.0, 200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/FunctionDefinitionPropertyConverterTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.api.FunctionKind;
+import org.kie.dmn.model.v1_2.TFunctionDefinition;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FunctionDefinitionPropertyConverterTest {
+
+    private static final String FUNCTION_DEFINITION_UUID = "fd-uuid";
+
+    private static final String FUNCTION_DEFINITION_DESCRIPTION = "fd-description";
+
+    private static final String FUNCTION_DEFINITION_QNAME_LOCALPART = "fd-local";
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    @Test
+    public void testWBFromDMN() {
+        final org.kie.dmn.model.api.FunctionDefinition dmn = new TFunctionDefinition();
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        literalExpression.setId(EXPRESSION_UUID);
+
+        dmn.setId(FUNCTION_DEFINITION_UUID);
+        dmn.setDescription(FUNCTION_DEFINITION_DESCRIPTION);
+        dmn.setTypeRef(new QName(FUNCTION_DEFINITION_QNAME_LOCALPART));
+        dmn.setKind(FunctionKind.JAVA);
+        dmn.setExpression(literalExpression);
+
+        final FunctionDefinition wb = FunctionDefinitionPropertyConverter.wbFromDMN(dmn, hasComponentWidthsConsumer);
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getId()).isNotNull();
+        assertThat(wb.getId().getValue()).isEqualTo(FUNCTION_DEFINITION_UUID);
+        assertThat(wb.getDescription()).isNotNull();
+        assertThat(wb.getDescription().getValue()).isEqualTo(FUNCTION_DEFINITION_DESCRIPTION);
+        assertThat(wb.getTypeRef()).isNotNull();
+        assertThat(wb.getTypeRef().getLocalPart()).isEqualTo(FUNCTION_DEFINITION_QNAME_LOCALPART);
+        assertThat(wb.getKind()).isNotNull();
+        assertThat(wb.getKind()).isEqualTo(FunctionDefinition.Kind.JAVA);
+        assertThat(wb.getExpression()).isNotNull();
+        assertThat(wb.getExpression().getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getExpression());
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final FunctionDefinition wb = new FunctionDefinition();
+        final LiteralExpression literalExpression = new LiteralExpression();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+
+        wb.getId().setValue(FUNCTION_DEFINITION_UUID);
+        wb.getDescription().setValue(FUNCTION_DEFINITION_DESCRIPTION);
+        wb.setTypeRef(new org.kie.workbench.common.dmn.api.property.dmn.QName(org.kie.workbench.common.dmn.api.property.dmn.QName.NULL_NS_URI,
+                                                                              FUNCTION_DEFINITION_QNAME_LOCALPART));
+        wb.setKind(FunctionDefinition.Kind.JAVA);
+        wb.setExpression(literalExpression);
+
+        final org.kie.dmn.model.api.FunctionDefinition dmn = FunctionDefinitionPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getId()).isNotNull();
+        assertThat(dmn.getId()).isEqualTo(FUNCTION_DEFINITION_UUID);
+        assertThat(dmn.getDescription()).isNotNull();
+        assertThat(dmn.getDescription()).isEqualTo(FUNCTION_DEFINITION_DESCRIPTION);
+        assertThat(dmn.getTypeRef()).isNotNull();
+        assertThat(dmn.getTypeRef().getLocalPart()).isEqualTo(FUNCTION_DEFINITION_QNAME_LOCALPART);
+        assertThat(dmn.getKind()).isNotNull();
+        assertThat(dmn.getKind()).isEqualTo(FunctionKind.JAVA);
+        assertThat(dmn.getExpression()).isNotNull();
+        assertThat(dmn.getExpression().getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InvocationPropertyConverterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TInvocation;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InvocationPropertyConverterTest {
+
+    private static final String INVOCATION_UUID = "i-uuid";
+
+    private static final String INVOCATION_DESCRIPTION = "i-description";
+
+    private static final String INVOCATION_QNAME_LOCALPART = "i-local";
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    @Test
+    public void testWBFromDMN() {
+        final org.kie.dmn.model.api.Invocation dmn = new TInvocation();
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        literalExpression.setId(EXPRESSION_UUID);
+
+        dmn.setId(INVOCATION_UUID);
+        dmn.setDescription(INVOCATION_DESCRIPTION);
+        dmn.setTypeRef(new QName(INVOCATION_QNAME_LOCALPART));
+        dmn.setExpression(literalExpression);
+
+        final Invocation wb = InvocationPropertyConverter.wbFromDMN(dmn, hasComponentWidthsConsumer);
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getId()).isNotNull();
+        assertThat(wb.getId().getValue()).isEqualTo(INVOCATION_UUID);
+        assertThat(wb.getDescription()).isNotNull();
+        assertThat(wb.getDescription().getValue()).isEqualTo(INVOCATION_DESCRIPTION);
+        assertThat(wb.getTypeRef()).isNotNull();
+        assertThat(wb.getTypeRef().getLocalPart()).isEqualTo(INVOCATION_QNAME_LOCALPART);
+        assertThat(wb.getExpression()).isNotNull();
+        assertThat(wb.getExpression().getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getExpression());
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final Invocation wb = new Invocation();
+        final LiteralExpression literalExpression = new LiteralExpression();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+
+        wb.getId().setValue(INVOCATION_UUID);
+        wb.getDescription().setValue(INVOCATION_DESCRIPTION);
+        wb.setTypeRef(new org.kie.workbench.common.dmn.api.property.dmn.QName(org.kie.workbench.common.dmn.api.property.dmn.QName.NULL_NS_URI,
+                                                                              INVOCATION_QNAME_LOCALPART));
+        wb.setExpression(literalExpression);
+
+        final org.kie.dmn.model.api.Invocation dmn = InvocationPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getId()).isNotNull();
+        assertThat(dmn.getId()).isEqualTo(INVOCATION_UUID);
+        assertThat(dmn.getDescription()).isNotNull();
+        assertThat(dmn.getDescription()).isEqualTo(INVOCATION_DESCRIPTION);
+        assertThat(dmn.getTypeRef()).isNotNull();
+        assertThat(dmn.getTypeRef().getLocalPart()).isEqualTo(INVOCATION_QNAME_LOCALPART);
+        assertThat(dmn.getExpression()).isNotNull();
+        assertThat(dmn.getExpression().getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ListPropertyConverterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TList;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.List;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListPropertyConverterTest {
+
+    private static final String LIST_UUID = "l-uuid";
+
+    private static final String LIST_DESCRIPTION = "l-description";
+
+    private static final String LIST_QNAME_LOCALPART = "l-local";
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    @Test
+    public void testWBFromDMN() {
+        final org.kie.dmn.model.api.List dmn = new TList();
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        literalExpression.setId(EXPRESSION_UUID);
+
+        dmn.setId(LIST_UUID);
+        dmn.setDescription(LIST_DESCRIPTION);
+        dmn.setTypeRef(new QName(LIST_QNAME_LOCALPART));
+        dmn.getExpression().add(literalExpression);
+
+        final List wb = ListPropertyConverter.wbFromDMN(dmn, hasComponentWidthsConsumer);
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getId()).isNotNull();
+        assertThat(wb.getId().getValue()).isEqualTo(LIST_UUID);
+        assertThat(wb.getDescription()).isNotNull();
+        assertThat(wb.getDescription().getValue()).isEqualTo(LIST_DESCRIPTION);
+        assertThat(wb.getTypeRef()).isNotNull();
+        assertThat(wb.getTypeRef().getLocalPart()).isEqualTo(LIST_QNAME_LOCALPART);
+        assertThat(wb.getExpression()).isNotNull();
+        assertThat(wb.getExpression().size()).isEqualTo(1);
+        assertThat(wb.getExpression().get(0).getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getExpression().get(0));
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final List wb = new List();
+        final LiteralExpression literalExpression = new LiteralExpression();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+
+        wb.getId().setValue(LIST_UUID);
+        wb.getDescription().setValue(LIST_DESCRIPTION);
+        wb.setTypeRef(new org.kie.workbench.common.dmn.api.property.dmn.QName(org.kie.workbench.common.dmn.api.property.dmn.QName.NULL_NS_URI,
+                                                                              LIST_QNAME_LOCALPART));
+        wb.getExpression().add(literalExpression);
+
+        final org.kie.dmn.model.api.List dmn = ListPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getId()).isNotNull();
+        assertThat(dmn.getId()).isEqualTo(LIST_UUID);
+        assertThat(dmn.getDescription()).isNotNull();
+        assertThat(dmn.getDescription()).isEqualTo(LIST_DESCRIPTION);
+        assertThat(dmn.getTypeRef()).isNotNull();
+        assertThat(dmn.getTypeRef().getLocalPart()).isEqualTo(LIST_QNAME_LOCALPART);
+        assertThat(dmn.getExpression()).isNotNull();
+        assertThat(dmn.getExpression().size()).isEqualTo(1);
+        assertThat(dmn.getExpression().get(0).getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/RelationPropertyConverterTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.model.v1_2.TInformationItem;
+import org.kie.dmn.model.v1_2.TList;
+import org.kie.dmn.model.v1_2.TLiteralExpression;
+import org.kie.dmn.model.v1_2.TRelation;
+import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
+import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
+import org.kie.workbench.common.dmn.api.definition.v1_1.List;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RelationPropertyConverterTest {
+
+    private static final String RELATION_UUID = "r-uuid";
+
+    private static final String RELATION_DESCRIPTION = "r-description";
+
+    private static final String RELATION_QNAME_LOCALPART = "r-local";
+
+    private static final String EXPRESSION_UUID = "uuid";
+
+    @Mock
+    private BiConsumer<String, HasComponentWidths> hasComponentWidthsConsumer;
+
+    @Mock
+    private Consumer<ComponentWidths> componentWidthsConsumer;
+
+    @Captor
+    private ArgumentCaptor<HasComponentWidths> hasComponentWidthsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ComponentWidths> componentWidthsCaptor;
+
+    @Test
+    public void testWBFromDMN() {
+        final org.kie.dmn.model.api.Relation dmn = new TRelation();
+        final org.kie.dmn.model.api.InformationItem informationItem = new TInformationItem();
+        final org.kie.dmn.model.api.List list = new TList();
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = new TLiteralExpression();
+        literalExpression.setId(EXPRESSION_UUID);
+        list.getExpression().add(literalExpression);
+
+        dmn.setId(RELATION_UUID);
+        dmn.setDescription(RELATION_DESCRIPTION);
+        dmn.setTypeRef(new QName(RELATION_QNAME_LOCALPART));
+        dmn.getColumn().add(informationItem);
+        dmn.getRow().add(list);
+
+        final Relation wb = RelationPropertyConverter.wbFromDMN(dmn, hasComponentWidthsConsumer);
+
+        assertThat(wb).isNotNull();
+        assertThat(wb.getId()).isNotNull();
+        assertThat(wb.getId().getValue()).isEqualTo(RELATION_UUID);
+        assertThat(wb.getDescription()).isNotNull();
+        assertThat(wb.getDescription().getValue()).isEqualTo(RELATION_DESCRIPTION);
+        assertThat(wb.getTypeRef()).isNotNull();
+        assertThat(wb.getTypeRef().getLocalPart()).isEqualTo(RELATION_QNAME_LOCALPART);
+        assertThat(wb.getColumn()).isNotNull();
+        assertThat(wb.getColumn().size()).isEqualTo(1);
+        assertThat(wb.getColumn().get(0)).isNotNull();
+        assertThat(wb.getRow()).isNotNull();
+        assertThat(wb.getRow().size()).isEqualTo(1);
+        assertThat(wb.getRow().get(0)).isNotNull();
+        assertThat(wb.getRow().get(0).getExpression()).isNotNull();
+        assertThat(wb.getRow().get(0).getExpression().size()).isEqualTo(1);
+        assertThat(wb.getRow().get(0).getExpression().get(0).getId().getValue()).isEqualTo(EXPRESSION_UUID);
+
+        verify(hasComponentWidthsConsumer).accept(eq(EXPRESSION_UUID),
+                                                  hasComponentWidthsCaptor.capture());
+
+        final HasComponentWidths hasComponentWidths = hasComponentWidthsCaptor.getValue();
+        assertThat(hasComponentWidths).isNotNull();
+        assertThat(hasComponentWidths).isEqualTo(wb.getRow().get(0).getExpression().get(0));
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final Relation wb = new Relation();
+        final InformationItem informationItem = new InformationItem();
+        final List list = new List();
+        final LiteralExpression literalExpression = new LiteralExpression();
+        literalExpression.getComponentWidths().set(0, 200.0);
+        literalExpression.getId().setValue(EXPRESSION_UUID);
+        list.getExpression().add(literalExpression);
+
+        wb.getId().setValue(RELATION_UUID);
+        wb.getDescription().setValue(RELATION_DESCRIPTION);
+        wb.setTypeRef(new org.kie.workbench.common.dmn.api.property.dmn.QName(org.kie.workbench.common.dmn.api.property.dmn.QName.NULL_NS_URI,
+                                                                              RELATION_QNAME_LOCALPART));
+        wb.getColumn().add(informationItem);
+        wb.getRow().add(list);
+
+        final org.kie.dmn.model.api.Relation dmn = RelationPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getId()).isNotNull();
+        assertThat(dmn.getId()).isEqualTo(RELATION_UUID);
+        assertThat(dmn.getDescription()).isNotNull();
+        assertThat(dmn.getDescription()).isEqualTo(RELATION_DESCRIPTION);
+        assertThat(dmn.getTypeRef()).isNotNull();
+        assertThat(dmn.getTypeRef().getLocalPart()).isEqualTo(RELATION_QNAME_LOCALPART);
+        assertThat(dmn.getColumn()).isNotNull();
+        assertThat(dmn.getColumn().size()).isEqualTo(1);
+        assertThat(dmn.getColumn().get(0)).isNotNull();
+        assertThat(dmn.getRow()).isNotNull();
+        assertThat(dmn.getRow().size()).isEqualTo(1);
+        assertThat(dmn.getRow().get(0)).isNotNull();
+        assertThat(dmn.getRow().get(0).getExpression()).isNotNull();
+        assertThat(dmn.getRow().get(0).getExpression().size()).isEqualTo(1);
+        assertThat(dmn.getRow().get(0).getExpression().get(0).getId()).isEqualTo(EXPRESSION_UUID);
+
+        verify(componentWidthsConsumer).accept(componentWidthsCaptor.capture());
+
+        final ComponentWidths componentWidths = componentWidthsCaptor.getValue();
+        assertThat(componentWidths).isNotNull();
+        assertThat(componentWidths.getDmnElementRef().getLocalPart()).isEqualTo(EXPRESSION_UUID);
+        assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
+        assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/UnaryTestsPropertyConverterTest.java
@@ -74,33 +74,32 @@ public class UnaryTestsPropertyConverterTest {
     }
 
     @Test
-    public void testWbFromDMNEnumeration(){
+    public void testWbFromDMNEnumeration() {
         testWbFromDMN(ENUMERATION);
     }
 
     @Test
-    public void testWbFromDMNRange(){
+    public void testWbFromDMNRange() {
         testWbFromDMN(RANGE);
     }
 
     @Test
-    public void testWbFromDMNExpression(){
+    public void testWbFromDMNExpression() {
         testWbFromDMN(EXPRESSION);
     }
 
-
     @Test
-    public void testDmnFromWBEnumeration(){
+    public void testDmnFromWBEnumeration() {
         testDmnFromWB(ENUMERATION);
     }
 
     @Test
-    public void testDmnFromWBRange(){
+    public void testDmnFromWBRange() {
         testDmnFromWB(RANGE);
     }
 
     @Test
-    public void testDmnFromWBExpression(){
+    public void testDmnFromWBExpression() {
         testDmnFromWB(EXPRESSION);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegisterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegisterTest.java
@@ -15,6 +15,8 @@
  */
 package org.kie.workbench.common.dmn.backend.definition.v1_1.dd;
 
+import java.util.Optional;
+
 import javax.xml.namespace.QName;
 
 import com.thoughtworks.xstream.XStream;
@@ -23,6 +25,8 @@ import com.thoughtworks.xstream.io.xml.QNameMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_2.TDefinitions;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -33,9 +37,11 @@ import static org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumen
 import static org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDIExtensionsRegister.COMPONENTS_WIDTHS_EXTENSION_ALIAS;
 import static org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDIExtensionsRegister.COMPONENT_WIDTHS_ALIAS;
 import static org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDIExtensionsRegister.COMPONENT_WIDTH_ALIAS;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DMNDIExtensionsRegisterTest {
@@ -73,7 +79,10 @@ public class DMNDIExtensionsRegisterTest {
 
     @Test
     public void testBeforeMarshal() {
-        register.beforeMarshal(mock(Object.class), qmap);
+        final DMNModelInstrumentedBase base = mock(TDefinitions.class);
+        when(base.getPrefixForNamespaceURI(anyString())).thenReturn(Optional.empty());
+
+        register.beforeMarshal(base, qmap);
 
         verify(qmap).registerMapping(qNameCaptor.capture(),
                                      eq(COMPONENTS_WIDTHS_EXTENSION_ALIAS));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegisterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/dd/DMNDIExtensionsRegisterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.backend.definition.v1_1.dd;
+
+import javax.xml.namespace.QName;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.io.xml.QNameMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace.KIE;
+import static org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDIExtensionsRegister.COMPONENTS_WIDTHS_EXTENSION_ALIAS;
+import static org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDIExtensionsRegister.COMPONENT_WIDTHS_ALIAS;
+import static org.kie.workbench.common.dmn.backend.definition.v1_1.dd.DMNDIExtensionsRegister.COMPONENT_WIDTH_ALIAS;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNDIExtensionsRegisterTest {
+
+    @Mock
+    private XStream xStream;
+
+    @Mock
+    private QNameMap qmap;
+
+    @Captor
+    private ArgumentCaptor<Converter> converterCaptor;
+
+    @Captor
+    private ArgumentCaptor<QName> qNameCaptor;
+
+    private DMNDIExtensionsRegister register;
+
+    @Before
+    public void setup() {
+        this.register = new DMNDIExtensionsRegister();
+    }
+
+    @Test
+    public void testRegisterExtensionConverters() {
+        register.registerExtensionConverters(xStream);
+
+        verify(xStream).processAnnotations(eq(ComponentsWidthsExtension.class));
+        verify(xStream).processAnnotations(eq(ComponentWidths.class));
+        verify(xStream).alias(eq(COMPONENT_WIDTH_ALIAS), eq(Double.class));
+        verify(xStream).registerConverter(converterCaptor.capture());
+
+        assertThat(converterCaptor.getValue()).isInstanceOf(ComponentWidthsConverter.class);
+    }
+
+    @Test
+    public void testBeforeMarshal() {
+        register.beforeMarshal(mock(Object.class), qmap);
+
+        verify(qmap).registerMapping(qNameCaptor.capture(),
+                                     eq(COMPONENTS_WIDTHS_EXTENSION_ALIAS));
+        final QName qName1 = qNameCaptor.getValue();
+        assertThat(qName1.getNamespaceURI()).isEqualTo(KIE.getUri());
+        assertThat(qName1.getLocalPart()).isEqualTo(COMPONENTS_WIDTHS_EXTENSION_ALIAS);
+        assertThat(qName1.getPrefix()).isEqualTo(KIE.getPrefix());
+
+        verify(qmap).registerMapping(qNameCaptor.capture(),
+                                     eq(COMPONENT_WIDTHS_ALIAS));
+        final QName qName2 = qNameCaptor.getValue();
+        assertThat(qName2.getNamespaceURI()).isEqualTo(KIE.getUri());
+        assertThat(qName2.getLocalPart()).isEqualTo(COMPONENT_WIDTHS_ALIAS);
+        assertThat(qName2.getPrefix()).isEqualTo(KIE.getPrefix());
+
+        verify(qmap).registerMapping(qNameCaptor.capture(),
+                                     eq(COMPONENT_WIDTH_ALIAS));
+        final QName qName3 = qNameCaptor.getValue();
+        assertThat(qName3.getNamespaceURI()).isEqualTo(KIE.getUri());
+        assertThat(qName3.getLocalPart()).isEqualTo(COMPONENT_WIDTH_ALIAS);
+        assertThat(qName3.getPrefix()).isEqualTo(KIE.getPrefix());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DROOLS-2262.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/resources/DROOLS-2262.dmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/kiegroup/drools/kie-dmn/_6C8EA88F-33F3-4738-BFC0-9308888C7FC3" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_09FCD159-E470-4047-801D-FD3465D65B14" name="_FCF28045-021F-4DC5-8971-32E5EEE80225" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/kiegroup/drools/kie-dmn/_6C8EA88F-33F3-4738-BFC0-9308888C7FC3">
+  <dmn:extensionElements></dmn:extensionElements>
+  <dmn:decision id="_37883BDC-DB54-4925-B539-A0F19B1DDE41" name="Decision-1">
+    <dmn:variable id="_DBE14FFE-4621-4685-B55B-ABF1A225D11A" name="Decision-1"></dmn:variable>
+    <dmn:decisionTable id="_E74E71BD-AA58-4C0D-A1FC-DB23EDB88637" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_EFE51438-5A7D-4EF6-B702-ACE65D674F00">
+        <dmn:inputExpression id="_67820F4C-9711-4695-8B02-A6DAAFD68D9E">
+          <dmn:text>input-1</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_0198058E-1412-43A1-B47C-C14860322B2B"></dmn:output>
+      <dmn:rule id="_AFC14AD7-AFDD-4BF0-B5D7-F04353BBA306">
+        <dmn:description>description</dmn:description>
+        <dmn:inputEntry id="_F166C590-E584-4F96-B64C-224313CB8535">
+          <dmn:text>in1</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_950A7BC4-A9D7-4A8A-8837-B6C93F8E6AA8">
+          <dmn:text>out1</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_E74E71BD-AA58-4C0D-A1FC-DB23EDB88637">
+            <kie:width>50.0</kie:width>
+            <kie:width>150.0</kie:width>
+            <kie:width>200.0</kie:width>
+            <kie:width>250.0</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_37883BDC-DB54-4925-B539-A0F19B1DDE41" dmnElementRef="_37883BDC-DB54-4925-B539-A0F19B1DDE41" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"></dmndi:FillColor>
+          <dmndi:StrokeColor red="0" green="0" blue="0"></dmndi:StrokeColor>
+          <dmndi:FontColor red="0" green="0" blue="0"></dmndi:FontColor>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="168" y="193" width="100" height="50"></dc:Bounds>
+        <dmndi:DMNLabel></dmndi:DMNLabel>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
@@ -20,10 +20,11 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProvider;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
@@ -32,7 +33,7 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 @ApplicationScoped
 public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvider {
 
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
     private DefinitionUtils definitionUtils;
 
     public TextAnnotationTextPropertyProviderImpl() {
@@ -40,7 +41,7 @@ public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvi
     }
 
     @Inject
-    public TextAnnotationTextPropertyProviderImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+    public TextAnnotationTextPropertyProviderImpl(final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                                   final DefinitionUtils definitionUtils) {
         this.canvasCommandFactory = canvasCommandFactory;
         this.definitionUtils = definitionUtils;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/builder/ObserverBuilderControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/builder/ObserverBuilderControl.java
@@ -21,11 +21,10 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.api.ClientDefinitionManager;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.builder.impl.Observer;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationMessages;
 import org.kie.workbench.common.stunner.core.client.service.ClientFactoryService;
 import org.kie.workbench.common.stunner.core.graph.processing.index.bounds.GraphBoundsIndexer;
@@ -40,7 +39,7 @@ public class ObserverBuilderControl extends org.kie.workbench.common.stunner.cor
     public ObserverBuilderControl(final ClientDefinitionManager clientDefinitionManager,
                                   final ClientFactoryService clientFactoryServices,
                                   final RuleManager ruleManager,
-                                  final @DMNEditor CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                  final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                   final ClientTranslationMessages translationMessages,
                                   final GraphBoundsIndexer graphBoundsIndexer,
                                   final Event<CanvasSelectionEvent> canvasSelectionEvent) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/resize/DecisionServiceMoveDividerControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/resize/DecisionServiceMoveDividerControl.java
@@ -23,12 +23,13 @@ import java.util.logging.Logger;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionService;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.shape.view.decisionservice.DecisionServiceSVGShapeView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasHandlerRegistrationControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -52,7 +53,7 @@ public class DecisionServiceMoveDividerControl extends AbstractCanvasHandlerRegi
 
     private static Logger LOGGER = Logger.getLogger(DecisionServiceMoveDividerControl.class.getName());
 
-    private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private final DefaultCanvasCommandFactory canvasCommandFactory;
     private RequiresCommandManager.CommandManagerProvider<AbstractCanvasHandler> commandManagerProvider;
 
     protected DecisionServiceMoveDividerControl() {
@@ -60,7 +61,7 @@ public class DecisionServiceMoveDividerControl extends AbstractCanvasHandlerRegi
     }
 
     @Inject
-    public DecisionServiceMoveDividerControl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory) {
+    public DecisionServiceMoveDividerControl(final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory) {
         this.canvasCommandFactory = canvasCommandFactory;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNCreateNodeAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNCreateNodeAction.java
@@ -21,11 +21,11 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.api.ClientFactoryManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.GeneralCreateNodeAction;
 import org.kie.workbench.common.stunner.core.client.session.Session;
@@ -39,7 +39,7 @@ public class DMNCreateNodeAction extends GeneralCreateNodeAction {
                                final CanvasLayoutUtils canvasLayoutUtils,
                                final Event<CanvasSelectionEvent> selectionEvent,
                                final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                               final @DMNEditor CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory) {
+                               final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory) {
         super(clientFactoryManager,
               canvasLayoutUtils,
               selectionEvent,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommand.java
@@ -96,6 +96,8 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
 
             @Override
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext gce) {
+                dtable.getComponentWidths().remove(uiColumnIndex);
+
                 final int clauseIndex = getInputClauseIndex();
                 dtable.getRule().forEach(row -> row.getInputEntry().remove(clauseIndex));
                 dtable.getInput().remove(clauseIndex);
@@ -105,6 +107,8 @@ public class DeleteInputClauseCommand extends AbstractCanvasGraphCommand impleme
 
             @Override
             public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext gce) {
+                dtable.getComponentWidths().add(uiColumnIndex, oldUiModelColumn.getWidth());
+
                 final int clauseIndex = getInputClauseIndex();
                 dtable.getInput().add(clauseIndex,
                                       oldInputClause);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommand.java
@@ -96,6 +96,8 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
 
             @Override
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext gce) {
+                dtable.getComponentWidths().remove(uiColumnIndex);
+
                 final int clauseIndex = getOutputClauseIndex();
                 dtable.getRule().forEach(row -> row.getOutputEntry().remove(clauseIndex));
                 dtable.getOutput().remove(clauseIndex);
@@ -105,6 +107,8 @@ public class DeleteOutputClauseCommand extends AbstractCanvasGraphCommand implem
 
             @Override
             public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext gce) {
+                dtable.getComponentWidths().add(uiColumnIndex, oldUiModelColumn.getWidth());
+
                 final int clauseIndex = getOutputClauseIndex();
                 dtable.getOutput().add(clauseIndex,
                                        oldOutputClause);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommand.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.UnaryTests;
 import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
 import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
+import org.kie.workbench.common.dmn.client.commands.util.CommandUtils;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.DecisionTableUIModelMapperHelper;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.DecisionTableUIModelMapperHelper.DecisionTableSection;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
@@ -113,9 +114,10 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                                 relativeOldIndex,
                                 dtable.getInput(),
                                 inputClauseIndexesToMove);
-                    moveComponentWidths(index,
-                                        oldIndex,
-                                        uiColumnIndexesToMove);
+                    CommandUtils.moveComponentWidths(index,
+                                                     oldIndex,
+                                                     dtable.getComponentWidths(),
+                                                     uiColumnIndexesToMove);
 
                     final List<List<UnaryTests>> decisionRulesInputEntries = dtable.getRule()
                             .stream()
@@ -145,9 +147,10 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                                 relativeOldIndex,
                                 dtable.getOutput(),
                                 outputClauseIndexesToMove);
-                    moveComponentWidths(index,
-                                        oldIndex,
-                                        uiColumnIndexesToMove);
+                    CommandUtils.moveComponentWidths(index,
+                                                     oldIndex,
+                                                     dtable.getComponentWidths(),
+                                                     uiColumnIndexesToMove);
 
                     final List<List<LiteralExpression>> decisionRulesOutputEntries = dtable.getRule()
                             .stream()
@@ -180,25 +183,6 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                 } else if (relativeIndex > relativeOldIndex) {
                     clauses.addAll(relativeIndex - clausesToMove.size() + 1,
                                    clausesToMove);
-                }
-            }
-
-            private void moveComponentWidths(final int index,
-                                             final int oldIndex,
-                                             final List<Integer> uiColumnIndexes) {
-                final java.util.List<Double> componentWidths = dtable.getComponentWidths();
-                final java.util.List<Double> componentWidthsToMove = uiColumnIndexes
-                        .stream()
-                        .map(componentWidths::get)
-                        .collect(Collectors.toList());
-
-                uiColumnIndexes.forEach(i -> componentWidths.remove(oldIndex));
-                if (index < oldIndex) {
-                    componentWidths.addAll(index,
-                                           componentWidthsToMove);
-                } else if (index > oldIndex) {
-                    componentWidths.addAll(oldIndex + 1,
-                                           componentWidthsToMove);
                 }
             }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommand.java
@@ -101,15 +101,21 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                     final int relativeOldIndex = DecisionTableUIModelMapperHelper.getInputEntryIndex(dtable,
                                                                                                      oldIndex);
 
-                    final List<Integer> inputClauseIndexesToMove = columns
+                    final List<Integer> uiColumnIndexesToMove = columns
                             .stream()
                             .map(c -> uiModel.getColumns().indexOf(c))
+                            .collect(Collectors.toList());
+                    final List<Integer> inputClauseIndexesToMove = uiColumnIndexesToMove
+                            .stream()
                             .map(i -> DecisionTableUIModelMapperHelper.getInputEntryIndex(dtable, i))
                             .collect(Collectors.toList());
                     moveClauses(relativeIndex,
                                 relativeOldIndex,
                                 dtable.getInput(),
                                 inputClauseIndexesToMove);
+                    moveComponentWidths(index,
+                                        oldIndex,
+                                        uiColumnIndexesToMove);
 
                     final List<List<UnaryTests>> decisionRulesInputEntries = dtable.getRule()
                             .stream()
@@ -127,15 +133,21 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                                                                                                    index);
                     final int relativeOldIndex = DecisionTableUIModelMapperHelper.getOutputEntryIndex(dtable,
                                                                                                       oldIndex);
-                    final List<Integer> outputClauseIndexesToMove = columns
+                    final List<Integer> uiColumnIndexesToMove = columns
                             .stream()
                             .map(c -> uiModel.getColumns().indexOf(c))
+                            .collect(Collectors.toList());
+                    final List<Integer> outputClauseIndexesToMove = uiColumnIndexesToMove
+                            .stream()
                             .map(i -> DecisionTableUIModelMapperHelper.getOutputEntryIndex(dtable, i))
                             .collect(Collectors.toList());
                     moveClauses(relativeIndex,
                                 relativeOldIndex,
                                 dtable.getOutput(),
                                 outputClauseIndexesToMove);
+                    moveComponentWidths(index,
+                                        oldIndex,
+                                        uiColumnIndexesToMove);
 
                     final List<List<LiteralExpression>> decisionRulesOutputEntries = dtable.getRule()
                             .stream()
@@ -168,6 +180,25 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                 } else if (relativeIndex > relativeOldIndex) {
                     clauses.addAll(relativeIndex - clausesToMove.size() + 1,
                                    clausesToMove);
+                }
+            }
+
+            private void moveComponentWidths(final int index,
+                                             final int oldIndex,
+                                             final List<Integer> uiColumnIndexes) {
+                final java.util.List<Double> componentWidths = dtable.getComponentWidths();
+                final java.util.List<Double> componentWidthsToMove = uiColumnIndexes
+                        .stream()
+                        .map(componentWidths::get)
+                        .collect(Collectors.toList());
+
+                uiColumnIndexes.forEach(i -> componentWidths.remove(oldIndex));
+                if (index < oldIndex) {
+                    componentWidths.addAll(index,
+                                           componentWidthsToMove);
+                } else if (index > oldIndex) {
+                    componentWidths.addAll(oldIndex + 1,
+                                           componentWidthsToMove);
                 }
             }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommand.java
@@ -92,6 +92,8 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
 
             @Override
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext gce) {
+                relation.getComponentWidths().remove(uiColumnIndex);
+
                 final int iiIndex = uiColumnIndex - RelationUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT;
                 relation.getRow().forEach(row -> row.getExpression().remove(iiIndex));
                 relation.getColumn().remove(iiIndex);
@@ -101,6 +103,8 @@ public class DeleteRelationColumnCommand extends AbstractCanvasGraphCommand impl
 
             @Override
             public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext gce) {
+                relation.getComponentWidths().add(uiColumnIndex, oldUiModelColumn.getWidth());
+
                 final int iiIndex = uiColumnIndex - RelationUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT;
                 relation.getColumn().add(iiIndex,
                                          oldInformationItem);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.commands.expressions.types.relation;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.List;
@@ -104,8 +105,10 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                                          relativeOldIndex,
                                          relation.getColumn(),
                                          informationItemIndexesToMove);
-                    moveComponentWidths(Relation.STATIC_COLUMNS + relativeIndex,
-                                        Relation.STATIC_COLUMNS + relativeOldIndex);
+                    CommandUtils.moveComponentWidths(Relation.STATIC_COLUMNS + relativeIndex,
+                                                     Relation.STATIC_COLUMNS + relativeOldIndex,
+                                                     relation.getComponentWidths(),
+                                                     Collections.singletonList(oldIndex));
 
                     updateRowsData(relativeIndex,
                                    relativeOldIndex,
@@ -134,19 +137,6 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                 } else if (relativeIndex > relativeOldIndex) {
                     informationItems.addAll(relativeIndex - informationItemsToMove.size() + 1,
                                             informationItemsToMove);
-                }
-            }
-
-            private void moveComponentWidths(final int index,
-                                             final int oldIndex) {
-                final java.util.List<Double> componentWidths = relation.getComponentWidths();
-                final Double componentWidth = componentWidths.remove(oldIndex);
-                if (index < oldIndex) {
-                    componentWidths.add(index,
-                                        componentWidth);
-                } else if (index > oldIndex) {
-                    componentWidths.add(oldIndex + 1,
-                                        componentWidth);
                 }
             }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommand.java
@@ -104,6 +104,8 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                                          relativeOldIndex,
                                          relation.getColumn(),
                                          informationItemIndexesToMove);
+                    moveComponentWidths(Relation.STATIC_COLUMNS + relativeIndex,
+                                        Relation.STATIC_COLUMNS + relativeOldIndex);
 
                     updateRowsData(relativeIndex,
                                    relativeOldIndex,
@@ -132,6 +134,19 @@ public class MoveColumnsCommand extends AbstractCanvasGraphCommand implements Ve
                 } else if (relativeIndex > relativeOldIndex) {
                     informationItems.addAll(relativeIndex - informationItemsToMove.size() + 1,
                                             informationItemsToMove);
+                }
+            }
+
+            private void moveComponentWidths(final int index,
+                                             final int oldIndex) {
+                final java.util.List<Double> componentWidths = relation.getComponentWidths();
+                final Double componentWidth = componentWidths.remove(oldIndex);
+                if (index < oldIndex) {
+                    componentWidths.add(index,
+                                        componentWidth);
+                } else if (index > oldIndex) {
+                    componentWidths.add(oldIndex + 1,
+                                        componentWidth);
                 }
             }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/SetComponentWidthCanvasCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/SetComponentWidthCanvasCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+
+public class SetComponentWidthCanvasCommand extends AbstractCanvasCommand {
+
+    private final DMNGridColumn uiColumn;
+    private final double oldWidth;
+    private final double width;
+
+    public SetComponentWidthCanvasCommand(final DMNGridColumn uiColumn,
+                                          final double oldWidth,
+                                          final double width) {
+        this.uiColumn = uiColumn;
+        this.oldWidth = oldWidth;
+        this.width = width;
+    }
+
+    @Override
+    public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
+        try {
+            uiColumn.setWidth(width);
+            uiColumn.getGridWidget().batch();
+        } catch (Exception e) {
+            return CanvasCommandResultBuilder.FAILED;
+        }
+        return CanvasCommandResultBuilder.SUCCESS;
+    }
+
+    @Override
+    public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
+        try {
+            uiColumn.setWidth(oldWidth);
+            uiColumn.getGridWidget().batch();
+        } catch (Exception e) {
+            return CanvasCommandResultBuilder.FAILED;
+        }
+        return CanvasCommandResultBuilder.SUCCESS;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/SetComponentWidthCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/SetComponentWidthCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import org.kie.workbench.common.dmn.client.commands.VetoExecutionCommand;
+import org.kie.workbench.common.dmn.client.commands.VetoUndoCommand;
+import org.kie.workbench.common.dmn.client.commands.general.NoOperationGraphCommand;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+public class SetComponentWidthCommand extends AbstractCanvasGraphCommand implements VetoExecutionCommand,
+                                                                                    VetoUndoCommand {
+
+    private final DMNGridColumn uiColumn;
+    private final double oldWidth;
+    private final double width;
+
+    public SetComponentWidthCommand(final DMNGridColumn uiColumn,
+                                    final double oldWidth,
+                                    final double width) {
+        this.uiColumn = uiColumn;
+        this.oldWidth = oldWidth;
+        this.width = width;
+    }
+
+    @Override
+    protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
+        return new NoOperationGraphCommand();
+    }
+
+    @Override
+    protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
+        return new SetComponentWidthCanvasCommand(uiColumn,
+                                                  oldWidth,
+                                                  width);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
@@ -36,12 +36,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasGraphCommand;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
-import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
-import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.graph.command.impl.AbstractGraphCommand;
-import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.uberfire.client.workbench.widgets.listbar.ResizeFlowPanel;
 
@@ -157,23 +152,5 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
 
     private CanvasHandler getCanvasHandler() {
         return null != sessionManager.getCurrentSession() ? sessionManager.getCurrentSession().getCanvasHandler() : null;
-    }
-
-    public static class NoOperationGraphCommand extends AbstractGraphCommand {
-
-        @Override
-        protected CommandResult<RuleViolation> check(final GraphCommandExecutionContext context) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommand.java
@@ -19,9 +19,11 @@ package org.kie.workbench.common.dmn.client.commands.general;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainerUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasCommand;
@@ -29,12 +31,13 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultB
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 public class ClearExpressionTypeCommand extends BaseClearExpressionCommand {
 
     private final String nodeUUID;
     private final ExpressionGridCache expressionGridCache;
-    private final Optional<BaseExpressionGrid> oldExpressionGrid;
+    private final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oldExpressionGrid;
 
     public ClearExpressionTypeCommand(final GridCellTuple cellTuple,
                                       final String nodeUUID,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NoOperationGraphCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/NoOperationGraphCommand.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.commands.general;
+
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.graph.command.impl.AbstractGraphCommand;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+public class NoOperationGraphCommand extends AbstractGraphCommand {
+
+    @Override
+    protected CommandResult<RuleViolation> check(final GraphCommandExecutionContext context) {
+        return GraphCommandResultBuilder.SUCCESS;
+    }
+
+    @Override
+    public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
+        return GraphCommandResultBuilder.SUCCESS;
+    }
+
+    @Override
+    public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
+        return GraphCommandResultBuilder.SUCCESS;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/CommandUtils.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.commands.util;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
@@ -65,6 +66,25 @@ public class CommandUtils {
         } else if (index > oldBlockStart) {
             allRows.addAll(index - rowsToMove.size() + 1,
                            rowsToMove);
+        }
+    }
+
+    public static void moveComponentWidths(final int index,
+                                           final int oldIndex,
+                                           final List<Double> componentWidths,
+                                           final List<Integer> uiColumnIndexes) {
+        final java.util.List<Double> componentWidthsToMove = uiColumnIndexes
+                .stream()
+                .map(componentWidths::get)
+                .collect(Collectors.toList());
+
+        uiColumnIndexes.forEach(i -> componentWidths.remove(oldIndex));
+        if (index < oldIndex) {
+            componentWidths.addAll(index,
+                                   componentWidthsToMove);
+        } else if (index > oldIndex) {
+            componentWidths.addAll(oldIndex + 1,
+                                   componentWidthsToMove);
         }
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapper.java
@@ -75,18 +75,17 @@ public class ExpressionContainerUIModelMapper extends BaseUIModelMapper<Expressi
 
         final Optional<ExpressionEditorDefinition<Expression>> expressionEditorDefinition = expressionEditorDefinitions.get().getExpressionEditorDefinition(expression);
         expressionEditorDefinition.ifPresent(definition -> {
-            Optional<BaseExpressionGrid> editor = expressionGridCache.get().getExpressionGrid(uuid);
+            Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = expressionGridCache.get().getExpressionGrid(uuid);
             if (!editor.isPresent()) {
-                final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                                  Optional.of(uuid),
-                                                                                  hasExpression,
-                                                                                  expression,
-                                                                                  hasName,
-                                                                                  0);
+                final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                         Optional.of(uuid),
+                                                                                                                                                         hasExpression,
+                                                                                                                                                         hasName,
+                                                                                                                                                         0);
                 expressionGridCache.get().putExpressionGrid(uuid, oEditor);
                 editor = oEditor;
             }
-            final Optional<BaseExpressionGrid> _editor = editor;
+            final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> _editor = editor;
             uiModel.setCell(0,
                             0,
                             () -> new ContextGridCell<>(new ExpressionCellValue(_editor),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
@@ -82,6 +83,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     private ListSelectorView.Presenter listSelector;
     private SessionManager sessionManager;
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
     private Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     private Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
@@ -104,6 +106,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                     final ListSelectorView.Presenter listSelector,
                                     final SessionManager sessionManager,
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                    final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                     final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent) {
@@ -116,6 +119,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
+        this.canvasCommandFactory = canvasCommandFactory;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
         this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
         this.domainObjectSelectionEvent = domainObjectSelectionEvent;
@@ -164,6 +168,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                                               listSelector,
                                                               sessionManager,
                                                               sessionCommandManager,
+                                                              canvasCommandFactory,
                                                               expressionEditorDefinitionsSupplier,
                                                               getExpressionGridCacheSupplier(),
                                                               this::setExpressionTypeText,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/BaseEditorDefinition.java
@@ -17,11 +17,13 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.enterprise.event.Event;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
@@ -31,7 +33,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -42,7 +43,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
     protected DefinitionUtils definitionUtils;
     protected SessionManager sessionManager;
     protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    protected CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    protected DefaultCanvasCommandFactory canvasCommandFactory;
     protected Event<ExpressionEditorChanged> editorSelectedEvent;
     protected Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     protected Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
@@ -56,7 +57,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
     public BaseEditorDefinition(final DefinitionUtils definitionUtils,
                                 final SessionManager sessionManager,
                                 final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                final DefaultCanvasCommandFactory canvasCommandFactory,
                                 final Event<ExpressionEditorChanged> editorSelectedEvent,
                                 final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                 final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -73,7 +74,7 @@ public abstract class BaseEditorDefinition<E extends Expression, D extends GridD
         this.translationService = translationService;
     }
 
-    protected abstract D makeGridData(final Optional<E> expression);
+    protected abstract D makeGridData(final Supplier<Optional<E>> expression);
 
     protected DMNGridPanel getGridPanel() {
         return ((DMNSession) sessionManager.getCurrentSession()).getGridPanel();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/ExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/ExpressionEditorDefinition.java
@@ -22,7 +22,9 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 public interface ExpressionEditorDefinition<T extends Expression> extends ExpressionEditorModelEnricher<T> {
 
@@ -32,10 +34,9 @@ public interface ExpressionEditorDefinition<T extends Expression> extends Expres
 
     Optional<T> getModelClass();
 
-    Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                           final Optional<String> nodeUUID,
-                                           final HasExpression hasExpression,
-                                           final Optional<T> expression,
-                                           final Optional<HasName> hasName,
-                                           final int nesting);
+    Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                  final Optional<String> nodeUUID,
+                                                                                                                  final HasExpression hasExpression,
+                                                                                                                  final Optional<HasName> hasName,
+                                                                                                                  final int nesting);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinition.java
@@ -28,8 +28,10 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ContextEntry;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -37,17 +39,18 @@ import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverV
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @ApplicationScoped
 public class ContextEditorDefinition extends BaseEditorDefinition<Context, ContextGridData> {
@@ -63,7 +66,7 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
     public ContextEditorDefinition(final DefinitionUtils definitionUtils,
                                    final SessionManager sessionManager,
                                    final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                   final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                   final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                    final Event<ExpressionEditorChanged> editorSelectedEvent,
                                    final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                    final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -122,20 +125,18 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
     }
 
     @Override
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<Context> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new ContextGrid(parent,
                                            nodeUUID,
                                            hasExpression,
-                                           expression,
                                            hasName,
                                            getGridPanel(),
                                            getGridLayer(),
-                                           makeGridData(expression),
+                                           makeGridData(() -> Optional.ofNullable((Context) hasExpression.getExpression())),
                                            definitionUtils,
                                            sessionManager,
                                            sessionCommandManager,
@@ -152,7 +153,7 @@ public class ContextEditorDefinition extends BaseEditorDefinition<Context, Conte
     }
 
     @Override
-    protected ContextGridData makeGridData(final Optional<Context> expression) {
+    protected ContextGridData makeGridData(final Supplier<Optional<Context>> expression) {
         return new ContextGridData(new DMNGridData(),
                                    sessionManager,
                                    sessionCommandManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridData.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.context;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.context.MoveRowsCommand;
@@ -36,13 +37,13 @@ public class ContextGridData extends DelegatingGridData {
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final Optional<Context> expression;
+    private final Supplier<Optional<Context>> expression;
     private final Command canvasOperation;
 
     public ContextGridData(final DMNGridData delegate,
                            final SessionManager sessionManager,
                            final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                           final Optional<Context> expression,
+                           final Supplier<Optional<Context>> expression,
                            final Command canvasOperation) {
         super(delegate);
         this.sessionManager = sessionManager;
@@ -63,7 +64,7 @@ public class ContextGridData extends DelegatingGridData {
     @Override
     public void moveRowsTo(final int index,
                            final List<GridRow> rows) {
-        expression.ifPresent(context -> {
+        expression.get().ifPresent(context -> {
             final AbstractCanvasHandler handler = (AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler();
             final MoveRowsCommand command = new MoveRowsCommand(context,
                                                                 delegate,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridRowNumberColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridRowNumberColumn.java
@@ -24,10 +24,13 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.im
 
 public class ContextGridRowNumberColumn extends BaseGridColumn<Integer> implements IsRowDragHandle {
 
-    public ContextGridRowNumberColumn(final List<HeaderMetaData> headerMetaData) {
+    public static final double DEFAULT_WIDTH = 50.0;
+
+    public ContextGridRowNumberColumn(final List<HeaderMetaData> headerMetaData,
+                                      final double width) {
         super(headerMetaData,
               new IntegerColumnRenderer(),
-              50.0);
+              width);
         setMovable(false);
         setResizable(false);
         setFloatable(true);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextUIModelMapper.java
@@ -96,14 +96,13 @@ public class ContextUIModelMapper extends BaseUIModelMapper<Context> {
 
                     final Optional<ExpressionEditorDefinition<Expression>> expressionEditorDefinition = expressionEditorDefinitionsSupplier.get().getExpressionEditorDefinition(expression);
                     expressionEditorDefinition.ifPresent(ed -> {
-                        final Optional<BaseExpressionGrid> editor = ed.getEditor(new GridCellTuple(rowIndex,
-                                                                                                   columnIndex,
-                                                                                                   gridWidget),
-                                                                                 Optional.empty(),
-                                                                                 ce,
-                                                                                 expression,
-                                                                                 Optional.ofNullable(ce.getVariable()),
-                                                                                 nesting + 1);
+                        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = ed.getEditor(new GridCellTuple(rowIndex,
+                                                                                                                                                                          columnIndex,
+                                                                                                                                                                          gridWidget),
+                                                                                                                                                        Optional.empty(),
+                                                                                                                                                        ce,
+                                                                                                                                                        Optional.ofNullable(ce.getVariable()),
+                                                                                                                                                        nesting + 1);
 
                         uiModel.get().setCell(rowIndex,
                                               columnIndex,
@@ -141,7 +140,7 @@ public class ContextUIModelMapper extends BaseUIModelMapper<Context> {
                     cell.get().ifPresent(v -> {
                         final ExpressionCellValue ecv = (ExpressionCellValue) v;
                         ecv.getValue().ifPresent(beg -> {
-                            beg.getExpression().ifPresent(e -> context.getContextEntry()
+                            beg.getExpression().get().ifPresent(e -> context.getContextEntry()
                                     .get(rowIndex)
                                     .setExpression((Expression) e));
                         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionCellValue.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionCellValue.java
@@ -18,17 +18,20 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.context;
 
 import java.util.Optional;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-public class ExpressionCellValue extends BaseGridCellValue<Optional<BaseExpressionGrid>> {
+public class ExpressionCellValue extends BaseGridCellValue<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> {
 
-    public ExpressionCellValue(final Optional<BaseExpressionGrid> editor) {
+    public ExpressionCellValue(final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor) {
         super(editor);
     }
 
     public Optional<Double> getMinimumWidth() {
-        final Optional<BaseExpressionGrid> editor = getValue();
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = getValue();
         if (editor.isPresent()) {
             final BaseExpressionGrid beg = editor.get();
             return Optional.of(beg.getMinimumWidth());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
@@ -20,8 +20,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionColumn;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -29,38 +31,41 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.HasDOMElementResources;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.BaseGridColumnRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridWidgetRegistry;
 
-public class ExpressionEditorColumn extends DMNGridColumn<GridWidget, Optional<BaseExpressionGrid>> implements HasDOMElementResources {
+public class ExpressionEditorColumn extends DMNGridColumn<BaseGrid<? extends Expression>, Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> implements HasDOMElementResources {
 
     public ExpressionEditorColumn(final GridWidgetRegistry registry,
                                   final HeaderMetaData headerMetaData,
-                                  final GridWidget gridWidget) {
+                                  final double width,
+                                  final BaseGrid<? extends Expression> gridWidget) {
         this(registry,
              Collections.singletonList(headerMetaData),
+             width,
              gridWidget);
     }
 
     public ExpressionEditorColumn(final GridWidgetRegistry registry,
                                   final List<HeaderMetaData> headerMetaData,
-                                  final GridWidget gridWidget) {
+                                  final double width,
+                                  final BaseGrid<? extends Expression> gridWidget) {
         this(headerMetaData,
              new ExpressionEditorColumnRenderer(registry),
+             width,
              gridWidget);
     }
 
     protected ExpressionEditorColumn(final List<HeaderMetaData> headerMetaData,
-                                     final BaseGridColumnRenderer<Optional<BaseExpressionGrid>> renderer,
-                                     final GridWidget gridWidget) {
+                                     final BaseGridColumnRenderer<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> renderer,
+                                     final double width,
+                                     final BaseGrid<? extends Expression> gridWidget) {
         super(headerMetaData,
               renderer,
+              width,
               gridWidget);
         setMovable(false);
         setResizable(false);
-
-        setWidthInternal(UndefinedExpressionColumn.DEFAULT_WIDTH);
     }
 
     @Override
@@ -76,7 +81,7 @@ public class ExpressionEditorColumn extends DMNGridColumn<GridWidget, Optional<B
                     final GridCellValue<?> value = cell.getValue();
                     if (value instanceof ExpressionCellValue) {
                         final ExpressionCellValue ecv = (ExpressionCellValue) value;
-                        final Optional<BaseExpressionGrid> editor = ecv.getValue();
+                        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = ecv.getValue();
                         final double padding = editor.map(BaseExpressionGrid::getPadding).orElse(0.0);
                         minimumWidth = Math.max(minimumWidth,
                                                 ecv.getMinimumWidth().orElse(0.0) + padding * 2);
@@ -112,7 +117,7 @@ public class ExpressionEditorColumn extends DMNGridColumn<GridWidget, Optional<B
                     final GridCellValue<?> value = cell.getValue();
                     if (value instanceof ExpressionCellValue) {
                         final ExpressionCellValue ecv = (ExpressionCellValue) value;
-                        final Optional<BaseExpressionGrid> editor = ecv.getValue();
+                        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = ecv.getValue();
                         if (editor.isPresent()) {
                             final BaseExpressionGrid beg = editor.get();
                             updateWidthOfLastColumn(beg, columnWidth);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRenderer.java
@@ -21,13 +21,16 @@ import java.util.Optional;
 import com.ait.lienzo.client.core.shape.Group;
 import com.google.gwt.core.client.GWT;
 import org.kie.soup.commons.validation.PortablePreconditions;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.BaseGridColumnRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridWidgetRegistry;
 
-public class ExpressionEditorColumnRenderer extends BaseGridColumnRenderer<Optional<BaseExpressionGrid>> {
+public class ExpressionEditorColumnRenderer extends BaseGridColumnRenderer<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> {
 
     private final GridWidgetRegistry registry;
 
@@ -36,7 +39,7 @@ public class ExpressionEditorColumnRenderer extends BaseGridColumnRenderer<Optio
     }
 
     @Override
-    public Group renderCell(final GridCell<Optional<BaseExpressionGrid>> cell,
+    public Group renderCell(final GridCell<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> cell,
                             final GridBodyCellRenderContext context) {
         if (cell == null || cell.getValue() == null) {
             return null;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/NameColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/NameColumn.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellE
 public class NameColumn extends EditableNameAndDataTypeColumn<ContextGrid> {
 
     public NameColumn(final List<HeaderMetaData> headerMetaData,
+                      final double width,
                       final ContextGrid gridWidget,
                       final Predicate<Integer> isEditable,
                       final Consumer<HasName> clearDisplayNameConsumer,
@@ -42,6 +43,7 @@ public class NameColumn extends EditableNameAndDataTypeColumn<ContextGrid> {
                       final NameAndDataTypePopoverView.Presenter editor,
                       final Optional<String> editorTitle) {
         super(headerMetaData,
+              width,
               gridWidget,
               isEditable,
               clearDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/NameColumnHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/NameColumnHeaderMetaData.java
@@ -35,7 +35,6 @@ public class NameColumnHeaderMetaData extends NameAndDataTypeHeaderMetaData<Cont
     private static final String NAME_DATA_TYPE_COLUMN_GROUP = "NameColumnHeaderMetaData$NameAndDataTypeColumn";
 
     public NameColumnHeaderMetaData(final HasExpression hasExpression,
-                                    final Optional<Context> expression,
                                     final Optional<HasName> hasName,
                                     final Consumer<HasName> clearDisplayNameConsumer,
                                     final BiConsumer<HasName, Name> setDisplayNameConsumer,
@@ -44,7 +43,6 @@ public class NameColumnHeaderMetaData extends NameAndDataTypeHeaderMetaData<Cont
                                     final NameAndDataTypePopoverView.Presenter editor,
                                     final Optional<String> editorTitle) {
         super(hasExpression,
-              expression,
               hasName,
               clearDisplayNameConsumer,
               setDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinition.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -26,6 +27,9 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hitpolicy.HitPolicyPopoverView;
@@ -33,17 +37,18 @@ import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverV
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @ApplicationScoped
 public class DecisionTableEditorDefinition extends BaseEditorDefinition<DecisionTable, DecisionTableGridData> {
@@ -60,7 +65,7 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
     public DecisionTableEditorDefinition(final DefinitionUtils definitionUtils,
                                          final SessionManager sessionManager,
                                          final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                         final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                         final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                          final Event<ExpressionEditorChanged> editorSelectedEvent,
                                          final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                          final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -107,20 +112,18 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
 
     @Override
     @SuppressWarnings("unused")
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<DecisionTable> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new DecisionTableGrid(parent,
                                                  nodeUUID,
                                                  hasExpression,
-                                                 expression,
                                                  hasName,
                                                  getGridPanel(),
                                                  getGridLayer(),
-                                                 makeGridData(expression),
+                                                 makeGridData(() -> Optional.ofNullable((DecisionTable) hasExpression.getExpression())),
                                                  definitionUtils,
                                                  sessionManager,
                                                  sessionCommandManager,
@@ -137,7 +140,7 @@ public class DecisionTableEditorDefinition extends BaseEditorDefinition<Decision
     }
 
     @Override
-    protected DecisionTableGridData makeGridData(final Optional<DecisionTable> expression) {
+    protected DecisionTableGridData makeGridData(final Supplier<Optional<DecisionTable>> expression) {
         return new DecisionTableGridData(new DMNGridData(),
                                          sessionManager,
                                          sessionCommandManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -49,6 +49,7 @@ import org.kie.workbench.common.dmn.client.commands.expressions.types.dtable.Del
 import org.kie.workbench.common.dmn.client.commands.expressions.types.dtable.DeleteOutputClauseCommand;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.dtable.SetBuiltinAggregatorCommand;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.dtable.SetHitPolicyCommand;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.commands.general.DeleteHasNameCommand;
 import org.kie.workbench.common.dmn.client.commands.general.SetHasNameCommand;
 import org.kie.workbench.common.dmn.client.commands.general.SetTypeRefCommand;
@@ -62,6 +63,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextArea
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.LiteralExpressionGridRow;
@@ -70,7 +72,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
@@ -115,7 +116,6 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     public DecisionTableGrid(final GridCellTuple parent,
                              final Optional<String> nodeUUID,
                              final HasExpression hasExpression,
-                             final Optional<DecisionTable> expression,
                              final Optional<HasName> hasName,
                              final DMNGridPanel gridPanel,
                              final DMNGridLayer gridLayer,
@@ -123,7 +123,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                              final DefinitionUtils definitionUtils,
                              final SessionManager sessionManager,
                              final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                             final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                             final DefaultCanvasCommandFactory canvasCommandFactory,
                              final Event<ExpressionEditorChanged> editorSelectedEvent,
                              final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                              final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -136,7 +136,6 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
         super(parent,
               nodeUUID,
               hasExpression,
-              expression,
               hasName,
               gridPanel,
               gridLayer,
@@ -170,31 +169,40 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     @Override
     public DecisionTableUIModelMapper makeUiModelMapper() {
         return new DecisionTableUIModelMapper(this::getModel,
-                                              () -> expression,
+                                              getExpression(),
                                               listSelector);
     }
 
     @Override
     public void initialiseUiColumns() {
-        expression.ifPresent(e -> {
+        int uiColumnIndex = 0;
+        if (getExpression().get().isPresent()) {
+            final DecisionTable e = getExpression().get().get();
             model.appendColumn(new DecisionTableRowNumberColumn(e::getHitPolicy,
                                                                 e::getAggregation,
                                                                 cellEditorControls,
                                                                 hitPolicyEditor,
                                                                 Optional.of(translationService.getTranslation(DMNEditorConstants.DecisionTableEditor_EditHitPolicy)),
+                                                                getAndSetInitialWidth(uiColumnIndex++, DecisionTableRowNumberColumn.DEFAULT_WIDTH),
                                                                 this));
-            e.getInput().forEach(ic -> model.appendColumn(makeInputClauseColumn(ic)));
-            e.getOutput().forEach(oc -> model.appendColumn(makeOutputClauseColumn(oc)));
+            for (int index = 0; index < e.getInput().size(); index++) {
+                model.appendColumn(makeInputClauseColumn(uiColumnIndex++, e.getInput().get(index)));
+            }
+            for (int index = 0; index < e.getOutput().size(); index++) {
+                model.appendColumn(makeOutputClauseColumn(uiColumnIndex++, e.getOutput().get(index)));
+            }
             model.appendColumn(new DescriptionColumn(new BaseHeaderMetaData(translationService.format(DMNEditorConstants.DecisionTableEditor_DescriptionColumnHeader),
                                                                             DESCRIPTION_GROUP),
                                                      textAreaFactory,
+                                                     getAndSetInitialWidth(uiColumnIndex, DMNGridColumn.DEFAULT_WIDTH),
                                                      this));
-        });
+        }
 
         getRenderer().setColumnRenderConstraint((isSelectionLayer, gridColumn) -> !isSelectionLayer);
     }
 
-    private InputClauseColumn makeInputClauseColumn(final InputClause ic) {
+    private InputClauseColumn makeInputClauseColumn(final int index,
+                                                    final InputClause ic) {
         final InputClauseColumn column = new InputClauseColumn(new InputClauseColumnHeaderMetaData(wrapInputClauseIntoHasName(ic),
                                                                                                    ic::getInputExpression,
                                                                                                    clearDisplayNameConsumer(false),
@@ -204,6 +212,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                                                                                    headerEditor,
                                                                                                    Optional.of(translationService.getTranslation(DMNEditorConstants.DecisionTableEditor_EditInputClause))),
                                                                textAreaFactory,
+                                                               getAndSetInitialWidth(index, DMNGridColumn.DEFAULT_WIDTH),
                                                                this);
         return column;
     }
@@ -223,9 +232,11 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
         };
     }
 
-    private OutputClauseColumn makeOutputClauseColumn(final OutputClause oc) {
+    private OutputClauseColumn makeOutputClauseColumn(final int index,
+                                                      final OutputClause oc) {
         final OutputClauseColumn column = new OutputClauseColumn(outputClauseHeaderMetaData(oc),
                                                                  textAreaFactory,
+                                                                 getAndSetInitialWidth(index, DMNGridColumn.DEFAULT_WIDTH),
                                                                  this);
         return column;
     }
@@ -237,10 +248,9 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     private Supplier<List<GridColumn.HeaderMetaData>> outputClauseHeaderMetaData(final OutputClause oc) {
         return () -> {
             final List<GridColumn.HeaderMetaData> metaData = new ArrayList<>();
-            expression.ifPresent(dtable -> {
+            getExpression().get().ifPresent(dtable -> {
                 if (hasName.isPresent()) {
                     metaData.add(new OutputClauseColumnExpressionNameHeaderMetaData(hasExpression,
-                                                                                    expression,
                                                                                     hasName,
                                                                                     clearDisplayNameConsumer(true, oc, dtable),
                                                                                     setDisplayNameConsumer(true, oc, dtable),
@@ -358,7 +368,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
 
     @Override
     public void initialiseUiModel() {
-        expression.ifPresent(e -> {
+        getExpression().get().ifPresent(e -> {
             e.getRule().forEach(r -> {
                 int columnIndex = 0;
                 model.appendRow(makeDecisionTableRow());
@@ -385,7 +395,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
         final java.util.List<ListSelectorItem> items = new ArrayList<>();
         final boolean isMultiColumn = SelectionUtils.isMultiColumn(model);
 
-        getExpression().ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             final DecisionTableUIModelMapperHelper.DecisionTableSection section = DecisionTableUIModelMapperHelper.getSection(dtable, uiColumnIndex);
             switch (section) {
                 case INPUT_CLAUSES:
@@ -487,15 +497,14 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     }
 
     void addInputClause(final int index) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             final InputClause clause = new InputClause();
-            final InputClauseColumn inputClauseColumn = makeInputClauseColumn(clause);
 
             final CommandResult<CanvasViolation> result = sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                                                                         new AddInputClauseCommand(dtable,
                                                                                                                   clause,
                                                                                                                   model,
-                                                                                                                  inputClauseColumn,
+                                                                                                                  () -> makeInputClauseColumn(index, clause),
                                                                                                                   index,
                                                                                                                   uiModelMapper,
                                                                                                                   () -> resize(BaseExpressionGrid.RESIZE_EXISTING),
@@ -509,7 +518,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     }
 
     void deleteInputClause(final int index) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new DeleteInputClauseCommand(dtable,
                                                                        model,
@@ -521,15 +530,14 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     }
 
     void addOutputClause(final int index) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             final OutputClause clause = new OutputClause();
-            final OutputClauseColumn outputClauseColumn = makeOutputClauseColumn(clause);
 
             final CommandResult<CanvasViolation> result = sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                                                                         new AddOutputClauseCommand(dtable,
                                                                                                                    clause,
                                                                                                                    model,
-                                                                                                                   outputClauseColumn,
+                                                                                                                   () -> makeOutputClauseColumn(index, clause),
                                                                                                                    index,
                                                                                                                    uiModelMapper,
                                                                                                                    () -> resize(BaseExpressionGrid.RESIZE_EXISTING),
@@ -543,7 +551,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     }
 
     void deleteOutputClause(final int index) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new DeleteOutputClauseCommand(dtable,
                                                                         model,
@@ -555,7 +563,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     }
 
     void addDecisionRule(final int index) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             final GridRow decisionTableRow = makeDecisionTableRow();
             final DecisionRule decisionRule = DecisionRuleFactory.makeDecisionRule(dtable);
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
@@ -570,7 +578,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     }
 
     void deleteDecisionRule(final int index) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new DeleteDecisionRuleCommand(dtable,
                                                                         model,
@@ -580,7 +588,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     }
 
     void duplicateDecisionRule(final int index) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             final GridRow decisionTableRow = makeDecisionTableRow();
             final DecisionRule decisionRule = DecisionRuleFactory.duplicateDecisionRule(index, dtable);
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
@@ -596,18 +604,18 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
 
     @Override
     public HitPolicy getHitPolicy() {
-        return expression.orElseThrow(() -> new IllegalArgumentException("DecisionTable has not been set.")).getHitPolicy();
+        return getExpression().get().orElseThrow(() -> new IllegalArgumentException("DecisionTable has not been set.")).getHitPolicy();
     }
 
     @Override
     public BuiltinAggregator getBuiltinAggregator() {
-        return expression.orElseThrow(() -> new IllegalArgumentException("DecisionTable has not been set.")).getAggregation();
+        return getExpression().get().orElseThrow(() -> new IllegalArgumentException("DecisionTable has not been set.")).getAggregation();
     }
 
     @Override
     public void setHitPolicy(final HitPolicy hitPolicy,
                              final Command onSuccess) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder = new CompositeCommand.Builder<>();
             commandBuilder.addCommand(new SetBuiltinAggregatorCommand(dtable,
                                                                       null,
@@ -626,7 +634,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
 
     @Override
     public void setBuiltinAggregator(final BuiltinAggregator aggregator) {
-        expression.ifPresent(dtable -> {
+        getExpression().get().ifPresent(dtable -> {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new SetBuiltinAggregatorCommand(dtable,
                                                                           aggregator,
@@ -642,8 +650,8 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
             return;
         }
 
-        if (expression.isPresent()) {
-            final DecisionTable dtable = expression.get();
+        if (getExpression().get().isPresent()) {
+            final DecisionTable dtable = getExpression().get().get();
             final DecisionTableUIModelMapperHelper.DecisionTableSection section = DecisionTableUIModelMapperHelper.getSection(dtable, uiColumnIndex);
             switch (section) {
                 case INPUT_CLAUSES:
@@ -664,8 +672,8 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     @Override
     public void doAfterHeaderSelectionChange(final int uiHeaderRowIndex,
                                              final int uiHeaderColumnIndex) {
-        if (expression.isPresent()) {
-            final DecisionTable dtable = expression.get();
+        if (getExpression().get().isPresent()) {
+            final DecisionTable dtable = getExpression().get().get();
             final DecisionTableUIModelMapperHelper.DecisionTableSection section = DecisionTableUIModelMapperHelper.getSection(dtable, uiHeaderColumnIndex);
             switch (section) {
                 case INPUT_CLAUSES:

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridData.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.kie.soup.commons.util.Lists;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
@@ -39,13 +40,13 @@ public class DecisionTableGridData extends DelegatingGridData {
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final Optional<DecisionTable> expression;
+    private final Supplier<Optional<DecisionTable>> expression;
     private final Command canvasOperation;
 
     public DecisionTableGridData(final DMNGridData delegate,
                                  final SessionManager sessionManager,
                                  final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                 final Optional<DecisionTable> expression,
+                                 final Supplier<Optional<DecisionTable>> expression,
                                  final Command canvasOperation) {
         super(delegate);
         this.sessionManager = sessionManager;
@@ -68,12 +69,12 @@ public class DecisionTableGridData extends DelegatingGridData {
     @Override
     public void moveRowsTo(final int index,
                            final List<GridRow> rows) {
-        expression.ifPresent(dtable -> sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
-                                                                     new MoveRowsCommand(dtable,
-                                                                                         delegate,
-                                                                                         index,
-                                                                                         rows,
-                                                                                         canvasOperation)));
+        expression.get().ifPresent(dtable -> sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
+                                                                           new MoveRowsCommand(dtable,
+                                                                                               delegate,
+                                                                                               index,
+                                                                                               rows,
+                                                                                               canvasOperation)));
     }
 
     @Override
@@ -89,11 +90,11 @@ public class DecisionTableGridData extends DelegatingGridData {
     @Override
     public void moveColumnsTo(final int index,
                               final List<GridColumn<?>> columns) {
-        expression.ifPresent(dtable -> sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
-                                                                     new MoveColumnsCommand(dtable,
-                                                                                            delegate,
-                                                                                            index,
-                                                                                            columns,
-                                                                                            canvasOperation)));
+        expression.get().ifPresent(dtable -> sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
+                                                                           new MoveColumnsCommand(dtable,
+                                                                                                  delegate,
+                                                                                                  index,
+                                                                                                  columns,
+                                                                                                  canvasOperation)));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableRowNumberColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableRowNumberColumn.java
@@ -29,13 +29,14 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.im
 
 public class DecisionTableRowNumberColumn extends DMNGridColumn<DecisionTableGrid, Integer> implements IsRowDragHandle {
 
-    private static final double DEFAULT_WIDTH = 50.0;
+    public static final double DEFAULT_WIDTH = 50.0;
 
     public DecisionTableRowNumberColumn(final Supplier<HitPolicy> hitPolicySupplier,
                                         final Supplier<BuiltinAggregator> builtinAggregatorSupplier,
                                         final CellEditorControlsView.Presenter cellEditorControls,
                                         final HitPolicyPopoverView.Presenter editor,
                                         final Optional<String> editorTitle,
+                                        final double width,
                                         final DecisionTableGrid gridWidget) {
         super(new RowNumberColumnHeaderMetaData(hitPolicySupplier,
                                                 builtinAggregatorSupplier,
@@ -44,11 +45,10 @@ public class DecisionTableRowNumberColumn extends DMNGridColumn<DecisionTableGri
                                                 editorTitle,
                                                 gridWidget),
               new IntegerColumnRenderer(),
+              width,
               gridWidget);
         setMovable(false);
         setResizable(false);
         setFloatable(true);
-
-        setWidthInternal(DEFAULT_WIDTH);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DescriptionColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DescriptionColumn.java
@@ -35,17 +35,21 @@ public class DescriptionColumn extends DMNSimpleGridColumn<DecisionTableGrid, St
 
     public DescriptionColumn(final HeaderMetaData headerMetaData,
                              final TextAreaSingletonDOMElementFactory factory,
+                             final double width,
                              final DecisionTableGrid gridWidget) {
         this(Collections.singletonList(headerMetaData),
              factory,
+             width,
              gridWidget);
     }
 
     public DescriptionColumn(final List<HeaderMetaData> headerMetaData,
                              final TextAreaSingletonDOMElementFactory factory,
+                             final double width,
                              final DecisionTableGrid gridWidget) {
         super(headerMetaData,
               new DescriptionColumnRenderer(factory),
+              width,
               gridWidget);
         this.factory = PortablePreconditions.checkNotNull("factory",
                                                           factory);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/InputClauseColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/InputClauseColumn.java
@@ -36,17 +36,21 @@ public class InputClauseColumn extends DMNSimpleGridColumn<DecisionTableGrid, St
 
     public InputClauseColumn(final HeaderMetaData headerMetaData,
                              final TextAreaSingletonDOMElementFactory factory,
+                             final double width,
                              final DecisionTableGrid gridWidget) {
         this(Collections.singletonList(headerMetaData),
              factory,
+             width,
              gridWidget);
     }
 
     public InputClauseColumn(final List<HeaderMetaData> headerMetaData,
                              final TextAreaSingletonDOMElementFactory factory,
+                             final double width,
                              final DecisionTableGrid gridWidget) {
         super(headerMetaData,
               new NameAndDataTypeDOMElementColumnRenderer<>(factory),
+              width,
               gridWidget);
         this.factory = PortablePreconditions.checkNotNull("factory",
                                                           factory);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumn.java
@@ -38,9 +38,11 @@ public class OutputClauseColumn extends DMNSimpleGridColumn<DecisionTableGrid, S
 
     public OutputClauseColumn(final Supplier<List<HeaderMetaData>> headerMetaDataSupplier,
                               final TextAreaSingletonDOMElementFactory factory,
+                              final double width,
                               final DecisionTableGrid gridWidget) {
         super(headerMetaDataSupplier.get(),
               new NameAndDataTypeDOMElementColumnRenderer<>(factory),
+              width,
               gridWidget);
         this.headerMetaDataSupplier = PortablePreconditions.checkNotNull("headerMetaDataSupplier",
                                                                          headerMetaDataSupplier);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumnExpressionNameHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumnExpressionNameHeaderMetaData.java
@@ -36,7 +36,6 @@ public class OutputClauseColumnExpressionNameHeaderMetaData extends NameAndDataT
     private static final String NAME_DATA_TYPE_COLUMN_GROUP = "OutputClauseColumnExpressionNameHeaderMetaData$NameAndDataTypeColumn";
 
     public OutputClauseColumnExpressionNameHeaderMetaData(final HasExpression hasExpression,
-                                                          final Optional<DecisionTable> expression,
                                                           final Optional<HasName> hasName,
                                                           final Consumer<HasName> clearDisplayNameConsumer,
                                                           final BiConsumer<HasName, Name> setDisplayNameConsumer,
@@ -45,7 +44,6 @@ public class OutputClauseColumnExpressionNameHeaderMetaData extends NameAndDataT
                                                           final NameAndDataTypePopoverView.Presenter editor,
                                                           final Optional<String> editorTitle) {
         super(hasExpression,
-              expression,
               hasName,
               clearDisplayNameConsumer,
               setDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/EmptyColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/EmptyColumn.java
@@ -24,15 +24,20 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.im
 
 class EmptyColumn extends BaseGridColumn<String> {
 
-    EmptyColumn(final List<HeaderMetaData> headerMetaData) {
+    static final double DEFAULT_WIDTH = 50.0;
+
+    EmptyColumn(final List<HeaderMetaData> headerMetaData,
+                final double width) {
         this(headerMetaData,
-             new StringColumnRenderer());
+             new StringColumnRenderer(),
+             width);
     }
 
     private EmptyColumn(final List<HeaderMetaData> headerMetaData,
-                        final GridColumnRenderer<String> columnRenderer) {
+                        final GridColumnRenderer<String> columnRenderer,
+                        final double width) {
         super(headerMetaData,
               columnRenderer,
-              50.0);
+              width);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumn.java
@@ -19,25 +19,30 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.function;
 import java.util.Collections;
 import java.util.List;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionEditorColumn;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridWidgetRegistry;
 
 public class FunctionColumn extends ExpressionEditorColumn {
 
     public FunctionColumn(final GridWidgetRegistry registry,
                           final HeaderMetaData headerMetaData,
-                          final GridWidget gridWidget) {
+                          final double width,
+                          final BaseGrid<? extends Expression> gridWidget) {
         this(registry,
              Collections.singletonList(headerMetaData),
+             width,
              gridWidget);
     }
 
     public FunctionColumn(final GridWidgetRegistry registry,
                           final List<HeaderMetaData> headerMetaData,
-                          final GridWidget gridWidget) {
+                          final double width,
+                          final BaseGrid<? extends Expression> gridWidget) {
         super(headerMetaData,
               new FunctionColumnRenderer(registry),
+              width,
               gridWidget);
         setMovable(false);
         setResizable(false);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumnNameHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumnNameHeaderMetaData.java
@@ -35,7 +35,6 @@ public class FunctionColumnNameHeaderMetaData extends NameAndDataTypeHeaderMetaD
     private static final String NAME_DATA_TYPE_COLUMN_GROUP = "FunctionColumnNameHeaderMetaData$NameAndDataTypeColumn";
 
     public FunctionColumnNameHeaderMetaData(final HasExpression hasExpression,
-                                            final Optional<FunctionDefinition> expression,
                                             final Optional<HasName> hasName,
                                             final Consumer<HasName> clearDisplayNameConsumer,
                                             final BiConsumer<HasName, Name> setDisplayNameConsumer,
@@ -44,7 +43,6 @@ public class FunctionColumnNameHeaderMetaData extends NameAndDataTypeHeaderMetaD
                                             final NameAndDataTypePopoverView.Presenter editor,
                                             final Optional<String> editorTitle) {
         super(hasExpression,
-              expression,
               hasName,
               clearDisplayNameConsumer,
               setDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumnParametersHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumnParametersHeaderMetaData.java
@@ -37,11 +37,11 @@ public class FunctionColumnParametersHeaderMetaData extends EditablePopupHeaderM
 
     static final String PARAMETER_COLUMN_GROUP = "FunctionColumnParametersHeaderMetaData$Parameters";
 
-    private final Supplier<FunctionDefinition> functionSupplier;
+    private final Supplier<Optional<FunctionDefinition>> functionSupplier;
     private final FunctionGrid gridWidget;
     private final TranslationService translationService;
 
-    public FunctionColumnParametersHeaderMetaData(final Supplier<FunctionDefinition> functionSupplier,
+    public FunctionColumnParametersHeaderMetaData(final Supplier<Optional<FunctionDefinition>> functionSupplier,
                                                   final TranslationService translationService,
                                                   final CellEditorControlsView.Presenter cellEditorControls,
                                                   final ParametersPopoverView.Presenter editor,
@@ -92,12 +92,12 @@ public class FunctionColumnParametersHeaderMetaData extends EditablePopupHeaderM
     }
 
     String getExpressionLanguageTitle() {
-        final FunctionDefinition.Kind kind = KindUtilities.getKind(functionSupplier.get());
+        final FunctionDefinition.Kind kind = KindUtilities.getKind(functionSupplier.get().get());
         return kind == null ? translationService.getTranslation(DMNEditorConstants.FunctionEditor_Undefined) : kind.code();
     }
 
     String getFormalParametersTitle() {
-        final List<InformationItem> formalParameters = functionSupplier.get().getFormalParameter();
+        final List<InformationItem> formalParameters = functionSupplier.get().get().getFormalParameter();
         final StringBuilder sb = new StringBuilder();
         sb.append("(");
         if (!formalParameters.isEmpty()) {
@@ -108,6 +108,6 @@ public class FunctionColumnParametersHeaderMetaData extends EditablePopupHeaderM
     }
 
     boolean hasFormalParametersSet() {
-        return !functionSupplier.get().getFormalParameter().isEmpty();
+        return !functionSupplier.get().get().getFormalParameter().isEmpty();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinition.java
@@ -26,9 +26,11 @@ import javax.inject.Inject;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -38,17 +40,18 @@ import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverV
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @ApplicationScoped
 public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefinition, DMNGridData> {
@@ -68,7 +71,7 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
     public FunctionEditorDefinition(final DefinitionUtils definitionUtils,
                                     final SessionManager sessionManager,
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                    final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -124,20 +127,18 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
     }
 
     @Override
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<FunctionDefinition> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new FunctionGrid(parent,
                                             nodeUUID,
                                             hasExpression,
-                                            expression,
                                             hasName,
                                             getGridPanel(),
                                             getGridLayer(),
-                                            makeGridData(expression),
+                                            makeGridData(() -> Optional.ofNullable(((FunctionDefinition) hasExpression.getExpression()))),
                                             definitionUtils,
                                             sessionManager,
                                             sessionCommandManager,
@@ -157,7 +158,7 @@ public class FunctionEditorDefinition extends BaseEditorDefinition<FunctionDefin
     }
 
     @Override
-    protected DMNGridData makeGridData(final Optional<FunctionDefinition> expression) {
+    protected DMNGridData makeGridData(final Supplier<Optional<FunctionDefinition>> expression) {
         return new DMNGridData();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionKindRowColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionKindRowColumn.java
@@ -26,16 +26,18 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellE
 
 public class FunctionKindRowColumn extends EmptyColumn {
 
-    public FunctionKindRowColumn(final Supplier<FunctionDefinition> functionSupplier,
+    public FunctionKindRowColumn(final Supplier<Optional<FunctionDefinition>> functionSupplier,
                                  final CellEditorControlsView.Presenter cellEditorControls,
                                  final KindPopoverView.Presenter editor,
                                  final Optional<String> editorTitle,
+                                 final double width,
                                  final FunctionGrid gridWidget) {
         super(Collections.singletonList(new FunctionKindRowColumnHeaderMetaData(functionSupplier,
                                                                                 cellEditorControls,
                                                                                 editor,
                                                                                 editorTitle,
-                                                                                gridWidget)));
+                                                                                gridWidget)),
+              width);
         setMovable(false);
         setResizable(false);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionKindRowColumnHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionKindRowColumnHeaderMetaData.java
@@ -30,9 +30,9 @@ class FunctionKindRowColumnHeaderMetaData extends EditablePopupHeaderMetaData<Ha
     private static final String EXPRESSION_TYPE_GROUP = "ExpressionTypeGroup";
 
     private final FunctionGrid gridWidget;
-    private final Supplier<FunctionDefinition> functionSupplier;
+    private final Supplier<Optional<FunctionDefinition>> functionSupplier;
 
-    FunctionKindRowColumnHeaderMetaData(final Supplier<FunctionDefinition> functionSupplier,
+    FunctionKindRowColumnHeaderMetaData(final Supplier<Optional<FunctionDefinition>> functionSupplier,
                                         final CellEditorControlsView.Presenter cellEditorControls,
                                         final KindPopoverView.Presenter editor,
                                         final Optional<String> editorTitle,
@@ -62,6 +62,6 @@ class FunctionKindRowColumnHeaderMetaData extends EditablePopupHeaderMetaData<Ha
 
     @Override
     public String getTitle() {
-        return functionSupplier.get().getKind().code();
+        return functionSupplier.get().get().getKind().code();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapper.java
@@ -97,13 +97,11 @@ public class FunctionUIModelMapper extends BaseUIModelMapper<FunctionDefinition>
         final GridCellTuple expressionParent = new GridCellTuple(rowIndex,
                                                                  columnIndex,
                                                                  gridWidget);
-        final Optional<Expression> expression = Optional.ofNullable(function.getExpression());
-        final Optional<BaseExpressionGrid> editor = ed.getEditor(expressionParent,
-                                                                 Optional.empty(),
-                                                                 function,
-                                                                 expression,
-                                                                 Optional.empty(),
-                                                                 nesting);
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = ed.getEditor(expressionParent,
+                                                                                                                                        Optional.empty(),
+                                                                                                                                        function,
+                                                                                                                                        Optional.empty(),
+                                                                                                                                        nesting);
         uiModel.get().setCell(rowIndex,
                               columnIndex,
                               () -> new FunctionGridCell<>(new ExpressionCellValue(editor),
@@ -123,7 +121,7 @@ public class FunctionUIModelMapper extends BaseUIModelMapper<FunctionDefinition>
         dmnModel.get().ifPresent(function -> {
             cell.get().ifPresent(v -> {
                 final ExpressionCellValue ecv = (ExpressionCellValue) v;
-                ecv.getValue().ifPresent(beg -> function.setExpression((Expression) beg.getExpression().orElse(null)));
+                ecv.getValue().ifPresent(beg -> function.setExpression((Expression) beg.getExpression().get().orElse(null)));
             });
         });
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseSupplementaryFunctionEditorDefinition.java
@@ -27,25 +27,28 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
 import org.kie.workbench.common.dmn.api.definition.v1_1.ContextEntry;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEditorDefinition<Context, FunctionSupplementaryGridData> {
 
@@ -60,7 +63,7 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
     public BaseSupplementaryFunctionEditorDefinition(final DefinitionUtils definitionUtils,
                                                      final SessionManager sessionManager,
                                                      final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                                     final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                                     final DefaultCanvasCommandFactory canvasCommandFactory,
                                                      final Event<ExpressionEditorChanged> editorSelectedEvent,
                                                      final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                                      final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -105,20 +108,18 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
     }
 
     @Override
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<Context> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new FunctionSupplementaryGrid(parent,
                                                          nodeUUID,
                                                          hasExpression,
-                                                         expression,
                                                          hasName,
                                                          getGridPanel(),
                                                          getGridLayer(),
-                                                         makeGridData(expression),
+                                                         makeGridData(() -> Optional.ofNullable(((Context) hasExpression.getExpression()))),
                                                          definitionUtils,
                                                          sessionManager,
                                                          sessionCommandManager,
@@ -134,7 +135,7 @@ public abstract class BaseSupplementaryFunctionEditorDefinition extends BaseEdit
     }
 
     @Override
-    protected FunctionSupplementaryGridData makeGridData(final Optional<Context> expression) {
+    protected FunctionSupplementaryGridData makeGridData(final Supplier<Optional<Context>> expression) {
         return new FunctionSupplementaryGridData(new DMNGridData(),
                                                  sessionManager,
                                                  sessionCommandManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridData.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.function.s
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.function.supplementary.MoveRowsCommand;
@@ -34,13 +35,13 @@ public class FunctionSupplementaryGridData extends DelegatingGridData {
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final Optional<Context> expression;
+    private final Supplier<Optional<Context>> expression;
     private final Command canvasOperation;
 
     public FunctionSupplementaryGridData(final DMNGridData delegate,
                                          final SessionManager sessionManager,
                                          final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                         final Optional<Context> expression,
+                                         final Supplier<Optional<Context>> expression,
                                          final Command canvasOperation) {
         super(delegate);
         this.sessionManager = sessionManager;
@@ -61,11 +62,11 @@ public class FunctionSupplementaryGridData extends DelegatingGridData {
     @Override
     public void moveRowsTo(final int index,
                            final List<GridRow> rows) {
-        expression.ifPresent(context -> sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
-                                                                      new MoveRowsCommand(context,
-                                                                                          delegate,
-                                                                                          index,
-                                                                                          rows,
-                                                                                          canvasOperation)));
+        expression.get().ifPresent(context -> sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
+                                                                            new MoveRowsCommand(context,
+                                                                                                delegate,
+                                                                                                index,
+                                                                                                rows,
+                                                                                                canvasOperation)));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/NameColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/NameColumn.java
@@ -24,9 +24,11 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 
 public class NameColumn extends DMNGridColumn<FunctionSupplementaryGrid, InformationItemCell.HasNameCell> {
 
-    public NameColumn(final FunctionSupplementaryGrid gridWidget) {
+    public NameColumn(final double width,
+                      final FunctionSupplementaryGrid gridWidget) {
         super(Collections.emptyList(),
               new NameAndDataTypeColumnRenderer(),
+              width,
               gridWidget);
 
         setMovable(false);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinition.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.FunctionGridSupplementaryEditor;
@@ -36,7 +37,6 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -58,7 +58,7 @@ public class JavaFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
     public JavaFunctionEditorDefinition(final DefinitionUtils definitionUtils,
                                         final SessionManager sessionManager,
                                         final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                        final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                        final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinition.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.FunctionGridSupplementaryEditor;
@@ -36,7 +37,6 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorCh
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -58,7 +58,7 @@ public class PMMLFunctionEditorDefinition extends BaseSupplementaryFunctionEdito
     public PMMLFunctionEditorDefinition(final DefinitionUtils definitionUtils,
                                         final SessionManager sessionManager,
                                         final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                        final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                        final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationColumnHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationColumnHeaderMetaData.java
@@ -35,7 +35,6 @@ public class InvocationColumnHeaderMetaData extends NameAndDataTypeHeaderMetaDat
     private static final String NAME_DATA_TYPE_COLUMN_GROUP = "InvocationColumnHeaderMetaData$NameAndDataTypeColumn";
 
     public InvocationColumnHeaderMetaData(final HasExpression hasExpression,
-                                          final Optional<Invocation> expression,
                                           final Optional<HasName> hasName,
                                           final Consumer<HasName> clearDisplayNameConsumer,
                                           final BiConsumer<HasName, Name> setDisplayNameConsumer,
@@ -44,7 +43,6 @@ public class InvocationColumnHeaderMetaData extends NameAndDataTypeHeaderMetaDat
                                           final NameAndDataTypePopoverView.Presenter editor,
                                           final Optional<String> editorTitle) {
         super(hasExpression,
-              expression,
               hasName,
               clearDisplayNameConsumer,
               setDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinition.java
@@ -27,10 +27,12 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Binding;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -38,17 +40,18 @@ import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverV
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @ApplicationScoped
 public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation, InvocationGridData> {
@@ -64,7 +67,7 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
     public InvocationEditorDefinition(final DefinitionUtils definitionUtils,
                                       final SessionManager sessionManager,
                                       final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                      final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                      final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                       final Event<ExpressionEditorChanged> editorSelectedEvent,
                                       final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                       final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -122,20 +125,18 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
     }
 
     @Override
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<Invocation> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new InvocationGrid(parent,
                                               nodeUUID,
                                               hasExpression,
-                                              expression,
                                               hasName,
                                               getGridPanel(),
                                               getGridLayer(),
-                                              makeGridData(expression),
+                                              makeGridData(() -> Optional.ofNullable((Invocation) hasExpression.getExpression())),
                                               definitionUtils,
                                               sessionManager,
                                               sessionCommandManager,
@@ -152,7 +153,7 @@ public class InvocationEditorDefinition extends BaseEditorDefinition<Invocation,
     }
 
     @Override
-    protected InvocationGridData makeGridData(final Optional<Invocation> expression) {
+    protected InvocationGridData makeGridData(final Supplier<Optional<Invocation>> expression) {
         return new InvocationGridData(new DMNGridData(),
                                       sessionManager,
                                       sessionCommandManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridData.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.invocation
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.invocation.MoveRowsCommand;
@@ -34,13 +35,13 @@ public class InvocationGridData extends DelegatingGridData {
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final Optional<Invocation> expression;
+    private final Supplier<Optional<Invocation>> expression;
     private final Command canvasOperation;
 
     public InvocationGridData(final DMNGridData delegate,
                               final SessionManager sessionManager,
                               final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                              final Optional<Invocation> expression,
+                              final Supplier<Optional<Invocation>> expression,
                               final Command canvasOperation) {
         super(delegate);
         this.sessionManager = sessionManager;
@@ -61,7 +62,7 @@ public class InvocationGridData extends DelegatingGridData {
     @Override
     public void moveRowsTo(final int index,
                            final List<GridRow> rows) {
-        expression.ifPresent(invocation -> {
+        expression.get().ifPresent(invocation -> {
             final AbstractCanvasHandler handler = (AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler();
             sessionCommandManager.execute(handler,
                                           new MoveRowsCommand(invocation,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationParameterColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationParameterColumn.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellE
 public class InvocationParameterColumn extends EditableNameAndDataTypeColumn<InvocationGrid> {
 
     public InvocationParameterColumn(final List<HeaderMetaData> headerMetaData,
+                                     final double width,
                                      final InvocationGrid gridWidget,
                                      final Predicate<Integer> isEditable,
                                      final Consumer<HasName> clearDisplayNameConsumer,
@@ -42,6 +43,7 @@ public class InvocationParameterColumn extends EditableNameAndDataTypeColumn<Inv
                                      final NameAndDataTypePopoverView.Presenter editor,
                                      final Optional<String> editorTitle) {
         super(headerMetaData,
+              width,
               gridWidget,
               isEditable,
               clearDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapper.java
@@ -93,14 +93,13 @@ public class InvocationUIModelMapper extends BaseUIModelMapper<Invocation> {
 
                     final Optional<ExpressionEditorDefinition<Expression>> expressionEditorDefinition = expressionEditorDefinitionsSupplier.get().getExpressionEditorDefinition(expression);
                     expressionEditorDefinition.ifPresent(ed -> {
-                        final Optional<BaseExpressionGrid> editor = ed.getEditor(new GridCellTuple(rowIndex,
-                                                                                                   columnIndex,
-                                                                                                   gridWidget),
-                                                                                 Optional.empty(),
-                                                                                 binding,
-                                                                                 expression,
-                                                                                 Optional.ofNullable(binding.getParameter()),
-                                                                                 nesting + 1);
+                        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = ed.getEditor(new GridCellTuple(rowIndex,
+                                                                                                                                                                          columnIndex,
+                                                                                                                                                                          gridWidget),
+                                                                                                                                                        Optional.empty(),
+                                                                                                                                                        binding,
+                                                                                                                                                        Optional.ofNullable(binding.getParameter()),
+                                                                                                                                                        nesting + 1);
                         uiModel.get().setCell(rowIndex,
                                               columnIndex,
                                               () -> new InvocationGridCell<>(new ExpressionCellValue(editor),
@@ -130,7 +129,7 @@ public class InvocationUIModelMapper extends BaseUIModelMapper<Invocation> {
                     cell.get().ifPresent(v -> {
                         final ExpressionCellValue ecv = (ExpressionCellValue) v;
                         ecv.getValue().ifPresent(beg -> {
-                            beg.getExpression().ifPresent(e -> invocation.getBinding()
+                            beg.getExpression().get().ifPresent(e -> invocation.getBinding()
                                     .get(rowIndex)
                                     .setExpression((Expression) e));
                         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumn.java
@@ -35,9 +35,11 @@ public class LiteralExpressionColumn extends DMNSimpleGridColumn<LiteralExpressi
 
     public LiteralExpressionColumn(final List<HeaderMetaData> headerMetaData,
                                    final TextAreaSingletonDOMElementFactory factory,
+                                   final double width,
                                    final LiteralExpressionGrid gridWidget) {
         super(headerMetaData,
               new NameAndDataTypeDOMElementColumnRenderer<>(factory),
+              width,
               gridWidget);
         this.factory = PortablePreconditions.checkNotNull("factory",
                                                           factory);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumnHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumnHeaderMetaData.java
@@ -35,7 +35,6 @@ public class LiteralExpressionColumnHeaderMetaData extends NameAndDataTypeHeader
     private static final String NAME_DATA_TYPE_COLUMN_GROUP = "LiteralExpressionColumnHeaderMetaData$NameAndDataTypeColumn";
 
     public LiteralExpressionColumnHeaderMetaData(final HasExpression hasExpression,
-                                                 final Optional<LiteralExpression> expression,
                                                  final Optional<HasName> hasName,
                                                  final Consumer<HasName> clearDisplayNameConsumer,
                                                  final BiConsumer<HasName, Name> setDisplayNameConsumer,
@@ -44,7 +43,6 @@ public class LiteralExpressionColumnHeaderMetaData extends NameAndDataTypeHeader
                                                  final NameAndDataTypePopoverView.Presenter editor,
                                                  final Optional<String> editorTitle) {
         super(hasExpression,
-              expression,
               hasName,
               clearDisplayNameConsumer,
               setDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinition.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.literal;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -25,24 +26,28 @@ import javax.inject.Inject;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @ApplicationScoped
 public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<LiteralExpression, DMNGridData> {
@@ -57,7 +62,7 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
     public LiteralExpressionEditorDefinition(final DefinitionUtils definitionUtils,
                                              final SessionManager sessionManager,
                                              final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                             final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                             final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                              final Event<ExpressionEditorChanged> editorSelectedEvent,
                                              final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                              final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -92,20 +97,18 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
     }
 
     @Override
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<LiteralExpression> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new LiteralExpressionGrid(parent,
                                                      nodeUUID,
                                                      hasExpression,
-                                                     expression,
                                                      hasName,
                                                      getGridPanel(),
                                                      getGridLayer(),
-                                                     makeGridData(expression),
+                                                     makeGridData(() -> Optional.ofNullable((LiteralExpression) hasExpression.getExpression())),
                                                      definitionUtils,
                                                      sessionManager,
                                                      sessionCommandManager,
@@ -121,7 +124,7 @@ public class LiteralExpressionEditorDefinition extends BaseEditorDefinition<Lite
     }
 
     @Override
-    protected DMNGridData makeGridData(final Optional<LiteralExpression> expression) {
+    protected DMNGridData makeGridData(final Supplier<Optional<LiteralExpression>> expression) {
         return new DMNGridData();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseDelegatingExpressionGrid;
@@ -38,6 +39,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSel
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.handlers.DelegatingGridWidgetCellSelectorMouseEventHandler;
 import org.kie.workbench.common.dmn.client.widgets.grid.handlers.DelegatingGridWidgetEditCellMouseEventHandler;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
@@ -47,7 +49,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -66,7 +67,6 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
     public LiteralExpressionGrid(final GridCellTuple parent,
                                  final Optional<String> nodeUUID,
                                  final HasExpression hasExpression,
-                                 final Optional<LiteralExpression> expression,
                                  final Optional<HasName> hasName,
                                  final DMNGridPanel gridPanel,
                                  final DMNGridLayer gridLayer,
@@ -74,7 +74,7 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
                                  final DefinitionUtils definitionUtils,
                                  final SessionManager sessionManager,
                                  final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                 final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                 final DefaultCanvasCommandFactory canvasCommandFactory,
                                  final Event<ExpressionEditorChanged> editorSelectedEvent,
                                  final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                  final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -86,7 +86,6 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
         super(parent,
               nodeUUID,
               hasExpression,
-              expression,
               hasName,
               gridPanel,
               gridLayer,
@@ -133,7 +132,7 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
     @Override
     public LiteralExpressionUIModelMapper makeUiModelMapper() {
         return new LiteralExpressionUIModelMapper(this::getModel,
-                                                  () -> expression,
+                                                  getExpression(),
                                                   listSelector);
     }
 
@@ -142,7 +141,6 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
         final List<GridColumn.HeaderMetaData> headerMetaData = new ArrayList<>();
         if (nesting == 0) {
             headerMetaData.add(new LiteralExpressionColumnHeaderMetaData(hasExpression,
-                                                                         expression,
                                                                          hasName,
                                                                          clearDisplayNameConsumer(true),
                                                                          setDisplayNameConsumer(true),
@@ -154,6 +152,7 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
 
         final GridColumn literalExpressionColumn = new LiteralExpressionColumn(headerMetaData,
                                                                                getBodyTextAreaFactory(),
+                                                                               getAndSetInitialWidth(0, DMNGridColumn.DEFAULT_WIDTH),
                                                                                this);
 
         model.appendColumn(literalExpressionColumn);
@@ -161,7 +160,7 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
 
     @Override
     protected void initialiseUiModel() {
-        expression.ifPresent(e -> {
+        getExpression().get().ifPresent(e -> {
             model.appendRow(new LiteralExpressionGridRow(getExpressionTextLineHeight(getRenderer().getTheme())));
             uiModelMapper.fromDMNModel(0,
                                        0);
@@ -177,7 +176,7 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
     @SuppressWarnings("unused")
     public void doAfterSelectionChange(final int uiRowIndex,
                                        final int uiColumnIndex) {
-        getExpression().ifPresent(this::fireDomainObjectSelectionEvent);
+        getExpression().get().ifPresent(this::fireDomainObjectSelectionEvent);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumn.java
@@ -34,9 +34,11 @@ public class RelationColumn extends DMNSimpleGridColumn<RelationGrid, String> im
 
     public RelationColumn(final HeaderMetaData headerMetaData,
                           final TextAreaSingletonDOMElementFactory factory,
+                          final double width,
                           final RelationGrid gridWidget) {
         super(headerMetaData,
               new NameAndDataTypeDOMElementColumnRenderer<>(factory),
+              width,
               gridWidget);
         this.factory = PortablePreconditions.checkNotNull("factory",
                                                           factory);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinition.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.relation;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -25,26 +26,30 @@ import javax.inject.Inject;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @ApplicationScoped
 public class RelationEditorDefinition extends BaseEditorDefinition<Relation, RelationGridData> {
@@ -59,7 +64,7 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
     public RelationEditorDefinition(final DefinitionUtils definitionUtils,
                                     final SessionManager sessionManager,
                                     final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                    final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                    final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -115,20 +120,18 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
 
     @Override
     @SuppressWarnings("unused")
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<Relation> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new RelationGrid(parent,
                                             nodeUUID,
                                             hasExpression,
-                                            expression,
                                             hasName,
                                             getGridPanel(),
                                             getGridLayer(),
-                                            makeGridData(expression),
+                                            makeGridData(() -> Optional.ofNullable(((Relation) hasExpression.getExpression()))),
                                             definitionUtils,
                                             sessionManager,
                                             sessionCommandManager,
@@ -144,7 +147,7 @@ public class RelationEditorDefinition extends BaseEditorDefinition<Relation, Rel
     }
 
     @Override
-    protected RelationGridData makeGridData(final Optional<Relation> expression) {
+    protected RelationGridData makeGridData(final Supplier<Optional<Relation>> expression) {
         return new RelationGridData(new DMNGridData(),
                                     sessionManager,
                                     sessionCommandManager,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionColumn.java
@@ -38,11 +38,13 @@ public class UndefinedExpressionColumn extends DMNGridColumn<UndefinedExpression
     private final UndefinedExpressionSelectorPopoverView.Presenter undefinedExpressionSelector;
     private final TranslationService translationService;
 
-    public UndefinedExpressionColumn(final UndefinedExpressionGrid gridWidget,
+    public UndefinedExpressionColumn(final double width,
+                                     final UndefinedExpressionGrid gridWidget,
                                      final CellEditorControlsView.Presenter cellEditorControls,
                                      final UndefinedExpressionSelectorPopoverView.Presenter undefinedExpressionSelector,
                                      final TranslationService translationService) {
         this(Collections.emptyList(),
+             width,
              gridWidget,
              cellEditorControls,
              undefinedExpressionSelector,
@@ -50,18 +52,18 @@ public class UndefinedExpressionColumn extends DMNGridColumn<UndefinedExpression
     }
 
     public UndefinedExpressionColumn(final List<HeaderMetaData> headerMetaData,
+                                     final double width,
                                      final UndefinedExpressionGrid gridWidget,
                                      final CellEditorControlsView.Presenter cellEditorControls,
                                      final UndefinedExpressionSelectorPopoverView.Presenter undefinedExpressionSelector,
                                      final TranslationService translationService) {
         super(headerMetaData,
               new UndefinedExpressionColumnRenderer(),
+              width,
               gridWidget);
         this.cellEditorControls = cellEditorControls;
         this.undefinedExpressionSelector = undefinedExpressionSelector;
         this.translationService = translationService;
-
-        setWidthInternal(UndefinedExpressionColumn.DEFAULT_WIDTH);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionEditorDefinition.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.BaseEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -36,17 +37,18 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @ApplicationScoped
 public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Expression, DMNGridData> {
@@ -62,7 +64,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
     public UndefinedExpressionEditorDefinition(final DefinitionUtils definitionUtils,
                                                final SessionManager sessionManager,
                                                final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                               final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                               final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
                                                final Event<ExpressionEditorChanged> editorSelectedEvent,
                                                final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                                final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -99,20 +101,18 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
     }
 
     @Override
-    public Optional<BaseExpressionGrid> getEditor(final GridCellTuple parent,
-                                                  final Optional<String> nodeUUID,
-                                                  final HasExpression hasExpression,
-                                                  final Optional<Expression> expression,
-                                                  final Optional<HasName> hasName,
-                                                  final int nesting) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getEditor(final GridCellTuple parent,
+                                                                                                                         final Optional<String> nodeUUID,
+                                                                                                                         final HasExpression hasExpression,
+                                                                                                                         final Optional<HasName> hasName,
+                                                                                                                         final int nesting) {
         return Optional.of(new UndefinedExpressionGrid(parent,
                                                        nodeUUID,
                                                        hasExpression,
-                                                       expression,
                                                        hasName,
                                                        getGridPanel(),
                                                        getGridLayer(),
-                                                       makeGridData(expression),
+                                                       makeGridData(() -> Optional.ofNullable(hasExpression.getExpression())),
                                                        definitionUtils,
                                                        sessionManager,
                                                        sessionCommandManager,
@@ -130,7 +130,7 @@ public class UndefinedExpressionEditorDefinition extends BaseEditorDefinition<Ex
     }
 
     @Override
-    protected DMNGridData makeGridData(final Optional<Expression> expression) {
+    protected DMNGridData makeGridData(final Supplier<Optional<Expression>> expression) {
         return new DMNGridData();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapper.java
@@ -55,15 +55,14 @@ public class UndefinedExpressionUIModelMapper extends BaseUIModelMapper<Expressi
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void toDMNModel(final int rowIndex,
                            final int columnIndex,
                            final Supplier<Optional<GridCellValue<?>>> cell) {
         cell.get().ifPresent(v -> {
             final ExpressionCellValue ecv = (ExpressionCellValue) v;
             ecv.getValue().ifPresent(beg -> {
-                hasExpression.setExpression((Expression) beg.getExpression().orElse(null));
-                beg.getExpression().ifPresent(e -> ((Expression) e).setParent(hasExpression.asDMNModelInstrumentedBase()));
+                hasExpression.setExpression(beg.getExpression().get().orElse(null));
+                beg.getExpression().get().ifPresent(e -> e.setParent(hasExpression.asDMNModelInstrumentedBase()));
             });
         });
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/dnd/DMNGridWidgetDnDMouseUpHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/dnd/DMNGridWidgetDnDMouseUpHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.widgets.dnd;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.ait.lienzo.client.core.event.NodeMouseUpEvent;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDMouseUpHandler;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+public class DMNGridWidgetDnDMouseUpHandler extends GridWidgetDnDMouseUpHandler {
+
+    public DMNGridWidgetDnDMouseUpHandler(final GridLayer layer,
+                                          final GridWidgetDnDHandlersState state) {
+        super(layer, state);
+    }
+
+    @Override
+    public void onNodeMouseUp(final NodeMouseUpEvent event) {
+        if (state.getOperation() == GridWidgetDnDHandlersState.GridWidgetHandlersOperation.COLUMN_RESIZE) {
+            final GridWidget gridWidget = state.getActiveGridWidget();
+            final List<GridColumn<?>> gridColumns = state.getActiveGridColumns();
+            if (isBaseGrid(gridWidget) && isSingleDMNColumn(gridColumns)) {
+                final BaseGrid uiGridWidget = (BaseGrid) gridWidget;
+                final DMNGridColumn uiColumn = (DMNGridColumn) gridColumns.get(0);
+                uiGridWidget.registerColumnResizeCompleted(uiColumn,
+                                                           state.getEventInitialColumnWidth());
+            }
+        }
+        super.onNodeMouseUp(event);
+    }
+
+    private boolean isBaseGrid(final GridWidget gridWidget) {
+        return gridWidget instanceof BaseGrid;
+    }
+
+    private boolean isSingleDMNColumn(final List<GridColumn<?>> gridColumns) {
+        if (Objects.isNull(gridColumns) || gridColumns.size() != 1) {
+            return false;
+        }
+        return gridColumns.get(0) instanceof DMNGridColumn;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseDelegatingExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseDelegatingExpressionGrid.java
@@ -26,6 +26,7 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorControls;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
@@ -38,7 +39,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -54,7 +54,6 @@ public abstract class BaseDelegatingExpressionGrid<E extends Expression, D exten
     public BaseDelegatingExpressionGrid(final GridCellTuple parent,
                                         final Optional<String> nodeUUID,
                                         final HasExpression hasExpression,
-                                        final Optional<E> expression,
                                         final Optional<HasName> hasName,
                                         final DMNGridPanel gridPanel,
                                         final DMNGridLayer gridLayer,
@@ -63,7 +62,7 @@ public abstract class BaseDelegatingExpressionGrid<E extends Expression, D exten
                                         final DefinitionUtils definitionUtils,
                                         final SessionManager sessionManager,
                                         final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                        final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                        final DefaultCanvasCommandFactory canvasCommandFactory,
                                         final Event<ExpressionEditorChanged> editorSelectedEvent,
                                         final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                         final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
@@ -74,7 +73,6 @@ public abstract class BaseDelegatingExpressionGrid<E extends Expression, D exten
         super(parent,
               nodeUUID,
               hasExpression,
-              expression,
               hasName,
               gridPanel,
               gridLayer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCache.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCache.java
@@ -18,15 +18,18 @@ package org.kie.workbench.common.dmn.client.widgets.grid;
 
 import java.util.Optional;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasControl;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 public interface ExpressionGridCache extends CanvasControl<AbstractCanvas> {
 
-    Optional<BaseExpressionGrid> getExpressionGrid(final String nodeUUID);
+    Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getExpressionGrid(final String nodeUUID);
 
     void putExpressionGrid(final String nodeUUID,
-                           final Optional<BaseExpressionGrid> gridWidget);
+                           final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> gridWidget);
 
     void removeExpressionGrid(final String nodeUUID);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImpl.java
@@ -22,13 +22,16 @@ import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasControl;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @Dependent
 public class ExpressionGridCacheImpl extends AbstractCanvasControl<AbstractCanvas> implements ExpressionGridCache {
 
-    private Map<String, Optional<BaseExpressionGrid>> cache = new HashMap<>();
+    private Map<String, Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> cache = new HashMap<>();
 
     @Override
     protected void doInit() {
@@ -41,13 +44,13 @@ public class ExpressionGridCacheImpl extends AbstractCanvasControl<AbstractCanva
     }
 
     @Override
-    public Optional<BaseExpressionGrid> getExpressionGrid(final String nodeUUID) {
+    public Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> getExpressionGrid(final String nodeUUID) {
         return cache.getOrDefault(nodeUUID, Optional.empty());
     }
 
     @Override
     public void putExpressionGrid(final String nodeUUID,
-                                  final Optional<BaseExpressionGrid> gridWidget) {
+                                  final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> gridWidget) {
         if (gridWidget.isPresent()) {
             if (gridWidget.get().isCacheable()) {
                 cache.put(nodeUUID, gridWidget);
@@ -61,7 +64,7 @@ public class ExpressionGridCacheImpl extends AbstractCanvasControl<AbstractCanva
     }
 
     //Package-protected for Unit Tests
-    Map<String, Optional<BaseExpressionGrid>> getContent() {
+    Map<String, Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> getContent() {
         return cache;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/EditableNameAndDataTypeColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/EditableNameAndDataTypeColumn.java
@@ -28,6 +28,7 @@ import com.ait.lienzo.client.core.types.Point2D;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.InformationItemCell;
@@ -35,16 +36,18 @@ import org.kie.workbench.common.dmn.client.editors.types.HasNameAndTypeRef;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNSimpleGridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
 import static org.kie.workbench.common.dmn.api.definition.v1_1.common.HasTypeRefHelper.getNotNullHasTypeRefs;
 
-public abstract class EditableNameAndDataTypeColumn<G extends BaseExpressionGrid> extends DMNSimpleGridColumn<G, InformationItemCell.HasNameCell> {
+public abstract class EditableNameAndDataTypeColumn<G extends BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> extends DMNSimpleGridColumn<G, InformationItemCell.HasNameCell> {
 
     private final Predicate<Integer> isEditable;
     private final Consumer<HasName> clearDisplayNameConsumer;
@@ -55,6 +58,7 @@ public abstract class EditableNameAndDataTypeColumn<G extends BaseExpressionGrid
     private final Optional<String> editorTitle;
 
     public EditableNameAndDataTypeColumn(final HeaderMetaData headerMetaData,
+                                         final double width,
                                          final G gridWidget,
                                          final Predicate<Integer> isEditable,
                                          final Consumer<HasName> clearDisplayNameConsumer,
@@ -64,6 +68,7 @@ public abstract class EditableNameAndDataTypeColumn<G extends BaseExpressionGrid
                                          final NameAndDataTypePopoverView.Presenter editor,
                                          final Optional<String> editorTitle) {
         this(Collections.singletonList(headerMetaData),
+             width,
              gridWidget,
              isEditable,
              clearDisplayNameConsumer,
@@ -75,6 +80,7 @@ public abstract class EditableNameAndDataTypeColumn<G extends BaseExpressionGrid
     }
 
     public EditableNameAndDataTypeColumn(final List<HeaderMetaData> headerMetaData,
+                                         final double width,
                                          final G gridWidget,
                                          final Predicate<Integer> isEditable,
                                          final Consumer<HasName> clearDisplayNameConsumer,
@@ -85,6 +91,7 @@ public abstract class EditableNameAndDataTypeColumn<G extends BaseExpressionGrid
                                          final Optional<String> editorTitle) {
         super(headerMetaData,
               new NameAndDataTypeColumnRenderer(),
+              width,
               gridWidget);
         this.isEditable = isEditable;
         this.clearDisplayNameConsumer = clearDisplayNameConsumer;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/KeyboardOperationEditGridCell.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/KeyboardOperationEditGridCell.java
@@ -18,8 +18,10 @@ package org.kie.workbench.common.dmn.client.widgets.grid.columns;
 
 import java.util.Optional;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.util.ColumnIndexUtilities;
@@ -49,7 +51,7 @@ public class KeyboardOperationEditGridCell extends KeyboardOperationEditCell {
                               ColumnIndexUtilities.findUiColumnIndex(model.getColumns(),
                                                                      selectedCell.getColumnIndex())).getValue();
         if (value instanceof ExpressionCellValue) {
-            final Optional<BaseExpressionGrid> grid = ((ExpressionCellValue) value).getValue();
+            final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> grid = ((ExpressionCellValue) value).getValue();
             grid.ifPresent(baseExpressionGrid -> {
                 gridLayer.select(baseExpressionGrid);
                 baseExpressionGrid.selectFirstCell();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaData.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaData.java
@@ -50,7 +50,6 @@ public abstract class NameAndDataTypeHeaderMetaData<E extends Expression> extend
     private final BiConsumer<HasTypeRef, QName> setTypeRefConsumer;
 
     public NameAndDataTypeHeaderMetaData(final HasExpression hasExpression,
-                                         final Optional<E> expression,
                                          final Optional<HasName> hasName,
                                          final Consumer<HasName> clearDisplayNameConsumer,
                                          final BiConsumer<HasName, Name> setDisplayNameConsumer,
@@ -59,7 +58,7 @@ public abstract class NameAndDataTypeHeaderMetaData<E extends Expression> extend
                                          final NameAndDataTypePopoverView.Presenter editor,
                                          final Optional<String> editorTitle) {
         this(hasName,
-             () -> TypeRefUtils.getTypeRefOfExpression(expression.get(), hasExpression),
+             () -> TypeRefUtils.getTypeRefOfExpression(hasExpression.getExpression(), hasExpression),
              clearDisplayNameConsumer,
              setDisplayNameConsumer,
              setTypeRefConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNGridColumn.java
@@ -19,15 +19,16 @@ package org.kie.workbench.common.dmn.client.widgets.grid.model;
 import java.util.List;
 
 import org.kie.soup.commons.util.Lists;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.HasDOMElementResources;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
 
-public abstract class DMNGridColumn<G extends GridWidget, T> extends BaseGridColumn<T> implements HasDOMElementResources {
+public abstract class DMNGridColumn<G extends BaseGrid<? extends Expression>, T> extends BaseGridColumn<T> implements HasDOMElementResources {
 
     public static final double DEFAULT_WIDTH = 100.0;
 
@@ -35,25 +36,46 @@ public abstract class DMNGridColumn<G extends GridWidget, T> extends BaseGridCol
 
     public DMNGridColumn(final HeaderMetaData headerMetaData,
                          final GridColumnRenderer<T> columnRenderer,
+                         final double width,
                          final G gridWidget) {
         this(new Lists.Builder<HeaderMetaData>()
                      .add(headerMetaData)
                      .build(),
              columnRenderer,
+             width,
              gridWidget);
     }
 
     public DMNGridColumn(final List<HeaderMetaData> headerMetaData,
                          final GridColumnRenderer<T> columnRenderer,
+                         final double width,
                          final G gridWidget) {
         super(headerMetaData,
               columnRenderer,
-              DEFAULT_WIDTH);
+              width);
         this.gridWidget = gridWidget;
     }
 
-    public void setWidthInternal(final double width) {
+    public G getGridWidget() {
+        return gridWidget;
+    }
+
+    @Override
+    public void setWidth(final double width) {
+        setComponentWidth(width);
         super.setWidth(width);
+    }
+
+    public void setWidthInternal(final double width) {
+        setComponentWidth(width);
+        super.setWidth(width);
+    }
+
+    protected void setComponentWidth(final double width) {
+        gridWidget.getExpression().get().ifPresent(e -> {
+            final int index = gridWidget.getModel().getColumns().indexOf(DMNGridColumn.this);
+            e.getComponentWidths().set(index, width);
+        });
     }
 
     public void updateWidthOfPeers() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNSimpleGridColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/DMNSimpleGridColumn.java
@@ -18,27 +18,32 @@ package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
 import java.util.List;
 
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
 
-public abstract class DMNSimpleGridColumn<G extends GridWidget, T> extends DMNGridColumn<G, T> {
+public abstract class DMNSimpleGridColumn<G extends BaseGrid<? extends Expression>, T> extends DMNGridColumn<G, T> {
 
     public DMNSimpleGridColumn(final HeaderMetaData headerMetaData,
                                final GridColumnRenderer<T> columnRenderer,
+                               final double width,
                                final G gridWidget) {
         super(headerMetaData,
               columnRenderer,
+              width,
               gridWidget);
     }
 
     public DMNSimpleGridColumn(final List<HeaderMetaData> headerMetaData,
                                final GridColumnRenderer<T> columnRenderer,
+                               final double width,
                                final G gridWidget) {
         super(headerMetaData,
               columnRenderer,
+              width,
               gridWidget);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/GridCellTuple.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import com.google.gwt.user.client.ui.RequiresResize;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
@@ -80,7 +81,7 @@ public class GridCellTuple implements RequiresResize {
                 final GridCellValue<?> value = cell.getValue();
                 if (value instanceof ExpressionCellValue) {
                     final ExpressionCellValue ecv = (ExpressionCellValue) value;
-                    final Optional<BaseExpressionGrid> editor = ecv.getValue();
+                    final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = ecv.getValue();
                     if (editor.isPresent()) {
                         final BaseExpressionGrid beg = editor.get();
                         width = Math.max(width, requiredWidthSupplier.apply(beg));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -33,10 +33,12 @@ import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContain
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.dnd.DMNGridWidgetDnDMouseUpHandler;
 import org.kie.workbench.common.dmn.client.widgets.dnd.DelegatingGridWidgetDndMouseMoveHandler;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDMouseMoveHandler;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDMouseUpHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager;
@@ -207,5 +209,11 @@ public class DMNGridLayer extends DefaultGridLayer {
     protected GridWidgetDnDMouseMoveHandler getGridWidgetDnDMouseMoveHandler() {
         return new DelegatingGridWidgetDndMouseMoveHandler(this,
                                                            getGridWidgetHandlersState());
+    }
+
+    @Override
+    protected GridWidgetDnDMouseUpHandler getGridWidgetDnDMouseUpHandler() {
+        return new DMNGridWidgetDnDMouseUpHandler(this,
+                                                  getGridWidgetHandlersState());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImplTest.java
@@ -21,11 +21,11 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.InputData;
 import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
@@ -45,12 +45,14 @@ import static org.mockito.Mockito.when;
 public class TextAnnotationTextPropertyProviderImplTest {
 
     public static final String NAME_FIELD = "name";
+
     public static final String NAME_VALUE = "text";
+
     @Mock
     private DefinitionUtils definitionUtils;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private Element<? extends Definition> element;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/resize/DecisionServiceMoveDividerControlTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/resize/DecisionServiceMoveDividerControlTest.java
@@ -24,12 +24,12 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionService;
 import org.kie.workbench.common.dmn.api.property.dmn.DecisionServiceDividerLineY;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.shape.view.decisionservice.DecisionServiceSVGShapeView;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
@@ -75,7 +75,7 @@ public class DecisionServiceMoveDividerControlTest {
     private Shape shape;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private RequiresCommandManager.CommandManagerProvider<AbstractCanvasHandler> commandManagerProvider;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/context/AddContextEntryCommandTest.java
@@ -162,7 +162,6 @@ public class AddContextEntryCommandTest {
                                                                                                              any(Optional.class),
                                                                                                              any(HasExpression.class),
                                                                                                              any(Optional.class),
-                                                                                                             any(Optional.class),
                                                                                                              anyInt());
         this.uiModelMapper = new ContextUIModelMapper(gridWidget,
                                                       () -> uiModel,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
@@ -48,6 +48,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -105,7 +106,7 @@ public class AddInputClauseCommandTest {
         this.command = spy(new AddInputClauseCommand(dtable,
                                                      inputClause,
                                                      uiModel,
-                                                     uiInputClauseColumn,
+                                                     () -> uiInputClauseColumn,
                                                      index,
                                                      uiModelMapper,
                                                      executeCanvasOperation,
@@ -341,6 +342,33 @@ public class AddInputClauseCommandTest {
 
         verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
+    }
+
+    @Test
+    public void testComponentWidths() {
+        makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
+
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(canvasHandler);
+        final Command<AbstractCanvasHandler, CanvasViolation> canvasCommand = command.newCanvasCommand(canvasHandler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(graphCommandExecutionContext));
+        assertEquals(CanvasCommandResultBuilder.SUCCESS,
+                     canvasCommand.execute(canvasHandler));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+        assertNull(dtable.getComponentWidths().get(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT));
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(graphCommandExecutionContext));
+        assertEquals(CanvasCommandResultBuilder.SUCCESS,
+                     canvasCommand.undo(canvasHandler));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
     }
 
     private void addRuleWithInputClauseValues(String... inputClauseValues) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -111,7 +111,7 @@ public class AddOutputClauseCommandTest {
         this.command = spy(new AddOutputClauseCommand(dtable,
                                                       outputClause,
                                                       uiModel,
-                                                      uiOutputClauseColumn,
+                                                      () -> uiOutputClauseColumn,
                                                       index,
                                                       uiModelMapper,
                                                       executeCanvasOperation,
@@ -402,6 +402,33 @@ public class AddOutputClauseCommandTest {
 
         verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
+    }
+
+    @Test
+    public void testComponentWidths() {
+        makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
+
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(canvasHandler);
+        final Command<AbstractCanvasHandler, CanvasViolation> canvasCommand = command.newCanvasCommand(canvasHandler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(graphCommandExecutionContext));
+        assertEquals(CanvasCommandResultBuilder.SUCCESS,
+                     canvasCommand.execute(canvasHandler));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+        assertNull(dtable.getComponentWidths().get(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT));
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(graphCommandExecutionContext));
+        assertEquals(CanvasCommandResultBuilder.SUCCESS,
+                     canvasCommand.undo(canvasHandler));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
     }
 
     private void addRuleWithOutputClauseValues(String... outputClauseValues) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Deci
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.DescriptionColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.InputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteInputClauseCommandTest {
@@ -240,5 +242,29 @@ public class DeleteInputClauseCommandTest {
 
         verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
+    }
+
+    @Test
+    public void testComponentWidths() {
+        when(uiInputClauseColumn.getWidth()).thenReturn(DMNGridColumn.DEFAULT_WIDTH);
+
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(canvasHandler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(graphCommandExecutionContext));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(graphCommandExecutionContext));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+        assertEquals(DMNGridColumn.DEFAULT_WIDTH,
+                     dtable.getComponentWidths().get(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT),
+                     0.0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Deci
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.DescriptionColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteOutputClauseCommandTest {
@@ -240,5 +242,29 @@ public class DeleteOutputClauseCommandTest {
 
         verify(undoCanvasOperation).execute();
         verify(command).updateParentInformation();
+    }
+
+    @Test
+    public void testComponentWidths() {
+        when(uiOutputClauseColumn.getWidth()).thenReturn(DMNGridColumn.DEFAULT_WIDTH);
+
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(canvasHandler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(graphCommandExecutionContext));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(graphCommandExecutionContext));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+        assertEquals(DMNGridColumn.DEFAULT_WIDTH,
+                     dtable.getComponentWidths().get(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT),
+                     0.0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/MoveColumnsCommandTest.java
@@ -305,6 +305,67 @@ public class MoveColumnsCommandTest {
         graphCommand.execute(graphCommandExecutionContext);
     }
 
+    @Test
+    public void testInputClauseComponentWidths() {
+        moveColumnsToPositionCommand(Arrays.asList(uiInputClauseColumnTwo, uiInputClauseColumnThree), 1);
+
+        assertComponentWidths(1, 2, 3);
+    }
+
+    @Test
+    public void testOutputClauseComponentWidths() {
+        moveColumnsToPositionCommand(Arrays.asList(uiOutputClauseColumnTwo, uiOutputClauseColumnThree), 4);
+
+        assertComponentWidths(4, 5, 6);
+    }
+
+    private void assertComponentWidths(final int uiColumn1Index,
+                                       final int uiColumn2Index,
+                                       final int uiColumn3Index) {
+        final List<Double> componentWidths = dtable.getComponentWidths();
+        componentWidths.set(uiColumn1Index, 10.0);
+        componentWidths.set(uiColumn2Index, 20.0);
+        componentWidths.set(uiColumn3Index, 30.0);
+
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(canvasHandler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(graphCommandExecutionContext));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+
+        assertEquals(20.0,
+                     dtable.getComponentWidths().get(uiColumn1Index),
+                     0.0);
+        assertEquals(30.0,
+                     dtable.getComponentWidths().get(uiColumn2Index),
+                     0.0);
+        assertEquals(10.0,
+                     dtable.getComponentWidths().get(uiColumn3Index),
+                     0.0);
+
+        //Move UI columns as MoveColumnsCommand.undo() relies on the UiModel being updated
+        command.newCanvasCommand(canvasHandler).execute(canvasHandler);
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(graphCommandExecutionContext));
+
+        assertEquals(dtable.getRequiredComponentWidthCount(),
+                     dtable.getComponentWidths().size());
+        assertEquals(10.0,
+                     dtable.getComponentWidths().get(uiColumn1Index),
+                     0.0);
+        assertEquals(20.0,
+                     dtable.getComponentWidths().get(uiColumn2Index),
+                     0.0);
+        assertEquals(30.0,
+                     dtable.getComponentWidths().get(uiColumn3Index),
+                     0.0);
+    }
+
     private void assertClauses(final int... clausesIndexes) {
         assertEquals(inputClauseOne, dtable.getInput().get(clausesIndexes[0]));
         assertEquals(inputClauseTwo, dtable.getInput().get(clausesIndexes[1]));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/SetKindCommandTest.java
@@ -21,10 +21,12 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
@@ -41,6 +43,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -57,7 +60,7 @@ public class SetKindCommandTest {
     private GridColumn mockColumn;
 
     @Mock
-    private org.uberfire.mvp.Command executeCanvasOperation;
+    private ParameterizedCommand<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> executeCanvasOperation;
 
     @Mock
     private org.uberfire.mvp.Command undoCanvasOperation;
@@ -72,14 +75,14 @@ public class SetKindCommandTest {
     private RuleManager ruleManager;
 
     @Mock
-    private BaseExpressionGrid originalEditor;
+    private BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper> originalEditor;
 
     private LiteralExpression originalExpression = new LiteralExpression();
 
     private FunctionDefinition.Kind originalKind = FunctionDefinition.Kind.FEEL;
 
     @Mock
-    private BaseExpressionGrid newEditor;
+    private BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper> newEditor;
 
     private LiteralExpression newExpression = new LiteralExpression();
 
@@ -118,7 +121,8 @@ public class SetKindCommandTest {
                                           newKind,
                                           Optional.of(newExpression),
                                           executeCanvasOperation,
-                                          undoCanvasOperation);
+                                          undoCanvasOperation,
+                                          () -> Optional.of(newEditor));
     }
 
     @Test
@@ -204,7 +208,7 @@ public class SetKindCommandTest {
         assertEquals(newEditor,
                      ((ExpressionCellValue) uiModel.getCell(0, 0).getValue()).getValue().get());
 
-        verify(executeCanvasOperation).execute();
+        verify(executeCanvasOperation).execute(Optional.of(newEditor));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.v1_1.List;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.DecisionTableUIModelMapperHelper;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationDefaultValueUtilities;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
@@ -45,6 +46,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -110,7 +112,7 @@ public class AddRelationColumnCommandTest {
         command = spy(new AddRelationColumnCommand(relation,
                                                    informationItem,
                                                    uiModel,
-                                                   uiModelColumn,
+                                                   () -> uiModelColumn,
                                                    uiColumnIndex,
                                                    uiModelMapper,
                                                    executeCanvasOperation,
@@ -439,5 +441,30 @@ public class AddRelationColumnCommandTest {
         verify(command).updateParentInformation();
 
         verify(undoCanvasOperation).execute();
+    }
+
+    @Test
+    public void testComponentWidths() {
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(handler);
+        final Command<AbstractCanvasHandler, CanvasViolation> canvasCommand = command.newCanvasCommand(handler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(gce));
+        assertEquals(CanvasCommandResultBuilder.SUCCESS,
+                     canvasCommand.execute(handler));
+
+        assertEquals(relation.getRequiredComponentWidthCount(),
+                     relation.getComponentWidths().size());
+        assertNull(relation.getComponentWidths().get(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT));
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(gce));
+        assertEquals(CanvasCommandResultBuilder.SUCCESS,
+                     canvasCommand.undo(handler));
+
+        assertEquals(relation.getRequiredComponentWidthCount(),
+                     relation.getComponentWidths().size());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -49,6 +50,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteRelationColumnCommandTest {
@@ -362,5 +364,31 @@ public class DeleteRelationColumnCommandTest {
         verify(command).updateParentInformation();
 
         verify(undoCanvasOperation).execute();
+    }
+
+    @Test
+    public void testComponentWidths() {
+        makeCommand();
+
+        when(uiModelColumn.getWidth()).thenReturn(DMNGridColumn.DEFAULT_WIDTH);
+
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(handler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(gce));
+
+        assertEquals(relation.getRequiredComponentWidthCount(),
+                     relation.getComponentWidths().size());
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(gce));
+
+        assertEquals(relation.getRequiredComponentWidthCount(),
+                     relation.getComponentWidths().size());
+        assertEquals(DMNGridColumn.DEFAULT_WIDTH,
+                     relation.getComponentWidths().get(1),
+                     0.0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/MoveColumnsCommandTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.commands.expressions.types.relation;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -207,7 +208,7 @@ public class MoveColumnsCommandTest extends BaseMoveCommandsTest<MoveColumnsComm
     }
 
     @Test
-    public void testCanvasCommandUndoMoveUp() {
+    public void testCanvasCommandUndoMoveLeft() {
         setupCommand(1,
                      uiModel.getColumns().get(2));
 
@@ -257,5 +258,46 @@ public class MoveColumnsCommandTest extends BaseMoveCommandsTest<MoveColumnsComm
                      uiModel.getCell(1, 1).getValue().getValue());
         assertEquals("value" + columnIndexes[1],
                      uiModel.getCell(1, 2).getValue().getValue());
+    }
+
+    @Test
+    public void testComponentWidths() {
+        setupCommand(1,
+                     uiModel.getColumns().get(2));
+        final List<Double> componentWidths = relation.getComponentWidths();
+        componentWidths.set(1, 10.0);
+        componentWidths.set(2, 20.0);
+
+        final Command<GraphCommandExecutionContext, RuleViolation> graphCommand = command.newGraphCommand(handler);
+
+        //Execute
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.execute(gce));
+
+        assertEquals(relation.getRequiredComponentWidthCount(),
+                     relation.getComponentWidths().size());
+
+        assertEquals(20.0,
+                     relation.getComponentWidths().get(1),
+                     0.0);
+        assertEquals(10.0,
+                     relation.getComponentWidths().get(2),
+                     0.0);
+
+        //Move UI columns as MoveColumnsCommand.undo() relies on the UiModel being updated
+        command.newCanvasCommand(handler).execute(handler);
+
+        //Undo
+        assertEquals(GraphCommandResultBuilder.SUCCESS,
+                     graphCommand.undo(gce));
+
+        assertEquals(relation.getRequiredComponentWidthCount(),
+                     relation.getComponentWidths().size());
+        assertEquals(10.0,
+                     relation.getComponentWidths().get(1),
+                     0.0);
+        assertEquals(20.0,
+                     relation.getComponentWidths().get(2),
+                     0.0);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/SetComponentWidthCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/SetComponentWidthCommandTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.commands.general.NoOperationGraphCommand;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetComponentWidthCommandTest {
+
+    private static final double WIDTH = 100.0;
+
+    private static final double OLD_WIDTH = 200.0;
+
+    @Mock
+    private DMNGridColumn uiColumn;
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private BaseGrid uiGridWidget;
+
+    private SetComponentWidthCommand command;
+
+    @Before
+    public void setup() {
+        this.command = new SetComponentWidthCommand(uiColumn,
+                                                    OLD_WIDTH,
+                                                    WIDTH);
+
+        when(uiColumn.getGridWidget()).thenReturn(uiGridWidget);
+    }
+
+    @Test
+    public void testTypes() {
+        assertThat(command.newGraphCommand(canvasHandler)).isInstanceOf(NoOperationGraphCommand.class);
+        assertThat(command.newCanvasCommand(canvasHandler)).isInstanceOf(SetComponentWidthCanvasCommand.class);
+    }
+
+    @Test
+    public void testExecute() {
+        assertThat(command.getCanvasCommand(canvasHandler).execute(canvasHandler)).isEqualTo(CanvasCommandResultBuilder.SUCCESS);
+
+        verify(uiColumn).setWidth(WIDTH);
+        verify(uiGridWidget).batch();
+    }
+
+    @Test
+    public void testExecuteThenUndo() {
+        assertThat(command.getCanvasCommand(canvasHandler).execute(canvasHandler)).isEqualTo(CanvasCommandResultBuilder.SUCCESS);
+
+        verify(uiColumn).setWidth(WIDTH);
+        verify(uiGridWidget).batch();
+
+        assertThat(command.getCanvasCommand(canvasHandler).undo(canvasHandler)).isEqualTo(CanvasCommandResultBuilder.SUCCESS);
+
+        verify(uiColumn).setWidth(OLD_WIDTH);
+        verify(uiGridWidget, times(2)).batch();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/ClearExpressionTypeCommandTest.java
@@ -25,9 +25,11 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContainerUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -45,7 +47,7 @@ public class ClearExpressionTypeCommandTest extends BaseClearExpressionCommandTe
     private ExpressionContainerUIModelMapper uiModelMapper;
 
     @Mock
-    private BaseExpressionGrid expressionGrid;
+    private BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper> expressionGrid;
 
     @Before
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NoOperationGraphCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NoOperationGraphCommandTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.commands.general;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NoOperationGraphCommandTest {
+
+    @Mock
+    private GraphCommandExecutionContext context;
+
+    private NoOperationGraphCommand command;
+
+    @Before
+    public void setup() {
+        this.command = new NoOperationGraphCommand();
+    }
+
+    @Test
+    public void testCheck() {
+        assertThat(command.check(context)).isEqualTo(GraphCommandResultBuilder.SUCCESS);
+    }
+
+    @Test
+    public void testExecute() {
+        assertThat(command.execute(context)).isEqualTo(GraphCommandResultBuilder.SUCCESS);
+    }
+
+    @Test
+    public void testUndo() {
+        assertThat(command.undo(context)).isEqualTo(GraphCommandResultBuilder.SUCCESS);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerUIModelMapperTest.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCacheImpl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -44,6 +45,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 
@@ -52,9 +54,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExpressionContainerUIModelMapperTest {
@@ -114,8 +116,8 @@ public class ExpressionContainerUIModelMapperTest {
         uiModel = new BaseGridData();
         uiModel.appendRow(new BaseGridRow());
         uiModel.appendColumn(uiExpressionColumn);
-        doReturn(0).when(uiExpressionColumn).getIndex();
-        doReturn(MINIMUM_COLUMN_WIDTH).when(uiExpressionColumn).getMinimumWidth();
+        when(uiExpressionColumn.getIndex()).thenReturn(0);
+        when(uiExpressionColumn.getMinimumWidth()).thenReturn(MINIMUM_COLUMN_WIDTH);
 
         parent = new GridCellTuple(0, 0, expressionContainerGrid);
 
@@ -123,24 +125,22 @@ public class ExpressionContainerUIModelMapperTest {
         expressionEditorDefinitions.add(literalExpressionEditorDefinition);
         expressionEditorDefinitions.add(undefinedExpressionEditorDefinition);
 
-        doReturn(expressionEditorDefinitions).when(expressionEditorDefinitionsSupplier).get();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditorDefinition).getModelClass();
-        doReturn(true).when(literalExpressionEditor).isCacheable();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditor).getExpression();
-        doReturn(Optional.of(literalExpressionEditor)).when(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(HasExpression.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(Optional.class),
-                                                                                                         anyInt());
+        when(expressionEditorDefinitionsSupplier.get()).thenReturn(expressionEditorDefinitions);
+        when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(literalExpression));
+        when(literalExpressionEditor.isCacheable()).thenReturn(true);
+        when(literalExpressionEditor.getExpression()).thenReturn(() -> Optional.of(literalExpression));
+        when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                         any(Optional.class),
+                                                         any(HasExpression.class),
+                                                         any(Optional.class),
+                                                         anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 
-        doReturn(Optional.empty()).when(undefinedExpressionEditorDefinition).getModelClass();
-        doReturn(Optional.of(undefinedExpressionEditor)).when(undefinedExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                             any(Optional.class),
-                                                                                                             any(HasExpression.class),
-                                                                                                             any(Optional.class),
-                                                                                                             any(Optional.class),
-                                                                                                             anyInt());
+        when(undefinedExpressionEditorDefinition.getModelClass()).thenReturn(Optional.empty());
+        when(undefinedExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                           any(Optional.class),
+                                                           any(HasExpression.class),
+                                                           any(Optional.class),
+                                                           anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
 
         expressionGridCache = spy(new ExpressionGridCacheImpl());
         mapper = new ExpressionContainerUIModelMapper(parent,
@@ -166,7 +166,6 @@ public class ExpressionContainerUIModelMapperTest {
         verify(undefinedExpressionEditorDefinition).getEditor(eq(parent),
                                                               nodeUUIDCaptor.capture(),
                                                               eq(hasExpression),
-                                                              eq(Optional.ofNullable(expression)),
                                                               eq(Optional.of(hasName)),
                                                               eq(0));
         final Optional<String> nodeUUID = nodeUUIDCaptor.getValue();
@@ -187,7 +186,6 @@ public class ExpressionContainerUIModelMapperTest {
         verify(literalExpressionEditorDefinition).getEditor(eq(parent),
                                                             nodeUUIDCaptor.capture(),
                                                             eq(hasExpression),
-                                                            eq(Optional.of(expression)),
                                                             eq(Optional.of(hasName)),
                                                             eq(0));
         final Optional<String> nodeUUID = nodeUUIDCaptor.getValue();
@@ -205,7 +203,6 @@ public class ExpressionContainerUIModelMapperTest {
         verify(literalExpressionEditorDefinition).getEditor(eq(parent),
                                                             nodeUUIDCaptor.capture(),
                                                             eq(hasExpression),
-                                                            eq(Optional.of(expression)),
                                                             eq(Optional.of(hasName)),
                                                             eq(0));
 
@@ -218,7 +215,6 @@ public class ExpressionContainerUIModelMapperTest {
         verify(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
                                                             any(Optional.class),
                                                             any(HasExpression.class),
-                                                            any(Optional.class),
                                                             any(Optional.class),
                                                             anyInt());
         verify(expressionGridCache).putExpressionGrid(anyString(),
@@ -247,7 +243,7 @@ public class ExpressionContainerUIModelMapperTest {
         assertThat(gridCellValue).isInstanceOf(ExpressionCellValue.class);
 
         final ExpressionCellValue ecv = (ExpressionCellValue) gridCellValue;
-        final Optional<BaseExpressionGrid> editor = ecv.getValue();
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor = ecv.getValue();
 
         assertThat(editor.isPresent()).isTrue();
         assertThat(editor.get()).isInstanceOf(clazz);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
@@ -124,6 +125,9 @@ public class ExpressionEditorViewImplTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
+    private DefaultCanvasCommandFactory canvasCommandFactory;
+
+    @Mock
     private Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier;
 
     @Mock
@@ -196,7 +200,6 @@ public class ExpressionEditorViewImplTest {
                                                                        any(Optional.class),
                                                                        any(HasExpression.class),
                                                                        any(Optional.class),
-                                                                       any(Optional.class),
                                                                        anyInt());
         doReturn(new BaseGridData()).when(editor).getModel();
 
@@ -207,6 +210,7 @@ public class ExpressionEditorViewImplTest {
                                                      listSelector,
                                                      sessionManager,
                                                      sessionCommandManager,
+                                                     canvasCommandFactory,
                                                      expressionEditorDefinitionsSupplier,
                                                      refreshFormPropertiesEvent,
                                                      domainObjectSelectionEvent));
@@ -225,7 +229,6 @@ public class ExpressionEditorViewImplTest {
                                                            any(Optional.class),
                                                            any(HasExpression.class),
                                                            any(Optional.class),
-                                                           any(Optional.class),
                                                            anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
 
         when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(new LiteralExpression()));
@@ -234,7 +237,6 @@ public class ExpressionEditorViewImplTest {
         when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
                                                          any(Optional.class),
                                                          any(HasExpression.class),
-                                                         any(Optional.class),
                                                          any(Optional.class),
                                                          anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/BaseContextUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/BaseContextUIModelMapperTest.java
@@ -51,8 +51,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class BaseContextUIModelMapperTest<M extends ContextUIModelMapper> {
@@ -112,31 +112,29 @@ public abstract class BaseContextUIModelMapperTest<M extends ContextUIModelMappe
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.uiModel.appendColumn(uiNameColumn);
         this.uiModel.appendColumn(uiExpressionEditorColumn);
-        doReturn(0).when(uiRowNumberColumn).getIndex();
-        doReturn(1).when(uiNameColumn).getIndex();
-        doReturn(2).when(uiExpressionEditorColumn).getIndex();
+        when(uiRowNumberColumn.getIndex()).thenReturn(0);
+        when(uiNameColumn.getIndex()).thenReturn(1);
+        when(uiExpressionEditorColumn.getIndex()).thenReturn(2);
 
         final ExpressionEditorDefinitions expressionEditorDefinitions = new ExpressionEditorDefinitions();
         expressionEditorDefinitions.add(literalExpressionEditorDefinition);
         expressionEditorDefinitions.add(undefinedExpressionEditorDefinition);
 
-        doReturn(expressionEditorDefinitions).when(expressionEditorDefinitionsSupplier).get();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditorDefinition).getModelClass();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditor).getExpression();
-        doReturn(Optional.of(literalExpressionEditor)).when(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(HasExpression.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(Optional.class),
-                                                                                                         anyInt());
+        when(expressionEditorDefinitionsSupplier.get()).thenReturn(expressionEditorDefinitions);
+        when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(literalExpression));
+        when(literalExpressionEditor.getExpression()).thenReturn(() -> Optional.of(literalExpression));
+        when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                         any(Optional.class),
+                                                         any(HasExpression.class),
+                                                         any(Optional.class),
+                                                         anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 
-        doReturn(Optional.empty()).when(undefinedExpressionEditorDefinition).getModelClass();
-        doReturn(Optional.of(undefinedExpressionEditor)).when(undefinedExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                             any(Optional.class),
-                                                                                                             any(HasExpression.class),
-                                                                                                             any(Optional.class),
-                                                                                                             any(Optional.class),
-                                                                                                             anyInt());
+        when(undefinedExpressionEditorDefinition.getModelClass()).thenReturn(Optional.empty());
+        when(undefinedExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                           any(Optional.class),
+                                                           any(HasExpression.class),
+                                                           any(Optional.class),
+                                                           anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
 
         this.context = new Context();
         this.context.getContextEntry().add(new ContextEntry() {{
@@ -166,7 +164,6 @@ public abstract class BaseContextUIModelMapperTest<M extends ContextUIModelMappe
         verify(undefinedExpressionEditorDefinition).getEditor(parentCaptor.capture(),
                                                               eq(Optional.empty()),
                                                               eq(context.getContextEntry().get(0)),
-                                                              eq(Optional.empty()),
                                                               eq(Optional.of(context.getContextEntry().get(0).getVariable())),
                                                               eq(1));
         final GridCellTuple parent = parentCaptor.getValue();
@@ -188,7 +185,6 @@ public abstract class BaseContextUIModelMapperTest<M extends ContextUIModelMappe
         verify(literalExpressionEditorDefinition).getEditor(parentCaptor.capture(),
                                                             eq(Optional.empty()),
                                                             eq(context.getContextEntry().get(1)),
-                                                            eq(Optional.of(context.getContextEntry().get(1).getExpression())),
                                                             eq(Optional.empty()),
                                                             eq(1));
         final GridCellTuple parent = parentCaptor.getValue();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextEditorDefinitionTest.java
@@ -28,6 +28,8 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -37,6 +39,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -44,7 +47,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -85,7 +87,7 @@ public class ContextEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -203,13 +205,12 @@ public class ContextEditorDefinitionTest {
 
     @Test
     public void testEditor() {
-        final Optional<Context> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        when(hasExpression.getExpression()).thenReturn(definition.getModelClass().get());
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertTrue(oEditor.isPresent());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ContextGridDataTest.java
@@ -74,7 +74,7 @@ public class ContextGridDataTest {
         this.uiModel = new ContextGridData(delegate,
                                            sessionManager,
                                            sessionCommandManager,
-                                           expression,
+                                           () -> expression,
                                            canvasOperation);
 
         doReturn(session).when(sessionManager).getCurrentSession();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionCellValueTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionCellValueTest.java
@@ -20,9 +20,12 @@ import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -37,7 +40,7 @@ public class ExpressionCellValueTest {
 
     private ExpressionCellValue ecv;
 
-    private void setup(final Optional<BaseExpressionGrid> editor) {
+    private void setup(final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> editor) {
         this.ecv = new ExpressionCellValue(editor);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRendererTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnRendererTest.java
@@ -24,9 +24,12 @@ import com.google.gwtmockito.GwtMockito;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
@@ -48,7 +51,7 @@ public class ExpressionEditorColumnRendererTest {
     private GridBodyCellRenderContext context;
 
     @Mock
-    private BaseExpressionGrid widget;
+    private BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper> widget;
 
     @Mock
     private Group renderedGroup;
@@ -56,7 +59,7 @@ public class ExpressionEditorColumnRendererTest {
     @Mock
     private Group editorGroup;
 
-    private GridCell<Optional<BaseExpressionGrid>> cell;
+    private GridCell<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> cell;
 
     private ExpressionEditorColumnRenderer renderer;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.dmn.api.definition.v1_1.InputClause;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause;
 import org.kie.workbench.common.dmn.api.definition.v1_1.UnaryTests;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hitpolicy.HitPolicyPopoverView;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
@@ -44,7 +45,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Graph;
@@ -89,7 +89,7 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionTest.java
@@ -22,9 +22,12 @@ import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,13 +66,11 @@ public class DecisionTableEditorDefinitionTest extends BaseDecisionTableEditorDe
 
     @Test
     public void testEditor() {
-        final Optional<DecisionTable> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertThat(oEditor).isPresent();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridDataTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
@@ -70,7 +71,7 @@ public class DecisionTableGridDataTest {
 
     private DecisionTableGridData uiModel;
 
-    private Optional<DecisionTable> expression = Optional.of(new DecisionTable());
+    private Supplier<Optional<DecisionTable>> expression = () -> Optional.of(new DecisionTable());
 
     @Before
     public void setup() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DescriptionColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DescriptionColumnTest.java
@@ -62,6 +62,7 @@ public class DescriptionColumnTest extends BaseDOMElementSingletonColumnTest<Tex
     protected DescriptionColumn getColumn() {
         return new DescriptionColumn(headerMetaData,
                                      factory,
+                                     DescriptionColumn.DEFAULT_WIDTH,
                                      gridWidget);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/InputClauseColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/InputClauseColumnTest.java
@@ -24,6 +24,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.mocks.MockHasDOME
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.BaseDOMElementSingletonColumnTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.TextAreaDOMElement;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.mock;
@@ -65,6 +66,7 @@ public class InputClauseColumnTest extends BaseDOMElementSingletonColumnTest<Tex
     protected InputClauseColumn getColumn() {
         return new InputClauseColumn(headerMetaData,
                                      factory,
+                                     DMNGridColumn.DEFAULT_WIDTH,
                                      gridWidget);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/OutputClauseColumnTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.mocks.MockHasDOME
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.BaseDOMElementSingletonColumnTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.TextAreaDOMElement;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
@@ -72,6 +73,7 @@ public class OutputClauseColumnTest extends BaseDOMElementSingletonColumnTest<Te
         headerMetaData.add(this.headerMetaData);
         return new OutputClauseColumn(() -> headerMetaData,
                                       factory,
+                                      DMNGridColumn.DEFAULT_WIDTH,
                                       gridWidget);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumnParametersHeaderMetaDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionColumnParametersHeaderMetaDataTest.java
@@ -62,14 +62,14 @@ public class FunctionColumnParametersHeaderMetaDataTest {
 
     private FunctionDefinition function;
 
-    private Supplier<FunctionDefinition> functionSupplier;
+    private Supplier<Optional<FunctionDefinition>> functionSupplier;
 
     private FunctionColumnParametersHeaderMetaData header;
 
     @Before
     public void setup() {
         this.function = new FunctionDefinition();
-        this.functionSupplier = () -> function;
+        this.functionSupplier = () -> Optional.ofNullable(function);
         this.header = new FunctionColumnParametersHeaderMetaData(functionSupplier,
                                                                  translationService,
                                                                  cellEditorControls,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionEditorDefinitionTest.java
@@ -27,8 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -40,6 +42,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -47,7 +50,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -86,7 +88,7 @@ public class FunctionEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -207,13 +209,12 @@ public class FunctionEditorDefinitionTest {
 
     @Test
     public void testEditor() {
-        final Optional<FunctionDefinition> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        when(hasExpression.getExpression()).thenReturn(definition.getModelClass().get());
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertTrue(oEditor.isPresent());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionKindRowColumnHeaderMetaDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionKindRowColumnHeaderMetaDataTest.java
@@ -34,7 +34,7 @@ public class FunctionKindRowColumnHeaderMetaDataTest {
 
     private FunctionDefinition function;
 
-    private Supplier<FunctionDefinition> functionSupplier;
+    private Supplier<Optional<FunctionDefinition>> functionSupplier;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -51,7 +51,7 @@ public class FunctionKindRowColumnHeaderMetaDataTest {
     @Before
     public void setup() {
         this.function = new FunctionDefinition();
-        this.functionSupplier = () -> function;
+        this.functionSupplier = () -> Optional.ofNullable(function);
 
         this.functionKindRow = new FunctionKindRowColumnHeaderMetaData(functionSupplier,
                                                                        cellEditorControls,
@@ -62,7 +62,7 @@ public class FunctionKindRowColumnHeaderMetaDataTest {
 
     @Test
     public void testGetTitle() {
-        final String expected = functionSupplier.get().getKind().code();
+        final String expected = functionSupplier.get().get().getKind().code();
         assertEquals(expected, functionKindRow.getTitle());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionUIModelMapperTest.java
@@ -49,8 +49,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FunctionUIModelMapperTest {
@@ -104,36 +104,34 @@ public class FunctionUIModelMapperTest {
         this.uiModel.appendRow(new BaseGridRow());
         this.uiModel.appendRow(new BaseGridRow());
         this.uiModel.appendColumn(uiExpressionEditorColumn);
-        doReturn(0).when(uiExpressionEditorColumn).getIndex();
-        doReturn(uiModel).when(gridWidget).getModel();
+        when(uiExpressionEditorColumn.getIndex()).thenReturn(0);
+        when(gridWidget.getModel()).thenReturn(uiModel);
 
         //Core Editor definitions
         final ExpressionEditorDefinitions expressionEditorDefinitions = new ExpressionEditorDefinitions();
         expressionEditorDefinitions.add(literalExpressionEditorDefinition);
 
-        doReturn(expressionEditorDefinitions).when(expressionEditorDefinitionsSupplier).get();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditorDefinition).getModelClass();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditor).getExpression();
-        doReturn(Optional.of(literalExpressionEditor)).when(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(HasExpression.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(Optional.class),
-                                                                                                         anyInt());
+        when(expressionEditorDefinitionsSupplier.get()).thenReturn(expressionEditorDefinitions);
+        when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(literalExpression));
+        when(literalExpressionEditor.getExpression()).thenReturn(() -> Optional.of(literalExpression));
+        when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                         any(Optional.class),
+                                                         any(HasExpression.class),
+                                                         any(Optional.class),
+                                                         anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 
         //Supplementary Editor definitions
         final ExpressionEditorDefinitions supplementaryEditorDefinitions = new ExpressionEditorDefinitions();
         supplementaryEditorDefinitions.add(supplementaryEditorDefinition);
 
-        doReturn(supplementaryEditorDefinitions).when(supplementaryEditorDefinitionsSupplier).get();
-        doReturn(Optional.of(context)).when(supplementaryEditorDefinition).getModelClass();
-        doReturn(Optional.of(context)).when(supplementaryEditor).getExpression();
-        doReturn(Optional.of(supplementaryEditor)).when(supplementaryEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                 any(Optional.class),
-                                                                                                 any(HasExpression.class),
-                                                                                                 any(Optional.class),
-                                                                                                 any(Optional.class),
-                                                                                                 anyInt());
+        when(supplementaryEditorDefinitionsSupplier.get()).thenReturn(supplementaryEditorDefinitions);
+        when(supplementaryEditorDefinition.getModelClass()).thenReturn(Optional.of(context));
+        when(supplementaryEditor.getExpression()).thenReturn(() -> Optional.of(context));
+        when(supplementaryEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                     any(Optional.class),
+                                                     any(HasExpression.class),
+                                                     any(Optional.class),
+                                                     anyInt())).thenReturn(Optional.of(supplementaryEditor));
 
         this.function = new FunctionDefinition();
 
@@ -191,7 +189,6 @@ public class FunctionUIModelMapperTest {
         verify(definition).getEditor(parentCaptor.capture(),
                                      eq(Optional.empty()),
                                      eq(function),
-                                     eq(Optional.ofNullable(function.getExpression())),
                                      eq(Optional.empty()),
                                      eq(1));
         final GridCellTuple parent = parentCaptor.getValue();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGridDataTest.java
@@ -76,7 +76,7 @@ public class FunctionSupplementaryGridDataTest {
         this.uiModel = new FunctionSupplementaryGridData(delegate,
                                                          sessionManager,
                                                          sessionCommandManager,
-                                                         expression,
+                                                         () -> expression,
                                                          canvasOperation);
 
         doReturn(session).when(sessionManager).getCurrentSession();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionEditorDefinitionTest.java
@@ -27,7 +27,9 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -37,6 +39,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -44,11 +47,11 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -81,7 +84,7 @@ public class JavaFunctionEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -179,13 +182,12 @@ public class JavaFunctionEditorDefinitionTest {
 
     @Test
     public void testEditor() {
-        final Optional<Context> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        when(hasExpression.getExpression()).thenReturn(definition.getModelClass().get());
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertTrue(oEditor.isPresent());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/java/JavaFunctionSupplementaryGridTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary;
+package org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.java;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.java.JavaFunctionEditorDefinition;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.BaseFunctionSupplementaryGridTest;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class JavaFunctionSupplementaryGridTest extends BaseFunctionSupplementaryGridTest<JavaFunctionEditorDefinition> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionEditorDefinitionTest.java
@@ -27,7 +27,9 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -37,6 +39,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -44,11 +47,11 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -81,7 +84,7 @@ public class PMMLFunctionEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -179,13 +182,12 @@ public class PMMLFunctionEditorDefinitionTest {
 
     @Test
     public void testEditor() {
-        final Optional<Context> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        when(hasExpression.getExpression()).thenReturn(definition.getModelClass().get());
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertTrue(oEditor.isPresent());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/PMMLFunctionSupplementaryGridTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary;
+package org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.pmml;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.pmml.PMMLFunctionEditorDefinition;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.BaseFunctionSupplementaryGridTest;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class PMMLFunctionSupplementaryGridTest extends BaseFunctionSupplementaryGridTest<PMMLFunctionEditorDefinition> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationEditorDefinitionTest.java
@@ -27,8 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Invocation;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
@@ -38,6 +40,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -45,7 +48,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -86,7 +88,7 @@ public class InvocationEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -210,13 +212,12 @@ public class InvocationEditorDefinitionTest {
 
     @Test
     public void testEditor() {
-        final Optional<Invocation> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        when(hasExpression.getExpression()).thenReturn(definition.getModelClass().get());
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertTrue(oEditor.isPresent());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridDataTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.invocation
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
@@ -65,7 +66,7 @@ public class InvocationGridDataTest {
 
     private InvocationGridData uiModel;
 
-    private Optional<Invocation> expression = Optional.of(new Invocation());
+    private Supplier<Optional<Invocation>> expression = () -> Optional.of(new Invocation());
 
     @Before
     public void setup() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationGridTest.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Transform;
@@ -42,6 +43,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.invocation.AddParameterBindingCommand;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.invocation.ClearExpressionTypeCommand;
 import org.kie.workbench.common.dmn.client.commands.expressions.types.invocation.DeleteParameterBindingCommand;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.commands.general.DeleteCellValueCommand;
 import org.kie.workbench.common.dmn.client.commands.general.DeleteHasNameCommand;
 import org.kie.workbench.common.dmn.client.commands.general.DeleteHeaderValueCommand;
@@ -68,6 +70,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextBoxS
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
@@ -77,7 +80,6 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -114,7 +116,6 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -200,7 +201,7 @@ public class InvocationGridTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -318,27 +319,25 @@ public class InvocationGridTest {
         expressionEditorDefinitions.add(literalExpressionEditorDefinition);
         expressionEditorDefinitions.add(undefinedExpressionEditorDefinition);
 
-        doReturn(expressionEditorDefinitions).when(expressionEditorDefinitionsSupplier).get();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditorDefinition).getModelClass();
-        doReturn(Optional.of(literalExpressionEditor)).when(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(HasExpression.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(Optional.class),
-                                                                                                         anyInt());
+        when(expressionEditorDefinitionsSupplier.get()).thenReturn(expressionEditorDefinitions);
+        when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(literalExpression));
+        when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                         any(Optional.class),
+                                                         any(HasExpression.class),
+                                                         any(Optional.class),
+                                                         anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 
-        doReturn(parent).when(undefinedExpressionEditor).getParentInformation();
-        doReturn(Optional.empty()).when(undefinedExpressionEditorDefinition).getModelClass();
-        doReturn(Optional.of(undefinedExpressionEditor)).when(undefinedExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                             any(Optional.class),
-                                                                                                             any(HasExpression.class),
-                                                                                                             any(Optional.class),
-                                                                                                             any(Optional.class),
-                                                                                                             anyInt());
+        when(undefinedExpressionEditor.getParentInformation()).thenReturn(parent);
+        when(undefinedExpressionEditorDefinition.getModelClass()).thenReturn(Optional.empty());
+        when(undefinedExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                           any(Optional.class),
+                                                           any(HasExpression.class),
+                                                           any(Optional.class),
+                                                           anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
 
-        doReturn(session).when(sessionManager).getCurrentSession();
-        doReturn(canvasHandler).when(session).getCanvasHandler();
-        doReturn(graphContext).when(canvasHandler).getGraphExecutionContext();
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(canvasHandler.getGraphExecutionContext()).thenReturn(graphContext);
 
         final Decision decision = new Decision();
         decision.setName(new Name("name"));
@@ -368,10 +367,10 @@ public class InvocationGridTest {
     }
 
     private void setupGrid(final int nesting) {
+        this.hasExpression.setExpression(expression.get());
         this.grid = spy((InvocationGrid) definition.getEditor(parent,
                                                               nesting == 0 ? Optional.of(NODE_UUID) : Optional.empty(),
                                                               hasExpression,
-                                                              expression,
                                                               hasName,
                                                               nesting).get());
 
@@ -404,6 +403,34 @@ public class InvocationGridTest {
         final ExpressionCellValue dcv0 = (ExpressionCellValue) uiModel.getCell(0, 2).getValue();
         assertEquals(undefinedExpressionEditor,
                      dcv0.getValue().get());
+    }
+
+    @Test
+    public void testInitialColumnWidthsFromDefinition() {
+        setupGrid(0);
+
+        assertComponentWidths(50.0,
+                              DMNGridColumn.DEFAULT_WIDTH,
+                              UndefinedExpressionColumn.DEFAULT_WIDTH);
+    }
+
+    @Test
+    public void testInitialColumnWidthsFromExpression() {
+        final List<Double> componentWidths = expression.get().getComponentWidths();
+        componentWidths.set(0, 100.0);
+        componentWidths.set(1, 200.0);
+        componentWidths.set(2, 300.0);
+
+        setupGrid(0);
+
+        assertComponentWidths(100.0,
+                              200.0,
+                              300.0);
+    }
+
+    private void assertComponentWidths(final double... widths) {
+        final GridData uiModel = grid.getModel();
+        IntStream.range(0, widths.length).forEach(i -> assertEquals(widths[i], uiModel.getColumns().get(i).getWidth(), 0.0));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/invocation/InvocationUIModelMapperTest.java
@@ -54,8 +54,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InvocationUIModelMapperTest {
@@ -106,23 +106,22 @@ public class InvocationUIModelMapperTest {
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.uiModel.appendColumn(uiNameColumn);
         this.uiModel.appendColumn(uiExpressionEditorColumn);
-        doReturn(0).when(uiRowNumberColumn).getIndex();
-        doReturn(1).when(uiNameColumn).getIndex();
-        doReturn(2).when(uiExpressionEditorColumn).getIndex();
-        doReturn(uiModel).when(gridWidget).getModel();
+        when(uiRowNumberColumn.getIndex()).thenReturn(0);
+        when(uiNameColumn.getIndex()).thenReturn(1);
+        when(uiExpressionEditorColumn.getIndex()).thenReturn(2);
+        when(gridWidget.getModel()).thenReturn(uiModel);
 
         final ExpressionEditorDefinitions expressionEditorDefinitions = new ExpressionEditorDefinitions();
         expressionEditorDefinitions.add(literalExpressionEditorDefinition);
 
-        doReturn(expressionEditorDefinitions).when(expressionEditorDefinitionsSupplier).get();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditorDefinition).getModelClass();
-        doReturn(Optional.of(literalExpression)).when(literalExpressionEditor).getExpression();
-        doReturn(Optional.of(literalExpressionEditor)).when(literalExpressionEditorDefinition).getEditor(any(GridCellTuple.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(HasExpression.class),
-                                                                                                         any(Optional.class),
-                                                                                                         any(Optional.class),
-                                                                                                         anyInt());
+        when(expressionEditorDefinitionsSupplier.get()).thenReturn(expressionEditorDefinitions);
+        when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(literalExpression));
+        when(literalExpressionEditor.getExpression()).thenReturn(() -> Optional.of(literalExpression));
+        when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
+                                                         any(Optional.class),
+                                                         any(HasExpression.class),
+                                                         any(Optional.class),
+                                                         anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 
         final LiteralExpression invocationExpression = new LiteralExpression();
         invocationExpression.getText().setValue("invocation-expression");
@@ -180,7 +179,6 @@ public class InvocationUIModelMapperTest {
         verify(literalExpressionEditorDefinition).getEditor(parentCaptor.capture(),
                                                             eq(Optional.empty()),
                                                             eq(invocation.getBinding().get(0)),
-                                                            eq(Optional.of(invocation.getBinding().get(0).getExpression())),
                                                             eq(Optional.of(invocation.getBinding().get(0).getParameter())),
                                                             eq(1));
         final GridCellTuple parent = parentCaptor.getValue();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumnTest.java
@@ -67,6 +67,7 @@ public class LiteralExpressionColumnTest extends BaseDOMElementSingletonColumnTe
     protected LiteralExpressionColumn getColumn() {
         return new LiteralExpressionColumn(Collections.singletonList(headerMetaData),
                                            factory,
+                                           LiteralExpressionColumn.DEFAULT_WIDTH,
                                            gridWidget);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionEditorDefinitionTest.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
@@ -33,6 +35,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -40,11 +43,11 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -75,7 +78,7 @@ public class LiteralExpressionEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -149,13 +152,12 @@ public class LiteralExpressionEditorDefinitionTest {
 
     @Test
     public void testEditor() {
-        final Optional<LiteralExpression> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        when(hasExpression.getExpression()).thenReturn(definition.getModelClass().get());
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertThat(oEditor).isPresent();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationColumnTest.java
@@ -23,6 +23,7 @@ import org.gwtbootstrap3.client.ui.TextArea;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.editors.expressions.mocks.MockHasDOMElementResourcesHeaderMetaData;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionEditorColumn;
@@ -30,6 +31,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.BaseDOMElementSingletonColumnTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.TextAreaDOMElement;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.Mock;
@@ -88,6 +90,7 @@ public class RelationColumnTest extends BaseDOMElementSingletonColumnTest<TextAr
     protected RelationColumn getColumn() {
         return new RelationColumn(headerMetaData,
                                   factory,
+                                  RelationColumn.DEFAULT_WIDTH,
                                   gridWidget);
     }
 
@@ -156,7 +159,7 @@ public class RelationColumnTest extends BaseDOMElementSingletonColumnTest<TextAr
     private final void assertMinimumWidth(final double peerWidth,
                                           final double relationGridWidth,
                                           final double expectedMinimumWidth,
-                                          final Optional<BaseExpressionGrid>... peers) {
+                                          final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>... peers) {
         doReturn(peerWidth).when(peerExpressionEditor).getMinimumWidth();
         doReturn(relationGridWidth).when(gridWidget).getWidth();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationEditorDefinitionTest.java
@@ -25,8 +25,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Relation;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
@@ -34,6 +36,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.kie.workbench.common.dmn.client.widgets.layer.DMNGridLayer;
@@ -41,11 +44,11 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -79,7 +82,7 @@ public class RelationEditorDefinitionTest {
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
@@ -176,13 +179,12 @@ public class RelationEditorDefinitionTest {
 
     @Test
     public void testEditor() {
-        final Optional<Relation> expression = definition.getModelClass();
-        final Optional<BaseExpressionGrid> oEditor = definition.getEditor(parent,
-                                                                          Optional.empty(),
-                                                                          hasExpression,
-                                                                          expression,
-                                                                          hasName,
-                                                                          0);
+        when(hasExpression.getExpression()).thenReturn(definition.getModelClass().get());
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> oEditor = definition.getEditor(parent,
+                                                                                                                                                 Optional.empty(),
+                                                                                                                                                 hasExpression,
+                                                                                                                                                 hasName,
+                                                                                                                                                 0);
 
         assertThat(oEditor).isPresent();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridDataTest.java
@@ -39,7 +39,6 @@ import org.uberfire.mvp.Command;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -51,7 +50,13 @@ public class RelationGridDataTest {
     private GridRow gridRow;
 
     @Mock
-    private GridColumn gridColumn;
+    private GridColumn gridColumn1;
+
+    @Mock
+    private GridColumn gridColumn2;
+
+    @Mock
+    private GridColumn gridColumn3;
 
     @Mock
     private SessionManager sessionManager;
@@ -80,7 +85,7 @@ public class RelationGridDataTest {
         this.uiModel = new RelationGridData(delegate,
                                             sessionManager,
                                             sessionCommandManager,
-                                            expression,
+                                            () -> expression,
                                             canvasOperation);
 
         doReturn(session).when(sessionManager).getCurrentSession();
@@ -108,7 +113,7 @@ public class RelationGridDataTest {
     @Test
     public void testMoveColumnTo() {
         uiModel.moveColumnTo(0,
-                             gridColumn);
+                             gridColumn1);
 
         verify(sessionCommandManager).execute(eq(canvasHandler),
                                               any(MoveColumnsCommand.class));
@@ -117,7 +122,7 @@ public class RelationGridDataTest {
     @Test
     public void testMoveColumnsTo() {
         uiModel.moveColumnsTo(0,
-                              Collections.singletonList(gridColumn));
+                              Collections.singletonList(gridColumn1));
 
         verify(sessionCommandManager).execute(eq(canvasHandler),
                                               any(MoveColumnsCommand.class));
@@ -125,35 +130,94 @@ public class RelationGridDataTest {
 
     @Test
     public void testAppendColumn() {
-        uiModel.appendColumn(gridColumn);
+        uiModel.appendColumn(gridColumn1);
 
-        verify(delegate).appendColumn(eq(gridColumn));
+        verify(delegate).appendColumn(eq(gridColumn1));
 
-        verify(gridColumn).setResizable(eq(false));
+        verify(gridColumn1).setResizable(eq(false));
+    }
+
+    @Test
+    public void testAppendColumns() {
+        uiModel.appendColumn(gridColumn1);
+
+        reset(gridColumn1);
+
+        uiModel.appendColumn(gridColumn2);
+
+        verify(gridColumn1).setResizable(eq(false));
+        verify(gridColumn2).setResizable(eq(false));
+
+        reset(gridColumn1, gridColumn2);
+
+        uiModel.appendColumn(gridColumn3);
+
+        verify(gridColumn1).setResizable(eq(false));
+        verify(gridColumn2).setResizable(eq(true));
+        verify(gridColumn3).setResizable(eq(false));
     }
 
     @Test
     public void testInsertColumn() {
-        uiModel.insertColumn(0, gridColumn);
+        uiModel.insertColumn(0, gridColumn1);
 
         verify(delegate).insertColumn(eq(0),
-                                      eq(gridColumn));
+                                      eq(gridColumn1));
 
-        verify(gridColumn).setResizable(eq(false));
+        verify(gridColumn1).setResizable(eq(false));
+    }
+
+    @Test
+    public void testInsertColumnsInOrder() {
+        uiModel.insertColumn(0, gridColumn1);
+
+        reset(gridColumn1);
+
+        uiModel.insertColumn(1, gridColumn2);
+
+        verify(gridColumn1).setResizable(eq(false));
+        verify(gridColumn2).setResizable(eq(false));
+
+        reset(gridColumn1, gridColumn2);
+
+        uiModel.insertColumn(2, gridColumn3);
+
+        verify(gridColumn1).setResizable(eq(false));
+        verify(gridColumn2).setResizable(eq(true));
+        verify(gridColumn3).setResizable(eq(false));
+    }
+
+    @Test
+    public void testInsertColumnsNotInOrder() {
+        uiModel.insertColumn(0, gridColumn1);
+
+        reset(gridColumn1);
+
+        uiModel.insertColumn(0, gridColumn2);
+
+        verify(gridColumn1).setResizable(eq(false));
+        verify(gridColumn2).setResizable(eq(false));
+
+        reset(gridColumn1, gridColumn2);
+
+        uiModel.insertColumn(0, gridColumn3);
+
+        verify(gridColumn1).setResizable(eq(false));
+        verify(gridColumn2).setResizable(eq(true));
+        verify(gridColumn3).setResizable(eq(false));
     }
 
     @Test
     public void testDeleteColumn() {
-        final GridColumn<?> anotherGridColumn = mock(GridColumn.class);
-        uiModel.appendColumn(anotherGridColumn);
-        uiModel.appendColumn(gridColumn);
+        uiModel.appendColumn(gridColumn1);
+        uiModel.appendColumn(gridColumn2);
 
         //Reset as methods were invoked by the appendColumn(..) calls
-        reset(anotherGridColumn);
-        uiModel.deleteColumn(gridColumn);
+        reset(gridColumn1);
+        uiModel.deleteColumn(gridColumn2);
 
-        verify(delegate).deleteColumn(eq(gridColumn));
+        verify(delegate).deleteColumn(eq(gridColumn2));
 
-        verify(anotherGridColumn).setResizable(eq(false));
+        verify(gridColumn1).setResizable(eq(false));
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
@@ -40,7 +40,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowS
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RelationUIModelMapperTest {
@@ -73,9 +73,9 @@ public class RelationUIModelMapperTest {
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.uiModel.appendColumn(uiRelationColumn1);
         this.uiModel.appendColumn(uiRelationColumn2);
-        doReturn(0).when(uiRowNumberColumn).getIndex();
-        doReturn(1).when(uiRelationColumn1).getIndex();
-        doReturn(2).when(uiRelationColumn2).getIndex();
+        when(uiRowNumberColumn.getIndex()).thenReturn(0);
+        when(uiRelationColumn1.getIndex()).thenReturn(1);
+        when(uiRelationColumn2.getIndex()).thenReturn(2);
 
         this.relation = new Relation();
         this.relation.getColumn().add(new InformationItem());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionColumnTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -100,12 +99,14 @@ public class UndefinedExpressionColumnTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setup() {
-        doReturn(parent).when(gridWidget).getParentInformation();
-        doReturn(parentGridWidget).when(parent).getGridWidget();
-        doReturn(parentGridData).when(parentGridWidget).getModel();
-        doReturn(Collections.singletonList(parentGridColumn)).when(parentGridData).getColumns();
+        when(gridWidget.getExpression()).thenReturn(Optional::empty);
+        when(gridWidget.getParentInformation()).thenReturn(parent);
+        when(parent.getGridWidget()).thenReturn(parentGridWidget);
+        when(parentGridWidget.getModel()).thenReturn(parentGridData);
+        when(parentGridData.getColumns()).thenReturn(Collections.singletonList(parentGridColumn));
 
-        this.column = spy(new UndefinedExpressionColumn(gridWidget,
+        this.column = spy(new UndefinedExpressionColumn(UndefinedExpressionColumn.DEFAULT_WIDTH,
+                                                        gridWidget,
                                                         cellEditorControls,
                                                         undefinedExpressionSelector,
                                                         translationService));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/UndefinedExpressionUIModelMapperTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase;
-import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
@@ -38,7 +38,6 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +45,7 @@ import static org.mockito.Mockito.when;
 public class UndefinedExpressionUIModelMapperTest {
 
     @Mock
-    private Expression expression;
+    private LiteralExpression expression;
 
     @Mock
     private HasExpression hasExpression;
@@ -97,7 +96,7 @@ public class UndefinedExpressionUIModelMapperTest {
 
     @Test
     public void testToDMNModelNoEditor() {
-        doReturn(Optional.empty()).when(editor).getExpression();
+        when(editor.getExpression()).thenReturn(Optional::empty);
 
         mapper.toDMNModel(0, 0, cellValueSupplier);
 
@@ -106,7 +105,7 @@ public class UndefinedExpressionUIModelMapperTest {
 
     @Test
     public void testToDMNModelWithEditor() {
-        doReturn(Optional.of(expression)).when(editor).getExpression();
+        when(editor.getExpression()).thenReturn(() -> Optional.of(expression));
 
         mapper.toDMNModel(0, 0, cellValueSupplier);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/dnd/DMNGridWidgetDnDMouseUpHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/dnd/DMNGridWidgetDnDMouseUpHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.widgets.dnd;
+
+import java.util.Collections;
+
+import com.ait.lienzo.client.core.event.NodeMouseUpEvent;
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Style;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState.GridWidgetHandlersOperation;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DMNGridWidgetDnDMouseUpHandlerTest {
+
+    private static final double INITIAL_WIDTH = 250.0;
+
+    @Mock
+    private GridLayer layer;
+
+    @Mock
+    private Viewport viewport;
+
+    @Mock
+    private DivElement element;
+
+    @Mock
+    private Style style;
+
+    @Mock
+    private NodeMouseUpEvent event;
+
+    @Mock
+    private BaseGrid activeGridWidget;
+
+    @Mock
+    private DMNGridColumn activeGridColumn;
+
+    private GridWidgetDnDHandlersState state;
+
+    private DMNGridWidgetDnDMouseUpHandler handler;
+
+    @Before
+    public void setup() {
+        this.state = new GridWidgetDnDHandlersState();
+        this.handler = new DMNGridWidgetDnDMouseUpHandler(layer, state);
+
+        when(layer.getViewport()).thenReturn(viewport);
+        when(viewport.getElement()).thenReturn(element);
+        when(element.getStyle()).thenReturn(style);
+    }
+
+    @Test
+    public void testColumnResize() {
+        state.setOperation(GridWidgetHandlersOperation.COLUMN_RESIZE);
+        state.setActiveGridWidget(activeGridWidget);
+        state.setActiveGridColumns(Collections.singletonList(activeGridColumn));
+        state.setEventInitialColumnWidth(INITIAL_WIDTH);
+
+        handler.onNodeMouseUp(event);
+
+        verify(activeGridWidget).registerColumnResizeCompleted(activeGridColumn,
+                                                               INITIAL_WIDTH);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGridTest.java
@@ -22,6 +22,7 @@ import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
@@ -32,7 +33,6 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -69,7 +69,7 @@ public abstract class BaseExpressionGridTest {
     protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Mock
-    protected CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    protected DefaultCanvasCommandFactory canvasCommandFactory;
 
     @Mock
     protected CellEditorControlsView.Presenter cellEditorControls;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/ExpressionGridCacheImplTest.java
@@ -22,8 +22,11 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseUIModelMapper;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -53,7 +56,7 @@ public class ExpressionGridCacheImplTest {
 
     @Test
     public void testPutExpressionGridWhenEditorIsCacheable() {
-        final Map<String, Optional<BaseExpressionGrid>> content = cache.getContent();
+        final Map<String, Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> content = cache.getContent();
         when(editor.isCacheable()).thenReturn(true);
 
         cache.putExpressionGrid(UUID,
@@ -81,7 +84,7 @@ public class ExpressionGridCacheImplTest {
 
         cache.putExpressionGrid(UUID, Optional.of(editor));
 
-        final Optional<BaseExpressionGrid> content = cache.getExpressionGrid(UUID);
+        final Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>> content = cache.getExpressionGrid(UUID);
         assertThat(content).isPresent();
         assertThat(content.get()).isEqualTo(editor);
     }
@@ -93,7 +96,7 @@ public class ExpressionGridCacheImplTest {
 
     @Test
     public void testRemoveExpressionGrid() {
-        final Map<String, Optional<BaseExpressionGrid>> content = cache.getContent();
+        final Map<String, Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> content = cache.getContent();
         when(editor.isCacheable()).thenReturn(true);
         cache.putExpressionGrid(UUID, Optional.of(editor));
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/EditableNameAndDataTypeColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/EditableNameAndDataTypeColumnTest.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.context.Inf
 import org.kie.workbench.common.dmn.client.editors.types.HasNameAndTypeRef;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -125,8 +126,11 @@ public class EditableNameAndDataTypeColumnTest {
 
     @Before
     public void setup() {
+        when(gridWidget.getExpression()).thenReturn(Optional::empty);
+
         this.cell = new BaseGridCell<>(new BaseGridCellValue<>(HasNameAndDataTypeCell.wrap(informationItem)));
         this.column = spy(new EditableNameAndDataTypeColumn<ContextGrid>(headerMetaData,
+                                                                         DMNGridColumn.DEFAULT_WIDTH,
                                                                          gridWidget,
                                                                          isEditable,
                                                                          clearDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaDataHasExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaDataHasExpressionTest.java
@@ -35,11 +35,8 @@ public class NameAndDataTypeHeaderMetaDataHasExpressionTest extends BaseNameAndD
 
     private Decision hasExpression = new Decision();
 
-    private Optional<LiteralExpression> expression = Optional.of(new LiteralExpression());
-
     public void setup(final Optional<HasName> hasName) {
         this.metaData = new NameAndDataTypeHeaderMetaData<LiteralExpression>(hasExpression,
-                                                                             expression,
                                                                              hasName,
                                                                              clearDisplayNameConsumer,
                                                                              setDisplayNameConsumer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaDataTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/NameAndDataTypeHeaderMetaDataTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -51,7 +52,14 @@ public class NameAndDataTypeHeaderMetaDataTest extends BaseNameAndDataTypeHeader
     @Test
     public void testGetHasTypeRefs() {
 
-        metaData = new NameAndDataTypeHeaderMetaData(null, null, null, null, null, null, null, null) {
+        metaData = new NameAndDataTypeHeaderMetaData(HasExpression.NOP,
+                                                     Optional.empty(),
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null) {
 
             public String getColumnGroup() {
                 return null;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionContain
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
+import org.kie.workbench.common.dmn.client.widgets.dnd.DMNGridWidgetDnDMouseUpHandler;
 import org.kie.workbench.common.dmn.client.widgets.dnd.DelegatingGridWidgetDndMouseMoveHandler;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridTheme;
@@ -123,6 +124,11 @@ public class DMNGridLayerTest {
     @Test
     public void checkGridWidgetDnDMouseMoveHandler() {
         assertTrue(gridLayer.getGridWidgetDnDMouseMoveHandler() instanceof DelegatingGridWidgetDndMouseMoveHandler);
+    }
+
+    @Test
+    public void checkGridWidgetDnDMouseUpHandler() {
+        assertTrue(gridLayer.getGridWidgetDnDMouseUpHandler() instanceof DMNGridWidgetDnDMouseUpHandler);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2262

@etirelli @tarilabs FYI the _format_ of the expression widths is as below.

This is your opportunity to shout before it's committed and becomes KIE's _standard_!!
```
<dmndi:DMNDI>
  <dmndi:DMNDiagram>
    <di:extension>
      <kie:ComponentsWidthsExtension>
        <kie:ComponentWidths dmnElementRef="_E74E71BD-AA58-4C0D-A1FC-DB23EDB88637">
          <kie:width>50.0</kie:width>
          <kie:width>150.0</kie:width>
          <kie:width>200.0</kie:width>
          <kie:width>250.0</kie:width>
        </kie:ComponentWidths>
      </kie:ComponentsWidthsExtension>
    </di:extension>
    ...
```
Where `dmnElementRef` is the `HREF` to an `Expression` and `<kie:width>` is the width of a _component_ of the `Expression` (i.e. column). The order of the widths follows the order of the columns in the Boxed Expression Grid.