### PR TITLE
Fix relative path problems in kie-wb-common-compiler-offprocess-classpath

### DIFF
--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/pom.xml
@@ -604,7 +604,10 @@
           </execution>
         </executions>
         <configuration>
-          <arguments>${version.org.kie},${project.basedir}</arguments>
+          <arguments>
+            <argument>${version.org.kie}</argument>
+            <argument>${project.basedir}</argument>
+          </arguments>
           <mainClass>org.kie.workbench.common.services.backend.compiler.offprocess.generator.ClassPathMavenGenerator</mainClass>
         </configuration>
       </plugin>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/pom.xml
@@ -604,7 +604,7 @@
           </execution>
         </executions>
         <configuration>
-          <arguments>${version.org.kie}</arguments>
+          <arguments>${version.org.kie},${project.basedir}</arguments>
           <mainClass>org.kie.workbench.common.services.backend.compiler.offprocess.generator.ClassPathMavenGenerator</mainClass>
         </configuration>
       </plugin>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/src/main/java/org/kie/workbench/common/services/backend/compiler/offprocess/generator/ClassPathMavenGenerator.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/src/main/java/org/kie/workbench/common/services/backend/compiler/offprocess/generator/ClassPathMavenGenerator.java
@@ -52,31 +52,16 @@ public class ClassPathMavenGenerator {
 
     public static void main(String[] args) throws Exception {
         String kieVersion = args[0];
-        String mavenRepo = getMavenRepo();
-        Path pwd = Paths.get("").toAbsolutePath();
-        StringBuilder sb = new StringBuilder();
-        sb.append(pwd.toAbsolutePath()).append(SEP).
-                append(servicesMod).append(SEP).
-                append(compilerMod).append(SEP).
-                append(offprocessMod).append(SEP).
-                append(cpathPathFile);
-        Path filePath = Paths.get(sb.toString());
+        String baseDir = args[1];
 
-        String content = new String(Files.readAllBytes(filePath));
-        String replaced = content.replace(mavenRepo, MAVEN_REPO_PLACEHOLDER);
+        String content = new String(Files.readAllBytes(Paths.get(baseDir + SEP + cpathPathFile)));
+        String replaced = content.replace(getMavenRepo(), MAVEN_REPO_PLACEHOLDER);
         replaced = replaceTargetInTheClassPathFile(kieVersion, replaced);
 
-        StringBuilder sbo = new StringBuilder();
-                    sbo.append(pwd.toAbsolutePath()).append(SEP).
-                            append(servicesMod).append(SEP).
-                            append(compilerMod).append(SEP).
-                            append(offprocessMod).append(SEP).
-                            append(TARGET).append(SEP).
-                            append("classes").append(SEP).
-                            append(classPathFile);
-        Path offProcessModule = Paths.get(sbo.toString());
+        Path offProcessModule = Paths.get(baseDir + SEP + "target" + SEP + "classes" + SEP + classPathFile);
         write(offProcessModule.toAbsolutePath().toString(), replaced);
-        logger.info("\n************************************\nSaving {} to {} \n************************************\n\n",classPathFile, offProcessModule.toAbsolutePath().toString());
+
+        logger.info("\n************************************\nSaving {} to {} \n************************************\n\n", classPathFile, offProcessModule.toAbsolutePath().toString());
     }
 
     private static String replaceTargetInTheClassPathFile(String kieVersion, String replaced) {


### PR DESCRIPTION
When building `kie-wb-common` outside its root dir (using `mvn -pl`, `mvn -f`, or even using [kiegroup-all](https://github.com/tiagobento/kiegroup-all)), I was getting a `java.nio.file.NoSuchFileException`.

The fix was to supply the `${project.basedir}` POM built-in property so that the `ClassPathMavenGenerator#main` method can work only with relative dirs.