### PR TITLE
JBPM-8118: Containment is never allowed when multiple selection.

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
@@ -520,10 +520,11 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                 connectionContent.setTargetConnection(MagnetConnection.Builder.at(target.getX() - xTarget, target.getY() - yTarget)); // Stunner connection x,y is relative to shape
             }
             if (e.getWaypoint().size() > 2) {
-                List<Point> sublist = e.getWaypoint().subList(1, e.getWaypoint().size() - 1);
-                for (Point p : sublist) {
-                    connectionContent.getControlPoints().add(ControlPoint.build(PointUtils.dmndiPointToPoint2D(p)));
-                }
+                connectionContent.setControlPoints(e.getWaypoint()
+                                                           .subList(1, e.getWaypoint().size() - 1)
+                                                           .stream()
+                                                           .map(p -> ControlPoint.build(PointUtils.dmndiPointToPoint2D(p)))
+                                                           .toArray(ControlPoint[]::new));
             }
         } else {
             // Set the source connection, if any.

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
@@ -530,12 +530,12 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
             // Set the source connection, if any.
             final Node sourceNode = edge.getSourceNode();
             if (null != sourceNode) {
-                connectionContent.setSourceConnection(MagnetConnection.Builder.forElement(sourceNode));
+                connectionContent.setSourceConnection(MagnetConnection.Builder.atCenter(sourceNode));
             }
             // Set the target connection, if any.
             final Node targetNode = edge.getTargetNode();
             if (null != targetNode) {
-                connectionContent.setTargetConnection(MagnetConnection.Builder.forElement(targetNode));
+                connectionContent.setTargetConnection(MagnetConnection.Builder.atCenter(targetNode));
             }
         }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -1737,8 +1737,8 @@ public class DMNMarshallerTest {
         ViewConnector connectionContent = (ViewConnector) myEdge.getContent();
         // DROOLS-3184: If the "connection source/target location is null" assume it's the centre of the shape.
         // keep Stunner behavior of constellation button
-        connectionContent.setSourceConnection(MagnetConnection.Builder.forElement(inputDataNode).setLocation(null).setAuto(true));
-        connectionContent.setTargetConnection(MagnetConnection.Builder.forElement(decisionNode).setLocation(null).setAuto(true));
+        connectionContent.setSourceConnection(MagnetConnection.Builder.atCenter(inputDataNode).setLocation(null).setAuto(true));
+        connectionContent.setTargetConnection(MagnetConnection.Builder.atCenter(decisionNode).setLocation(null).setAuto(true));
 
         DMNMarshaller.connectRootWithChild(diagramRoot, inputDataNode);
         DMNMarshaller.connectRootWithChild(diagramRoot, decisionNode);
@@ -1798,8 +1798,8 @@ public class DMNMarshallerTest {
         inputDataNode.getOutEdges().add(myEdge);
         textAnnotationNode.getInEdges().add(myEdge);
         ViewConnector connectionContent = (ViewConnector) myEdge.getContent();
-        connectionContent.setSourceConnection(MagnetConnection.Builder.forElement(inputDataNode));
-        connectionContent.setTargetConnection(MagnetConnection.Builder.forElement(textAnnotationNode));
+        connectionContent.setSourceConnection(MagnetConnection.Builder.atCenter(inputDataNode));
+        connectionContent.setTargetConnection(MagnetConnection.Builder.atCenter(textAnnotationNode));
 
         DMNMarshaller.connectRootWithChild(diagramRoot, inputDataNode);
         DMNMarshaller.connectRootWithChild(diagramRoot, textAnnotationNode);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -795,8 +795,8 @@ public class DMNMarshallerTest {
         assertEquals(552.2411708831787d, ((View) decision.getContent()).getBounds().getUpperLeft().getX() + targetLocation.getX(), 0.1d);
         assertEquals(226d, ((View) decision.getContent()).getBounds().getUpperLeft().getY() + targetLocation.getY(), 0.1d);
 
-        assertEquals(1, connectionContent.getControlPoints().size());
-        Point2D controlPointLocation = connectionContent.getControlPoints().get(0).getLocation();
+        assertEquals(1, connectionContent.getControlPoints().length);
+        Point2D controlPointLocation = connectionContent.getControlPoints()[0].getLocation();
         assertEquals(398.61898612976074d, controlPointLocation.getX(), 0.1d);
         assertEquals(116.99999809265137d, controlPointLocation.getY(), 0.1d);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/CreateNodeToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/CreateNodeToolboxAction.java
@@ -17,8 +17,10 @@
 package org.kie.workbench.common.dmn.client.canvas.controls.toolbox;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.GeneralCreateNodeAction;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
@@ -26,14 +28,14 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
 @DMNFlowActionsToolbox
-public class CreateNodeAction extends org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeAction {
+public class CreateNodeToolboxAction extends org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeToolboxAction {
 
     @Inject
-    public CreateNodeAction(final DefinitionUtils definitionUtils,
-                            final ClientTranslationService translationService,
-                            final @DMNEditor GeneralCreateNodeAction generalCreateNodeAction) {
+    public CreateNodeToolboxAction(final DefinitionUtils definitionUtils,
+                                   final ClientTranslationService translationService,
+                                   final @Any @DMNEditor ManagedInstance<GeneralCreateNodeAction> actions) {
         super(definitionUtils,
               translationService,
-              generalCreateNodeAction);
+              actions);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactory.java
@@ -29,8 +29,8 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.AbstractActionsToolboxFactory;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolboxView;
-import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateConnectorAction;
-import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeAction;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateConnectorToolboxAction;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeToolboxAction;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.FlowActionsToolbox;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ToolboxAction;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ToolboxDomainLookups;
@@ -47,14 +47,14 @@ public class DMNFlowActionsToolboxFactory
         extends AbstractActionsToolboxFactory {
 
     private final ToolboxDomainLookups toolboxDomainLookups;
-    private final ManagedInstance<CreateConnectorAction> createConnectorActions;
-    private final ManagedInstance<CreateNodeAction> createNodeActions;
+    private final ManagedInstance<CreateConnectorToolboxAction> createConnectorActions;
+    private final ManagedInstance<CreateNodeToolboxAction> createNodeActions;
     private final ManagedInstance<ActionsToolboxView> views;
 
     @Inject
     public DMNFlowActionsToolboxFactory(final ToolboxDomainLookups toolboxDomainLookups,
-                                        final @Any ManagedInstance<CreateConnectorAction> createConnectorActions,
-                                        final @Any @DMNFlowActionsToolbox ManagedInstance<CreateNodeAction> createNodeActions,
+                                        final @Any ManagedInstance<CreateConnectorToolboxAction> createConnectorActions,
+                                        final @Any @DMNFlowActionsToolbox ManagedInstance<CreateNodeToolboxAction> createNodeActions,
                                         final @Any @FlowActionsToolbox ManagedInstance<ActionsToolboxView> views) {
         this.toolboxDomainLookups = toolboxDomainLookups;
         this.createConnectorActions = createConnectorActions;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/DefaultCanvasCommandFactory.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.factory.canvas.AddChildNodeCommand;
+import org.kie.workbench.common.stunner.client.lienzo.canvas.command.LienzoCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -30,7 +31,7 @@ import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.V
 
 @DMNEditor
 @ApplicationScoped
-public class DefaultCanvasCommandFactory extends org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory {
+public class DefaultCanvasCommandFactory extends LienzoCanvasCommandFactory {
 
     protected DefaultCanvasCommandFactory() {
         super();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNCommonActionsToolboxFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNCommonActionsToolboxFactoryTest.java
@@ -33,7 +33,7 @@ import org.kie.workbench.common.stunner.core.client.components.toolbox.Toolbox;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolbox;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolboxFactory;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolboxView;
-import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.DeleteNodeAction;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.DeleteNodeToolboxAction;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ToolboxAction;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -64,7 +64,7 @@ public class DMNCommonActionsToolboxFactoryTest {
     private ActionsToolboxFactory commonActionsToolboxFactory;
 
     @Mock
-    private DeleteNodeAction deleteNodeAction;
+    private DeleteNodeToolboxAction deleteNodeAction;
 
     @Mock
     private DMNEditDecisionToolboxAction editDecisionToolboxActionInstance;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNFlowActionsToolboxFactoryTest.java
@@ -30,8 +30,8 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.components.toolbox.Toolbox;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolbox;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolboxView;
-import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateConnectorAction;
-import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeAction;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateConnectorToolboxAction;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.CreateNodeToolboxAction;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ToolboxDomainLookups;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
@@ -80,12 +80,12 @@ public class DMNFlowActionsToolboxFactoryTest {
     private CommonDomainLookups domainLookups;
 
     @Mock
-    private CreateConnectorAction createConnectorActionInstance;
-    private ManagedInstanceStub<CreateConnectorAction> createConnectorAction;
+    private CreateConnectorToolboxAction createConnectorActionInstance;
+    private ManagedInstanceStub<CreateConnectorToolboxAction> createConnectorAction;
 
     @Mock
-    private CreateNodeAction createNodeActionInstance;
-    private ManagedInstanceStub<CreateNodeAction> createNodeAction;
+    private CreateNodeToolboxAction createNodeActionInstance;
+    private ManagedInstanceStub<CreateNodeToolboxAction> createNodeAction;
 
     @Mock
     private ActionsToolboxView viewInstance;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoCanvasCommandFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.canvas.command;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessor;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ViewTraverseProcessor;
+
+@ApplicationScoped
+public class LienzoCanvasCommandFactory extends DefaultCanvasCommandFactory {
+
+    // CDI proxy.
+    protected LienzoCanvasCommandFactory() {
+        this(null, null);
+    }
+
+    @Inject
+    public LienzoCanvasCommandFactory(final @Any ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors,
+                                      final @Any ManagedInstance<ViewTraverseProcessor> viewTraverseProcessors) {
+        super(childrenTraverseProcessors, viewTraverseProcessors);
+    }
+
+    @Override
+    public CanvasCommand<AbstractCanvasHandler> resize(final Element<? extends View<?>> element,
+                                                       final BoundingBox boundingBox) {
+        return new LienzoResizeNodeCommand(element,
+                                           boundingBox);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoResizeNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoResizeNodeCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.canvas.command;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import org.kie.workbench.common.stunner.core.client.canvas.command.ResizeNodeCommand;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+public class LienzoResizeNodeCommand extends ResizeNodeCommand {
+
+    public LienzoResizeNodeCommand(final Element<? extends View> candidate,
+                                   final BoundingBox boundingBox) {
+        super(candidate, boundingBox, LOCATION_PROVIDER, ON_RESIZE);
+    }
+
+    private static final BiFunction<Shape, Integer, Point2D> LOCATION_PROVIDER =
+            (shape, index) -> {
+                final WiresShape wiresShape = (WiresShape) shape.getShapeView();
+                final WiresMagnet magnet = wiresShape.getMagnets().getMagnet(index);
+                return new Point2D(magnet.getX(), magnet.getY());
+            };
+
+    private static final Consumer<Shape> ON_RESIZE = shape -> {
+        final WiresShape wiresShape = (WiresShape) shape.getShapeView();
+        wiresShape.refresh();
+    };
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImpl.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.lienzo.canvas.controls;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -59,13 +60,23 @@ public class ConnectionAcceptorControlImpl
 
     private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     private final Event<CancelCanvasAction> cancelCanvasActionEvent;
+    private final Function<AbstractCanvasHandler, CanvasHighlight> highlightFactory;
     private CanvasHighlight canvasHighlight;
 
     @Inject
     public ConnectionAcceptorControlImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
                                          final Event<CancelCanvasAction> cancelCanvasActionEvent) {
+        this(canvasCommandFactory,
+             cancelCanvasActionEvent,
+             CanvasHighlight::new);
+    }
+
+    ConnectionAcceptorControlImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                  final Event<CancelCanvasAction> cancelCanvasActionEvent,
+                                  final Function<AbstractCanvasHandler, CanvasHighlight> highlightFactory) {
         this.canvasCommandFactory = canvasCommandFactory;
         this.cancelCanvasActionEvent = cancelCanvasActionEvent;
+        this.highlightFactory = highlightFactory;
     }
 
     @Override
@@ -82,7 +93,7 @@ public class ConnectionAcceptorControlImpl
 
     @Override
     protected void onInit(final WiresCanvas canvas) {
-        this.canvasHighlight = new CanvasHighlight(getCanvasHandler());
+        this.canvasHighlight = highlightFactory.apply(getCanvasHandler());
         canvas.getWiresManager().setConnectionAcceptor(CONNECTION_ACCEPTOR);
     }
 
@@ -279,7 +290,9 @@ public class ConnectionAcceptorControlImpl
                            final boolean valid) {
         canvasHighlight.unhighLight();
         if (null != node && valid) {
-            canvasHighlight.highLight(node);
+            if (!node.getInEdges().contains(connector)) {
+                canvasHighlight.highLight(node);
+            }
         } else if (null != node) {
             canvasHighlight.invalid(node);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImpl.java
@@ -311,7 +311,7 @@ public class ConnectionAcceptorControlImpl
     @SuppressWarnings("unchecked")
     public static MagnetConnection createConnection(final Element element) {
         return null != element ?
-                MagnetConnection.Builder.forElement(element) :
+                MagnetConnection.Builder.atCenter(element) :
                 null;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImpl.java
@@ -133,8 +133,7 @@ public class ContainmentAcceptorControlImpl extends AbstractAcceptorControl
                                    final Node[] children) {
         return Stream.of(children)
                 .map(GraphUtils::getParent)
-                .filter(childParent -> !Objects.equals(parent, childParent))
-                .count() == 0;
+                .noneMatch(childParent -> !Objects.equals(parent, childParent));
     }
 
     private final IContainmentAcceptor CONTAINMENT_ACCEPTOR = new IContainmentAcceptor() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImpl.java
@@ -18,7 +18,9 @@ package org.kie.workbench.common.stunner.client.lienzo.canvas.controls;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
@@ -39,6 +41,7 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 
 @Dependent
 @Default
@@ -98,6 +101,9 @@ public class ContainmentAcceptorControlImpl extends AbstractAcceptorControl
         if (parent == null && children.length >= 2) {
             return false;
         }
+        if (areInSameParent(parent, children)) {
+            return true;
+        }
         // Generate the commands and perform the execution.
         final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> builder =
                 new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
@@ -121,6 +127,14 @@ public class ContainmentAcceptorControlImpl extends AbstractAcceptorControl
             return success;
         }
         return true;
+    }
+
+    static boolean areInSameParent(final Element parent,
+                                   final Node[] children) {
+        return Stream.of(children)
+                .map(GraphUtils::getParent)
+                .filter(childParent -> !Objects.equals(parent, childParent))
+                .count() == 0;
     }
 
     private final IContainmentAcceptor CONTAINMENT_ACCEPTOR = new IContainmentAcceptor() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImpl.java
@@ -49,17 +49,24 @@ public class ContainmentAcceptorControlImpl extends AbstractAcceptorControl
         implements ContainmentAcceptorControl<AbstractCanvasHandler> {
 
     private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
+    private final Function<AbstractCanvasHandler, CanvasHighlight> highlightFactory;
     private CanvasHighlight canvasHighlight;
 
     @Inject
     public ContainmentAcceptorControlImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory) {
+        this(canvasCommandFactory, CanvasHighlight::new);
+    }
+
+    ContainmentAcceptorControlImpl(final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory,
+                                   final Function<AbstractCanvasHandler, CanvasHighlight> highlightFactory) {
         this.canvasCommandFactory = canvasCommandFactory;
+        this.highlightFactory = highlightFactory;
     }
 
     @Override
     protected void onInit(final WiresCanvas canvas) {
         canvas.getWiresManager().setContainmentAcceptor(CONTAINMENT_ACCEPTOR);
-        this.canvasHighlight = new CanvasHighlight(getCanvasHandler());
+        this.canvasHighlight = highlightFactory.apply(getCanvasHandler());
     }
 
     @Override
@@ -101,32 +108,33 @@ public class ContainmentAcceptorControlImpl extends AbstractAcceptorControl
         if (parent == null && children.length >= 2) {
             return false;
         }
-        if (areInSameParent(parent, children)) {
-            return true;
-        }
-        // Generate the commands and perform the execution.
-        final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> builder =
-                new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
-                        .forward();
-        for (final Node node : children) {
-            builder.addCommand(canvasCommandFactory.updateChildNode((Node) parent,
-                                                                    node));
-        }
-        if (builder.size() > 0) {
-            final Command<AbstractCanvasHandler, CanvasViolation> command = builder.size() == 1 ?
-                    builder.get(0) :
-                    builder.build();
-            final CommandResult<CanvasViolation> result =
-                    executor.apply(command);
-            final boolean success = isCommandSuccess(result);
-            if (highlights && !success) {
-                canvasHighlight.invalid(result.getViolations());
-            } else {
-                canvasHighlight.unhighLight();
+        boolean success = true;
+        if (!areInSameParent(parent, children)) {
+            // Generate the commands and perform the execution.
+            final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> builder =
+                    new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
+                            .forward();
+            for (final Node node : children) {
+                builder.addCommand(canvasCommandFactory.updateChildNode((Node) parent,
+                                                                        node));
             }
-            return success;
+            if (builder.size() > 0) {
+                final Command<AbstractCanvasHandler, CanvasViolation> command = builder.size() == 1 ?
+                        builder.get(0) :
+                        builder.build();
+                final CommandResult<CanvasViolation> result =
+                        executor.apply(command);
+                success = isCommandSuccess(result);
+                if (highlights && !success) {
+                    canvasHighlight.invalid(result.getViolations());
+                }
+            }
         }
-        return true;
+
+        if (success) {
+            canvasHighlight.unhighLight();
+        }
+        return success;
     }
 
     static boolean areInSameParent(final Element parent,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
@@ -246,6 +246,7 @@ public class LienzoMultipleSelectionControl<H extends AbstractCanvasHandler>
                                                       final double height) {
             provider.setSize(width,
                              height);
+            moveShapeToTop();
             return this;
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/wires/WiresCanvasView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/wires/WiresCanvasView.java
@@ -41,7 +41,7 @@ public class WiresCanvasView extends LienzoCanvasView<WiresLayer> {
     }
 
     @Override
-    public LienzoCanvasView add(final ShapeView<?> shape) {
+    public LienzoCanvasView<WiresLayer> add(final ShapeView<?> shape) {
         if (WiresUtils.isWiresShape(shape)) {
             layer.add((WiresShape) shape);
         } else if (WiresUtils.isWiresConnector(shape)) {
@@ -64,7 +64,7 @@ public class WiresCanvasView extends LienzoCanvasView<WiresLayer> {
     }
 
     @Override
-    public LienzoCanvasView delete(final ShapeView<?> shape) {
+    public LienzoCanvasView<WiresLayer> delete(final ShapeView<?> shape) {
         if (WiresUtils.isWiresShape(shape)) {
             layer.delete((WiresShape) shape);
         } else if (WiresUtils.isWiresConnector(shape)) {
@@ -93,6 +93,7 @@ public class WiresCanvasView extends LienzoCanvasView<WiresLayer> {
         final WiresShape childShape = (WiresShape) child;
         layer.addChild(parentShape,
                        childShape);
+        childShape.shapeMoved();
         return this;
     }
 
@@ -103,6 +104,7 @@ public class WiresCanvasView extends LienzoCanvasView<WiresLayer> {
         final WiresShape childShape = (WiresShape) child;
         layer.deleteChild(parentShape,
                           childShape);
+        childShape.shapeMoved();
         return this;
     }
 
@@ -113,6 +115,7 @@ public class WiresCanvasView extends LienzoCanvasView<WiresLayer> {
         final WiresShape childShape = (WiresShape) child;
         layer.dock(parentShape,
                    childShape);
+        childShape.shapeMoved();
         return this;
     }
 
@@ -121,6 +124,7 @@ public class WiresCanvasView extends LienzoCanvasView<WiresLayer> {
                                    final ShapeView<?> child) {
         final WiresShape childShape = (WiresShape) child;
         layer.undock(childShape);
+        childShape.shapeMoved();
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorView.java
@@ -17,14 +17,9 @@
 package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import com.ait.lienzo.client.core.shape.AbstractDirectionalMultiPointShape;
@@ -36,6 +31,7 @@ import com.ait.lienzo.client.core.shape.wires.WiresConnection;
 import com.ait.lienzo.client.core.shape.wires.WiresConnector;
 import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.client.core.types.Shadow;
 import com.ait.lienzo.shared.core.types.ColorName;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresUtils;
@@ -51,7 +47,6 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.content.view.DiscreteConnection;
 import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
-import org.kie.workbench.common.stunner.core.util.Counter;
 
 public class WiresConnectorView<T> extends WiresConnector
         implements
@@ -107,63 +102,55 @@ public class WiresConnectorView<T> extends WiresConnector
     }
 
     @Override
-    public List<ControlPoint> addControlPoints(final ControlPoint... controlPoint) {
-        if (validateControlPointShape()) {
-            final List<ControlPoint> result = Stream.of(controlPoint)
-                    .map(cp -> {
-                        double x = cp.getLocation().getX();
-                        double y = cp.getLocation().getY();
-                        addControlPoint(x, y, cp.getIndex() + 1);
-                        return cp;
-                    }).collect(Collectors.toList());
-            refrehControlPoints();
-            return result;
+    public ControlPoint[] getManageableControlPoints() {
+        final Point2DArray controlPoints = getControlPoints();
+        if (null != controlPoints) {
+            final int size = controlPoints.size() - 2;
+            final ControlPoint[] cps = new ControlPoint[size];
+            for (int i = 1; i <= size; i++) {
+                final com.ait.lienzo.client.core.types.Point2D controlPoint = controlPoints.get(i);
+                cps[i - 1] = ControlPoint.build(controlPoint.getX(),
+                                                controlPoint.getY());
+            }
+            return cps;
         }
-        return Collections.emptyList();
+        return new ControlPoint[0];
     }
 
     @Override
-    public T updateControlPoint(final ControlPoint controlPoint) {
-        if (validateControlPointShape()) {
-            final Point2D location = controlPoint.getLocation();
-            moveControlPoint(controlPoint.getIndex() + 1,
-                             new com.ait.lienzo.client.core.types.Point2D(location.getX(),
-                                                                          location.getY()));
-            refrehControlPoints();
-        }
+    public T addControlPoint(final ControlPoint controlPoint,
+                             final int index) {
+        addControlPoint(controlPoint.getLocation().getX(),
+                        controlPoint.getLocation().getY()
+                , index + 1);
+        refreshControlPoints();
         return cast();
     }
 
-    private void refrehControlPoints() {
+    @Override
+    public T updateControlPoints(final ControlPoint[] controlPoints) {
+        for (int i = 0; i < controlPoints.length; i++) {
+            final Point2D location = controlPoints[i].getLocation();
+            final com.ait.lienzo.client.core.types.Point2D lienzoPoint =
+                    new com.ait.lienzo.client.core.types.Point2D(location.getX(),
+                                                                 location.getY());
+            moveControlPoint(i + 1, lienzoPoint);
+        }
+        refreshControlPoints();
+        return cast();
+    }
+
+    @Override
+    public T deleteControlPoint(final int index) {
+        destroyControlPoints(new int[]{index + 1});
+        return cast();
+    }
+
+    private void refreshControlPoints() {
         getLine().refresh();
         if (null != getGroup().getLayer()) {
             getGroup().getLayer().batch();
         }
-    }
-
-    @Override
-    public T removeControlPoints(final ControlPoint... cps) {
-        if (validateControlPointShape()) {
-            final int[] indexes = Arrays.stream(cps)
-                    .filter(Objects::nonNull)
-                    .mapToInt(cp -> cp.getIndex() + 1)
-                    .toArray();
-            destroyControlPoints(indexes);
-        }
-        return cast();
-    }
-
-    private boolean validateControlPointShape() {
-        return getLine().isControlPointShape();
-    }
-
-    @Override
-    public List<ControlPoint> getShapeControlPoints() {
-        Counter counter = new Counter(-1);
-        return StreamSupport.stream(getControlPoints().spliterator(), false)
-                .map(point -> ControlPoint.build(new Point2D(point.getX(), point.getY()), counter.increment()))
-                .sequential()
-                .collect(Collectors.toList());
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorView.java
@@ -104,15 +104,16 @@ public class WiresConnectorView<T> extends WiresConnector
     @Override
     public ControlPoint[] getManageableControlPoints() {
         final Point2DArray controlPoints = getControlPoints();
-        if (null != controlPoints) {
-            final int size = controlPoints.size() - 2;
-            final ControlPoint[] cps = new ControlPoint[size];
-            for (int i = 1; i <= size; i++) {
-                final com.ait.lienzo.client.core.types.Point2D controlPoint = controlPoints.get(i);
-                cps[i - 1] = ControlPoint.build(controlPoint.getX(),
-                                                controlPoint.getY());
-            }
-            return cps;
+        if (null != controlPoints && controlPoints.size() > 2) {
+            // Notice first and last CP from lienzo's connector are discarded,
+            // as they're considered the Connection's on Stunner side, so not
+            // part of the model's ControlPoint array.
+            return StreamSupport.stream(controlPoints.spliterator(), false)
+                    .limit(controlPoints.size() - 1)
+                    .skip(1)
+                    .map(controlPoint -> ControlPoint.build(controlPoint.getX(),
+                                                            controlPoint.getY()))
+                    .toArray(ControlPoint[]::new);
         }
         return new ControlPoint[0];
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresCompositeControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresCompositeControl.java
@@ -19,15 +19,22 @@ package org.kie.workbench.common.stunner.client.lienzo.wires;
 import com.ait.lienzo.client.core.shape.wires.WiresContainer;
 import com.ait.lienzo.client.core.shape.wires.handlers.MouseEvent;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresCompositeControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresLayerIndex;
 import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.tooling.common.api.java.util.function.Supplier;
 
 public abstract class DelegateWiresCompositeControl implements WiresCompositeControl {
 
     protected abstract WiresCompositeControl getDelegate();
 
     @Override
-    public void setContext(Context provider) {
-        getDelegate().setContext(provider);
+    public void useIndex(Supplier<WiresLayerIndex> index) {
+        getDelegate().useIndex(index);
+    }
+
+    @Override
+    public Context getContext() {
+        return getDelegate().getContext();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresCompositeControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresCompositeControl.java
@@ -98,8 +98,8 @@ public abstract class DelegateWiresCompositeControl implements WiresCompositeCon
     }
 
     @Override
-    public boolean onMoveComplete() {
-        return getDelegate().onMoveComplete();
+    public void onMoveComplete() {
+        getDelegate().onMoveComplete();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresShapeControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresShapeControl.java
@@ -131,8 +131,8 @@ public abstract class DelegateWiresShapeControl implements WiresShapeControl,
     }
 
     @Override
-    public boolean onMoveComplete() {
-        return getDelegate().onMoveComplete();
+    public void onMoveComplete() {
+        getDelegate().onMoveComplete();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresShapeControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresShapeControl.java
@@ -22,16 +22,23 @@ import com.ait.lienzo.client.core.shape.wires.handlers.MouseEvent;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresBoundsConstraintControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresContainmentControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresDockingControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresLayerIndex;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresMagnetsControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresParentPickerControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeControlImpl;
 import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.tooling.common.api.java.util.function.Supplier;
 
 public abstract class DelegateWiresShapeControl implements WiresShapeControl,
                                                            WiresBoundsConstraintControl.SupportsOptionalBounds<DelegateWiresShapeControl> {
 
     public abstract WiresShapeControlImpl getDelegate();
+
+    @Override
+    public void useIndex(Supplier<WiresLayerIndex> index) {
+        getDelegate().useIndex(index);
+    }
 
     @Override
     public void setAlignAndDistributeControl(AlignAndDistributeControl control) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/StunnerWiresControlFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/wires/StunnerWiresControlFactory.java
@@ -27,6 +27,7 @@ import com.ait.lienzo.client.core.shape.wires.handlers.WiresCompositeControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectionControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresControlFactory;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresLayerIndex;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeHighlight;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresConnectorControlImpl;
@@ -51,7 +52,7 @@ public class StunnerWiresControlFactory implements WiresControlFactory {
     @Override
     public WiresShapeControl newShapeControl(final WiresShape shape,
                                              final WiresManager wiresManager) {
-        return new StunnerWiresShapeControl(new WiresShapeControlImpl(shape, wiresManager));
+        return new StunnerWiresShapeControl(new WiresShapeControlImpl(shape));
     }
 
     @Override
@@ -82,5 +83,10 @@ public class StunnerWiresControlFactory implements WiresControlFactory {
     @Override
     public WiresShapeHighlight<PickerPart.ShapePart> newShapeHighlight(final WiresManager wiresManager) {
         return new StunnerWiresShapeStateHighlight(wiresManager);
+    }
+
+    @Override
+    public WiresLayerIndex newIndex(final WiresManager manager) {
+        return delegate.newIndex(manager);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoCanvasCommandFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoCanvasCommandFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.canvas.command;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.graph.Element;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class LienzoCanvasCommandFactoryTest {
+
+    private LienzoCanvasCommandFactory tested;
+
+    @Before
+    public void setUp() {
+        tested = new LienzoCanvasCommandFactory();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateResizeCommand() {
+        Element element = mock(Element.class);
+        BoundingBox boundingBox = new BoundingBox(0, 0, 1, 2);
+        final CanvasCommand<AbstractCanvasHandler> command = tested.resize(element, boundingBox);
+        assertNotNull(command);
+        assertTrue(command instanceof LienzoResizeNodeCommand);
+        LienzoResizeNodeCommand lienzoCommand = (LienzoResizeNodeCommand) command;
+        assertEquals(element, lienzoCommand.getCandidate());
+        assertEquals(boundingBox, lienzoCommand.getBoundingBox());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoResizeNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/command/LienzoResizeNodeCommandTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.canvas.command;
+
+import com.ait.lienzo.client.core.shape.wires.MagnetManager;
+import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext.WiresShapeViewExt;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class LienzoResizeNodeCommandTest {
+
+    @Mock
+    private Element node;
+
+    @Mock
+    private Shape shape;
+
+    @Mock
+    private WiresShapeViewExt shapeView;
+
+    @Mock
+    private MagnetManager.Magnets magnets;
+
+    @Mock
+    private WiresMagnet magnet;
+
+    private LienzoResizeNodeCommand tested;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() {
+        when(shape.getShapeView()).thenReturn(shapeView);
+        when(shapeView.getMagnets()).thenReturn(magnets);
+        when(magnets.getMagnet(eq(0))).thenReturn(magnet);
+        when(magnet.getX()).thenReturn(3d);
+        when(magnet.getY()).thenReturn(4d);
+        BoundingBox boundingBox = new BoundingBox(1, 2, 75, 50);
+        tested = new LienzoResizeNodeCommand(node, boundingBox);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateResizeCommand() {
+        tested.getOnResize().accept(shape);
+        verify(shapeView, times(1)).refresh();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMagnetLocationProvider() {
+        Point2D point = tested.getMagnetLocationProvider().apply(shape, 0);
+        assertEquals(Point2D.create(3d, 4d), point);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImplTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.command.SetConnectionSourceNodeCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.SetConnectionTargetNodeCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.event.CancelCanvasAction;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasHighlight;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
@@ -77,6 +78,8 @@ public class ConnectionAcceptorControlImplTest {
     private CanvasCommandManager<AbstractCanvasHandler> commandManager;
     @Mock
     private AbstractCanvasHandler canvasHandler;
+    @Mock
+    private CanvasHighlight highlight;
     @Mock
     private WiresCanvas canvas;
     @Mock
@@ -144,7 +147,9 @@ public class ConnectionAcceptorControlImplTest {
                                   eq(setConnectionTargetNodeCommand))).thenReturn(result);
         when(commandManager.execute(eq(canvasHandler),
                                     eq(setConnectionTargetNodeCommand))).thenReturn(result);
-        this.tested = new ConnectionAcceptorControlImpl(canvasCommandFactory, cancelCanvasActionEvent);
+        this.tested = new ConnectionAcceptorControlImpl(canvasCommandFactory,
+                                                        cancelCanvasActionEvent,
+                                                        canvasHandler1 -> highlight);
         this.tested.setCommandManagerProvider(() -> commandManager);
     }
 
@@ -180,6 +185,7 @@ public class ConnectionAcceptorControlImplTest {
                      setConnectionSourceNodeCommand.getEdge());
         assertEquals(connection,
                      setConnectionSourceNodeCommand.getConnection());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test
@@ -218,6 +224,7 @@ public class ConnectionAcceptorControlImplTest {
                      setConnectionTargetNodeCommand.getEdge());
         assertEquals(connection,
                      setConnectionTargetNodeCommand.getConnection());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test
@@ -256,6 +263,7 @@ public class ConnectionAcceptorControlImplTest {
                      setConnectionSourceNodeCommand.getEdge());
         assertEquals(connection,
                      setConnectionSourceNodeCommand.getConnection());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test
@@ -277,6 +285,7 @@ public class ConnectionAcceptorControlImplTest {
                      setConnectionTargetNodeCommand.getEdge());
         assertEquals(connection,
                      setConnectionTargetNodeCommand.getConnection());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test
@@ -299,6 +308,7 @@ public class ConnectionAcceptorControlImplTest {
                      setConnectionSourceNodeCommand.getEdge());
         assertEquals(connection,
                      setConnectionSourceNodeCommand.getConnection());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test
@@ -321,6 +331,7 @@ public class ConnectionAcceptorControlImplTest {
                      setConnectionTargetNodeCommand.getEdge());
         assertEquals(connection,
                      setConnectionTargetNodeCommand.getConnection());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImplTest.java
@@ -35,10 +35,15 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
+import org.kie.workbench.common.stunner.core.graph.impl.EdgeImpl;
+import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -142,5 +147,73 @@ public class ContainmentAcceptorControlImplTest {
                      updateChildNodeCommand.getParent());
         assertEquals(candidate,
                      updateChildNodeCommand.getCandidate());
+    }
+
+    @Test
+    public void testIsSameParent() {
+        Node parent = new NodeImpl<>("parentUUID");
+        Node child1 = new NodeImpl<>("child1");
+        setAsChild(parent, child1);
+        Node child2 = new NodeImpl<>("child2");
+        setAsChild(parent, child2);
+        Node[] children = {child1, child2};
+        boolean isSameParent = ContainmentAcceptorControlImpl.areInSameParent(parent, children);
+        assertTrue(isSameParent);
+    }
+
+    @Test
+    public void testIsNotSameParent1() {
+        Node parent = new NodeImpl<>("parentUUID");
+        Node child1 = new NodeImpl<>("child1");
+        Node child2 = new NodeImpl<>("child2");
+        setAsChild(parent, child2);
+        Node[] children = {child1, child2};
+        boolean isSameParent = ContainmentAcceptorControlImpl.areInSameParent(parent, children);
+        assertFalse(isSameParent);
+    }
+
+    @Test
+    public void testIsNotSameParent2() {
+        Node parent = new NodeImpl<>("parentUUID");
+        Node child1 = new NodeImpl<>("child1");
+        setAsChild(parent, child1);
+        Node child2 = new NodeImpl<>("child2");
+        Node[] children = {child1, child2};
+        boolean isSameParent = ContainmentAcceptorControlImpl.areInSameParent(parent, children);
+        assertFalse(isSameParent);
+    }
+
+    @Test
+    public void testIsNotSameParentAll() {
+        Node parent = new NodeImpl<>("parentUUID");
+        Node child1 = new NodeImpl<>("child1");
+        Node child2 = new NodeImpl<>("child2");
+        Node[] children = {child1, child2};
+        boolean isSameParent = ContainmentAcceptorControlImpl.areInSameParent(parent, children);
+        assertFalse(isSameParent);
+    }
+
+    @Test
+    public void testIsNotSameParentNull() {
+        Node parent = new NodeImpl<>("parentUUID");
+        Node child1 = new NodeImpl<>("child1");
+        setAsChild(parent, child1);
+        Node child2 = new NodeImpl<>("child2");
+        setAsChild(parent, child2);
+        Node[] children = {child1, child2};
+        boolean isSameParent = ContainmentAcceptorControlImpl.areInSameParent(null, children);
+        assertFalse(isSameParent);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setAsChild(final Node parent,
+                                   final Node child) {
+        Child childRel = new Child();
+        Edge childEdge = new EdgeImpl<>("child_" + parent.getUUID() + "_" + child.getUUID());
+        childEdge.setContent(childRel);
+        childEdge.setSourceNode(parent);
+        parent.getOutEdges().add(childEdge);
+        childEdge.setTargetNode(child);
+        child.getInEdges().add(childEdge);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ContainmentAcceptorControlImplTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvasView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateChildNodeCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasHighlight;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
@@ -62,6 +63,8 @@ public class ContainmentAcceptorControlImplTest {
     private CanvasCommandManager<AbstractCanvasHandler> commandManager;
     @Mock
     private AbstractCanvasHandler canvasHandler;
+    @Mock
+    private CanvasHighlight highlight;
     @Mock
     private WiresCanvas canvas;
     @Mock
@@ -102,7 +105,8 @@ public class ContainmentAcceptorControlImplTest {
                                   eq(updateChildNodeCommand))).thenReturn(result);
         when(commandManager.execute(eq(canvasHandler),
                                     eq(updateChildNodeCommand))).thenReturn(result);
-        this.tested = new ContainmentAcceptorControlImpl(canvasCommandFactory);
+        this.tested = new ContainmentAcceptorControlImpl(canvasCommandFactory,
+                                                         canvasHandler1 -> highlight);
         this.tested.setCommandManagerProvider(() -> commandManager);
     }
 
@@ -132,6 +136,7 @@ public class ContainmentAcceptorControlImplTest {
                      updateChildNodeCommand.getParent());
         assertEquals(candidate,
                      updateChildNodeCommand.getCandidate());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test
@@ -147,6 +152,7 @@ public class ContainmentAcceptorControlImplTest {
                      updateChildNodeCommand.getParent());
         assertEquals(candidate,
                      updateChildNodeCommand.getCandidate());
+        verify(highlight, times(1)).unhighLight();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
@@ -43,12 +43,12 @@ import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresUtils;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresShapeView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasPanel;
-import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPositionCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.event.ShapeLocationsChangedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactoryStub;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.ShapeViewExtStub;
@@ -169,7 +169,7 @@ public class LocationControlImplTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
-        this.canvasCommandFactory = new DefaultCanvasCommandFactory(null, null);
+        this.canvasCommandFactory = new CanvasCommandFactoryStub();
 
         this.shapeView = spy(new ShapeViewExtStub(shapeEventHandler,
                                                   hasControlPoints));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
@@ -16,9 +16,7 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.canvas.controls;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.MultiPath;
@@ -71,7 +69,6 @@ import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
-import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
@@ -258,8 +255,6 @@ public class LocationControlImplTest {
         final Edge connectorEdge = mock(Edge.class);
         final com.ait.lienzo.client.core.types.Point2D controlPointLienzo = new com.ait.lienzo.client.core.types.Point2D(100, 100);
         final Point2DArray controlPointsLienzo = new Point2DArray(controlPointLienzo);
-        final ControlPoint controlPoint = ControlPoint.build(new Point2D(0, 0), 0);
-        final List<ControlPoint> controlPoints = Arrays.asList(controlPoint);
         final ViewConnector viewConnector = mock(ViewConnector.class);
         Group parentGroup = mock(Group.class);
         BoundingBox parentBB = new BoundingBox(0, 0, 200, 200);
@@ -288,7 +283,6 @@ public class LocationControlImplTest {
         when(shape.getShapeView()).thenReturn(wiresShape);
         when(graphIndex.getEdge(connectorUUID)).thenReturn(connectorEdge);
         when(connectorEdge.getContent()).thenReturn(viewConnector);
-        when(viewConnector.getControlPoints()).thenReturn(controlPoints);
         when(connectorGroup.getUserData()).thenReturn(new WiresUtils.UserData(connectorUUID, ""));
 
         tested.init(canvasHandler);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ResizeControlImplTest.java
@@ -16,68 +16,41 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.canvas.controls;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
-import com.ait.lienzo.client.core.shape.wires.MagnetManager;
-import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresShapeView;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext.WiresShapeViewExt;
-import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasPanel;
-import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
-import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPositionCommand;
-import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPropertyCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactoryStub;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
-import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
-import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
-import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ResizeEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ResizeHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewHandler;
-import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.command.impl.AbstractCompositeCommand;
-import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
-import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
-import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
-import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
-import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Edge;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
-import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
-import org.kie.workbench.common.stunner.core.graph.content.relationship.Dock;
-import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
-import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
-import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
-import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
-import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -86,23 +59,8 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ResizeControlImplTest {
 
-    private static final String ROOT_UUID = "root-uuid1";
     private static final String ELEMENT_UUID = "element-uuid1";
-    private static final String DEF_ID = "def-id";
-    private static final String W_PROPERTY_ID = "w-property-id";
-    private static final String H_PROPERTY_ID = "h-property-id";
-    private static final String R_PROPERTY_ID = "r-property-id";
     private static final Bounds ELEMENT_BOUNDS = Bounds.create(10d, 20d, 30d, 40d);
-
-    private static final String DOCKED_NODE_UUID = UUID.uuid();
-    private static final String CONNECTOR_EDGE_UUID = UUID.uuid();
-    private static final String CONNECTOR_EDGE_TARGET_UUID = UUID.uuid();
-    private static final Double SHAPE_X = 0d;
-    private static final Double SHAPE_Y = 0d;
-    public static final double NEW_CONNECTION_X = 10d;
-    public static final double NEW_CONNECTION_Y = 20d;
-    public static final double NEW_CONNECTION_X_TARGET = 30d;
-    public static final double NEW_CONNECTION_Y_TARGET = 40d;
 
     @Mock
     private CanvasCommandManager<AbstractCanvasHandler> commandManager;
@@ -120,18 +78,6 @@ public class ResizeControlImplTest {
     private CanvasPanel canvasPanel;
 
     @Mock
-    private Diagram diagram;
-
-    @Mock
-    private Graph graph;
-
-    @Mock
-    private DefinitionSet graphContent;
-
-    @Mock
-    private Metadata metadata;
-
-    @Mock
     private Node element;
 
     @Mock
@@ -141,113 +87,19 @@ public class ResizeControlImplTest {
     private Shape<WiresShapeView> shape;
 
     @Mock
-    private Object definition;
-
-    @Mock
-    private Object wProperty;
-
-    @Mock
-    private Object hProperty;
-
-    @Mock
-    private Object rProperty;
-
-    @Mock
-    private DefinitionManager definitionManager;
-
-    @Mock
-    private AdapterManager adapterManager;
-
-    @Mock
-    private AdapterRegistry adapterRegistry;
-
-    @Mock
-    private DefinitionAdapter<Object> definitionAdapter;
-
-    @Mock
-    private PropertyAdapter propertyAdapter;
-
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
-
-    @Mock
     private WiresShapeViewExt shapeView;
 
     private ResizeControlImpl tested;
-
-    @Mock
-    private Edge dockEdge;
-
-    @Mock
-    private Node dockedNode;
-
-    @Mock
-    private Shape dockedShape;
-
-    @Mock
-    private ShapeView dockedShapeView;
-
-    @Mock
-    private Edge connectorEdge;
-
-    @Mock
-    private ViewConnector viewConnector;
-
-    @Mock
-    private ConnectorShape connectorShape;
-
-    @Mock
-    private MagnetManager.Magnets magnets;
-
-    @Mock
-    private WiresMagnet magnet;
-
-    private MagnetConnection magnetConnection;
-
-    @Mock
-    private Edge connectorEdgeTarget;
-
-    @Mock
-    private ViewConnector viewConnectorTarget;
-
-    @Mock
-    private ConnectorShape connectorShapeTarget;
-
-    @Mock
-    private WiresMagnet magnetTarget;
-
-    private MagnetConnection magnetConnectionTarget;
+    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
 
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
-        this.canvasCommandFactory = spy(new DefaultCanvasCommandFactory(null, null));
-
+        canvasCommandFactory = spy(new CanvasCommandFactoryStub());
         when(shapeView.supports(ViewEventType.RESIZE)).thenReturn(true);
-        when(canvasHandler.getDefinitionManager()).thenReturn(definitionManager);
-        when(definitionManager.adapters()).thenReturn(adapterManager);
-        when(adapterManager.registry()).thenReturn(adapterRegistry);
-        when(adapterManager.forProperty()).thenReturn(propertyAdapter);
-        when(adapterRegistry.getDefinitionAdapter(any(Class.class))).thenReturn(definitionAdapter);
-        when(adapterRegistry.getPropertyAdapter(anyObject())).thenReturn(propertyAdapter);
-        when(definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(DEF_ID));
-        when(propertyAdapter.getId(eq(wProperty))).thenReturn(W_PROPERTY_ID);
-        when(propertyAdapter.getId(eq(hProperty))).thenReturn(H_PROPERTY_ID);
-        when(propertyAdapter.getId(eq(rProperty))).thenReturn(R_PROPERTY_ID);
-        when(definitionAdapter.getMetaProperty(eq(PropertyMetaTypes.WIDTH),
-                                               eq(definition))).thenReturn(wProperty);
-        when(definitionAdapter.getMetaProperty(eq(PropertyMetaTypes.HEIGHT),
-                                               eq(definition))).thenReturn(hProperty);
-        when(definitionAdapter.getMetaProperty(eq(PropertyMetaTypes.RADIUS),
-                                               eq(definition))).thenReturn(rProperty);
         when(element.getUUID()).thenReturn(ELEMENT_UUID);
-        when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(element.getContent()).thenReturn(elementContent);
-        when(elementContent.getDefinition()).thenReturn(definition);
         when(elementContent.getBounds()).thenReturn(ELEMENT_BOUNDS);
-        when(graph.getContent()).thenReturn(graphContent);
-        when(diagram.getGraph()).thenReturn(graph);
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getCanvasRootUUID()).thenReturn(ROOT_UUID);
         when(canvasHandler.getCanvas()).thenReturn(canvas);
         when(canvasHandler.getAbstractCanvas()).thenReturn(canvas);
         when(canvas.getView()).thenReturn(canvasView);
@@ -256,38 +108,7 @@ public class ResizeControlImplTest {
         when(canvas.getShapes()).thenReturn(Collections.singletonList(shape));
         when(shape.getUUID()).thenReturn(ELEMENT_UUID);
         when(shape.getShapeView()).thenReturn(shapeView);
-        when(element.getOutEdges()).thenReturn(Arrays.asList(dockEdge, connectorEdge));
-        when(element.getInEdges()).thenReturn(Arrays.asList(connectorEdgeTarget));
-        when(dockEdge.getContent()).thenReturn(new Dock());
-        when(dockEdge.getTargetNode()).thenReturn(dockedNode);
-        when(dockedNode.getUUID()).thenReturn(DOCKED_NODE_UUID);
-        when(canvas.getShape(DOCKED_NODE_UUID)).thenReturn(dockedShape);
-        when(dockedShape.getShapeView()).thenReturn(dockedShapeView);
-        when(dockedShapeView.getShapeX()).thenReturn(SHAPE_X);
-        when(dockedShapeView.getShapeY()).thenReturn(SHAPE_Y);
-
-        when(connectorEdge.getSourceNode()).thenReturn(element);
-        when(connectorEdge.getContent()).thenReturn(viewConnector);
-        when(connectorEdge.getUUID()).thenReturn(CONNECTOR_EDGE_UUID);
-        when(connectorEdgeTarget.getTargetNode()).thenReturn(element);
-        when(connectorEdgeTarget.getContent()).thenReturn(viewConnectorTarget);
-        when(connectorEdgeTarget.getUUID()).thenReturn(CONNECTOR_EDGE_TARGET_UUID);
-
-        magnetConnection = new MagnetConnection.Builder().atX(0).atY(0).magnet(MagnetConnection.MAGNET_CENTER).build();
-        magnetConnectionTarget = new MagnetConnection.Builder().magnet(1).build();
-        when(viewConnector.getSourceConnection()).thenReturn(Optional.of(magnetConnection));
-        when(viewConnectorTarget.getTargetConnection()).thenReturn(Optional.of(magnetConnectionTarget));
-        when(canvas.getShape(CONNECTOR_EDGE_UUID)).thenReturn(connectorShape);
-        when(canvas.getShape(CONNECTOR_EDGE_TARGET_UUID)).thenReturn(connectorShapeTarget);
-        when(shapeView.getMagnets()).thenReturn(magnets);
-        when(magnets.getMagnet(MagnetConnection.MAGNET_CENTER)).thenReturn(magnet);
-        when(magnets.getMagnet(1)).thenReturn(magnetTarget);
-        when(magnet.getX()).thenReturn(NEW_CONNECTION_X);
-        when(magnet.getY()).thenReturn(NEW_CONNECTION_Y);
-        when(magnetTarget.getX()).thenReturn(NEW_CONNECTION_X_TARGET);
-        when(magnetTarget.getY()).thenReturn(NEW_CONNECTION_Y_TARGET);
-
-        this.tested = new ResizeControlImpl(canvasCommandFactory);
+        tested = new ResizeControlImpl(canvasCommandFactory);
         tested.setCommandManagerProvider(() -> commandManager);
     }
 
@@ -318,96 +139,38 @@ public class ResizeControlImplTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testResize() {
-        when(commandManager.execute(eq(canvasHandler),
-                                    any(Command.class))).thenReturn(CanvasCommandResultBuilder.SUCCESS);
         tested.init(canvasHandler);
         assertFalse(tested.isRegistered(element));
         tested.register(element);
         verify(shapeView,
                times(1)).supports(eq(ViewEventType.RESIZE));
-        final ArgumentCaptor<ResizeHandler> resizeHandlerArgumentCaptor =
+        ArgumentCaptor<ResizeHandler> resizeHandlerArgumentCaptor =
                 ArgumentCaptor.forClass(ResizeHandler.class);
         verify(shapeView,
                times(1)).addHandler(eq(ViewEventType.RESIZE),
                                     resizeHandlerArgumentCaptor.capture());
-
-        //assert initial connection position
-        assertEquals(magnetConnection.getLocation().getX(), 0, 0);
-        assertEquals(magnetConnection.getLocation().getY(), 0, 0);
-        assertNull(magnetConnectionTarget.getLocation());
-
-        final ResizeHandler resizeHandler = resizeHandlerArgumentCaptor.getValue();
-        final double x = 121.45d;
-        final double y = 23.456d;
-        final double width = 100d;
-        final double height = 200d;
-        final ResizeEvent event = new ResizeEvent(x,
-                                                  y,
-                                                  x,
-                                                  y,
-                                                  width,
-                                                  height);
+        final CanvasCommand expectedCommand = mock(CanvasCommand.class);
+        doAnswer(invocationOnMock -> expectedCommand).when(canvasCommandFactory).resize(eq(element), any(BoundingBox.class));
+        ResizeHandler resizeHandler = resizeHandlerArgumentCaptor.getValue();
+        double x = 121.45d;
+        double y = 23.456d;
+        double width = 100d;
+        double height = 200d;
+        ResizeEvent event = new ResizeEvent(x,
+                                            y,
+                                            x,
+                                            y,
+                                            width,
+                                            height);
         resizeHandler.end(event);
-        final ArgumentCaptor<Command> commandArgumentCaptor =
-                ArgumentCaptor.forClass(Command.class);
+
+        ArgumentCaptor<CanvasCommand> commandArgumentCaptor =
+                ArgumentCaptor.forClass(CanvasCommand.class);
         verify(commandManager,
                times(1)).execute(eq(canvasHandler),
                                  commandArgumentCaptor.capture());
-        final Command command = commandArgumentCaptor.getValue();
+        CanvasCommand command = commandArgumentCaptor.getValue();
         assertNotNull(command);
-        assertTrue(command instanceof AbstractCompositeCommand);
-        final List commands = ((AbstractCompositeCommand) command).getCommands();
-        assertNotNull(commands);
-        assertEquals(7,
-                     commands.size());
-        assertTrue(commands.get(0) instanceof UpdateElementPositionCommand);
-        final UpdateElementPositionCommand positionCommand = (UpdateElementPositionCommand) commands.get(0);
-        assertEquals(element,
-                     positionCommand.getElement());
-        assertEquals(new Point2D(x, y),
-                     positionCommand.getLocation());
-        assertTrue(commands.get(1) instanceof UpdateElementPropertyCommand);
-        final UpdateElementPropertyCommand wPropertyCommand = (UpdateElementPropertyCommand) commands.get(1);
-        assertEquals(element,
-                     wPropertyCommand.getElement());
-        assertEquals(W_PROPERTY_ID,
-                     wPropertyCommand.getPropertyId());
-        assertEquals(width,
-                     wPropertyCommand.getValue());
-        assertTrue(commands.get(2) instanceof UpdateElementPropertyCommand);
-        final UpdateElementPropertyCommand hPropertyCommand = (UpdateElementPropertyCommand) commands.get(2);
-        assertEquals(element,
-                     hPropertyCommand.getElement());
-        assertEquals(H_PROPERTY_ID,
-                     hPropertyCommand.getPropertyId());
-        assertEquals(height,
-                     hPropertyCommand.getValue());
-        assertTrue(commands.get(3) instanceof UpdateElementPropertyCommand);
-        final UpdateElementPropertyCommand rPropertyCommand = (UpdateElementPropertyCommand) commands.get(3);
-        assertEquals(element,
-                     rPropertyCommand.getElement());
-        assertEquals(R_PROPERTY_ID,
-                     rPropertyCommand.getPropertyId());
-        assertEquals(50d,
-                     rPropertyCommand.getValue());
-
-        //test parent with docked node resize
-        ArgumentCaptor<Point2D> shapePoint2DArgumentCaptor = ArgumentCaptor.forClass(Point2D.class);
-        verify(canvasCommandFactory, times(1)).updatePosition(eq(dockedNode), shapePoint2DArgumentCaptor.capture());
-        Point2D shapePoint = shapePoint2DArgumentCaptor.getValue();
-        assertEquals(shapePoint.getX(), SHAPE_X, 0);
-        assertEquals(shapePoint.getY(), SHAPE_Y, 0);
-
-        //test connections position on the node resize
-        //source connection
-        verify(canvasCommandFactory, times(1)).setSourceNode(element, connectorEdge, magnetConnection);
-        assertEquals(magnetConnection.getLocation().getX(), NEW_CONNECTION_X, 0);
-        assertEquals(magnetConnection.getLocation().getY(), NEW_CONNECTION_Y, 0);
-
-        //target connection
-        verify(canvasCommandFactory, times(1)).setTargetNode(element, connectorEdgeTarget, magnetConnectionTarget);
-        //assert new connection position after resize
-        assertEquals(magnetConnectionTarget.getLocation().getX(), NEW_CONNECTION_X_TARGET, 0);
-        assertEquals(magnetConnectionTarget.getLocation().getY(), NEW_CONNECTION_Y_TARGET, 0);
+        assertEquals(expectedCommand, command);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorViewTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires;
 
-import java.util.List;
-
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.MultiPathDecorator;
@@ -423,32 +421,51 @@ public class WiresConnectorViewTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testAddControlPoint() {
-        Point2D point1 = new Point2D(0.1, 0.2);
-        ControlPoint controlPoint1 = ControlPoint.build(point1.getX(), point1.getY(), 0);
-        IControlHandleList pointHandles = mock(IControlHandleList.class);
-        when(pointHandles.isEmpty()).thenReturn(true);
-        when(pointHandles.size()).thenReturn(0);
-        tested.setPointHandles(pointHandles);
-        List<ControlPoint> addedControlPoint = tested.addControlPoints(controlPoint1);
-        assertFalse(addedControlPoint.isEmpty());
-        assertEquals(controlPoint1, addedControlPoint.get(0));
-        ArgumentCaptor<Point2DArray> c1 = ArgumentCaptor.forClass(Point2DArray.class);
-        verify(line, atLeastOnce()).setPoint2DArray(c1.capture());
-        Point2DArray points1 = c1.getValue();
-        assertEquals(6, points1.size());
-        assertEquals(point1, points1.get(1));
+        Point2DArray cps = new Point2DArray(new Point2D(0, 0),
+                                            new Point2D(0.1, 0.2),
+                                            new Point2D(1, 2));
+        when(line.getPoint2DArray()).thenReturn(cps);
+        ControlPoint newCP = ControlPoint.build(0.5, 0.5);
+        tested.addControlPoint(newCP, 1);
+        ArgumentCaptor<Point2DArray> linePointsCaptor = ArgumentCaptor.forClass(Point2DArray.class);
+        verify(line, atLeastOnce()).setPoint2DArray(linePointsCaptor.capture());
+        Point2DArray linePoints = linePointsCaptor.getValue();
+        assertEquals(4, linePoints.size());
+        assertEquals(new Point2D(0.1, 0.2), linePoints.get(1));
+        assertEquals(new Point2D(0.5, 0.5), linePoints.get(2));
     }
 
     @Test
-    public void testGetShapeControlPoints() {
-        List<ControlPoint> controlPoints = tested.getShapeControlPoints();
-        for (int i = 1; i < controlPoints.size() - 1; i++) {
-            ControlPoint controlPoint = controlPoints.get(i);
-            Point2D point = point2DArray.get(i);
-            assertEquals(controlPoint.getLocation().getX(), point.getX(), 0);
-            assertEquals(controlPoint.getLocation().getY(), point.getY(), 0);
-            assertEquals(controlPoint.getIndex().intValue(), i);
-        }
+    @SuppressWarnings("unchecked")
+    public void testDeleteControlPoint() {
+        Point2DArray cps = new Point2DArray(new Point2D(0, 0),
+                                            new Point2D(0.1, 0.2),
+                                            new Point2D(1, 2));
+        when(line.getPoint2DArray()).thenReturn(cps);
+        tested.deleteControlPoint(0);
+        ArgumentCaptor<Point2DArray> linePointsCaptor = ArgumentCaptor.forClass(Point2DArray.class);
+        verify(line, atLeastOnce()).setPoint2DArray(linePointsCaptor.capture());
+        Point2DArray linePoints = linePointsCaptor.getValue();
+        assertEquals(2, linePoints.size());
+        assertEquals(new Point2D(0, 0), linePoints.get(0));
+        assertEquals(new Point2D(1, 2), linePoints.get(1));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUpdateControlPoint() {
+        Point2D p = new Point2D(0.1, 0.2);
+        Point2DArray cps = new Point2DArray(new Point2D(0, 0),
+                                            p,
+                                            new Point2D(1, 2));
+        when(line.getPoint2DArray()).thenReturn(cps);
+        IControlHandleList pointHandles = mock(IControlHandleList.class);
+        when(pointHandles.isEmpty()).thenReturn(false);
+        when(pointHandles.size()).thenReturn(1);
+        tested.setPointHandles(pointHandles);
+        tested.updateControlPoints(new ControlPoint[]{ControlPoint.build(0.5, 0.5)});
+        assertEquals(0.5, p.getX(), 0d);
+        assertEquals(0.5, p.getY(), 0d);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresConnectorViewTest.java
@@ -49,6 +49,7 @@ import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
@@ -416,6 +417,56 @@ public class WiresConnectorViewTest {
                times(1)).setAutoConnection(eq(false));
         verify(tailWiresConnection,
                times(1)).setMagnet(eq(null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetEmptyControlPoints() {
+        Point2DArray linePoints = new Point2DArray(new Point2D(0, 0),
+                                                   new Point2D(1, 2));
+        when(line.getPoint2DArray()).thenReturn(linePoints);
+        ControlPoint[] controlPoints = tested.getManageableControlPoints();
+        assertNotNull(controlPoints);
+        assertEquals(0, controlPoints.length);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetEmptyControlPoints2() {
+        Point2DArray linePoints = new Point2DArray(new Point2D(0, 0));
+        when(line.getPoint2DArray()).thenReturn(linePoints);
+        ControlPoint[] controlPoints = tested.getManageableControlPoints();
+        assertNotNull(controlPoints);
+        assertEquals(0, controlPoints.length);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetControlPoints() {
+        Point2DArray linePoints = new Point2DArray(new Point2D(0, 0),
+                                                   new Point2D(0.1, 0.2),
+                                                   new Point2D(0.3, 0.4),
+                                                   new Point2D(0.5, 0.6),
+                                                   new Point2D(1, 2));
+        when(line.getPoint2DArray()).thenReturn(linePoints);
+        ControlPoint[] controlPoints = tested.getManageableControlPoints();
+        assertNotNull(controlPoints);
+        assertEquals(3, controlPoints.length);
+        ControlPoint controlPoint0 = controlPoints[0];
+        assertNotNull(controlPoint0);
+        assertNotNull(controlPoint0.getLocation());
+        assertEquals(0.1d, controlPoint0.getLocation().getX(), 0d);
+        assertEquals(0.2d, controlPoint0.getLocation().getY(), 0d);
+        ControlPoint controlPoint1 = controlPoints[1];
+        assertNotNull(controlPoint1);
+        assertNotNull(controlPoint1.getLocation());
+        assertEquals(0.3d, controlPoint1.getLocation().getX(), 0d);
+        assertEquals(0.4d, controlPoint1.getLocation().getY(), 0d);
+        ControlPoint controlPoint2 = controlPoints[2];
+        assertNotNull(controlPoint2);
+        assertNotNull(controlPoint2.getLocation());
+        assertEquals(0.5d, controlPoint2.getLocation().getX(), 0d);
+        assertEquals(0.6d, controlPoint2.getLocation().getY(), 0d);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresCompositeControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresCompositeControlTest.java
@@ -49,13 +49,6 @@ public class DelegateWiresCompositeControlTest {
     }
 
     @Test
-    public void testContext() {
-        WiresCompositeControl.Context context = mock(WiresCompositeControl.Context.class);
-        tested.setContext(context);
-        verify(delegate, times(1)).setContext(eq(context));
-    }
-
-    @Test
     public void testControlMethods() {
         tested.execute();
         verify(delegate, times(1)).execute();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresShapeControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/wires/DelegateWiresShapeControlTest.java
@@ -21,7 +21,7 @@ import com.ait.lienzo.client.core.shape.wires.handlers.MouseEvent;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresContainmentControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresDockingControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresMagnetsControl;
-import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerCachedControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresParentPickerControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeControlImpl;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
@@ -58,7 +58,7 @@ public class DelegateWiresShapeControlTest {
     private WiresContainmentControl containmentControl;
 
     @Mock
-    private WiresParentPickerCachedControl parentPickerControl;
+    private WiresParentPickerControl parentPickerControl;
 
     private DelegateWiresShapeControl tested;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/wires/StunnerWiresShapeControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/wires/StunnerWiresShapeControlTest.java
@@ -21,7 +21,7 @@ import com.ait.lienzo.client.core.shape.wires.IContainmentAcceptor;
 import com.ait.lienzo.client.core.shape.wires.IDockingAcceptor;
 import com.ait.lienzo.client.core.shape.wires.ILocationAcceptor;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
-import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerCachedControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresParentPickerControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeControlImpl;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
@@ -45,7 +45,7 @@ public class StunnerWiresShapeControlTest {
     private WiresShapeControlImpl delegate;
 
     @Mock
-    private WiresParentPickerCachedControl parentPickerControl;
+    private WiresParentPickerControl parentPickerControl;
 
     @Mock
     private WiresShapeView shapeView;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/AbstractMenuDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/AbstractMenuDevCommand.java
@@ -15,10 +15,13 @@
  */
 package org.kie.workbench.common.stunner.client.widgets.menu.dev;
 
+import java.util.logging.Level;
+
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
+import org.kie.workbench.common.stunner.core.client.util.StunnerClientLogger;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 
@@ -50,5 +53,10 @@ public abstract class AbstractMenuDevCommand
 
     protected Graph getGraph() {
         return null != getDiagram() ? getDiagram().getGraph() : null;
+    }
+
+    protected static void logTask(final Runnable task) {
+        StunnerClientLogger.logTask(Level.FINEST,
+                                    task);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/ClearCommandHistoryDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/ClearCommandHistoryDevCommand.java
@@ -51,7 +51,7 @@ public class ClearCommandHistoryDevCommand extends AbstractMenuDevCommand {
         try {
             final EditorSession session = (EditorSession) getSession();
             if (null != session) {
-                session.getCommandRegistry().getCommandHistory().clear();
+                session.getCommandRegistry().clear();
             }
         } catch (ClassCastException e) {
             LOGGER.log(Level.WARNING,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogBoundsDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogBoundsDevCommand.java
@@ -48,6 +48,6 @@ public class LogBoundsDevCommand extends AbstractSelectedNodeDevCommand {
 
     @Override
     protected void execute(final Node<? extends View<?>, Edge> node) {
-        StunnerClientLogger.logBounds(node);
+        logTask(() -> StunnerClientLogger.logBounds(node));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogCommandHistoryDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogCommandHistoryDevCommand.java
@@ -48,7 +48,7 @@ public class LogCommandHistoryDevCommand extends AbstractMenuDevCommand {
     @Override
     public void execute() {
         try {
-            StunnerClientLogger.logCommandHistory((EditorSession) getSession());
+            logTask(() -> StunnerClientLogger.logCommandHistory((EditorSession) getSession()));
         } catch (ClassCastException e) {
             LOGGER.log(Level.WARNING,
                        "Session is not an instance of ClientFullSession");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogDefinitionDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogDefinitionDevCommand.java
@@ -44,11 +44,13 @@ public class LogDefinitionDevCommand extends AbstractSelectedNodeDevCommand {
 
     @Override
     protected void execute(final Node<? extends View<?>, Edge> node) {
-        if (null == node) {
-            StunnerClientLogger.log("No item selected!");
-        } else {
-            StunnerClientLogger.logDefinition(getCanvasHandler().getDefinitionManager(),
-                                              node.getContent().getDefinition());
-        }
+        logTask(() -> {
+            if (null == node) {
+                StunnerClientLogger.log("No item selected!");
+            } else {
+                StunnerClientLogger.logDefinition(getCanvasHandler().getDefinitionManager(),
+                                                  node.getContent().getDefinition());
+            }
+        });
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogGraphDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogGraphDevCommand.java
@@ -41,6 +41,6 @@ public class LogGraphDevCommand extends AbstractMenuDevCommand {
 
     @Override
     public void execute() {
-        StunnerLogger.log(getGraph());
+        logTask(() -> StunnerLogger.log(getGraph()));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogMagnetsDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogMagnetsDevCommand.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.menu.dev.impl;
+
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.ait.lienzo.client.core.shape.wires.MagnetManager;
+import com.ait.lienzo.client.core.shape.wires.WiresConnection;
+import com.ait.lienzo.client.core.shape.wires.WiresConnector;
+import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.tooling.nativetools.client.collection.NFastArrayList;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+@Dependent
+public class LogMagnetsDevCommand extends AbstractSelectionDevCommand {
+
+    private static Logger LOGGER = Logger.getLogger(LogMagnetsDevCommand.class.getName());
+
+    @Inject
+    public LogMagnetsDevCommand(SessionManager sessionManager) {
+        super(sessionManager);
+    }
+
+    @Override
+    public String getText() {
+        return "Log magnets";
+    }
+
+    @Override
+    protected void execute(final Collection<Element<? extends View<?>>> items) {
+        for (final Element<? extends View<?>> item : items) {
+            logTask(() -> logMagnets(item));
+        }
+    }
+
+    private void logMagnets(Element<? extends View<?>> element) {
+        if (null != element.asNode()) {
+            final Shape shape = getCanvasHandler().getCanvas().getShape(element.getUUID());
+            final WiresShape wiresShape = (WiresShape) shape.getShapeView();
+            final MagnetManager.Magnets magnets = wiresShape.getMagnets();
+            if (null != magnets) {
+                log("---- Magnets [" + element.getUUID() + "] ------");
+                for (int i = 0; i < magnets.size(); i++) {
+                    WiresMagnet magnet = magnets.getMagnet(i);
+                    NFastArrayList<WiresConnection> connections = magnet.getConnections();
+                    WiresConnector connector = null;
+                    if (null != connections && !connections.isEmpty()) {
+                        WiresConnection connection = connections.iterator().next();
+                        connector = connection.getConnector();
+                    }
+                    log("[" + i + "] - " + connector);
+                }
+                log("-------------------------------------------------------");
+            } else {
+                log("No magnets are set.");
+            }
+        }
+    }
+
+    private static void log(final String message) {
+        LOGGER.log(Level.INFO, message);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogNodeEdgesDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogNodeEdgesDevCommand.java
@@ -49,6 +49,10 @@ public class LogNodeEdgesDevCommand extends AbstractSelectedNodeDevCommand {
 
     @Override
     protected void execute(final Node<? extends View<?>, Edge> node) {
+        logTask(() -> log(node));
+    }
+
+    private void log(final Node<? extends View<?>, Edge> node) {
         final String uuid = node.getUUID();
         try {
             final List<Edge> inEdges = node.getInEdges();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogSelectedEdgeDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogSelectedEdgeDevCommand.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.client.widgets.menu.dev.impl;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -58,6 +57,10 @@ public class LogSelectedEdgeDevCommand extends AbstractSelectionDevCommand {
 
     @Override
     protected void execute(final Collection<Element<? extends View<?>>> items) {
+        logTask(() -> logEdges(items));
+    }
+
+    private void logEdges(final Collection<Element<? extends View<?>>> items) {
         if (1 == items.size()) {
             final Element<? extends View<?>> e = items.iterator().next();
             if (null != e.asEdge()) {
@@ -70,11 +73,11 @@ public class LogSelectedEdgeDevCommand extends AbstractSelectionDevCommand {
         StunnerLogger.log(edge);
         if (edge.getContent() instanceof HasControlPoints) {
 
-            final List<ControlPoint> controlPoints = ((HasControlPoints) edge.getContent()).getControlPoints();
+            final ControlPoint[] controlPoints = ((HasControlPoints) edge.getContent()).getControlPoints();
             String s = "*** CPS = ";
-            if (null != controlPoints && !controlPoints.isEmpty()) {
+            if (null != controlPoints) {
                 for (ControlPoint cp : controlPoints) {
-                    s += " [" + cp.getIndex() + "=" + format(cp.getLocation()) + "] ";
+                    s += " [" + format(cp.getLocation()) + "] ";
                 }
                 s += " *** ";
             } else {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogSelectedItemsDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogSelectedItemsDevCommand.java
@@ -43,6 +43,10 @@ public class LogSelectedItemsDevCommand extends AbstractSelectionDevCommand {
 
     @Override
     protected void execute(final Collection<Element<? extends View<?>>> items) {
+        logTask(() -> logItems(items));
+    }
+
+    private void logItems(final Collection<Element<? extends View<?>>> items) {
         if (items.isEmpty()) {
             log("No items selected");
         } else {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogSessionDevCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/impl/LogSessionDevCommand.java
@@ -41,6 +41,6 @@ public class LogSessionDevCommand extends AbstractMenuDevCommand {
 
     @Override
     public void execute() {
-        StunnerClientLogger.logSessionInfo(getSession());
+        logTask(() -> StunnerClientLogger.logSessionInfo(getSession()));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/connection/ControlPointControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/connection/ControlPointControl.java
@@ -16,25 +16,22 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls.connection;
 
-import java.util.Map;
-
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasRegistrationControl;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
-import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 
 /**
- * Control responsible to manage {@link ControlPoint} operations: add, move on canvas.
+ * Control responsible to manage {@link ControlPoint} operations: add, move, remove on a canvas instance..
  */
 public interface ControlPointControl<H extends CanvasHandler> extends CanvasRegistrationControl<H, Element>,
                                                                       RequiresCommandManager<H> {
 
-    void addControlPoints(Edge candidate, ControlPoint... controlPoints);
+    void addControlPoint(Edge candidate, ControlPoint controlPoint, int index);
 
-    void moveControlPoints(Edge candidate, Map<ControlPoint, Point2D> pointsLocation);
+    void updateControlPoints(Edge candidate, ControlPoint[] controlPoints);
 
-    void removeControlPoint(Edge candidate, ControlPoint controlPoint);
+    void deleteControlPoint(Edge candidate, int index);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/resize/ResizeControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/resize/ResizeControl.java
@@ -30,10 +30,4 @@ public interface ResizeControl<C extends CanvasHandler, E extends Element>
     CommandResult<CanvasViolation> resize(final E element,
                                           final double width,
                                           final double height);
-
-    CommandResult<CanvasViolation> resize(final E element,
-                                          final double x,
-                                          final double y,
-                                          final double width,
-                                          final double height);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
@@ -34,85 +34,96 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 
 public interface CanvasCommandFactory<H extends CanvasHandler> {
 
-    CanvasCommand<H> addNode(final Node candidate,
-                             final String shapeSetId);
+    CanvasCommand<H> addNode(Node candidate,
+                             String shapeSetId);
 
-    CanvasCommand<H> addChildNode(final Node parent,
-                                  final Node candidate,
-                                  final String shapeSetId);
+    CanvasCommand<H> addChildNode(Node parent,
+                                  Node candidate,
+                                  String shapeSetId);
 
-    CanvasCommand<H> addDockedNode(final Node parent,
-                                   final Node candidate,
-                                   final String shapeSetId);
+    CanvasCommand<H> addDockedNode(Node parent,
+                                   Node candidate,
+                                   String shapeSetId);
 
-    CanvasCommand<H> deleteNode(final Node candidate);
+    CanvasCommand<H> deleteNode(Node candidate);
 
-    CanvasCommand<H> delete(final Collection<Element> candidates);
+    CanvasCommand<H> delete(Collection<Element> candidates);
 
-    CanvasCommand<H> addConnector(final Node sourceNode,
-                                  final Edge candidate,
-                                  final Connection connection,
-                                  final String shapeSetId);
+    CanvasCommand<H> addConnector(Node sourceNode,
+                                  Edge candidate,
+                                  Connection connection,
+                                  String shapeSetId);
 
-    CanvasCommand<H> deleteConnector(final Edge candidate);
+    CanvasCommand<H> deleteConnector(Edge candidate);
 
-    CanvasCommand<H> setChildNode(final Node parent,
-                                  final Node candidate);
+    CanvasCommand<H> cloneNode(Node candidate,
+                               String parentUuid,
+                               Point2D cloneLocation,
+                               Consumer<Node> callback);
 
-    CanvasCommand<H> removeChild(final Node parent,
-                                 final Node candidate);
+    CanvasCommand<H> cloneConnector(Edge candidate,
+                                    String sourceUUID,
+                                    String targetUUID,
+                                    String shapeSetId,
+                                    Consumer<Edge> callback);
 
-    CanvasCommand<H> updateChildNode(final Node parent,
-                                     final Node candidate);
+    CanvasCommand<H> setChildNode(Node parent,
+                                  Node candidate);
 
-    CanvasCommand<H> dockNode(final Node parent,
-                              final Node candidate);
+    CanvasCommand<H> removeChild(Node parent,
+                                 Node candidate);
 
-    CanvasCommand<H> unDockNode(final Node parent,
-                                final Node candidate);
+    CanvasCommand<H> updateChildNode(Node parent,
+                                     Node candidate);
 
-    CanvasCommand<H> updateDockNode(final Node parent,
-                                    final Node candidate);
+    CanvasCommand<H> dockNode(Node parent,
+                              Node candidate);
 
-    CanvasCommand<H> updateDockNode(final Node parent,
-                                    final Node candidate,
-                                    final boolean adjustPosition);
+    CanvasCommand<H> unDockNode(Node parent,
+                                Node candidate);
+
+    CanvasCommand<H> updateDockNode(Node parent,
+                                    Node candidate);
+
+    CanvasCommand<H> updateDockNode(Node parent,
+                                    Node candidate,
+                                    boolean adjustPosition);
 
     CanvasCommand<H> draw();
 
-    CanvasCommand<H> morphNode(final Node<? extends Definition<?>, Edge> candidate,
-                               final MorphDefinition morphDefinition,
-                               final String morphTarget,
-                               final String shapeSetId);
+    CanvasCommand<H> morphNode(Node<? extends Definition<?>, Edge> candidate,
+                               MorphDefinition morphDefinition,
+                               String morphTarget,
+                               String shapeSetId);
 
-    CanvasCommand<H> setSourceNode(final Node<? extends View<?>, Edge> node,
-                                   final Edge<? extends ViewConnector<?>, Node> edge,
-                                   final Connection connection);
+    CanvasCommand<H> updatePosition(Node<View<?>, Edge> element,
+                                    Point2D location);
 
-    CanvasCommand<H> setTargetNode(final Node<? extends View<?>, Edge> node,
-                                   final Edge<? extends ViewConnector<?>, Node> edge,
-                                   final Connection connection);
+    CanvasCommand<H> updatePropertyValue(Element element,
+                                         String propertyId,
+                                         Object value);
 
-    CanvasCommand<H> updatePosition(final Node<View<?>, Edge> element,
-                                    final Point2D location);
+    CanvasCommand<H> updateDomainObjectPropertyValue(DomainObject domainObject,
+                                                     String propertyId,
+                                                     Object value);
 
-    CanvasCommand<H> updatePropertyValue(final Element element,
-                                         final String propertyId,
-                                         final Object value);
+    CanvasCommand<H> setSourceNode(Node<? extends View<?>, Edge> node,
+                                   Edge<? extends ViewConnector<?>, Node> edge,
+                                   Connection connection);
 
-    CanvasCommand<H> updateDomainObjectPropertyValue(final DomainObject domainObject,
-                                                     final String propertyId,
-                                                     final Object value);
+    CanvasCommand<H> setTargetNode(Node<? extends View<?>, Edge> node,
+                                   Edge<? extends ViewConnector<?>, Node> edge,
+                                   Connection connection);
+
+    CanvasCommand<H> addControlPoint(Edge candidate,
+                                     ControlPoint controlPoint,
+                                     int index);
+
+    CanvasCommand<H> deleteControlPoint(Edge candidate,
+                                        int index);
+
+    CanvasCommand<H> updateControlPointPosition(Edge candidate,
+                                                ControlPoint[] controlPoints);
 
     CanvasCommand<H> clearCanvas();
-
-    CanvasCommand<H> cloneNode(Node candidate, String parentUuid, Point2D cloneLocation, Consumer<Node> callback);
-
-    CanvasCommand<H> cloneConnector(Edge candidate, String sourceUUID, String targetUUID, String shapeSetId, Consumer<Edge> callback);
-
-    CanvasCommand<H> addControlPoint(Edge candidate, ControlPoint... controlPoints);
-
-    CanvasCommand<H> deleteControlPoint(Edge candidate, ControlPoint... controlPoints);
-
-    CanvasCommand<H> updateControlPointPosition(Edge candidate, ControlPoint controlPoint, Point2D position);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactory.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.function.Consumer;
 
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
 import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -98,6 +99,9 @@ public interface CanvasCommandFactory<H extends CanvasHandler> {
 
     CanvasCommand<H> updatePosition(Node<View<?>, Edge> element,
                                     Point2D location);
+
+    CanvasCommand<H> resize(Element<? extends View<?>> element,
+                            BoundingBox boundingBox);
 
     CanvasCommand<H> updatePropertyValue(Element element,
                                          String propertyId,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/BoundingBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/BoundingBox.java
@@ -56,4 +56,9 @@ public final class BoundingBox {
     public double getHeight() {
         return maxY - minY;
     }
+
+    @Override
+    public String toString() {
+        return "{" + minX + ", " + minY + ", " + maxX + ", " + maxY + "}";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasManageableControlPoints.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasManageableControlPoints.java
@@ -16,17 +16,15 @@
 
 package org.kie.workbench.common.stunner.core.client.shape.view;
 
-import java.util.List;
-
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 
 public interface HasManageableControlPoints<T> extends HasControlPoints<T> {
 
-    List<ControlPoint> addControlPoints(ControlPoint... controlPoint);
+    T addControlPoint(ControlPoint controlPoint, int index);
 
-    List<ControlPoint> getShapeControlPoints();
+    T updateControlPoints(ControlPoint[] controlPoints);
 
-    T updateControlPoint(ControlPoint controlPoint);
+    T deleteControlPoint(int index);
 
-    T removeControlPoints(ControlPoint... controlPoint);
+    ControlPoint[] getManageableControlPoints();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/HasControlPoints.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/HasControlPoints.java
@@ -16,13 +16,11 @@
 
 package org.kie.workbench.common.stunner.core.graph.content;
 
-import java.util.List;
-
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 
 public interface HasControlPoints {
 
-    List<ControlPoint> getControlPoints();
+    ControlPoint[] getControlPoints();
 
-    void setControlPoints(List<ControlPoint> controlPoints);
+    void setControlPoints(ControlPoint[] controlPoints);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ControlPoint.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ControlPoint.java
@@ -26,32 +26,18 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
 public class ControlPoint {
 
     private Point2D location;
-    private Integer index;
 
     public static ControlPoint build(final Point2D location) {
-        return new ControlPoint(location, null);
-    }
-
-    public static ControlPoint build(final Point2D location,
-                                     final int index) {
-        return new ControlPoint(location, index);
+        return new ControlPoint(location);
     }
 
     public static ControlPoint build(final double x,
                                      final double y) {
-        return new ControlPoint(Point2D.create(x, y), null);
+        return new ControlPoint(Point2D.create(x, y));
     }
 
-    public static ControlPoint build(final double x,
-                                     final double y,
-                                     final int index) {
-        return new ControlPoint(Point2D.create(x, y), index);
-    }
-
-    public ControlPoint(final @MapsTo("location") Point2D location,
-                        final @MapsTo("index") Integer index) {
+    public ControlPoint(final @MapsTo("location") Point2D location) {
         this.location = location;
-        this.index = index;
     }
 
     public Point2D getLocation() {
@@ -62,12 +48,8 @@ public class ControlPoint {
         this.location = location;
     }
 
-    public Integer getIndex() {
-        return index;
-    }
-
-    public void setIndex(final Integer index) {
-        this.index = index;
+    public ControlPoint copy() {
+        return new ControlPoint(location.copy());
     }
 
     @Override
@@ -79,21 +61,16 @@ public class ControlPoint {
             return false;
         }
         final ControlPoint that = (ControlPoint) o;
-        return Objects.equals(location, that.location)
-                && Objects.equals(index, that.index);
+        return Objects.equals(location, that.location);
     }
 
     @Override
     public int hashCode() {
-        return HashUtil.combineHashCodes(Objects.hash(location),
-                                         null != index ? Objects.hash(index) : 0);
+        return HashUtil.combineHashCodes(Objects.hash(location));
     }
 
     @Override
     public String toString() {
-        return "ControlPoint{" +
-                "location=" + location +
-                ", index=" + index +
-                '}';
+        return "ControlPoint [" + location + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/Point2D.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/Point2D.java
@@ -63,6 +63,10 @@ public final class Point2D {
         this.y = y;
     }
 
+    public Point2D copy() {
+        return new Point2D(x, y);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
@@ -506,6 +506,6 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
 
     @Override
     public String toString() {
-        return this.getClass().getName() + " [" + getUuid() + "]";
+        return this.getClass().getSimpleName() + " [" + getUuid() + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommand.java
@@ -86,28 +86,14 @@ public abstract class AbstractCanvasGraphCommand
     @Override
     public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
         CommandResult<CanvasViolation> result = performOperationOnGraph(context, CommandOperation.EXECUTE);
-        boolean revertGraphCommand = false;
-        boolean revertCanvasCommand = false;
         if (canDoNexOperation(result)) {
-            final CommandResult<CanvasViolation> lastResult =
+            final CommandResult<CanvasViolation> canvasResult =
                     performOperationOnCanvas(context, CommandOperation.EXECUTE);
-            if (!canDoNexOperation(lastResult)) {
-                revertGraphCommand = true;
-                revertCanvasCommand = true;
-                result = lastResult;
+            if (!canDoNexOperation(canvasResult)) {
+                performOperationOnGraph(context, CommandOperation.UNDO);
+                return canvasResult;
             }
-        } else {
-            revertGraphCommand = true;
         }
-
-        if (revertGraphCommand) {
-            performOperationOnGraph(context, CommandOperation.UNDO);
-        }
-
-        if (revertCanvasCommand) {
-            performOperationOnCanvas(context, CommandOperation.UNDO);
-        }
-
         return result;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommand.java
@@ -37,15 +37,6 @@ public abstract class AbstractCanvasGraphCommand
         extends AbstractCanvasCommand
         implements HasGraphCommand<AbstractCanvasHandler> {
 
-    private boolean canvasCommandFirst = false;
-
-    public AbstractCanvasGraphCommand() {
-    }
-
-    public AbstractCanvasGraphCommand(boolean canvasCommandFirst) {
-        this.canvasCommandFirst = canvasCommandFirst;
-    }
-
     /**
      * The private instance of the graph command.
      * It's a private stateful command instance - will be used for undoing the operation on the graph.
@@ -85,29 +76,20 @@ public abstract class AbstractCanvasGraphCommand
 
     @Override
     public CommandResult<CanvasViolation> allow(final AbstractCanvasHandler context) {
-        final CommandResult<CanvasViolation> result = canvasCommandFirst ?
-                performOperationOnCanvas(context, CommandOperation.ALLOW) :
-                performOperationOnGraph(context, CommandOperation.ALLOW);
-
+        final CommandResult<CanvasViolation> result = performOperationOnGraph(context, CommandOperation.ALLOW);
         if (canDoNexOperation(result)) {
-            return canvasCommandFirst ? performOperationOnGraph(context, CommandOperation.ALLOW) :
-                    performOperationOnCanvas(context, CommandOperation.ALLOW);
+            return performOperationOnCanvas(context, CommandOperation.ALLOW);
         }
         return result;
     }
 
     @Override
     public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
-        CommandResult<CanvasViolation> result = canvasCommandFirst ?
-                performOperationOnCanvas(context, CommandOperation.EXECUTE) :
-                performOperationOnGraph(context, CommandOperation.EXECUTE);
-
+        CommandResult<CanvasViolation> result = performOperationOnGraph(context, CommandOperation.EXECUTE);
         boolean revertGraphCommand = false;
         boolean revertCanvasCommand = false;
-
         if (canDoNexOperation(result)) {
-            final CommandResult<CanvasViolation> lastResult = canvasCommandFirst ?
-                    performOperationOnGraph(context, CommandOperation.EXECUTE) :
+            final CommandResult<CanvasViolation> lastResult =
                     performOperationOnCanvas(context, CommandOperation.EXECUTE);
             if (!canDoNexOperation(lastResult)) {
                 revertGraphCommand = true;
@@ -131,14 +113,9 @@ public abstract class AbstractCanvasGraphCommand
 
     @Override
     public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
-        final CommandResult<CanvasViolation> result = canvasCommandFirst ?
-                performOperationOnCanvas(context, CommandOperation.UNDO) :
-                performOperationOnGraph(context, CommandOperation.UNDO);
-
+        final CommandResult<CanvasViolation> result = performOperationOnGraph(context, CommandOperation.UNDO);
         if (canDoNexOperation(result)) {
-            return canvasCommandFirst ?
-                    performOperationOnGraph(context, CommandOperation.UNDO) :
-                    performOperationOnCanvas(context, CommandOperation.UNDO);
+            return performOperationOnCanvas(context, CommandOperation.UNDO);
         }
         return result;
     }
@@ -201,17 +178,5 @@ public abstract class AbstractCanvasGraphCommand
 
     private boolean canDoNexOperation(CommandResult<CanvasViolation> result) {
         return null == result || !CommandUtils.isError(result);
-    }
-
-    @Override
-    public String toString() {
-        return "[" +
-                this.getClass().getName() +
-                "]" +
-                " [canvasCommand=" +
-                (null != canvasCommand ? canvasCommand.toString() : "null") +
-                " [graphCommand=" +
-                (null != graphCommand ? graphCommand.toString() : null) +
-                "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasChildNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasChildNodeCommand.java
@@ -72,9 +72,9 @@ public class AddCanvasChildNodeCommand extends AbstractRegistrationCanvasNodeCom
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [parent=" + getUUID(parent) + "," +
-                " candidate=" + getUUID(getCandidate()) + "," +
-                " shapeSet=" + getShapeSetId() + "]";
+                "candidate=" + getUUID(getCandidate()) + "," +
+                "shapeSet=" + getShapeSetId() + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasControlPointCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasControlPointCommand.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
+import java.util.function.Consumer;
+
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -55,13 +57,9 @@ public class AddCanvasControlPointCommand extends AbstractCanvasCommand {
     @Override
     public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
         allow(context);
-        final HasManageableControlPoints<?> view = getManageableControlPoints(context, candidate);
-        // Hide control points.
-        view.hideControlPoints();
-        // Add the new control point at the given index.
-        view.addControlPoint(controlPoint, index);
-        // Show control points.
-        view.showControlPoints(HasControlPoints.ControlPointType.POINTS);
+        consumeControlPoints(context,
+                             candidate,
+                             view -> view.addControlPoint(controlPoint, index));
         return buildResult();
     }
 
@@ -81,6 +79,20 @@ public class AddCanvasControlPointCommand extends AbstractCanvasCommand {
     public static ControlPoint[] getControlPoints(final Edge edge) {
         ViewConnector<?> connector = (ViewConnector<?>) edge.getContent();
         return connector.getControlPoints();
+    }
+
+    public static void consumeControlPoints(final AbstractCanvasHandler context,
+                                            final Edge edge,
+                                            final Consumer<HasManageableControlPoints> consumer) {
+        final HasManageableControlPoints<?> view = getManageableControlPoints(context, edge);
+        final boolean visible = view.areControlsVisible();
+        if (visible) {
+            view.hideControlPoints();
+        }
+        consumer.accept(view);
+        if (visible) {
+            view.showControlPoints(HasControlPoints.ControlPointType.POINTS);
+        }
     }
 
     public static HasManageableControlPoints<?> getManageableControlPoints(final AbstractCanvasHandler context,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasDockedNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasDockedNodeCommand.java
@@ -68,9 +68,9 @@ public class AddCanvasDockedNodeCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [parent=" + getUUID(parent) + "," +
-                " candidate=" + getUUID(candidate) + "," +
-                " shapeSet=" + ssid + "]";
+                "candidate=" + getUUID(candidate) + "," +
+                "shapeSet=" + ssid + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasNodeCommand.java
@@ -41,8 +41,8 @@ public class AddCanvasNodeCommand extends AbstractRegistrationCanvasNodeCommand 
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [candidate=" + getUUID(getCandidate()) + "," +
-                " shapeSet=" + getShapeSetId() + "]";
+                "shapeSet=" + getShapeSetId() + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddChildNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddChildNodeCommand.java
@@ -60,4 +60,12 @@ public class AddChildNodeCommand extends AbstractCanvasGraphCommand {
     public String getShapeSetId() {
         return shapeSetId;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [parent=" + getUUID(getParent()) + "," +
+                "candidate=" + getUUID(getCandidate()) + "," +
+                "shapeSet=" + getShapeSetId() + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddConnectorCommand.java
@@ -71,4 +71,13 @@ public class AddConnectorCommand extends AbstractCanvasGraphCommand {
     public String getShapeSetId() {
         return shapeSetId;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [source=" + getUUID(getSource()) + "," +
+                "candidate=" + getUUID(getCandidate()) + "," +
+                "connection=" + connection + "," +
+                "shapeSet=" + getShapeSetId() + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddControlPointCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddControlPointCommand.java
@@ -15,9 +15,6 @@
  */
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
-import java.util.Objects;
-import java.util.stream.Stream;
-
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -31,27 +28,32 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 public class AddControlPointCommand extends AbstractCanvasGraphCommand {
 
     private final Edge edge;
-    private final ControlPoint[] controlPoints;
+    private final ControlPoint controlPoint;
+    private final int index;
 
     public AddControlPointCommand(final Edge edge,
-                                  final ControlPoint[] controlPoints) {
-        //check if canvas should be executed before graph (when user add it not the marshaller)
-        super(isCanvasCommandFirst(controlPoints));
+                                  final ControlPoint controlPoint,
+                                  final int index) {
         this.edge = edge;
-        this.controlPoints = controlPoints;
-    }
-
-    private static boolean isCanvasCommandFirst(ControlPoint[] controlPoints) {
-        return Stream.of(controlPoints).map(ControlPoint::getIndex).anyMatch(Objects::isNull);
+        this.controlPoint = controlPoint;
+        this.index = index;
     }
 
     @Override
     protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
-        return new org.kie.workbench.common.stunner.core.graph.command.impl.AddControlPointCommand(edge, controlPoints);
+        return new org.kie.workbench.common.stunner.core.graph.command.impl.AddControlPointCommand(edge.getUUID(), controlPoint, index);
     }
 
     @Override
     protected AbstractCanvasCommand newCanvasCommand(final AbstractCanvasHandler context) {
-        return new AddCanvasControlPointCommand(edge, controlPoints);
+        return new AddCanvasControlPointCommand(edge, controlPoint, index);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [edge=" + getUUID(edge) + "," +
+                "controlPoint=" + controlPoint + "," +
+                "index=" + index + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddDockedNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddDockedNodeCommand.java
@@ -51,4 +51,12 @@ public class AddDockedNodeCommand extends AbstractCanvasGraphCommand {
                                               candidate,
                                               ssid);
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [parent=" + getUUID(parent) + "," +
+                "candidate=" + getUUID(candidate) + "," +
+                "shapeSet=" + ssid + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddNodeCommand.java
@@ -54,4 +54,11 @@ public class AddNodeCommand extends AbstractCanvasGraphCommand {
     public String getShapeSetId() {
         return shapeSetId;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(getCandidate()) + "," +
+                "shapeSet=" + getShapeSetId() + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CanvasDockNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CanvasDockNodeCommand.java
@@ -105,8 +105,8 @@ public class CanvasDockNodeCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [parent=" + getParent() + "," +
-                " candidate=" + getCandidate() + "]";
+                "candidate=" + getCandidate() + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CanvasUndockNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CanvasUndockNodeCommand.java
@@ -85,8 +85,8 @@ public class CanvasUndockNodeCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [parent=" + getUUID(parent) + "," +
-                " candidate=" + getUUID(child) + "]";
+                "candidate=" + getUUID(child) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/ClearCanvasCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/ClearCanvasCommand.java
@@ -35,4 +35,9 @@ public class ClearCanvasCommand extends AbstractCanvasCommand {
     public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
         throw new UnsupportedOperationException("Undo operation for Clear Canvas Command is still not supported.");
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/ClearCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/ClearCommand.java
@@ -37,4 +37,9 @@ public class ClearCommand extends AbstractCanvasGraphCommand {
     protected AbstractCanvasCommand newCanvasCommand(final AbstractCanvasHandler context) {
         return new ClearCanvasCommand();
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneCanvasNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneCanvasNodeCommand.java
@@ -148,4 +148,12 @@ public class CloneCanvasNodeCommand extends AbstractCanvasCommand {
     public String getShapeSetId() {
         return shapeSetId;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(getCandidate()) + "," +
+                "parent=" + getUUID(getParent()) + "," +
+                "shapeSet=" + getShapeSetId() + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneConnectorCommand.java
@@ -76,4 +76,13 @@ public class CloneConnectorCommand extends AbstractCanvasGraphCommand {
     protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
         return command;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(candidate) + "," +
+                "source=" + sourceUUID + "," +
+                "target=" + targetUUID + "," +
+                "shapeSet=" + shapeSetId + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneNodeCommand.java
@@ -105,4 +105,12 @@ public class CloneNodeCommand extends AbstractCanvasGraphCommand {
     protected String getParentUuid() {
         return parentUuid;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(getCandidate()) + "," +
+                "parent=" + parentUuid + "," +
+                "cloneLocation=" + cloneLocation + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
@@ -19,9 +19,6 @@ package org.kie.workbench.common.stunner.core.client.canvas.command;
 import java.util.Collection;
 import java.util.function.Consumer;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
@@ -40,20 +37,13 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessor;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ViewTraverseProcessor;
 
-@ApplicationScoped
-public class DefaultCanvasCommandFactory implements CanvasCommandFactory<AbstractCanvasHandler> {
+public abstract class DefaultCanvasCommandFactory implements CanvasCommandFactory<AbstractCanvasHandler> {
 
     private final ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors;
     private final ManagedInstance<ViewTraverseProcessor> viewTraverseProcessors;
 
-    protected DefaultCanvasCommandFactory() {
-        this(null,
-             null);
-    }
-
-    @Inject
-    public DefaultCanvasCommandFactory(final ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors,
-                                       final ManagedInstance<ViewTraverseProcessor> viewTraverseProcessors) {
+    protected DefaultCanvasCommandFactory(final ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors,
+                                          final ManagedInstance<ViewTraverseProcessor> viewTraverseProcessors) {
         this.childrenTraverseProcessors = childrenTraverseProcessors;
         this.viewTraverseProcessors = viewTraverseProcessors;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DefaultCanvasCommandFactory.java
@@ -234,18 +234,18 @@ public class DefaultCanvasCommandFactory implements CanvasCommandFactory<Abstrac
     }
 
     @Override
-    public CanvasCommand<AbstractCanvasHandler> addControlPoint(Edge candidate, ControlPoint... controlPoints) {
-        return new AddControlPointCommand(candidate, controlPoints);
+    public CanvasCommand<AbstractCanvasHandler> addControlPoint(Edge candidate, ControlPoint controlPoint, int index) {
+        return new AddControlPointCommand(candidate, controlPoint, index);
     }
 
     @Override
-    public CanvasCommand<AbstractCanvasHandler> deleteControlPoint(Edge candidate, ControlPoint... controlPoints) {
-        return new DeleteControlPointCommand(candidate, controlPoints);
+    public CanvasCommand<AbstractCanvasHandler> deleteControlPoint(Edge candidate, int index) {
+        return new DeleteControlPointCommand(candidate, index);
     }
 
     @Override
-    public CanvasCommand<AbstractCanvasHandler> updateControlPointPosition(Edge candidate, ControlPoint controlPoint, Point2D position) {
-        return new UpdateControlPointPositionCommand(candidate, controlPoint, position);
+    public CanvasCommand<AbstractCanvasHandler> updateControlPointPosition(Edge candidate, ControlPoint[] controlPoints) {
+        return new UpdateControlPointPositionCommand(candidate, controlPoints);
     }
 
     protected ChildrenTraverseProcessor newChildrenTraverseProcessor() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasConnectorCommand.java
@@ -68,9 +68,9 @@ public class DeleteCanvasConnectorCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [candidate=" + getUUID(candidate) + "," +
-                " sourceNode=" + getUUID(candidate.getSourceNode()) + "," +
-                " targetNode=" + getUUID(candidate.getTargetNode()) + "]";
+                "sourceNode=" + getUUID(candidate.getSourceNode()) + "," +
+                "targetNode=" + getUUID(candidate.getTargetNode()) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommand.java
@@ -19,14 +19,12 @@ package org.kie.workbench.common.stunner.core.client.canvas.command;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasManageableControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations;
 
-import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.getManageableControlPoints;
+import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.consumeControlPoints;
 import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.getViewControlPoints;
 
 public class DeleteCanvasControlPointCommand extends AbstractCanvasCommand {
@@ -50,14 +48,12 @@ public class DeleteCanvasControlPointCommand extends AbstractCanvasCommand {
     @Override
     public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
         allow(context);
-        final HasManageableControlPoints<?> view = getManageableControlPoints(context, candidate);
-        this.deletedControlPoint = view.getManageableControlPoints()[index];
-        // Hide control points.
-        view.hideControlPoints();
-        // Delete the control point at the given index.
-        view.deleteControlPoint(index);
-        // Show control points.
-        view.showControlPoints(HasControlPoints.ControlPointType.POINTS);
+        consumeControlPoints(context,
+                             candidate,
+                             view -> {
+                                 this.deletedControlPoint = view.getManageableControlPoints()[index];
+                                 view.deleteControlPoint(index);
+                             });
         return buildResult();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommand.java
@@ -17,40 +17,59 @@
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
-import org.kie.workbench.common.stunner.core.client.util.ShapeUtils;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasManageableControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
+import org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations;
+
+import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.getManageableControlPoints;
+import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.getViewControlPoints;
 
 public class DeleteCanvasControlPointCommand extends AbstractCanvasCommand {
 
     private final Edge candidate;
-    private final ControlPoint[] controlPoints;
+    private final int index;
+    private ControlPoint deletedControlPoint;
 
-    public DeleteCanvasControlPointCommand(final Edge candidate, final ControlPoint... controlPoints) {
+    public DeleteCanvasControlPointCommand(final Edge candidate,
+                                           final int index) {
         this.candidate = candidate;
-        this.controlPoints = controlPoints;
+        this.index = index;
     }
 
     @Override
-    public CommandResult<CanvasViolation> execute(AbstractCanvasHandler context) {
-        ShapeUtils.hideControlPoints(candidate, context);
-        ShapeUtils.removeControlPoints(candidate, context, controlPoints);
-        ShapeUtils.showControlPoints(candidate, context);
+    public CommandResult<CanvasViolation> allow(final AbstractCanvasHandler context) {
+        ControlPointValidations.checkDeleteControlPoint(getViewControlPoints(context, candidate), index);
+        return CanvasCommandResultBuilder.SUCCESS;
+    }
+
+    @Override
+    public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
+        allow(context);
+        final HasManageableControlPoints<?> view = getManageableControlPoints(context, candidate);
+        this.deletedControlPoint = view.getManageableControlPoints()[index];
+        // Hide control points.
+        view.hideControlPoints();
+        // Delete the control point at the given index.
+        view.deleteControlPoint(index);
+        // Show control points.
+        view.showControlPoints(HasControlPoints.ControlPointType.POINTS);
         return buildResult();
     }
 
     @Override
-    public CommandResult<CanvasViolation> undo(AbstractCanvasHandler context) {
-        return newUndoCommand().execute(context);
+    public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
+        return new AddCanvasControlPointCommand(candidate, deletedControlPoint, index).execute(context);
     }
 
-    protected AddCanvasControlPointCommand newUndoCommand() {
-        return new AddCanvasControlPointCommand(candidate, controlPoints);
-    }
-
-    protected ControlPoint[] getControlPoints() {
-        return controlPoints;
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(candidate) + "," +
+                "index=" + index + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasNodeCommand.java
@@ -100,8 +100,8 @@ public class DeleteCanvasNodeCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [parent=" + getUUID(parent) + "," +
-                " candidate=" + getUUID(candidate) + "]";
+                "candidate=" + getUUID(candidate) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteConnectorCommand.java
@@ -43,4 +43,10 @@ public class DeleteConnectorCommand extends AbstractCanvasGraphCommand {
     protected AbstractCanvasCommand newCanvasCommand(final AbstractCanvasHandler context) {
         return new DeleteCanvasConnectorCommand(candidate);
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + candidate + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteControlPointCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteControlPointCommand.java
@@ -19,7 +19,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
-import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 /**
@@ -28,21 +27,28 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 public class DeleteControlPointCommand extends AbstractCanvasGraphCommand {
 
     private final Edge candidate;
-    private final ControlPoint[] controlPoints;
+    private final int index;
 
     public DeleteControlPointCommand(final Edge candidate,
-                                     final ControlPoint[] controlPoints) {
+                                     final int index) {
         this.candidate = candidate;
-        this.controlPoints = controlPoints;
+        this.index = index;
     }
 
     @Override
     protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
-        return new org.kie.workbench.common.stunner.core.graph.command.impl.DeleteControlPointCommand(candidate, controlPoints);
+        return new org.kie.workbench.common.stunner.core.graph.command.impl.DeleteControlPointCommand(candidate.getUUID(), index);
     }
 
     @Override
     protected AbstractCanvasCommand newCanvasCommand(final AbstractCanvasHandler context) {
-        return new DeleteCanvasControlPointCommand(candidate, controlPoints);
+        return new DeleteCanvasControlPointCommand(candidate, index);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(candidate) + "," +
+                "index=" + index + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteElementsCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteElementsCommand.java
@@ -63,6 +63,12 @@ public class DeleteElementsCommand extends AbstractCanvasGraphCommand {
         return command;
     }
 
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [elements=" + elements + "]";
+    }
+
     protected class CanvasMultipleDeleteProcessor
             implements org.kie.workbench.common.stunner.core.graph.command.impl.DeleteElementsCommand.DeleteCallback {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommand.java
@@ -75,6 +75,12 @@ public class DeleteNodeCommand extends AbstractCanvasGraphCommand {
         return deleteProcessor.getCommand();
     }
 
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(getCandidate()) + "]";
+    }
+
     public static class CanvasDeleteProcessor implements SafeDeleteNodeCommand.SafeDeleteNodeCommandCallback {
 
         private transient CompositeCommand<AbstractCanvasHandler, CanvasViolation> command;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DockNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DockNodeCommand.java
@@ -62,4 +62,11 @@ public class DockNodeCommand extends AbstractCanvasGraphCommand {
     public Node getCandidate() {
         return candidate;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(getCandidate()) + "," +
+                "parent=" + getUUID(getParent()) + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DrawCanvasCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DrawCanvasCommand.java
@@ -191,4 +191,9 @@ public class DrawCanvasCommand extends AbstractCanvasCommand {
                 .build()
                 .execute(context);
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
@@ -154,10 +154,9 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        final Node parent = getParent().orElse(null);
-        return getClass().getName() +
-                " [parent=" + (null != parent ? parent.getUUID() : "null") + "," +
-                " candidate=" + getUUID(candidate) + "," +
-                " shapeSet=" + shapeSetId + "]";
+        return getClass().getSimpleName() +
+                " [parent=" + getUUID(getParent().orElse(null)) + "," +
+                "candidate=" + getUUID(candidate) + "," +
+                "shapeSet=" + shapeSetId + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphNodeCommand.java
@@ -31,7 +31,6 @@ public class MorphNodeCommand extends AbstractCanvasGraphCommand {
     private MorphDefinition morphDefinition;
     private String morphTarget;
     private String shapeSetId;
-    private String oldMorphTarget;
 
     public MorphNodeCommand(final Node<? extends Definition<?>, Edge> candidate,
                             final MorphDefinition morphDefinition,
@@ -56,5 +55,11 @@ public class MorphNodeCommand extends AbstractCanvasGraphCommand {
         return new MorphCanvasNodeCommand(candidate,
                                           morphDefinition,
                                           shapeSetId);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(candidate) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/RemoveCanvasChildCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/RemoveCanvasChildCommand.java
@@ -62,8 +62,8 @@ public class RemoveCanvasChildCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [parent=" + getUUID(parent) + "," +
-                " child=" + getUUID(child) + "]";
+                "child=" + getUUID(child) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/RemoveChildCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/RemoveChildCommand.java
@@ -56,4 +56,11 @@ public class RemoveChildCommand extends AbstractCanvasGraphCommand {
     public Node getCandidate() {
         return child;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [child=" + getUUID(getCandidate()) + "," +
+                "parent=" + getUUID(getParent()) + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/ResizeNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/ResizeNodeCommand.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.command;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
+import org.kie.workbench.common.stunner.core.client.util.ShapeUtils;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.command.impl.AbstractCompositeCommand;
+import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+
+import static org.kie.workbench.common.stunner.core.graph.util.GraphUtils.getDockedNodes;
+
+public class ResizeNodeCommand extends AbstractCanvasCompositeCommand {
+
+    private final Element<? extends View> candidate;
+    private final BoundingBox boundingBox;
+    private final BiFunction<Shape, Integer, Point2D> magnetLocationProvider;
+    private final Consumer<Shape> onResize;
+
+    private double widthBefore;
+    private double heightBefore;
+
+    public ResizeNodeCommand(final Element<? extends View> candidate,
+                             final BoundingBox boundingBox,
+                             final BiFunction<Shape, Integer, Point2D> magnetLocationProvider) {
+        this(candidate, boundingBox, magnetLocationProvider, shape -> {
+        });
+    }
+
+    public ResizeNodeCommand(final Element<? extends View> candidate,
+                             final BoundingBox boundingBox,
+                             final BiFunction<Shape, Integer, Point2D> magnetLocationProvider,
+                             final Consumer<Shape> onResize) {
+        this.candidate = candidate;
+        this.boundingBox = boundingBox;
+        this.magnetLocationProvider = magnetLocationProvider;
+        this.onResize = onResize;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected AbstractCompositeCommand<AbstractCanvasHandler, CanvasViolation> initialize(final AbstractCanvasHandler context) {
+        super.initialize(context);
+
+        widthBefore = candidate.getContent().getBounds().getWidth();
+        heightBefore = candidate.getContent().getBounds().getHeight();
+        final double w = boundingBox.getMaxX();
+        final double h = boundingBox.getMaxY();
+
+        // Execute the update position and update property/ies command/s on the bean instance to achieve the new bounds.
+        final List<Command<AbstractCanvasHandler, CanvasViolation>> commands = getResizeCommands(context,
+                                                                                                 w,
+                                                                                                 h);
+        if (null != commands) {
+            final Node<View<?>, Edge> node = (Node<View<?>, Edge>) candidate;
+
+            commands.forEach(this::addCommand);
+
+            //Updating Docked nodes position
+            if (GraphUtils.hasDockedNodes(node)) {
+                updateDockedNodesPosition(context, node);
+            }
+
+            //Updating connection positions to the node
+            if (GraphUtils.hasConnections(node)) {
+                updateConnectionsPositions(context, node);
+            }
+        }
+
+        return this;
+    }
+
+    @Override
+    public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
+        final CommandResult<CanvasViolation> result = super.execute(context);
+        return postOperation(context, result, boundingBox.getMaxX(), boundingBox.getMaxY());
+    }
+
+    @Override
+    public CommandResult<CanvasViolation> undo(AbstractCanvasHandler context) {
+        final CommandResult<CanvasViolation> result = super.undo(context);
+        return postOperation(context, result, widthBefore, heightBefore);
+    }
+
+    public Element<? extends View> getCandidate() {
+        return candidate;
+    }
+
+    public BoundingBox getBoundingBox() {
+        return boundingBox;
+    }
+
+    public BiFunction<Shape, Integer, Point2D> getMagnetLocationProvider() {
+        return magnetLocationProvider;
+    }
+
+    public Consumer<Shape> getOnResize() {
+        return onResize;
+    }
+
+    CommandResult<CanvasViolation> postOperation(final AbstractCanvasHandler context,
+                                                 final CommandResult<CanvasViolation> result,
+                                                 final double width,
+                                                 final double height) {
+        if (!CommandUtils.isError(result)) {
+            final Point2D current = GraphUtils.getPosition(candidate.getContent());
+            final Bounds newBounds = Bounds.create(current.getX(),
+                                                   current.getY(),
+                                                   current.getX() + width,
+                                                   current.getY() + height);
+
+            candidate.getContent().setBounds(newBounds);
+            final ShapeView shapeView = getShape(context, candidate.getUUID()).getShapeView();
+            ShapeUtils.setSizeFromBoundingBox(shapeView, width, height);
+            onResize.accept(getShape(context, candidate.getUUID()));
+        }
+        return result;
+    }
+
+    private void updateConnectionsPositions(final AbstractCanvasHandler canvasHandler,
+                                            final Node<View<?>, Edge> node) {
+        GraphUtils.getSourceConnections(node)
+                .forEach(edge -> edge.getContent()
+                        .getSourceConnection()
+                        .ifPresent(connection -> handleConnections(canvasHandler, node, () -> connection, () -> new SetConnectionSourceNodeCommand(node, edge, connection)))
+                );
+
+        GraphUtils.getTargetConnections(node)
+                .forEach(edge -> edge.getContent()
+                        .getTargetConnection()
+                        .ifPresent(connection -> handleConnections(canvasHandler, node, () -> connection, () -> new SetConnectionTargetNodeCommand(node, edge, connection))
+                        )
+                );
+    }
+
+    private void handleConnections(final AbstractCanvasHandler canvasHandler,
+                                   final Node<View<?>, Edge> node,
+                                   final Supplier<Connection> connectionSupplier,
+                                   final Supplier<CanvasCommand<AbstractCanvasHandler>> commandSupplier) {
+        final Connection connection = connectionSupplier.get();
+        if (Objects.isNull(connection) || !(connection instanceof MagnetConnection)) {
+            return;
+        }
+
+        final MagnetConnection magnetConnection = (MagnetConnection) connection;
+        magnetConnection.getMagnetIndex().ifPresent(index -> {
+            final Shape shape = getShape(canvasHandler, node.getUUID());
+            if (null != shape) {
+                final Point2D location = magnetLocationProvider.apply(shape, index);
+                magnetConnection.setLocation(location);
+                addCommand(commandSupplier.get());
+            }
+        });
+    }
+
+    private void updateDockedNodesPosition(final AbstractCanvasHandler canvasHandler,
+                                           final Node<View<?>, Edge> node) {
+        getDockedNodes(node)
+                .stream()
+                .forEach(docked -> {
+                    final Shape shape = getShape(canvasHandler, docked.getUUID());
+                    final double dockedX = shape.getShapeView().getShapeX();
+                    final double dockedY = shape.getShapeView().getShapeY();
+                    addCommand(new UpdateElementPositionCommand(docked, new Point2D(dockedX, dockedY)));
+                });
+    }
+
+    private static Shape getShape(final AbstractCanvasHandler canvasHandler,
+                                  final String uuid) {
+        return canvasHandler.getCanvas().getShape(uuid);
+    }
+
+    /**
+     * It provides the necessary canvas commands in order to update the domain model with new values that will met
+     * the new bounding box size.
+     * It always updates the element's position, as resize can update it, and it updates as well some of the bean's properties.
+     */
+    private List<Command<AbstractCanvasHandler, CanvasViolation>> getResizeCommands(final AbstractCanvasHandler canvasHandler,
+                                                                                    final double w,
+                                                                                    final double h) {
+        final Definition content = candidate.getContent();
+        final Object def = content.getDefinition();
+        final DefinitionAdapter<Object> adapter =
+                canvasHandler.getDefinitionManager()
+                        .adapters().registry().getDefinitionAdapter(def.getClass());
+        final List<Command<AbstractCanvasHandler, CanvasViolation>> result =
+                new LinkedList<>();
+        final Object width = adapter.getMetaProperty(PropertyMetaTypes.WIDTH,
+                                                     def);
+        if (null != width) {
+            appendCommandForModelProperty(canvasHandler,
+                                          width,
+                                          w,
+                                          result);
+        }
+        final Object height = adapter.getMetaProperty(PropertyMetaTypes.HEIGHT,
+                                                      def);
+        if (null != height) {
+            appendCommandForModelProperty(canvasHandler,
+                                          height,
+                                          h,
+                                          result);
+        }
+        final Object radius = adapter.getMetaProperty(PropertyMetaTypes.RADIUS,
+                                                      def);
+        if (null != radius) {
+            final double r = w > h ? (h / 2) : (w / 2);
+            appendCommandForModelProperty(canvasHandler,
+                                          radius,
+                                          r,
+                                          result);
+        }
+        return result;
+    }
+
+    private void appendCommandForModelProperty(final AbstractCanvasHandler canvasHandler,
+                                               final Object property,
+                                               final Object value,
+                                               final List<Command<AbstractCanvasHandler, CanvasViolation>> result) {
+        final String id = canvasHandler.getDefinitionManager().adapters().forProperty().getId(property);
+        result.add(new UpdateElementPropertyCommand(candidate,
+                                                    id,
+                                                    value));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(candidate) + "," +
+                "box=" + boundingBox + "]";
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasChildNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasChildNodeCommand.java
@@ -69,8 +69,8 @@ public class SetCanvasChildNodeCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [parent=" + getUUID(parent) + "," +
-                " candidate=" + getUUID(candidate) + "]";
+                "candidate=" + getUUID(candidate) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
@@ -38,8 +38,6 @@ public class SetCanvasConnectionCommand extends AbstractCanvasCommand {
     public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
         final Node source = edge.getSourceNode();
         final Node target = edge.getTargetNode();
-        ShapeUtils.updateEdgeConnections(edge,
-                                         context);
         ShapeUtils.applyConnections(edge,
                                     context,
                                     MutationContext.STATIC);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
@@ -63,9 +63,9 @@ public class SetCanvasConnectionCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [candidate=" + getUUID(edge) + "," +
-                " sourceNode=" + getUUID(edge.getSourceNode()) + "," +
-                " targetNode=" + getUUID(edge.getTargetNode()) + "]";
+                "sourceNode=" + getUUID(edge.getSourceNode()) + "," +
+                "targetNode=" + getUUID(edge.getTargetNode()) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetChildNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetChildNodeCommand.java
@@ -52,4 +52,11 @@ public class SetChildNodeCommand extends AbstractCanvasGraphCommand {
     public Node getCandidate() {
         return candidate;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(getCandidate()) + "," +
+                "parent=" + getUUID(getParent()) + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetConnectionSourceNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetConnectionSourceNodeCommand.java
@@ -62,4 +62,12 @@ public class SetConnectionSourceNodeCommand extends AbstractCanvasGraphCommand {
     public Connection getConnection() {
         return connection;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [node=" + getUUID(getNode()) + "," +
+                "edge=" + getUUID(getEdge()) + "," +
+                "connection=" + connection + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetConnectionTargetNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetConnectionTargetNodeCommand.java
@@ -62,4 +62,12 @@ public class SetConnectionTargetNodeCommand extends AbstractCanvasGraphCommand {
     public Connection getConnection() {
         return connection;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [node=" + getUUID(getNode()) + "," +
+                "edge=" + getUUID(getEdge()) + "," +
+                "connection=" + connection + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UnDockNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UnDockNodeCommand.java
@@ -55,4 +55,11 @@ public class UnDockNodeCommand extends AbstractCanvasGraphCommand {
     public Node getCandidate() {
         return child;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [parent=" + getUUID(getParent()) + "," +
+                "child=" + getUUID(getCandidate()) + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommand.java
@@ -22,15 +22,13 @@ import java.util.stream.Stream;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasManageableControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations;
 
+import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.consumeControlPoints;
 import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.getControlPoints;
-import static org.kie.workbench.common.stunner.core.client.canvas.command.AddCanvasControlPointCommand.getManageableControlPoints;
 
 /**
  * Update a given {@link ControlPoint} position on Canvas.
@@ -61,13 +59,9 @@ public class UpdateCanvasControlPointPositionCommand extends AbstractCanvasComma
     @Override
     public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
         allow(context);
-        final HasManageableControlPoints<?> view = getManageableControlPoints(context, edge);
-        // Hide control points.
-        view.hideControlPoints();
-        // Delete the control point at the given index.
-        view.updateControlPoints(controlPoints);
-        // Show control points.
-        view.showControlPoints(HasControlPoints.ControlPointType.POINTS);
+        consumeControlPoints(context,
+                             edge,
+                             view -> view.updateControlPoints(controlPoints));
         return buildResult();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommand.java
@@ -49,7 +49,6 @@ public class UpdateCanvasControlPointPositionCommand extends AbstractCanvasComma
         oldControlPoints = Stream.of(getControlPoints(edge))
                 .map(ControlPoint::copy)
                 .toArray(ControlPoint[]::new);
-        ;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPositionCommand.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 
 import static org.kie.workbench.common.stunner.core.client.canvas.util.CanvasUtils.areBoundsExceeded;
 import static org.kie.workbench.common.stunner.core.client.canvas.util.CanvasUtils.createBoundsExceededCommandResult;
@@ -86,7 +87,8 @@ public class UpdateCanvasElementPositionCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
-                " [element=" + getUUID(element) + "]";
+        return getClass().getSimpleName() +
+                " [element=" + getUUID(element) + "," +
+                "position=" + GraphUtils.getPosition(element.getContent()) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPositionCommand.java
@@ -61,7 +61,7 @@ public class UpdateCanvasElementPositionCommand extends AbstractCanvasCommand {
         }
         context.updateElementPosition(element, MutationContext.STATIC);
         moveConnectorsToTop(context);
-        return buildResult();
+        return allowResult;
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPropertyCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPropertyCommand.java
@@ -43,7 +43,7 @@ public class UpdateCanvasElementPropertyCommand extends AbstractCanvasCommand {
 
     @Override
     public String toString() {
-        return getClass().getName() +
+        return getClass().getSimpleName() +
                 " [element=" + getUUID(element) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateChildNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateChildNodeCommand.java
@@ -96,9 +96,8 @@ public class UpdateChildNodeCommand extends AbstractCanvasCompositeCommand {
 
     @Override
     public String toString() {
-        return getClass().getName()
-                + " [parent=" + getUUID(parent)
-                + " [candidate=" + getUUID(candidate)
-                + " {" + super.toString() + "}";
+        return getClass().getSimpleName() +
+                " [parent=" + getUUID(parent) + "," +
+                "candidate=" + getUUID(candidate) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateControlPointPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateControlPointPositionCommand.java
@@ -15,13 +15,14 @@
  */
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
+import java.util.Arrays;
+
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
-import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 /**
@@ -30,36 +31,32 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 public class UpdateControlPointPositionCommand extends AbstractCanvasGraphCommand {
 
     private final Edge candidate;
-    private final ControlPoint controlPoint;
-    private final Point2D position;
+    private final ControlPoint[] controlPoints;
 
     public UpdateControlPointPositionCommand(final Edge candidate,
-                                             final ControlPoint controlPoint,
-                                             final Point2D position) {
+                                             final ControlPoint[] controlPoints) {
         this.candidate = candidate;
-        this.controlPoint = controlPoint;
-        this.position = position;
+        this.controlPoints = controlPoints;
     }
 
     @Override
     protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
-        return new org.kie.workbench.common.stunner.core.graph.command.impl.UpdateControlPointPositionCommand(candidate, controlPoint, position);
+        return new org.kie.workbench.common.stunner.core.graph.command.impl.UpdateControlPointPositionCommand(candidate.getUUID(), controlPoints);
     }
 
     @Override
     protected Command<AbstractCanvasHandler, CanvasViolation> newCanvasCommand(final AbstractCanvasHandler context) {
-        return new UpdateCanvasControlPointPositionCommand(candidate, controlPoint);
+        return new UpdateCanvasControlPointPositionCommand(candidate, controlPoints);
     }
 
     public Edge getCandidate() {
         return candidate;
     }
 
-    public ControlPoint getControlPoint() {
-        return controlPoint;
-    }
-
-    public Point2D getPosition() {
-        return position;
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [candidate=" + getUUID(getCandidate()) + "," +
+                "controlPoints=" + Arrays.toString(controlPoints) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDockNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDockNodeCommand.java
@@ -111,9 +111,8 @@ public class UpdateDockNodeCommand extends AbstractCanvasCompositeCommand {
 
     @Override
     public String toString() {
-        return getClass().getName()
-                + " [parent=" + getUUID(parent)
-                + " [candidate=" + getUUID(candidate)
-                + " {" + super.toString() + "}";
+        return getClass().getSimpleName() +
+                " [parent=" + getUUID(parent) + "," +
+                "candidate=" + getUUID(candidate) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateDomainObjectPropertyCommand.java
@@ -66,4 +66,12 @@ public class UpdateDomainObjectPropertyCommand extends AbstractCanvasGraphComman
     protected AbstractCanvasCommand newCanvasCommand(final AbstractCanvasHandler context) {
         return new RefreshPropertiesPanelCommand();
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [domainObject=" + domainObject.getDomainObjectUUID() + "," +
+                "propertyId=" + propertyId + "," +
+                "value=" + value + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateElementPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateElementPositionCommand.java
@@ -55,4 +55,11 @@ public class UpdateElementPositionCommand extends AbstractCanvasGraphCommand {
     public Point2D getLocation() {
         return location;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [element=" + getUUID(element) + "," +
+                "location=" + location + "]";
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateElementPropertyCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateElementPropertyCommand.java
@@ -41,12 +41,12 @@ public class UpdateElementPropertyCommand extends AbstractCanvasGraphCommand {
     @SuppressWarnings("unchecked")
     protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
         return (element instanceof Node ?
-            new UpdateElementPropertyValueCommand((Node) element,
-                                                  propertyId,
-                                                  value) :
-            new UpdateElementPropertyValueCommand(element.getUUID(),
-                                                  propertyId,
-                                                  value));
+                new UpdateElementPropertyValueCommand((Node) element,
+                                                      propertyId,
+                                                      value) :
+                new UpdateElementPropertyValueCommand(element.getUUID(),
+                                                      propertyId,
+                                                      value));
     }
 
     @Override
@@ -64,5 +64,13 @@ public class UpdateElementPropertyCommand extends AbstractCanvasGraphCommand {
 
     public Object getValue() {
         return value;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +
+                " [element=" + getUUID(element) + "," +
+                "propertyId=" + propertyId + "," +
+                "value=" + value + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/AbstractElementBuilderControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/AbstractElementBuilderControl.java
@@ -46,6 +46,7 @@ import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.processing.index.bounds.GraphBoundsIndexer;
@@ -58,8 +59,6 @@ import org.kie.workbench.common.stunner.core.rule.context.CardinalityContext;
 import org.kie.workbench.common.stunner.core.rule.context.impl.RuleContextBuilder;
 import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
 import org.kie.workbench.common.stunner.core.util.UUID;
-
-import static org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection.Builder.forElement;
 
 public abstract class AbstractElementBuilderControl extends AbstractCanvasHandlerControl<AbstractCanvasHandler>
         implements ElementBuilderControl<AbstractCanvasHandler> {
@@ -268,15 +267,17 @@ public abstract class AbstractElementBuilderControl extends AbstractCanvasHandle
                                    final double x,
                                    final double y,
                                    final CommandsCallback commandsCallback) {
-        //Command<AbstractCanvasHandler, CanvasViolation> command = null;
         final List<Command<AbstractCanvasHandler, CanvasViolation>> commandList = new LinkedList<>();
         if (element instanceof Node) {
             final Node<View<?>, Edge> node = (Node<View<?>, Edge>) element;
             commandList.addAll(getNodeBuildCommands(node, parent, parentAssignment, x, y));
         } else if (element instanceof Edge && null != parent) {
-            commandList.add(canvasCommandFactory.addConnector(parent, (Edge) element, forElement(parent), getShapeSetId()));
+            commandList.add(canvasCommandFactory.addConnector(parent,
+                                                              (Edge) element,
+                                                              MagnetConnection.Builder.atCenter(parent),
+                                                              getShapeSetId()));
         } else {
-            throw new RuntimeException("Unrecognized element type for " + element);
+            throw new IllegalStateException("Unrecognized element type for " + element);
         }
 
         commandsCallback.onComplete(element.getUUID(), commandList);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/EdgeBuilderControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/builder/impl/EdgeBuilderControlImpl.java
@@ -76,7 +76,7 @@ public class EdgeBuilderControlImpl
             final CommandResult<CanvasViolation> cr1 = getCommandManager().allow(wch,
                                                                                  commandFactory.setSourceNode(inNode,
                                                                                                               edge,
-                                                                                                              MagnetConnection.Builder.forElement(inNode)));
+                                                                                                              MagnetConnection.Builder.forTarget(inNode, outNode)));
             allowsSourceConn = isAllowed(cr1);
         }
         boolean allowsTargetConn = true;
@@ -84,7 +84,7 @@ public class EdgeBuilderControlImpl
             final CommandResult<CanvasViolation> cr2 = getCommandManager().allow(wch,
                                                                                  commandFactory.setTargetNode(outNode,
                                                                                                               edge,
-                                                                                                              MagnetConnection.Builder.forElement(outNode)));
+                                                                                                              MagnetConnection.Builder.forTarget(outNode, inNode)));
             allowsTargetConn = isAllowed(cr2);
         }
         return allowsSourceConn & allowsTargetConn;
@@ -108,12 +108,12 @@ public class EdgeBuilderControlImpl
         final CompositeCommand.Builder commandBuilder = new CompositeCommand.Builder()
                 .addCommand(commandFactory.addConnector(inNode,
                                                         edge,
-                                                        MagnetConnection.Builder.forElement(inNode),
+                                                        MagnetConnection.Builder.forTarget(inNode, outNode),
                                                         ssid));
         if (null != outNode) {
             commandBuilder.addCommand(commandFactory.setTargetNode(outNode,
                                                                    edge,
-                                                                   MagnetConnection.Builder.forElement(outNode)));
+                                                                   MagnetConnection.Builder.forTarget(outNode, inNode)));
         }
         final CommandResult<CanvasViolation> results = getCommandManager().execute(wch,
                                                                                    commandBuilder.build());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/shortcut/AbstractAppendNodeShortcut.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/keyboard/shortcut/AbstractAppendNodeShortcut.java
@@ -18,8 +18,6 @@ package org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.sh
 
 import java.util.Set;
 
-import javax.inject.Inject;
-
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.GeneralCreateNodeAction;
@@ -36,7 +34,6 @@ public abstract class AbstractAppendNodeShortcut implements KeyboardShortcut<Abs
 
     private GeneralCreateNodeAction generalCreateNodeAction;
 
-    @Inject
     public AbstractAppendNodeShortcut(final ToolboxDomainLookups toolboxDomainLookups,
                                       final DefinitionsCacheRegistry definitionsCacheRegistry,
                                       final GeneralCreateNodeAction generalCreateNodeAction) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/util/CanvasUtils.java
@@ -43,7 +43,7 @@ public class CanvasUtils {
                                                                              .setUUID(canvasHandler.getUuid()));
 
         return new CommandResultImpl<>(
-                CommandResult.Type.ERROR,
+                CommandResult.Type.WARNING,
                 Collections.singleton(cv)
         );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/AbstractSessionCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/AbstractSessionCommandManager.java
@@ -173,8 +173,7 @@ public abstract class AbstractSessionCommandManager
         this.listener = listener;
     }
 
-    @SuppressWarnings("unchecked")
-    protected CommandManager<AbstractCanvasHandler, CanvasViolation> setDelegateListener(final CommandListener<AbstractCanvasHandler, CanvasViolation> listener) {
+    protected CanvasCommandManager<AbstractCanvasHandler> getDelegateCommandManager() {
         final ClientSession<AbstractCanvas, AbstractCanvasHandler> session = getCurrentSession();
         CanvasCommandManager<AbstractCanvasHandler> commandManager = null;
         if (session instanceof EditorSession) {
@@ -182,6 +181,12 @@ public abstract class AbstractSessionCommandManager
         } else if (session instanceof ViewerSession) {
             commandManager = ((ViewerSession) session).getCommandManager();
         }
+        return commandManager;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected CommandManager<AbstractCanvasHandler, CanvasViolation> setDelegateListener(final CommandListener<AbstractCanvasHandler, CanvasViolation> listener) {
+        CanvasCommandManager<AbstractCanvasHandler> commandManager = getDelegateCommandManager();
         if (commandManager != null) {
             final HasCommandListener<CommandListener<AbstractCanvasHandler, CanvasViolation>> hasCommandListener =
                     (HasCommandListener<CommandListener<AbstractCanvasHandler, CanvasViolation>>) commandManager;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseDownEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.mouse.CanvasMouseUpEvent;
 import org.kie.workbench.common.stunner.core.client.session.event.SessionDestroyedEvent;
@@ -59,21 +60,22 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
     private final SessionManager sessionManager;
     private Stack<Command<AbstractCanvasHandler, CanvasViolation>> commands;
 
-    private boolean roolback;
+    private boolean rollback;
 
+    // CDI proxy.
     protected RequestCommandManager() {
         this(null);
-    }
-
-    @Inject
-    public RequestCommandManager(final SessionManager sessionManager) {
-        this.sessionManager = sessionManager;
-        this.roolback = false;
     }
 
     @Override
     protected SessionManager getClientSessionManager() {
         return sessionManager;
+    }
+
+    @Inject
+    public RequestCommandManager(final SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+        this.rollback = false;
     }
 
     @Override
@@ -104,12 +106,8 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
                 public void onExecute(final AbstractCanvasHandler context,
                                       final Command<AbstractCanvasHandler, CanvasViolation> command,
                                       final CommandResult<CanvasViolation> result) {
-                    LOGGER.log(Level.FINEST,
-                               "Adding command [" + command + "] into current request command builder.");
                     if (CommandUtils.isError(result)) {
-                        LOGGER.log(Level.FINEST,
-                                   "Command failed - rollback");
-                        roolback = true;
+                        rollback = true;
                     } else if (commands != null) {
                         commands.push(command);
                     } else {
@@ -193,10 +191,8 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
                                "A new client request cannot be started!");
             clear();
         }
-        LOGGER.log(Level.FINEST,
-                   "New client request started.");
         commands = new Stack<>();
-        roolback = false;
+        rollback = false;
     }
 
     /**
@@ -206,21 +202,16 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
     private void complete() {
         if (isRequestStarted()) {
             final boolean hasCommands = !commands.isEmpty();
-            if (hasCommands && roolback) {
-                LOGGER.log(Level.FINEST,
-                           "Performing rollback for commands in current requrest.");
+            if (hasCommands && rollback) {
                 final AbstractCanvasHandler canvasHandler = getCurrentSession().getCanvasHandler();
                 commands.forEach(c -> c.undo(canvasHandler));
             } else if (hasCommands) {
                 // If any commands have been aggregated, let's composite them and add into the registry.
-                LOGGER.log(Level.FINEST,
-                           "Adding commands for current request into registry [size=" + commands.size() + "]");
                 getRegistry().register(new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
+                                               .forward() // PLEASE DO NOT CHANGE THIS!
                                                .addCommands(new ArrayList<>(commands))
                                                .build());
             }
-            LOGGER.log(Level.FINEST,
-                       "Current client request completed.");
         } else {
             LOGGER.log(Level.WARNING,
                        "Current client request has not been started.");
@@ -238,6 +229,10 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
             commands.clear();
             commands = null;
         }
-        roolback = false;
+        rollback = false;
+    }
+
+    private CanvasHandler getCurrentCanvasHandler() {
+        return getClientSessionManager().getCurrentSession().getCanvasHandler();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManager.java
@@ -207,8 +207,12 @@ public class RequestCommandManager extends AbstractSessionCommandManager {
                 commands.forEach(c -> c.undo(canvasHandler));
             } else if (hasCommands) {
                 // If any commands have been aggregated, let's composite them and add into the registry.
+                // Notice the composite command is set to the default "reverse" undo order. So it means
+                // that any component that relies on RequestCommandManager must consider that commands will
+                // be undo in the reverse order. Otherwise, each component should composite the commands to execute
+                // and set the desired undo order in it's state, and finally perform the execution via this command manager.
                 getRegistry().register(new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
-                                               .forward() // PLEASE DO NOT CHANGE THIS!
+                                               .forward() // PLEASE DO NOT CHANGE THIS, see comment above.
                                                .addCommands(new ArrayList<>(commands))
                                                .build());
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/drag/NodeDragProxyImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/drag/NodeDragProxyImpl.java
@@ -123,8 +123,8 @@ public class NodeDragProxyImpl implements NodeDragProxy<AbstractCanvasHandler> {
 
                                        private MagnetConnection[] createShapeConnections() {
                                            return new MagnetConnection[]{
-                                                   MagnetConnection.Builder.forElement(inEdgeSourceNode),
-                                                   MagnetConnection.Builder.forElement(node)
+                                                   MagnetConnection.Builder.forTarget(inEdgeSourceNode, node),
+                                                   MagnetConnection.Builder.forTarget(node, inEdgeSourceNode)
                                            };
                                        }
                                    });

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/AbstractToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/AbstractToolboxAction.java
@@ -57,6 +57,10 @@ public abstract class AbstractToolboxAction implements ToolboxAction<AbstractCan
                 definitionUtils.getTitle(titleDefinitionId);
     }
 
+    protected DefinitionUtils getDefinitionUtils() {
+        return definitionUtils;
+    }
+
     @Override
     public Glyph getGlyph(final AbstractCanvasHandler canvasHandler,
                           final String uuid) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CommonActionsToolboxFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CommonActionsToolboxFactory.java
@@ -44,14 +44,14 @@ public class CommonActionsToolboxFactory
         extends AbstractActionsToolboxFactory {
 
     private final CanvasCommandFactory<AbstractCanvasHandler> commandFactory;
-    private final Supplier<DeleteNodeAction> deleteNodeActions;
+    private final Supplier<DeleteNodeToolboxAction> deleteNodeActions;
     private final Command deleteNodeActionsDestroyer;
     private final Supplier<ActionsToolboxView> views;
     private final Command viewsDestroyer;
 
     @Inject
     public CommonActionsToolboxFactory(final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
-                                       final @Any ManagedInstance<DeleteNodeAction> deleteNodeActions,
+                                       final @Any ManagedInstance<DeleteNodeToolboxAction> deleteNodeActions,
                                        final @Any @CommonActionsToolbox ManagedInstance<ActionsToolboxView> views) {
         this(commandFactory,
              deleteNodeActions::get,
@@ -61,7 +61,7 @@ public class CommonActionsToolboxFactory
     }
 
     CommonActionsToolboxFactory(final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
-                                final Supplier<DeleteNodeAction> deleteNodeActions,
+                                final Supplier<DeleteNodeToolboxAction> deleteNodeActions,
                                 final Command deleteNodeActionsDestroyer,
                                 final Supplier<ActionsToolboxView> views,
                                 final Command viewsDestroyer) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateConnectorToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateConnectorToolboxAction.java
@@ -57,9 +57,9 @@ import org.kie.workbench.common.stunner.core.util.UUID;
  * toolbox's related node, to any other candidate canvas' node.
  */
 @Dependent
-public class CreateConnectorAction extends AbstractToolboxAction {
+public class CreateConnectorToolboxAction extends AbstractToolboxAction {
 
-    private static Logger LOGGER = Logger.getLogger(CreateConnectorAction.class.getName());
+    private static Logger LOGGER = Logger.getLogger(CreateConnectorToolboxAction.class.getName());
     static final String KEY_TITLE = "org.kie.workbench.common.stunner.core.client.toolbox.createNewConnector";
 
     private final ClientFactoryManager clientFactoryManager;
@@ -74,13 +74,13 @@ public class CreateConnectorAction extends AbstractToolboxAction {
     private DragProxy<AbstractCanvasHandler, ConnectorDragProxy.Item, DragProxyCallback> dragProxy;
 
     @Inject
-    public CreateConnectorAction(final DefinitionUtils definitionUtils,
-                                 final ClientFactoryManager clientFactoryManager,
-                                 final GraphBoundsIndexer graphBoundsIndexer,
-                                 final ConnectorDragProxy<AbstractCanvasHandler> connectorDragProxyFactory,
-                                 final EdgeBuilderControl<AbstractCanvasHandler> edgeBuilderControl,
-                                 final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                 final ClientTranslationService translationService) {
+    public CreateConnectorToolboxAction(final DefinitionUtils definitionUtils,
+                                        final ClientFactoryManager clientFactoryManager,
+                                        final GraphBoundsIndexer graphBoundsIndexer,
+                                        final ConnectorDragProxy<AbstractCanvasHandler> connectorDragProxyFactory,
+                                        final EdgeBuilderControl<AbstractCanvasHandler> edgeBuilderControl,
+                                        final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                        final ClientTranslationService translationService) {
         this(definitionUtils,
              clientFactoryManager,
              graphBoundsIndexer,
@@ -91,14 +91,14 @@ public class CreateConnectorAction extends AbstractToolboxAction {
              CanvasHighlight::new);
     }
 
-    CreateConnectorAction(final DefinitionUtils definitionUtils,
-                          final ClientFactoryManager clientFactoryManager,
-                          final GraphBoundsIndexer graphBoundsIndexer,
-                          final ConnectorDragProxy<AbstractCanvasHandler> connectorDragProxyFactory,
-                          final EdgeBuilderControl<AbstractCanvasHandler> edgeBuilderControl,
-                          final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                          final ClientTranslationService translationService,
-                          final Function<AbstractCanvasHandler, CanvasHighlight> canvasHighlightBuilder) {
+    CreateConnectorToolboxAction(final DefinitionUtils definitionUtils,
+                                 final ClientFactoryManager clientFactoryManager,
+                                 final GraphBoundsIndexer graphBoundsIndexer,
+                                 final ConnectorDragProxy<AbstractCanvasHandler> connectorDragProxyFactory,
+                                 final EdgeBuilderControl<AbstractCanvasHandler> edgeBuilderControl,
+                                 final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                 final ClientTranslationService translationService,
+                                 final Function<AbstractCanvasHandler, CanvasHighlight> canvasHighlightBuilder) {
         super(definitionUtils,
               translationService);
         this.clientFactoryManager = clientFactoryManager;
@@ -109,7 +109,7 @@ public class CreateConnectorAction extends AbstractToolboxAction {
         this.canvasHighlightBuilder = canvasHighlightBuilder;
     }
 
-    public CreateConnectorAction setEdgeId(final String edgeId) {
+    public CreateConnectorToolboxAction setEdgeId(final String edgeId) {
         this.edgeId = edgeId;
         return this;
     }
@@ -341,8 +341,8 @@ public class CreateConnectorAction extends AbstractToolboxAction {
 
     @Override
     public boolean equals(final Object o) {
-        if (o instanceof CreateConnectorAction) {
-            CreateConnectorAction other = (CreateConnectorAction) o;
+        if (o instanceof CreateConnectorToolboxAction) {
+            CreateConnectorToolboxAction other = (CreateConnectorToolboxAction) o;
             return other.edgeId.equals(edgeId);
         }
         return false;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/DefaultCreateNodeAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/DefaultCreateNodeAction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.components.toolbox.actions;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.api.ClientFactoryManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.Session;
+
+@Dependent
+@Default
+public class DefaultCreateNodeAction extends GeneralCreateNodeAction {
+
+    @Inject
+    public DefaultCreateNodeAction(final ClientFactoryManager clientFactoryManager,
+                                   final CanvasLayoutUtils canvasLayoutUtils,
+                                   final Event<CanvasSelectionEvent> selectionEvent,
+                                   final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                   final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory) {
+        super(clientFactoryManager,
+              canvasLayoutUtils,
+              selectionEvent,
+              sessionCommandManager,
+              canvasCommandFactory);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/DeleteNodeToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/DeleteNodeToolboxAction.java
@@ -40,19 +40,19 @@ import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
  * A toolbox action/operation for deleting an Element.
  */
 @Dependent
-public class DeleteNodeAction implements ToolboxAction<AbstractCanvasHandler> {
+public class DeleteNodeToolboxAction implements ToolboxAction<AbstractCanvasHandler> {
 
     private final ClientTranslationService translationService;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private final CanvasCommandFactory<AbstractCanvasHandler> commandFactory;
-    private final Predicate<DeleteNodeAction> confirmDelete;
+    private final Predicate<DeleteNodeToolboxAction> confirmDelete;
     private final Event<CanvasClearSelectionEvent> clearSelectionEvent;
 
     @Inject
-    public DeleteNodeAction(final ClientTranslationService translationService,
-                            final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                            final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
-                            final Event<CanvasClearSelectionEvent> clearSelectionEvent) {
+    public DeleteNodeToolboxAction(final ClientTranslationService translationService,
+                                   final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                   final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
+                                   final Event<CanvasClearSelectionEvent> clearSelectionEvent) {
         this(translationService,
              sessionCommandManager,
              commandFactory,
@@ -60,11 +60,11 @@ public class DeleteNodeAction implements ToolboxAction<AbstractCanvasHandler> {
              clearSelectionEvent);
     }
 
-    DeleteNodeAction(final ClientTranslationService translationService,
-                     final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                     final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
-                     final Predicate<DeleteNodeAction> confirmDelete,
-                     final Event<CanvasClearSelectionEvent> clearSelectionEvent) {
+    DeleteNodeToolboxAction(final ClientTranslationService translationService,
+                            final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                            final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
+                            final Predicate<DeleteNodeToolboxAction> confirmDelete,
+                            final Event<CanvasClearSelectionEvent> clearSelectionEvent) {
         this.translationService = translationService;
         this.sessionCommandManager = sessionCommandManager;
         this.commandFactory = commandFactory;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactory.java
@@ -59,9 +59,9 @@ public class FlowActionsToolboxFactory
 
     private final ToolboxDomainLookups toolboxDomainLookups;
     private final DomainProfileManager profileManager;
-    private final Supplier<CreateConnectorAction> createConnectorActions;
+    private final Supplier<CreateConnectorToolboxAction> createConnectorActions;
     private final Command createConnectorActionsDestroyer;
-    private final Supplier<CreateNodeAction> createNodeActions;
+    private final Supplier<CreateNodeToolboxAction> createNodeActions;
     private final Command createNodeActionsDestroyer;
     private final Supplier<ActionsToolboxView> views;
     private final Command viewsDestroyer;
@@ -69,8 +69,8 @@ public class FlowActionsToolboxFactory
     @Inject
     public FlowActionsToolboxFactory(final ToolboxDomainLookups toolboxDomainLookups,
                                      final DomainProfileManager profileManager,
-                                     final @Any ManagedInstance<CreateConnectorAction> createConnectorActions,
-                                     final @Any @FlowActionsToolbox ManagedInstance<CreateNodeAction> createNodeActions,
+                                     final @Any ManagedInstance<CreateConnectorToolboxAction> createConnectorActions,
+                                     final @Any @FlowActionsToolbox ManagedInstance<CreateNodeToolboxAction> createNodeActions,
                                      final @Any @FlowActionsToolbox ManagedInstance<ActionsToolboxView> views) {
         this(toolboxDomainLookups,
              profileManager,
@@ -84,9 +84,9 @@ public class FlowActionsToolboxFactory
 
     FlowActionsToolboxFactory(final ToolboxDomainLookups toolboxDomainLookups,
                               final DomainProfileManager profileManager,
-                              final Supplier<CreateConnectorAction> createConnectorActions,
+                              final Supplier<CreateConnectorToolboxAction> createConnectorActions,
                               final Command createConnectorActionsDestroyer,
-                              final Supplier<CreateNodeAction> createNodeActions,
+                              final Supplier<CreateNodeToolboxAction> createNodeActions,
                               final Command createNodeActionsDestroyer,
                               final Supplier<ActionsToolboxView> views,
                               final Command viewsDestroyer) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/GeneralCreateNodeAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/GeneralCreateNodeAction.java
@@ -62,6 +62,7 @@ public abstract class GeneralCreateNodeAction implements CreateNodeAction<Abstra
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void executeAction(final AbstractCanvasHandler canvasHandler,
                               final String sourceNodeId,
                               final String targetNodeId,
@@ -126,8 +127,13 @@ public abstract class GeneralCreateNodeAction implements CreateNodeAction<Abstra
                                                          final Edge<? extends ViewConnector<?>, Node> connector) {
         return canvasCommandFactory.addConnector(sourceNode,
                                                  connector,
-                                                 MagnetConnection.Builder.forElement(sourceNode, targetNode),
+                                                 buildConnectionBetween(sourceNode, targetNode),
                                                  canvasHandler.getDiagram().getMetadata().getShapeSetId());
+    }
+
+    protected MagnetConnection buildConnectionBetween(final Node<View<?>, Edge> sourceNode,
+                                                      final Node<View<?>, Edge> targetNode) {
+        return MagnetConnection.Builder.forTarget(sourceNode, targetNode);
     }
 
     private CanvasCommand<AbstractCanvasHandler> setEdgeTarget(final Edge<? extends ViewConnector<?>, Node> connector,
@@ -135,7 +141,7 @@ public abstract class GeneralCreateNodeAction implements CreateNodeAction<Abstra
                                                                final Node<View<?>, Edge> sourceNode) {
         return canvasCommandFactory.setTargetNode(targetNode,
                                                   connector,
-                                                  MagnetConnection.Builder.forElement(targetNode, sourceNode));
+                                                  buildConnectionBetween(targetNode, sourceNode));
     }
 
     private CanvasCommand<AbstractCanvasHandler> addNode(final CanvasHandler canvasHandler,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactory.java
@@ -52,7 +52,7 @@ public class MorphActionsToolboxFactory
 
     private final DefinitionUtils definitionUtils;
     private final DomainProfileManager profileManager;
-    private final Supplier<MorphNodeAction> morphNodeActions;
+    private final Supplier<MorphNodeToolboxAction> morphNodeActions;
     private final Command morphNodeActionsDestroyer;
     private final Supplier<ActionsToolboxView> views;
     private final Command viewsDestroyer;
@@ -60,7 +60,7 @@ public class MorphActionsToolboxFactory
     @Inject
     public MorphActionsToolboxFactory(final DefinitionUtils definitionUtils,
                                       final DomainProfileManager profileManager,
-                                      final @Any ManagedInstance<MorphNodeAction> morphNodeActions,
+                                      final @Any ManagedInstance<MorphNodeToolboxAction> morphNodeActions,
                                       final @Any @MorphActionsToolbox ManagedInstance<ActionsToolboxView> views) {
         this(definitionUtils,
              profileManager,
@@ -72,7 +72,7 @@ public class MorphActionsToolboxFactory
 
     MorphActionsToolboxFactory(final DefinitionUtils definitionUtils,
                                final DomainProfileManager profileManager,
-                               final Supplier<MorphNodeAction> morphNodeActions,
+                               final Supplier<MorphNodeToolboxAction> morphNodeActions,
                                final Command morphNodeActionsDestroyer,
                                final Supplier<ActionsToolboxView> views,
                                final Command viewsDestroyer) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphNodeToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphNodeToolboxAction.java
@@ -47,9 +47,9 @@ import org.kie.workbench.common.stunner.core.util.HashUtil;
  * A toolbox action/operation for an Element in order to morph it into another one.
  */
 @Dependent
-public class MorphNodeAction extends AbstractToolboxAction {
+public class MorphNodeToolboxAction extends AbstractToolboxAction {
 
-    private static Logger LOGGER = Logger.getLogger(MorphNodeAction.class.getName());
+    private static Logger LOGGER = Logger.getLogger(MorphNodeToolboxAction.class.getName());
     static final String KEY_TITLE = "org.kie.workbench.common.stunner.core.client.toolbox.morphInto";
 
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
@@ -61,12 +61,12 @@ public class MorphNodeAction extends AbstractToolboxAction {
     private String targetDefinitionId;
 
     @Inject
-    public MorphNodeAction(final DefinitionUtils definitionUtils,
-                           final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                           final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
-                           final ClientTranslationService translationService,
-                           final Event<CanvasSelectionEvent> selectionEvent,
-                           final Event<CanvasClearSelectionEvent> clearSelectionEventEvent) {
+    public MorphNodeToolboxAction(final DefinitionUtils definitionUtils,
+                                  final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                  final CanvasCommandFactory<AbstractCanvasHandler> commandFactory,
+                                  final ClientTranslationService translationService,
+                                  final Event<CanvasSelectionEvent> selectionEvent,
+                                  final Event<CanvasClearSelectionEvent> clearSelectionEventEvent) {
         super(definitionUtils,
               translationService);
         this.sessionCommandManager = sessionCommandManager;
@@ -75,12 +75,12 @@ public class MorphNodeAction extends AbstractToolboxAction {
         this.clearSelectionEventEvent = clearSelectionEventEvent;
     }
 
-    public MorphNodeAction setMorphDefinition(final MorphDefinition morphDefinition) {
+    public MorphNodeToolboxAction setMorphDefinition(final MorphDefinition morphDefinition) {
         this.morphDefinition = morphDefinition;
         return this;
     }
 
-    public MorphNodeAction setTargetDefinitionId(final String targetDefinitionId) {
+    public MorphNodeToolboxAction setTargetDefinitionId(final String targetDefinitionId) {
         this.targetDefinitionId = targetDefinitionId;
         return this;
     }
@@ -148,8 +148,8 @@ public class MorphNodeAction extends AbstractToolboxAction {
 
     @Override
     public boolean equals(final Object o) {
-        if (o instanceof MorphNodeAction) {
-            MorphNodeAction other = (MorphNodeAction) o;
+        if (o instanceof MorphNodeToolboxAction) {
+            MorphNodeToolboxAction other = (MorphNodeToolboxAction) o;
             return other.morphDefinition.equals(morphDefinition) &&
                     other.targetDefinitionId.equals(targetDefinitionId);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ConnectorShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ConnectorShape.java
@@ -16,20 +16,16 @@
 
 package org.kie.workbench.common.stunner.core.client.shape.impl;
 
-import java.util.List;
-
 import org.kie.workbench.common.stunner.core.client.shape.EdgeShape;
 import org.kie.workbench.common.stunner.core.client.shape.Lifecycle;
 import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
 import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasManageableControlPoints;
 import org.kie.workbench.common.stunner.core.client.shape.view.IsConnector;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.definition.shape.ShapeViewDef;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
-import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 
 /**
@@ -77,31 +73,6 @@ public class ConnectorShape<W, D extends ShapeViewDef<W, V>, V extends ShapeView
                           sourceConnection,
                           target,
                           targetConnection);
-    }
-
-    @SuppressWarnings("unchecked")
-    public List<ControlPoint> getControlPoints() {
-        return getShapeViewWithControlPoints().getShapeControlPoints();
-    }
-
-    @SuppressWarnings("unchecked")
-    public List<ControlPoint> addControlPoints(final ControlPoint... controlPoints) {
-        return getShapeViewWithControlPoints().addControlPoints(controlPoints);
-    }
-
-    public void removeControlPoints(final ControlPoint... controlPoints) {
-        getShapeViewWithControlPoints().removeControlPoints(controlPoints);
-    }
-
-    public void updateControlPoint(final ControlPoint controlPoint) {
-        getShapeViewWithControlPoints().updateControlPoint(controlPoint);
-    }
-
-    private HasManageableControlPoints getShapeViewWithControlPoints() {
-        if (!(getShapeView() instanceof HasManageableControlPoints)) {
-            throw new IllegalArgumentException("ShapeView should be a HasManageableControlPoints. " + getShapeView());
-        }
-        return (HasManageableControlPoints) getShapeView();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/SizeHandler.java
@@ -22,6 +22,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.HasRadius;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeViewHandler;
+import org.kie.workbench.common.stunner.core.client.util.ShapeUtils;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 /**
@@ -105,9 +106,7 @@ public class SizeHandler<W, V extends ShapeView> implements ShapeViewHandler<Vie
         if (view instanceof HasRadius) {
             final Double beanRadius = radiusProvider.apply(bean);
             final double radius = null != beanRadius ? beanRadius :
-                    (boundsWidth > boundsHeight ?
-                            boundsWidth / 2 :
-                            boundsHeight / 2);
+                    ShapeUtils.getRadiusForBoundingBox(boundsWidth, boundsHeight);
             final Double minRadius = minRadiusProvider.apply(bean);
             final Double maxRadius = maxRadiusProvider.apply(bean);
             if (radius > 0) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtils.java
@@ -32,6 +32,8 @@ import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
 import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasDragBounds;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasRadius;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasSize;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -139,6 +141,24 @@ public class ShapeUtils {
         // Update connector's view.
         connectorIds.forEach(id -> moveShapeToTop(canvasHandler,
                                                   id));
+    }
+
+    public static double getRadiusForBoundingBox(final double width,
+                                                 final double height) {
+        return (width > height ?
+                width / 2 :
+                height / 2);
+    }
+
+    public static void setSizeFromBoundingBox(final ShapeView view,
+                                              final double boundingBoxWidth,
+                                              final double boundingBoxHeight) {
+        if (view instanceof HasSize) {
+            ((HasSize) view).setSize(boundingBoxWidth, boundingBoxHeight);
+        } else if (view instanceof HasRadius) {
+            final double radius = getRadiusForBoundingBox(boundingBoxWidth, boundingBoxHeight);
+            ((HasRadius) view).setRadius(radius);
+        }
     }
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtils.java
@@ -49,8 +49,8 @@ import org.kie.workbench.common.stunner.core.graph.processing.traverse.tree.Tree
 public class ShapeUtils {
 
     @SuppressWarnings("unchecked")
-    public static void applyConnections(final Edge<?, ?> edge,
-                                        final CanvasHandler canvasHandler,
+    public static void applyConnections(final Edge<? extends ViewConnector<?>, Node> edge,
+                                        final AbstractCanvasHandler canvasHandler,
                                         final MutationContext mutationContext) {
         final Canvas<?> canvas = canvasHandler.getCanvas();
         final Node sourceNode = edge.getSourceNode();
@@ -62,6 +62,7 @@ public class ShapeUtils {
                                    source != null ? source.getShapeView() : null,
                                    target != null ? target.getShapeView() : null,
                                    mutationContext);
+        updateEdgeConnections(edge, canvasHandler);
     }
 
     public static ConnectorShape getConnectorShape(Edge edge, CanvasHandler canvasHandler) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtils.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.shape.EdgeShape;
 import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
-import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
 import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasDragBounds;
@@ -39,7 +38,6 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
 import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
-import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
@@ -66,35 +64,9 @@ public class ShapeUtils {
                                    mutationContext);
     }
 
-    public static List<ControlPoint> addControlPoints(final Edge edge, final CanvasHandler canvasHandler, final ControlPoint... controlPoints) {
-        return getConnectorShape(edge, canvasHandler).addControlPoints(controlPoints);
-    }
-
-    private static ConnectorShape getConnectorShape(Edge edge, CanvasHandler canvasHandler) {
+    public static ConnectorShape getConnectorShape(Edge edge, CanvasHandler canvasHandler) {
         validateConnector(edge);
         return (ConnectorShape) canvasHandler.getCanvas().getShape(edge.getUUID());
-    }
-
-    public static void removeControlPoints(final Edge edge, final CanvasHandler canvasHandler, final ControlPoint... controlPoints) {
-        getConnectorShape(edge, canvasHandler).removeControlPoints(controlPoints);
-    }
-
-    public static void updateControlPoint(final Edge edge,
-                                          final CanvasHandler canvasHandler,
-                                          final ControlPoint controlPoint) {
-        getConnectorShape(edge, canvasHandler).updateControlPoint(controlPoint);
-    }
-
-    public static List<ControlPoint> getControlPoints(final Edge edge, final CanvasHandler canvasHandler) {
-        return getConnectorShape(edge, canvasHandler).getControlPoints();
-    }
-
-    public static void hideControlPoints(final Edge edge, final CanvasHandler canvasHandler) {
-        getConnectorShape(edge, canvasHandler).applyState(ShapeState.NONE);
-    }
-
-    public static void showControlPoints(final Edge edge, final CanvasHandler canvasHandler) {
-        getConnectorShape(edge, canvasHandler).applyState(ShapeState.SELECTED);
     }
 
     private static void validateConnector(Edge edge) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/StunnerClientLogger.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/util/StunnerClientLogger.java
@@ -221,12 +221,34 @@ public class StunnerClientLogger {
         }
     }
 
+    public static void logTask(Level toLevel,
+                               Runnable task) {
+        Level level = getStunnerLogger().getLevel();
+        getStunnerLogger().setLevel(toLevel);
+        task.run();
+        getStunnerLogger().setLevel(level);
+    }
+
+    public static int switchToLogLevel(Level toLevel) {
+        final int idx = getCurrentLoggerLevelIndex();
+        getStunnerLogger().setLevel(toLevel);
+        return idx;
+    }
+
     public static void switchLogLevel() {
-        final Level level = Logger.getLogger("org.kie.workbench.common.stunner").getLevel();
-        final int idx = getLevelIndex(level);
+        final int idx = getCurrentLoggerLevelIndex();
         final Level newLevel = (idx > -1 && ((idx + 1) < LOG_LEVELS.length)) ? LOG_LEVELS[idx + 1] : LOG_LEVELS[0];
         GWT.log("*** Switching to log level: " + newLevel.toString());
-        Logger.getLogger("org.kie.workbench.common.stunner").setLevel(newLevel);
+        getStunnerLogger().setLevel(newLevel);
+    }
+
+    private static int getCurrentLoggerLevelIndex() {
+        final Level level = getStunnerLogger().getLevel();
+        return getLevelIndex(level);
+    }
+
+    private static Logger getStunnerLogger() {
+        return Logger.getLogger("org.kie.workbench.common.stunner");
     }
 
     private static final Level[] LOG_LEVELS = new Level[]{

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasControlPointCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasControlPointCommandTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.client.canvas.command;
 import org.junit.Before;
 import org.kie.workbench.common.stunner.core.client.shape.ConnectorViewStub;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
@@ -28,8 +29,13 @@ import org.kie.workbench.common.stunner.core.graph.impl.EdgeImpl;
 import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.Mock;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractCanvasControlPointCommandTest extends AbstractCanvasCommandTest {
@@ -67,5 +73,16 @@ public abstract class AbstractCanvasControlPointCommandTest extends AbstractCanv
         controlPoints = new ControlPoint[]{controlPoint1, controlPoint2, controlPoint3};
         viewConnector.setControlPoints(controlPoints);
         when(connectorView.getManageableControlPoints()).thenReturn(controlPoints);
+        when(connectorView.areControlsVisible()).thenReturn(true);
+    }
+
+    protected void checkControlPointsVisibilitySwitch(boolean areControlPointsVisible) {
+        if (areControlPointsVisible) {
+            verify(connectorView, times(1)).hideControlPoints();
+            verify(connectorView, times(1)).showControlPoints(eq(HasControlPoints.ControlPointType.POINTS));
+        } else {
+            verify(connectorView, never()).hideControlPoints();
+            verify(connectorView, never()).showControlPoints(any(HasControlPoints.ControlPointType.class));
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasControlPointCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasControlPointCommandTest.java
@@ -16,57 +16,56 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.command;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Before;
+import org.kie.workbench.common.stunner.core.client.shape.ConnectorViewStub;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
-import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
-import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnectorImpl;
+import org.kie.workbench.common.stunner.core.graph.impl.EdgeImpl;
 import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.Mock;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractCanvasControlPointCommandTest extends AbstractCanvasCommandTest {
 
-    protected ControlPoint controlPoint1;
-
-    protected ControlPoint controlPoint2;
-
-    protected Point2D location1;
-
     private static final String EDGE_UUID = UUID.uuid();
-
-    @Mock
-    protected Edge edge;
 
     @Mock
     protected ConnectorShape shape;
 
-    @Mock
-    protected ShapeView shapeView;
-
-    @Mock
-    private ViewConnector viewConnector;
-
-    protected List<ControlPoint> controlPointList;
+    protected Edge edge;
+    protected ViewConnector viewConnector;
+    protected ControlPoint[] controlPoints;
+    protected ControlPoint controlPoint1;
+    protected ControlPoint controlPoint2;
+    protected ControlPoint controlPoint3;
+    protected ConnectorViewStub connectorView;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         super.setUp();
-        location1 = new Point2D(0, 0);
-        controlPoint1 = ControlPoint.build(location1);
-        controlPoint2 = ControlPoint.build(location1, 1);
-        controlPointList = Arrays.asList(controlPoint1);
 
-        when(shape.getShapeView()).thenReturn(shapeView);
-        when(shape.addControlPoints(controlPoint1)).thenReturn(Arrays.asList(controlPoint2));
-        when(edge.getUUID()).thenReturn(EDGE_UUID);
-        when(edge.getContent()).thenReturn(viewConnector);
+        edge = new EdgeImpl<>(EDGE_UUID);
+        viewConnector = new ViewConnectorImpl<>(mock(Object.class), Bounds.createEmpty());
+        edge.setContent(viewConnector);
+
+        connectorView = spy(new ConnectorViewStub());
+        when(shape.getShapeView()).thenReturn(connectorView);
+        when(canvasHandler.getGraphIndex().get(EDGE_UUID)).thenReturn(edge);
         when(canvasHandler.getCanvas().getShape(EDGE_UUID)).thenReturn(shape);
+
+        controlPoint1 = ControlPoint.build(1, 1);
+        controlPoint2 = ControlPoint.build(2, 2);
+        controlPoint3 = ControlPoint.build(3, 3);
+        controlPoints = new ControlPoint[]{controlPoint1, controlPoint2, controlPoint3};
+        viewConnector.setControlPoints(controlPoints);
+        when(connectorView.getManageableControlPoints()).thenReturn(controlPoints);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommandTest.java
@@ -129,7 +129,7 @@ public class AbstractCanvasGraphCommandTest {
         when(graphCommand.execute(eq(graphContext))).thenReturn(GRAPH_COMMAND_FAILED);
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         verify(graphCommand, times(1)).execute(eq(graphContext));
-        verify(graphCommand, times(1)).undo(eq(graphContext));
+        verify(graphCommand, never()).undo(eq(graphContext));
         verify(canvasCommand, never()).execute(eq(canvasHandler));
         assertEquals(CommandResult.Type.ERROR, result.getType());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasConnectorCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasConnectorCommandTest.java
@@ -88,12 +88,12 @@ public class AddCanvasConnectorCommandTest extends AbstractCanvasCommandTest {
         verify(canvasHandler,
                times(1)).applyElementMutation(eq(candidate),
                                               any(MutationContext.class));
+        verify(canvasHandler,
+               times(1)).notifyCanvasElementUpdated(eq(source));
         verify(candidateShape,
                times(1)).applyConnections(eq(candidate),
                                           eq(sourceShapeView),
-                                          eq(null),
+                                          any(ShapeView.class),
                                           any(MutationContext.class));
-        verify(canvasHandler,
-               times(1)).notifyCanvasElementUpdated(eq(source));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasControlPointCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasControlPointCommandTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
@@ -33,6 +32,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddCanvasControlPointCommandTest extends AbstractCanvasControlPointCommandTest {
@@ -96,11 +96,20 @@ public class AddCanvasControlPointCommandTest extends AbstractCanvasControlPoint
 
     @Test
     public void execute() {
+        checkExecution(true);
+    }
+
+    @Test
+    public void executeWithCPsNotVisible() {
+        checkExecution(false);
+    }
+
+    private void checkExecution(boolean areControlPointsVisible) {
+        when(connectorView.areControlsVisible()).thenReturn(areControlPointsVisible);
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         assertFalse(CommandUtils.isError(result));
-        verify(connectorView, times(1)).hideControlPoints();
+        checkControlPointsVisibilitySwitch(areControlPointsVisible);
         verify(connectorView, times(1)).addControlPoint(eq(newControlPoint), eq(2));
-        verify(connectorView, times(1)).showControlPoints(eq(HasControlPoints.ControlPointType.POINTS));
         verify(connectorView, never()).updateControlPoints(any(ControlPoint[].class));
         verify(connectorView, never()).deleteControlPoint(anyInt());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasControlPointCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasControlPointCommandTest.java
@@ -20,46 +20,88 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddCanvasControlPointCommandTest extends AbstractCanvasControlPointCommandTest {
 
-    private AddCanvasControlPointCommand addCanvasControlPointCommand;
+    private AddCanvasControlPointCommand tested;
+    private ControlPoint newControlPoint;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        addCanvasControlPointCommand = spy(new AddCanvasControlPointCommand(edge, controlPoint1));
+        newControlPoint = ControlPoint.build(4, 4);
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 2);
     }
 
     @Test
-    public void testAllowSuccess() {
-        CommandResult<CanvasViolation> result = addCanvasControlPointCommand.allow(canvasHandler);
-        verify(shape).addControlPoints(controlPoint1);
+    public void testAllow() {
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 0);
+        CommandResult<CanvasViolation> result = tested.allow(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 1);
+        result = tested.allow(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 2);
+        result = tested.allow(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+        assertFalse(CommandUtils.isError(result));
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 3);
+        result = tested.allow(canvasHandler);
         assertFalse(CommandUtils.isError(result));
     }
 
-    @Test
-    public void testAllowError() {
-        when(shape.addControlPoints(controlPoint1)).thenReturn(controlPointList);
-        CommandResult<CanvasViolation> result = addCanvasControlPointCommand.allow(canvasHandler);
-        verify(shape).addControlPoints(controlPoint1);
-        assertTrue(CommandUtils.isError(result));
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCPIndex() {
+        // Index cannot be bigger than actual CP's length
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 4);
+        tested.allow(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCPIndexDuringExecute() {
+        // Index cannot be bigger than actual CP's length
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 4);
+        tested.execute(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCP() {
+        // the CP's location must be present
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 2);
+        newControlPoint.setLocation(null);
+        tested.allow(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCPDuringExecute() {
+        // the CP's location must be present
+        tested = new AddCanvasControlPointCommand(edge, newControlPoint, 2);
+        newControlPoint.setLocation(null);
+        tested.execute(canvasHandler);
     }
 
     @Test
     public void execute() {
-        CommandResult<CanvasViolation> result = addCanvasControlPointCommand.execute(canvasHandler);
-        verify(addCanvasControlPointCommand).allow(canvasHandler);
+        CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         assertFalse(CommandUtils.isError(result));
+        verify(connectorView, times(1)).hideControlPoints();
+        verify(connectorView, times(1)).addControlPoint(eq(newControlPoint), eq(2));
+        verify(connectorView, times(1)).showControlPoints(eq(HasControlPoints.ControlPointType.POINTS));
+        verify(connectorView, never()).updateControlPoints(any(ControlPoint[].class));
+        verify(connectorView, never()).deleteControlPoint(anyInt());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneCanvasNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/CloneCanvasNodeCommandTest.java
@@ -26,8 +26,8 @@ import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.shape.ConnectorViewStub;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
-import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.command.impl.AbstractCompositeCommand;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessor;
@@ -61,7 +61,7 @@ public class CloneCanvasNodeCommandTest extends AbstractCanvasCommandTest {
     private ConnectorShape edgeShape;
 
     @Mock
-    private ShapeView shapeView;
+    private ConnectorViewStub edgeShapeView;
 
     @Mock
     private ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessorManagedInstance;
@@ -78,7 +78,7 @@ public class CloneCanvasNodeCommandTest extends AbstractCanvasCommandTest {
 
         when(canvas.getShape(graphInstance.edge1.getUUID())).thenReturn(edgeShape);
         when(canvas.getShape(graphInstance.edge2.getUUID())).thenReturn(edgeShape);
-        when(edgeShape.getShapeView()).thenReturn(shapeView);
+        when(edgeShape.getShapeView()).thenReturn(edgeShapeView);
         when(childrenTraverseProcessorManagedInstance.get()).thenReturn(new ChildrenTraverseProcessorImpl(new TreeWalkTraverseProcessorImpl()));
 
         this.cloneCanvasNodeCommand = new CloneCanvasNodeCommand(parent,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommandTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
@@ -33,6 +32,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteCanvasControlPointCommandTest extends AbstractCanvasControlPointCommandTest {
@@ -84,12 +84,21 @@ public class DeleteCanvasControlPointCommandTest extends AbstractCanvasControlPo
 
     @Test
     public void testDeleteControlPoint() {
+        checkExecution(true);
+    }
+
+    @Test
+    public void testDeleteControlPointWhenNotVisible() {
+        checkExecution(false);
+    }
+
+    private void checkExecution(boolean areControlPointsVisible) {
+        when(connectorView.areControlsVisible()).thenReturn(areControlPointsVisible);
         tested = new DeleteCanvasControlPointCommand(edge, 0);
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         assertFalse(CommandUtils.isError(result));
-        verify(connectorView, times(1)).hideControlPoints();
+        checkControlPointsVisibilitySwitch(areControlPointsVisible);
         verify(connectorView, times(1)).deleteControlPoint(eq(0));
-        verify(connectorView, times(1)).showControlPoints(eq(HasControlPoints.ControlPointType.POINTS));
         verify(connectorView, never()).updateControlPoints(any(ControlPoint[].class));
         verify(connectorView, never()).addControlPoint(any(ControlPoint.class), anyInt());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteCanvasControlPointCommandTest.java
@@ -20,41 +20,77 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
-import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
-import org.mockito.InOrder;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteCanvasControlPointCommandTest extends AbstractCanvasControlPointCommandTest {
 
-    private DeleteCanvasControlPointCommand deleteCanvasControlPointCommand;
+    private DeleteCanvasControlPointCommand tested;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        this.deleteCanvasControlPointCommand = spy(new DeleteCanvasControlPointCommand(edge, controlPoint1));
+        this.tested = new DeleteCanvasControlPointCommand(edge, 0);
     }
 
     @Test
-    public void execute() {
-        CommandResult<CanvasViolation> result = deleteCanvasControlPointCommand.execute(canvasHandler);
-        InOrder inOrder = inOrder(shape);
-        inOrder.verify(shape).applyState(ShapeState.NONE);
-        inOrder.verify(shape).removeControlPoints(controlPoint1);
-        inOrder.verify(shape).applyState(ShapeState.SELECTED);
+    public void testChecks() {
+        tested = new DeleteCanvasControlPointCommand(edge, 0);
+        CommandResult<CanvasViolation> result = tested.allow(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+        tested = new DeleteCanvasControlPointCommand(edge, 1);
+        result = tested.allow(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+        tested = new DeleteCanvasControlPointCommand(edge, 2);
+        result = tested.allow(canvasHandler);
         assertFalse(CommandUtils.isError(result));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidIndex() {
+        tested = new DeleteCanvasControlPointCommand(edge, -1);
+        tested.allow(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIndexForbidden() {
+        tested = new DeleteCanvasControlPointCommand(edge, 3);
+        tested.allow(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidIndexDuringExecute() {
+        tested = new DeleteCanvasControlPointCommand(edge, -1);
+        tested.execute(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIndexForbiddenDuringExecute() {
+        tested = new DeleteCanvasControlPointCommand(edge, 3);
+        tested.execute(canvasHandler);
+    }
+
     @Test
-    public void undo() {
-        deleteCanvasControlPointCommand.undo(canvasHandler);
-        verify(deleteCanvasControlPointCommand).newUndoCommand();
+    public void testDeleteControlPoint() {
+        tested = new DeleteCanvasControlPointCommand(edge, 0);
+        CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+        verify(connectorView, times(1)).hideControlPoints();
+        verify(connectorView, times(1)).deleteControlPoint(eq(0));
+        verify(connectorView, times(1)).showControlPoints(eq(HasControlPoints.ControlPointType.POINTS));
+        verify(connectorView, never()).updateControlPoints(any(ControlPoint[].class));
+        verify(connectorView, never()).addControlPoint(any(ControlPoint.class), anyInt());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/ResizeNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/ResizeNodeCommandTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.command;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasPanel;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.command.impl.AbstractCompositeCommand;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
+import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
+import org.kie.workbench.common.stunner.core.definition.property.PropertyMetaTypes;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
+import org.kie.workbench.common.stunner.core.graph.content.relationship.Dock;
+import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+import org.kie.workbench.common.stunner.core.registry.definition.AdapterRegistry;
+import org.kie.workbench.common.stunner.core.util.UUID;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResizeNodeCommandTest {
+
+    private static final String ROOT_UUID = "root-uuid1";
+    private static final String ELEMENT_UUID = "element-uuid1";
+    private static final String DEF_ID = "def-id";
+    private static final String W_PROPERTY_ID = "w-property-id";
+    private static final String H_PROPERTY_ID = "h-property-id";
+    private static final String R_PROPERTY_ID = "r-property-id";
+    private static final Bounds ELEMENT_BOUNDS = Bounds.create(10d, 20d, 30d, 40d);
+
+    private static final String DOCKED_NODE_UUID = UUID.uuid();
+    private static final String CONNECTOR_EDGE_UUID = UUID.uuid();
+    private static final String CONNECTOR_EDGE_TARGET_UUID = UUID.uuid();
+    private static final Double SHAPE_X = 0d;
+    private static final Double SHAPE_Y = 0d;
+    public static final double NEW_CONNECTION_X = 10d;
+    public static final double NEW_CONNECTION_Y = 20d;
+    public static final double NEW_CONNECTION_X_TARGET = 30d;
+    public static final double NEW_CONNECTION_Y_TARGET = 40d;
+
+    @Mock
+    private CanvasCommandManager<AbstractCanvasHandler> commandManager;
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private AbstractCanvas canvas;
+
+    @Mock
+    private AbstractCanvas.CanvasView canvasView;
+
+    @Mock
+    private CanvasPanel canvasPanel;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Graph graph;
+
+    @Mock
+    private DefinitionSet graphContent;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
+    private Node element;
+
+    @Mock
+    private View elementContent;
+
+    @Mock
+    private Shape<ShapeView> shape;
+
+    @Mock
+    private ShapeView shapeView;
+
+    @Mock
+    private Object definition;
+
+    @Mock
+    private Object wProperty;
+
+    @Mock
+    private Object hProperty;
+
+    @Mock
+    private Object rProperty;
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private AdapterManager adapterManager;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private DefinitionAdapter<Object> definitionAdapter;
+
+    @Mock
+    private PropertyAdapter propertyAdapter;
+
+    @Mock
+    private Edge dockEdge;
+
+    @Mock
+    private Node dockedNode;
+
+    @Mock
+    private Shape dockedShape;
+
+    @Mock
+    private ShapeView dockedShapeView;
+
+    @Mock
+    private Edge connectorEdge;
+
+    @Mock
+    private ViewConnector viewConnector;
+
+    @Mock
+    private ConnectorShape connectorShape;
+
+    @Mock
+    private Edge connectorEdgeTarget;
+
+    @Mock
+    private ViewConnector viewConnectorTarget;
+
+    @Mock
+    private ConnectorShape connectorShapeTarget;
+
+    @Mock
+    private BiFunction<Shape, Integer, Point2D> magnetLocationProvider;
+
+    @Mock
+    private Consumer<Shape> onResize;
+
+    private ResizeNodeCommand tested;
+    private BoundingBox boundingBox;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        when(canvasHandler.getDefinitionManager()).thenReturn(definitionManager);
+        when(definitionManager.adapters()).thenReturn(adapterManager);
+        when(adapterManager.registry()).thenReturn(adapterRegistry);
+        when(adapterManager.forProperty()).thenReturn(propertyAdapter);
+        when(adapterRegistry.getDefinitionAdapter(any(Class.class))).thenReturn(definitionAdapter);
+        when(adapterRegistry.getPropertyAdapter(anyObject())).thenReturn(propertyAdapter);
+        when(definitionAdapter.getId(eq(definition))).thenReturn(DefinitionId.build(DEF_ID));
+        when(propertyAdapter.getId(eq(wProperty))).thenReturn(W_PROPERTY_ID);
+        when(propertyAdapter.getId(eq(hProperty))).thenReturn(H_PROPERTY_ID);
+        when(propertyAdapter.getId(eq(rProperty))).thenReturn(R_PROPERTY_ID);
+        when(definitionAdapter.getMetaProperty(eq(PropertyMetaTypes.WIDTH),
+                                               eq(definition))).thenReturn(wProperty);
+        when(definitionAdapter.getMetaProperty(eq(PropertyMetaTypes.HEIGHT),
+                                               eq(definition))).thenReturn(hProperty);
+        when(definitionAdapter.getMetaProperty(eq(PropertyMetaTypes.RADIUS),
+                                               eq(definition))).thenReturn(rProperty);
+        when(element.getUUID()).thenReturn(ELEMENT_UUID);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(element.getContent()).thenReturn(elementContent);
+        when(elementContent.getDefinition()).thenReturn(definition);
+        when(elementContent.getBounds()).thenReturn(ELEMENT_BOUNDS);
+        when(graph.getContent()).thenReturn(graphContent);
+        when(diagram.getGraph()).thenReturn(graph);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getCanvasRootUUID()).thenReturn(ROOT_UUID);
+        when(canvasHandler.getCanvas()).thenReturn(canvas);
+        when(canvasHandler.getAbstractCanvas()).thenReturn(canvas);
+        when(canvas.getView()).thenReturn(canvasView);
+        when(canvasView.getPanel()).thenReturn(canvasPanel);
+        when(canvas.getShape(eq(ELEMENT_UUID))).thenReturn(shape);
+        when(canvas.getShapes()).thenReturn(Collections.singletonList(shape));
+        when(shape.getUUID()).thenReturn(ELEMENT_UUID);
+        when(shape.getShapeView()).thenReturn(shapeView);
+        when(element.getOutEdges()).thenReturn(Arrays.asList(dockEdge, connectorEdge));
+        when(element.getInEdges()).thenReturn(Collections.singletonList(connectorEdgeTarget));
+        when(dockEdge.getContent()).thenReturn(new Dock());
+        when(dockEdge.getTargetNode()).thenReturn(dockedNode);
+        when(dockedNode.getUUID()).thenReturn(DOCKED_NODE_UUID);
+        when(canvas.getShape(DOCKED_NODE_UUID)).thenReturn(dockedShape);
+        when(dockedShape.getShapeView()).thenReturn(dockedShapeView);
+        when(dockedShapeView.getShapeX()).thenReturn(SHAPE_X);
+        when(dockedShapeView.getShapeY()).thenReturn(SHAPE_Y);
+
+        when(connectorEdge.getSourceNode()).thenReturn(element);
+        when(connectorEdge.getContent()).thenReturn(viewConnector);
+        when(connectorEdge.getUUID()).thenReturn(CONNECTOR_EDGE_UUID);
+        when(connectorEdgeTarget.getTargetNode()).thenReturn(element);
+        when(connectorEdgeTarget.getContent()).thenReturn(viewConnectorTarget);
+        when(connectorEdgeTarget.getUUID()).thenReturn(CONNECTOR_EDGE_TARGET_UUID);
+
+        MagnetConnection magnetConnection = new MagnetConnection.Builder().atX(0).atY(0).magnet(MagnetConnection.MAGNET_CENTER).build();
+        MagnetConnection magnetConnectionTarget = new MagnetConnection.Builder().magnet(1).build();
+        when(viewConnector.getSourceConnection()).thenReturn(Optional.of(magnetConnection));
+        when(viewConnectorTarget.getTargetConnection()).thenReturn(Optional.of(magnetConnectionTarget));
+        when(canvas.getShape(CONNECTOR_EDGE_UUID)).thenReturn(connectorShape);
+        when(canvas.getShape(CONNECTOR_EDGE_TARGET_UUID)).thenReturn(connectorShapeTarget);
+
+        boundingBox = new BoundingBox(0, 0, 100, 200);
+        tested = new ResizeNodeCommand(element,
+                                       boundingBox,
+                                       magnetLocationProvider,
+                                       onResize);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testInitialize() {
+        AbstractCompositeCommand<AbstractCanvasHandler, CanvasViolation> command = tested.initialize(canvasHandler);
+
+        assertNotNull(command);
+        final List commands = command.getCommands();
+        assertNotNull(commands);
+        assertEquals(6,
+                     commands.size());
+        assertTrue(commands.get(0) instanceof UpdateElementPropertyCommand);
+        final UpdateElementPropertyCommand wPropertyCommand = (UpdateElementPropertyCommand) commands.get(0);
+        assertEquals(element,
+                     wPropertyCommand.getElement());
+        assertEquals(W_PROPERTY_ID,
+                     wPropertyCommand.getPropertyId());
+        assertEquals(boundingBox.getWidth(),
+                     wPropertyCommand.getValue());
+        assertTrue(commands.get(1) instanceof UpdateElementPropertyCommand);
+        final UpdateElementPropertyCommand hPropertyCommand = (UpdateElementPropertyCommand) commands.get(1);
+        assertEquals(element,
+                     hPropertyCommand.getElement());
+        assertEquals(H_PROPERTY_ID,
+                     hPropertyCommand.getPropertyId());
+        assertEquals(boundingBox.getHeight(),
+                     hPropertyCommand.getValue());
+        assertTrue(commands.get(2) instanceof UpdateElementPropertyCommand);
+        final UpdateElementPropertyCommand rPropertyCommand = (UpdateElementPropertyCommand) commands.get(2);
+        assertEquals(element,
+                     rPropertyCommand.getElement());
+        assertEquals(R_PROPERTY_ID,
+                     rPropertyCommand.getPropertyId());
+        assertEquals(50d,
+                     rPropertyCommand.getValue());
+        verify(magnetLocationProvider, times(1)).apply(eq(shape), eq(0));
+        verify(magnetLocationProvider, times(1)).apply(eq(shape), eq(1));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPostOperation() {
+        CommandResult<CanvasViolation> result = CanvasCommandResultBuilder.SUCCESS;
+
+        CommandResult<CanvasViolation> cascasded = tested.postOperation(canvasHandler, result, 100, 200);
+
+        assertEquals(result, cascasded);
+        verify(onResize, times(1)).accept(eq(shape));
+        ArgumentCaptor<Bounds> boundsArgumentCaptor = ArgumentCaptor.forClass(Bounds.class);
+        verify(elementContent, times(1)).setBounds(boundsArgumentCaptor.capture());
+        assertEquals(Bounds.create(10, 20, 110, 220), boundsArgumentCaptor.getValue());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommandTest.java
@@ -20,40 +20,73 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateCanvasControlPointPositionCommandTest extends AbstractCanvasControlPointCommandTest {
 
+    private static final ControlPoint newControlPoint1 = ControlPoint.build(0.1, 0.2);
+    private static final ControlPoint newControlPoint2 = ControlPoint.build(0.3, 0.4);
+    private static final ControlPoint newControlPoint3 = ControlPoint.build(0.4, 0.5);
+
     private UpdateCanvasControlPointPositionCommand tested;
+    private ControlPoint[] newControlPoints;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        this.tested = spy(new UpdateCanvasControlPointPositionCommand(edge, controlPoint1));
+        newControlPoints = new ControlPoint[]{newControlPoint1, newControlPoint2, newControlPoint3};
+    }
+
+    @Test
+    public void testCheck() {
+        tested = new UpdateCanvasControlPointPositionCommand(edge, newControlPoints);
+        CommandResult<CanvasViolation> result = tested.allow(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCannotUpdateCPs() {
+        newControlPoints = new ControlPoint[]{newControlPoint1, newControlPoint2};
+        tested = new UpdateCanvasControlPointPositionCommand(edge, newControlPoints);
+        tested.allow(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCannotUpdateCPsDuringExecute() {
+        newControlPoints = new ControlPoint[]{newControlPoint1, newControlPoint2};
+        tested = new UpdateCanvasControlPointPositionCommand(edge, newControlPoints);
+        tested.execute(canvasHandler);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCannotUpdateCPs2() {
+        viewConnector.setControlPoints(new ControlPoint[]{controlPoint1, controlPoint2});
+        tested = new UpdateCanvasControlPointPositionCommand(edge, newControlPoints);
+        tested.allow(canvasHandler);
     }
 
     @Test
     public void execute() {
+        tested = new UpdateCanvasControlPointPositionCommand(edge, newControlPoints);
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         assertFalse(CommandUtils.isError(result));
-        verify(shape, times(1)).updateControlPoint(eq(controlPoint1));
-    }
-
-    @Test
-    public void executeAndUndo() {
-        CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
-        assertFalse(CommandUtils.isError(result));
-        CommandResult<CanvasViolation> undo = tested.undo(canvasHandler);
-        assertFalse(CommandUtils.isError(undo));
-        verify(shape, times(2)).updateControlPoint(eq(controlPoint1));
+        verify(connectorView, times(1)).hideControlPoints();
+        verify(connectorView, times(1)).updateControlPoints(eq(newControlPoints));
+        verify(connectorView, times(1)).showControlPoints(eq(HasControlPoints.ControlPointType.POINTS));
+        verify(connectorView, never()).addControlPoint(any(ControlPoint.class), anyInt());
+        verify(connectorView, never()).deleteControlPoint(anyInt());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasControlPointPositionCommandTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
@@ -33,6 +32,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateCanvasControlPointPositionCommandTest extends AbstractCanvasControlPointCommandTest {
@@ -80,12 +80,21 @@ public class UpdateCanvasControlPointPositionCommandTest extends AbstractCanvasC
 
     @Test
     public void execute() {
+        checkExecution(true);
+    }
+
+    @Test
+    public void executeWhenCPsNotVisible() {
+        checkExecution(false);
+    }
+
+    private void checkExecution(boolean areControlPointsVisible) {
+        when(connectorView.areControlsVisible()).thenReturn(areControlPointsVisible);
         tested = new UpdateCanvasControlPointPositionCommand(edge, newControlPoints);
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         assertFalse(CommandUtils.isError(result));
-        verify(connectorView, times(1)).hideControlPoints();
+        checkControlPointsVisibilitySwitch(areControlPointsVisible);
         verify(connectorView, times(1)).updateControlPoints(eq(newControlPoints));
-        verify(connectorView, times(1)).showControlPoints(eq(HasControlPoints.ControlPointType.POINTS));
         verify(connectorView, never()).addControlPoint(any(ControlPoint.class), anyInt());
         verify(connectorView, never()).deleteControlPoint(anyInt());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPositionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/UpdateCanvasElementPositionCommandTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -74,15 +73,15 @@ public class UpdateCanvasElementPositionCommandTest extends AbstractCanvasComman
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testOutOfBoundsError() {
+    public void testOutOfBoundsWarn() {
         tested = new UpdateCanvasElementPositionCommand(candidate, Point2D.create(550d, 550d));
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
-        assertEquals(CommandResult.Type.ERROR,
+        assertEquals(CommandResult.Type.WARNING,
                      result.getType());
         Iterator<CanvasViolation> violationsIt = result.getViolations().iterator();
         assertTrue(violationsIt.hasNext());
         verify(canvasHandler,
-               never()).updateElementPosition(eq(candidate),
-                                              any(MutationContext.class));
+               times(1)).updateElementPosition(eq(candidate),
+                                               any(MutationContext.class));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactoryStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandFactoryStub.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.command;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessor;
+import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ViewTraverseProcessor;
+
+public class CanvasCommandFactoryStub extends DefaultCanvasCommandFactory {
+
+    public CanvasCommandFactoryStub() {
+        this(null, null);
+    }
+
+    public CanvasCommandFactoryStub(ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors,
+                                    ManagedInstance<ViewTraverseProcessor> viewTraverseProcessors) {
+        super(childrenTraverseProcessors, viewTraverseProcessors);
+    }
+
+    @Override
+    public CanvasCommand<AbstractCanvasHandler> resize(Element<? extends View<?>> element, BoundingBox boundingBox) {
+        return null;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/RequestCommandManagerTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -215,6 +216,7 @@ public class RequestCommandManagerTest {
                                         int size) {
         assertNotNull(captured);
         assertTrue(captured instanceof CompositeCommand);
+        assertFalse(((CompositeCommand) captured).isUndoReverse());
         assertEquals(size,
                      ((CompositeCommand) captured).size());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CommonActionsToolboxFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CommonActionsToolboxFactoryTest.java
@@ -52,7 +52,7 @@ public class CommonActionsToolboxFactoryTest {
     private CanvasCommandFactory<AbstractCanvasHandler> commandFactory;
 
     @Mock
-    private DeleteNodeAction deleteNodeAction;
+    private DeleteNodeToolboxAction deleteNodeAction;
 
     @Mock
     private Command deleteNodeActionDestroyer;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateConnectorToolboxActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/CreateConnectorToolboxActionTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class CreateConnectorActionTest {
+public class CreateConnectorToolboxActionTest {
 
     private static final String NODE_UUID = "node1";
     private static final String EDGE_UUID = "edge1";
@@ -133,7 +133,7 @@ public class CreateConnectorActionTest {
     @Mock
     private DragProxy<AbstractCanvasHandler, ConnectorDragProxy.Item, DragProxyCallback> dragProxy;
 
-    private CreateConnectorAction tested;
+    private CreateConnectorToolboxAction tested;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -168,13 +168,13 @@ public class CreateConnectorActionTest {
                                             eq(500),
                                             any(DragProxyCallback.class))).thenReturn(dragProxy);
 
-        this.tested = new CreateConnectorAction(definitionUtils,
-                                                clientFactoryManager,
-                                                graphBoundsIndexer,
-                                                connectorDragProxyFactory,
-                                                edgeBuilderControl,
-                                                sessionCommandManager,
-                                                translationService,
+        this.tested = new CreateConnectorToolboxAction(definitionUtils,
+                                                       clientFactoryManager,
+                                                       graphBoundsIndexer,
+                                                       connectorDragProxyFactory,
+                                                       edgeBuilderControl,
+                                                       sessionCommandManager,
+                                                       translationService,
                                                 handler -> canvasHighlight)
                 .setEdgeId(EDGE_ID);
     }
@@ -187,7 +187,7 @@ public class CreateConnectorActionTest {
         tested.getTitle(canvasHandler,
                         NODE_UUID);
         verify(translationService,
-               times(1)).getValue(eq(CreateConnectorAction.KEY_TITLE));
+               times(1)).getValue(eq(CreateConnectorToolboxAction.KEY_TITLE));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/DeleteNodeToolboxActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/DeleteNodeToolboxActionTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class DeleteNodeActionTest {
+public class DeleteNodeToolboxActionTest {
 
     private static final String E_UUID = "e1";
 
@@ -68,7 +68,7 @@ public class DeleteNodeActionTest {
     @Mock
     private CanvasCommand<AbstractCanvasHandler> deleteNodeCommand;
 
-    private DeleteNodeAction tested;
+    private DeleteNodeToolboxAction tested;
 
     @Mock
     private EventSourceMock<CanvasClearSelectionEvent> clearSelectionEventEventSourceMock;
@@ -79,11 +79,11 @@ public class DeleteNodeActionTest {
         when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
         when(graphIndex.get(eq(E_UUID))).thenReturn(element);
         when(element.asNode()).thenReturn(element);
-        this.tested = new DeleteNodeAction(translationService,
-                                           sessionCommandManager,
-                                           commandFactory,
-                                           action -> true,
-                                           clearSelectionEventEventSourceMock);
+        this.tested = new DeleteNodeToolboxAction(translationService,
+                                                  sessionCommandManager,
+                                                  commandFactory,
+                                                  action -> true,
+                                                  clearSelectionEventEventSourceMock);
     }
 
     @Test
@@ -105,11 +105,11 @@ public class DeleteNodeActionTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testSkipAction() {
-        this.tested = new DeleteNodeAction(translationService,
-                                           sessionCommandManager,
-                                           commandFactory,
-                                           action -> false,
-                                           clearSelectionEventEventSourceMock);
+        this.tested = new DeleteNodeToolboxAction(translationService,
+                                                  sessionCommandManager,
+                                                  commandFactory,
+                                                  action -> false,
+                                                  clearSelectionEventEventSourceMock);
         final MouseClickEvent event = mock(MouseClickEvent.class);
         final ToolboxAction<AbstractCanvasHandler> cascade = tested.onMouseClick(canvasHandler, E_UUID, event);
         assertEquals(tested, cascade);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/FlowActionsToolboxFactoryTest.java
@@ -73,13 +73,13 @@ public class FlowActionsToolboxFactoryTest {
     private CommonDomainLookups domainLookups;
 
     @Mock
-    private CreateConnectorAction createConnectorAction;
+    private CreateConnectorToolboxAction createConnectorAction;
 
     @Mock
     private Command createConnectorActionDestroyer;
 
     @Mock
-    private CreateNodeAction createNodeAction;
+    private CreateNodeToolboxAction createNodeAction;
 
     @Mock
     private Command createNodeActionDestroyer;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/GeneralCreateNodeActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/GeneralCreateNodeActionTest.java
@@ -28,12 +28,12 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AddConnectorCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AddNodeCommand;
-import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.command.SetConnectionTargetNodeCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.UpdateElementPositionCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactoryStub;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.impl.DeferredCommand;
@@ -74,8 +74,7 @@ public class GeneralCreateNodeActionTest {
     @Mock
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
-    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory = new DefaultCanvasCommandFactory(null,
-                                                                                                               null);
+    private CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory = new CanvasCommandFactoryStub();
 
     private GeneralCreateNodeAction createNodeAction;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphActionsToolboxFactoryTest.java
@@ -87,7 +87,7 @@ public class MorphActionsToolboxFactoryTest {
     private MorphAdapter morphAdapter;
 
     @Mock
-    private MorphNodeAction morphNodeAction;
+    private MorphNodeToolboxAction morphNodeAction;
 
     @Mock
     private Command morphNodeActionDestroyer;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphNodeToolboxActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/MorphNodeToolboxActionTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class MorphNodeActionTest {
+public class MorphNodeToolboxActionTest {
 
     private static final String E_UUID = "e1";
     private static final String SSID_UUID = "ss1";
@@ -101,7 +101,7 @@ public class MorphNodeActionTest {
     @Mock
     private CanvasCommand<AbstractCanvasHandler> morphNodeCommand;
 
-    private MorphNodeAction tested;
+    private MorphNodeToolboxAction tested;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -120,12 +120,12 @@ public class MorphNodeActionTest {
         when(metadata.getShapeSetId()).thenReturn(SSID_UUID);
         when(graphIndex.get(eq(E_UUID))).thenReturn(element);
         when(element.asNode()).thenReturn((Node) element);
-        this.tested = new MorphNodeAction(definitionUtils,
-                                          sessionCommandManager,
-                                          commandFactory,
-                                          translationService,
-                                          canvasElementSelectedEvent,
-                                          canvasClearSelectionEventEventSourceMock)
+        this.tested = new MorphNodeToolboxAction(definitionUtils,
+                                                 sessionCommandManager,
+                                                 commandFactory,
+                                                 translationService,
+                                                 canvasElementSelectedEvent,
+                                                 canvasClearSelectionEventEventSourceMock)
                 .setMorphDefinition(morphDefinition)
                 .setTargetDefinitionId(MORPH_TARGET_ID);
     }
@@ -135,7 +135,7 @@ public class MorphNodeActionTest {
         tested.getTitle(canvasHandler,
                         E_UUID);
         verify(translationService,
-               times(1)).getValue(eq(MorphNodeAction.KEY_TITLE));
+               times(1)).getValue(eq(MorphNodeToolboxAction.KEY_TITLE));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ConnectorViewStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ConnectorViewStub.java
@@ -17,13 +17,16 @@
 package org.kie.workbench.common.stunner.core.client.shape;
 
 import org.kie.workbench.common.stunner.core.client.shape.view.BoundingBox;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasManageableControlPoints;
 import org.kie.workbench.common.stunner.core.client.shape.view.IsConnector;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 
 public class ConnectorViewStub implements ShapeView<Object>,
-                                          IsConnector {
+                                          IsConnector,
+                                          HasManageableControlPoints<Object> {
 
     public final static String UUID = "cv-stub";
 
@@ -174,5 +177,40 @@ public class ConnectorViewStub implements ShapeView<Object>,
     @Override
     public void setUserData(Object userData) {
 
+    }
+
+    @Override
+    public Object addControlPoint(ControlPoint controlPoint, int index) {
+        return this;
+    }
+
+    @Override
+    public Object updateControlPoints(ControlPoint[] controlPoints) {
+        return this;
+    }
+
+    @Override
+    public Object deleteControlPoint(int index) {
+        return this;
+    }
+
+    @Override
+    public ControlPoint[] getManageableControlPoints() {
+        return new ControlPoint[0];
+    }
+
+    @Override
+    public Object showControlPoints(ControlPointType type) {
+        return this;
+    }
+
+    @Override
+    public Object hideControlPoints() {
+        return this;
+    }
+
+    @Override
+    public boolean areControlsVisible() {
+        return false;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/util/ShapeUtilsTest.java
@@ -16,9 +16,6 @@
 
 package org.kie.workbench.common.stunner.core.client.util;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,12 +30,10 @@ import org.kie.workbench.common.stunner.core.client.shape.ShapeViewExtStub;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
-import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -72,10 +67,6 @@ public class ShapeUtilsTest {
 
     private TestingGraphInstanceBuilder.TestGraph2 instance2;
 
-    private ControlPoint controlPoint1;
-
-    private List<ControlPoint> controlPointList;
-
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
@@ -90,11 +81,6 @@ public class ShapeUtilsTest {
         when(canvas.getShape(eq(e2))).thenReturn(edge2Shape);
         when(edge1Shape.getShapeView()).thenReturn(edge1ShapeView);
         when(edge2Shape.getShapeView()).thenReturn(edge2ShapeView);
-
-        controlPoint1 = ControlPoint.build(0, 0);
-        controlPointList = Arrays.asList(controlPoint1);
-        when(edge1Shape.getControlPoints()).thenReturn(controlPointList);
-        when(edge1Shape.addControlPoints(controlPoint1)).thenReturn(controlPointList);
     }
 
     @Test
@@ -130,26 +116,6 @@ public class ShapeUtilsTest {
                times(1)).moveToTop();
         verify(edge2ShapeView,
                times(1)).moveToTop();
-    }
-
-    @Test
-    public void testAddControlPoints() {
-        List<ControlPoint> addedControlPoints = ShapeUtils.addControlPoints(instance2.edge1, canvasHandler, controlPoint1);
-        verify(edge1Shape).addControlPoints(controlPoint1);
-        assertEquals(addedControlPoints, controlPointList);
-    }
-
-    @Test
-    public void testRemoveControlPoints() {
-        ShapeUtils.removeControlPoints(instance2.edge1, canvasHandler, controlPoint1);
-        verify(edge1Shape).removeControlPoints(controlPoint1);
-    }
-
-    @Test
-    public void testGetControlPoints() {
-        List<ControlPoint> controlPoints = ShapeUtils.getControlPoints(instance2.edge1, canvasHandler);
-        verify(edge1Shape).getControlPoints();
-        assertEquals(controlPoints, controlPointList);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/AbstractCompositeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/AbstractCompositeCommand.java
@@ -124,7 +124,7 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
         return this;
     }
 
-    protected boolean isUndoReverse() {
+    public boolean isUndoReverse() {
         return true;
     }
 
@@ -188,7 +188,7 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
     }
 
     protected CommandResult<V> undoMultipleExecutedCommands(final T context,
-                                                          final List<Command<T, V>> commandStack) {
+                                                            final List<Command<T, V>> commandStack) {
         final List<CommandResult<V>> results = new LinkedList<>();
         commandStack.forEach(command -> results.add(doUndo(context,
                                                            command)));
@@ -209,9 +209,9 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
 
     @Override
     public String toString() {
-        String s = "[" + getClass().getName() + "]";
+        String s = "[" + getClass().getSimpleName() + "]";
         for (int x = 0; x < commands.size(); x++) {
-            s += " {(" + x + ") [" + commands.get(x) + "]} ";
+            s += " {(" + x + ")[" + commands.get(x) + "]}\n";
         }
         return s;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/AbstractCompositeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/AbstractCompositeCommand.java
@@ -22,8 +22,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Stack;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -36,8 +36,6 @@ import org.kie.workbench.common.stunner.core.rule.RuleSet;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
-
-    private static Logger LOGGER = Logger.getLogger(AbstractCompositeCommand.class.getName());
 
     protected final List<Command<T, V>> commands = new LinkedList<>();
     private boolean initialized = false;
@@ -83,22 +81,9 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
     }
 
     protected CommandResult<V> executeCommands(final T context) {
-        final Stack<Command<T, V>> executedCommands = new Stack<>();
-        final List<CommandResult<V>> results = new LinkedList<>();
-        for (final Command<T, V> command : commands) {
-            final CommandResult<V> violations = doExecute(context,
-                                                          command);
-            executedCommands.push(command);
-            LOGGER.log(Level.FINEST,
-                       "Execution of command [" + command + "] finished - Violations [" + violations + "]");
-            results.add(violations);
-            if (CommandResult.Type.ERROR.equals(violations.getType())) {
-                undoMultipleExecutedCommands(context,
-                                             executedCommands);
-                break;
-            }
-        }
-        return buildResult(results);
+        return processMultipleCommands(commands,
+                                       command -> doExecute(context, command),
+                                       command -> doUndo(context, command));
     }
 
     @Override
@@ -130,17 +115,11 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
 
     protected CommandResult<V> undo(final T context,
                                     final boolean reverse) {
-        final List<CommandResult<V>> results = new LinkedList<>();
         final List<Command<T, V>> collected = reverse ?
                 commands.stream().collect(reverse()) : commands.stream().collect(forward());
-        collected.forEach(command -> {
-            final CommandResult<V> violations = doUndo(context,
-                                                       command);
-            LOGGER.log(Level.FINEST,
-                       "Undo of command [" + command + "] finished - Violations [" + violations + "]");
-            results.add(violations);
-        });
-        return buildResult(results);
+        return processMultipleCommands(collected,
+                                       command -> doUndo(context, command),
+                                       command -> doExecute(context, command));
     }
 
     @SuppressWarnings("unchecked")
@@ -161,6 +140,36 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
             initialize(context);
             initialized = true;
         }
+    }
+
+    protected CommandResult<V> processMultipleFunctions(final Iterable<Command<T, V>> commands,
+                                                        final Function<Command<T, V>, CommandResult<V>> function,
+                                                        final Consumer<Iterable<Command<T, V>>> revertCandidates) {
+        final Stack<Command<T, V>> executedCommands = new Stack<>();
+        final List<CommandResult<V>> results = new LinkedList<>();
+        for (final Command<T, V> command : commands) {
+            final CommandResult<V> violations = function.apply(command);
+            results.add(violations);
+            if (CommandResult.Type.ERROR.equals(violations.getType())) {
+                revertCandidates.accept(executedCommands);
+                break;
+            }
+            executedCommands.push(command);
+        }
+        return buildResult(results);
+    }
+
+    protected CommandResult<V> processMultipleCommands(final Iterable<Command<T, V>> commands,
+                                                       final Function<Command<T, V>, CommandResult<V>> executorFunction,
+                                                       final Function<Command<T, V>, CommandResult<V>> revertFunction) {
+        return processMultipleFunctions(commands,
+                                        executorFunction,
+                                        revertCandidates -> {
+                                            processMultipleFunctions(revertCandidates,
+                                                                     revertFunction,
+                                                                     c -> {
+                                                                     });
+                                        });
     }
 
     protected CommandResult<V> buildResult(final List<CommandResult<V>> results) {
@@ -185,14 +194,6 @@ public abstract class AbstractCompositeCommand<T, V> implements Command<T, V> {
     private boolean hasMoreSeverity(final CommandResult.Type type,
                                     final CommandResult.Type reference) {
         return type.getSeverity() > reference.getSeverity();
-    }
-
-    protected CommandResult<V> undoMultipleExecutedCommands(final T context,
-                                                            final List<Command<T, V>> commandStack) {
-        final List<CommandResult<V>> results = new LinkedList<>();
-        commandStack.forEach(command -> results.add(doUndo(context,
-                                                           command)));
-        return buildResult(results);
     }
 
     private static <T> Collector<T, ?, List<T>> forward() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/CompositeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/CompositeCommand.java
@@ -56,7 +56,7 @@ public class CompositeCommand<T, V> extends AbstractCompositeCommand<T, V> {
     }
 
     @Override
-    protected boolean isUndoReverse() {
+    public boolean isUndoReverse() {
         return reverse;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/DeferredCompositeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/DeferredCompositeCommand.java
@@ -101,7 +101,7 @@ public class DeferredCompositeCommand<T, V> extends AbstractCompositeCommand<T, 
     }
 
     @Override
-    protected boolean isUndoReverse() {
+    public boolean isUndoReverse() {
         return reverse;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/DeferredCompositeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/DeferredCompositeCommand.java
@@ -20,8 +20,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.NonPortable;
@@ -41,8 +39,6 @@ import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
  */
 @Portable
 public class DeferredCompositeCommand<T, V> extends AbstractCompositeCommand<T, V> {
-
-    private static Logger LOGGER = Logger.getLogger(AbstractCompositeCommand.class.getName());
 
     private final boolean reverse;
 
@@ -80,20 +76,18 @@ public class DeferredCompositeCommand<T, V> extends AbstractCompositeCommand<T, 
         for (final Command<T, V> command : commands) {
             violations = doAllow(context,
                                  command);
-            LOGGER.log(Level.FINEST,
-                       "Allow of command [" + command + "] finished - Violations [" + violations + "]");
             if (!CommandUtils.isError(violations)) {
                 violations = doExecute(context,
                                        command);
                 executedCommands.push(command);
             }
 
-            LOGGER.log(Level.FINEST,
-                       "Execution of command [" + command + "] finished - Violations [" + violations + "]");
             results.add(violations);
             if (CommandUtils.isError(violations)) {
-                undoMultipleExecutedCommands(context,
-                                             executedCommands);
+                processMultipleFunctions(executedCommands,
+                                         executed -> doUndo(context, executed),
+                                         reverted -> {
+                                         });
                 break;
             }
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractControlPointCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractControlPointCommand.java
@@ -16,66 +16,28 @@
 
 package org.kie.workbench.common.stunner.core.graph.command.impl;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.kie.soup.commons.validation.PortablePreconditions;
-import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
-import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.graph.content.HasControlPoints;
-import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
-import org.kie.workbench.common.stunner.core.rule.RuleViolation;
-import org.kie.workbench.common.stunner.core.util.Counter;
 
 public abstract class AbstractControlPointCommand extends AbstractGraphCommand {
 
-    protected final Edge edge;
-    protected final ControlPoint[] controlPoints;
+    private final String edgeUUID;
 
-    public AbstractControlPointCommand(final Edge edge, final ControlPoint... controlPoints) {
-        this.controlPoints = PortablePreconditions.checkNotNull("controlPoints", controlPoints);
-        this.edge = PortablePreconditions.checkNotNull("edge", edge);
+    public AbstractControlPointCommand(final String edgeUUID) {
+        this.edgeUUID = PortablePreconditions.checkNotNull("edgeUUID", edgeUUID);
     }
 
-    @Override
-    public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
-        return newUndoCommand().execute(context);
+    protected HasControlPoints getEdgeControlPoints(final GraphCommandExecutionContext context) {
+        return (HasControlPoints) getEdge(context).getContent();
     }
 
-    protected CommandResult<RuleViolation> checkArguments() {
-        if (areArgumentsValid()) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-        return GraphCommandResultBuilder.FAILED;
+    public String getEdgeUUID() {
+        return edgeUUID;
     }
 
-    protected boolean areArgumentsValid() {
-        return getEdgeContent().getControlPoints().containsAll(getControlPointList());
-    }
-
-    protected List<ControlPoint> getControlPointList() {
-        return Stream.of(controlPoints).collect(Collectors.toList());
-    }
-
-    protected HasControlPoints getEdgeContent() {
-        return (HasControlPoints) edge.getContent();
-    }
-
-    protected List<ControlPoint> updateControlPointsIndex(final List<ControlPoint> controlPointsList) {
-        final Counter counter = new Counter(-1);
-        return controlPointsList.stream().sequential().map(cp -> {
-            cp.setIndex(counter.increment());
-            return cp;
-        }).collect(Collectors.toList());
-    }
-
-    protected abstract Command<GraphCommandExecutionContext, RuleViolation> newUndoCommand();
-
-    public ControlPoint[] getControlPoints() {
-        return controlPoints;
+    public Edge getEdge(final GraphCommandExecutionContext context) {
+        return context.getGraphIndex().getEdge(edgeUUID);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/AddControlPointCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/AddControlPointCommand.java
@@ -15,19 +15,19 @@
  */
 package org.kie.workbench.common.stunner.core.graph.command.impl;
 
-import java.util.LinkedList;
 import java.util.Objects;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
-import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
-import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.graph.content.HasControlPoints;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.checkAddControlPoint;
 
 /**
  * A Command which adds control points into and an edge.
@@ -35,51 +35,47 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 @Portable
 public class AddControlPointCommand extends AbstractControlPointCommand {
 
-    public AddControlPointCommand(final @MapsTo("edge") Edge edge,
-                                  final @MapsTo("controlPoints") ControlPoint... controlPoints) {
-        super(edge, controlPoints);
+    private final ControlPoint controlPoint;
+    private final int index;
+
+    public AddControlPointCommand(final @MapsTo("edgeUUID") String edgeUUID,
+                                  final @MapsTo("controlPoint") ControlPoint controlPoint,
+                                  final @MapsTo("index") int index) {
+        super(edgeUUID);
+        this.controlPoint = PortablePreconditions.checkNotNull("controlPoint", controlPoint);
+        this.index = index;
     }
 
     @Override
     protected CommandResult<RuleViolation> check(final GraphCommandExecutionContext context) {
-        return validateControlPoints() ?
-                GraphCommandResultBuilder.SUCCESS :
-                GraphCommandResultBuilder.FAILED;
-    }
-
-    private boolean validateControlPoints() {
-        return !getControlPointList().stream().map(ControlPoint::getIndex).anyMatch(Objects::isNull);
-    }
-
-    @Override
-    public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
-        CommandResult<RuleViolation> allowResult = allow(context);
-        if (CommandUtils.isError(allowResult)) {
-            return allowResult;
-        }
-
-        HasControlPoints edgeContent = getEdgeContent();
-        if (Objects.isNull(edgeContent.getControlPoints())) {
-            edgeContent.setControlPoints(new LinkedList<>());
-        }
-
-        //add on the right index position on the list
-        getControlPointList().stream().forEach(cp -> {
-            if (edgeContent.getControlPoints().size() > cp.getIndex()) {
-                edgeContent.getControlPoints().add(cp.getIndex(), new ControlPoint(cp.getLocation(), cp.getIndex()));
-            } else {
-                edgeContent.getControlPoints().add(cp);
-            }
-        });
-
-        //update index control points
-        updateControlPointsIndex(edgeContent.getControlPoints());
-
+        checkAddControlPoint(getEdgeControlPoints(context).getControlPoints(),
+                             controlPoint,
+                             index);
         return GraphCommandResultBuilder.SUCCESS;
     }
 
     @Override
-    protected DeleteControlPointCommand newUndoCommand() {
-        return new DeleteControlPointCommand(edge, controlPoints);
+    public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext context) {
+        check(context);
+        final HasControlPoints edgeControlPoints = getEdgeControlPoints(context);
+        final int size = Objects.isNull(edgeControlPoints.getControlPoints()) ? 0 :
+                edgeControlPoints.getControlPoints().length;
+        final ControlPoint[] cps = new ControlPoint[size + 1];
+        for (int i = 0; i < size + 1; i++) {
+            if (i < index) {
+                cps[i] = edgeControlPoints.getControlPoints()[i];
+            } else if (i == index) {
+                cps[i] = controlPoint;
+            } else {
+                cps[i] = edgeControlPoints.getControlPoints()[i - 1];
+            }
+        }
+        edgeControlPoints.setControlPoints(cps);
+        return GraphCommandResultBuilder.SUCCESS;
+    }
+
+    @Override
+    public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
+        return new DeleteControlPointCommand(getEdgeUUID(), index).execute(context);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/CloneNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/CloneNodeCommand.java
@@ -170,8 +170,14 @@ public class CloneNodeCommand extends AbstractGraphCompositeCommand {
         //in case of any error than rollback all commands
         CommandResult<RuleViolation> finalResult = buildResult(commandResults);
         if (CommandUtils.isError(finalResult)) {
-            undoMultipleExecutedCommands(context, childrenCommands);
-            undoMultipleExecutedCommands(context, getCommands());
+            processMultipleFunctions(childrenCommands,
+                                     c -> doUndo(context, c),
+                                     reverted -> {
+                                     });
+            processMultipleFunctions(getCommands(),
+                                     c -> doUndo(context, c),
+                                     reverted -> {
+                                     });
             return finalResult;
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/DeleteNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/DeleteNodeCommand.java
@@ -15,8 +15,6 @@
  */
 package org.kie.workbench.common.stunner.core.graph.command.impl;
 
-import java.util.logging.Logger;
-
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
@@ -31,8 +29,6 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
  */
 @Portable
 public final class DeleteNodeCommand extends DeregisterNodeCommand {
-
-    private static Logger LOGGER = Logger.getLogger(DeleteNodeCommand.class.getName());
 
     public DeleteNodeCommand(final @MapsTo("uuid") String uuid) {
         super(uuid);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/GraphCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/GraphCommandFactory.java
@@ -179,7 +179,9 @@ public class GraphCommandFactory {
         return new ClearGraphCommand(rootUUID);
     }
 
-    public AddControlPointCommand addControlPoint(Edge edge, ControlPoint... controlPoints){
-        return new AddControlPointCommand(edge, controlPoints);
+    public AddControlPointCommand addControlPoint(final Edge edge,
+                                                  final ControlPoint controlPoint,
+                                                  final int index) {
+        return new AddControlPointCommand(edge.getUUID(), controlPoint, index);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPositionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPositionCommand.java
@@ -111,13 +111,13 @@ public final class UpdateElementPositionCommand extends AbstractGraphCommand {
         final Node<? extends View<?>, Edge> element = getNodeNotNull(context);
         final Bounds targetBounds = getTargetBounds(element);
         final Bounds parentBounds = getParentBounds(getNodeNotNull(context), graph);
+        boundsConsumer.accept(targetBounds);
         if (areBoundsExceeded(element, targetBounds, parentBounds)) {
             return new GraphCommandResultBuilder()
                     .addViolation(new BoundsExceededViolation(parentBounds)
                                           .setUUID(node.getUUID()))
                     .build();
         }
-        boundsConsumer.accept(targetBounds);
         return GraphCommandResultBuilder.SUCCESS;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewConnectorImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewConnectorImpl.java
@@ -16,9 +16,9 @@
 
 package org.kie.workbench.common.stunner.core.graph.content.view;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -32,7 +32,7 @@ public final class ViewConnectorImpl<W> implements ViewConnector<W> {
     protected Bounds bounds;
     private Connection sourceConnection;
     private Connection targetConnection;
-    private List<ControlPoint> controlPoints;
+    private ControlPoint[] controlPoints;
 
     public ViewConnectorImpl(final @MapsTo("definition") W definition,
                              final @MapsTo("bounds") Bounds bounds) {
@@ -40,8 +40,7 @@ public final class ViewConnectorImpl<W> implements ViewConnector<W> {
         this.bounds = bounds;
         this.sourceConnection = null;
         this.targetConnection = null;
-        this.controlPoints = new ArrayList<>();
-
+        this.controlPoints = new ControlPoint[0];
     }
 
     @Override
@@ -81,23 +80,22 @@ public final class ViewConnectorImpl<W> implements ViewConnector<W> {
     }
 
     @Override
-    public List<ControlPoint> getControlPoints() {
+    public ControlPoint[] getControlPoints() {
         return controlPoints;
     }
 
     @Override
-    public void setControlPoints(List<ControlPoint> controlPoints) {
+    public void setControlPoints(ControlPoint[] controlPoints) {
         this.controlPoints = controlPoints;
     }
 
     @Override
     public int hashCode() {
-        getControlPoints().stream().map(ControlPoint::hashCode).toArray(Integer[]::new);
         return HashUtil.combineHashCodes(definition.hashCode(),
                                          bounds.hashCode(),
                                          getSourceConnection().hashCode(),
                                          getTargetConnection().hashCode(),
-                                         HashUtil.combineHashCodes(getControlPoints().stream()
+                                         HashUtil.combineHashCodes(Stream.of(getControlPoints())
                                                                            .map(ControlPoint::hashCode)
                                                                            .mapToInt(i -> i)
                                                                            .toArray()));
@@ -111,7 +109,7 @@ public final class ViewConnectorImpl<W> implements ViewConnector<W> {
                     bounds.equals(other.getBounds()) &&
                     getSourceConnection().equals(other.getSourceConnection()) &&
                     getTargetConnection().equals(other.getTargetConnection()) &&
-                    getControlPoints().equals(other.getControlPoints());
+                    Arrays.equals(getControlPoints(), other.getControlPoints());
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ControlPointValidations.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/ControlPointValidations.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
+
+public class ControlPointValidations {
+
+    public static Predicate<Integer> isControlPointIndexInvalid = index -> index < 0;
+
+    public static Predicate<ControlPoint> isControlPointInvalid = cp -> null == cp.getLocation();
+
+    public static BiPredicate<ControlPoint[], Integer> isAddingControlPointIndexForbidden =
+            (cps, index) -> (null != cps && index > cps.length) || (null == cps && index != 0);
+
+    public static BiPredicate<ControlPoint[], Integer> isDeletingControlPointIndexForbidden =
+            (cps, index) -> null != cps && (index + 1) > cps.length;
+
+    public static BiPredicate<ControlPoint[], ControlPoint[]> cannotControlPointsBeUpdated =
+            (cps1, cps2) -> (null != cps1 && null == cps2) || (null == cps1 && null != cps2) || (null == cps1)
+                    || (cps1.length != cps2.length);
+
+    public static void checkAddControlPoint(final ControlPoint[] controlPoints,
+                                            final ControlPoint controlPoint,
+                                            final int index) {
+        if (isControlPointIndexInvalid.test(index)) {
+            throw new IllegalArgumentException("The given index [" + index + "] for the new CP is not valid.");
+        }
+        if (isAddingControlPointIndexForbidden.test(controlPoints, index)) {
+            throw new IllegalArgumentException("Cannot add a new CP at the given index [" + index + "].");
+        }
+        if (isControlPointInvalid.test(controlPoint)) {
+            throw new IllegalArgumentException("The given CP is not valid");
+        }
+    }
+
+    public static void checkDeleteControlPoint(final ControlPoint[] controlPoints,
+                                               final int index) {
+        if (isControlPointIndexInvalid.test(index)) {
+            throw new IllegalArgumentException("The given index [" + index + "] for the new CP is not valid.");
+        }
+        if (isDeletingControlPointIndexForbidden.test(controlPoints, index)) {
+            throw new IllegalArgumentException("Cannot delete a new CP at the given index [" + index + "].");
+        }
+    }
+
+    public static void checkUpdateControlPoint(final ControlPoint[] controlPoints1,
+                                               final ControlPoint[] controlPoints2) {
+        if (cannotControlPointsBeUpdated.test(controlPoints1,
+                                              controlPoints2)) {
+            throw new IllegalArgumentException("The control points cannot be updated, length differs " +
+                                                       "[" + length(controlPoints1) +
+                                                       ":" + length(controlPoints2) + "].");
+        }
+    }
+
+    private static int length(final ControlPoint[] controlPoints) {
+        return null != controlPoints ? controlPoints.length : 0;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/handler/impl/EdgeCardinalityEvaluationHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/handler/impl/EdgeCardinalityEvaluationHandler.java
@@ -61,9 +61,7 @@ public class EdgeCardinalityEvaluationHandler implements RuleEvaluationHandler<E
         final int candidatesCount = context.getCandidateCount();
         final Optional<CardinalityContext.Operation> operation = context.getOperation();
         final EdgeCardinalityContext.Direction direction = rule.getDirection();
-        final Violation.Type type = operation
-                .filter(CardinalityContext.Operation.ADD::equals)
-                .isPresent() ? Violation.Type.ERROR : Violation.Type.WARNING;
+        final Violation.Type type = Violation.Type.WARNING;
         final int _count = !operation.isPresent() ? candidatesCount :
                 (operation.get().equals(CardinalityContext.Operation.ADD) ? candidatesCount + 1 :
                         (candidatesCount > 0 ? candidatesCount - 1 : 0)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/violations/BoundsExceededViolation.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/rule/violations/BoundsExceededViolation.java
@@ -32,6 +32,11 @@ public class BoundsExceededViolation extends AbstractRuleViolation {
     }
 
     @Override
+    public Type getViolationType() {
+        return Type.WARNING;
+    }
+
+    @Override
     public Optional<Object[]> getArguments() {
         return Optional.of(new Object[]{getUUID(),
                 bounds.getLowerRight().getX(),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/impl/DeferredCompositeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/impl/DeferredCompositeCommandTest.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -178,6 +179,7 @@ public class DeferredCompositeCommandTest {
         Command command = mock(Command.class);
         when(command.allow(commandExecutionContext)).thenReturn(allowResult);
         when(command.execute(commandExecutionContext)).thenReturn(executeResult);
+        when(command.undo(commandExecutionContext)).thenReturn(GraphCommandResultBuilder.SUCCESS);
         return command;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractCloneCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractCloneCommandTest.java
@@ -112,9 +112,9 @@ public abstract class AbstractCloneCommandTest extends AbstractGraphCommandTest 
 
         //edge mock
         connectorContent = new ViewConnectorImpl(connectorDefinition, Bounds.create(1d, 1d, 1d, 1d));
-        sourceConnection = MagnetConnection.Builder.forElement(graphInstance.startNode);
+        sourceConnection = MagnetConnection.Builder.atCenter(graphInstance.startNode);
         connectorContent.setSourceConnection(sourceConnection);
-        targetConnection = MagnetConnection.Builder.forElement(graphInstance.intermNode);
+        targetConnection = MagnetConnection.Builder.atCenter(graphInstance.intermNode);
         connectorContent.setTargetConnection(targetConnection);
         graphInstance.edge1.setContent(connectorContent);
         graphInstance.edge2.setContent(connectorContent);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractControlPointCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractControlPointCommandTest.java
@@ -16,21 +16,24 @@
 
 package org.kie.workbench.common.stunner.core.graph.command.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.mockito.Mock;
 
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 public class AbstractControlPointCommandTest extends AbstractGraphCommandTest {
 
+    static final String EDGE_UUID = "cpEdge";
+
     @Mock
     protected Edge edge;
+
+    @Mock
+    protected ViewConnector viewConnector;
 
     protected ControlPoint controlPoint1;
 
@@ -38,27 +41,16 @@ public class AbstractControlPointCommandTest extends AbstractGraphCommandTest {
 
     protected ControlPoint controlPoint3;
 
-    protected Point2D newLocation;
-
-    protected List<ControlPoint> controlPointList;
-
-    @Mock
-    protected ViewConnector viewConnector;
-
     public void setUp() {
         super.init();
-
-        newLocation = new Point2D(0, 0);
-        controlPoint1 = ControlPoint.build(new Point2D(1, 1), 1);
-        controlPoint2 = ControlPoint.build(new Point2D(2, 2), 2);
-        controlPoint3 = ControlPoint.build(new Point2D(3, 3), 3);
-        controlPointList = new ArrayList<ControlPoint>() {{
-            add(controlPoint1);
-            add(controlPoint2);
-            add(controlPoint3);
-        }};
-
+        when(edge.getUUID()).thenReturn(EDGE_UUID);
+        when(graphIndex.get(eq(EDGE_UUID))).thenReturn(edge);
+        when(graphIndex.getEdge(eq(EDGE_UUID))).thenReturn(edge);
+        controlPoint1 = ControlPoint.build(new Point2D(1, 1));
+        controlPoint2 = ControlPoint.build(new Point2D(2, 2));
+        controlPoint3 = ControlPoint.build(new Point2D(3, 3));
         when(edge.getContent()).thenReturn(viewConnector);
-        when(viewConnector.getControlPoints()).thenReturn(controlPointList);
+        when(viewConnector.getControlPoints())
+                .thenReturn(new ControlPoint[]{controlPoint1, controlPoint2, controlPoint3});
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPositionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/UpdateElementPositionCommandTest.java
@@ -42,7 +42,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -181,13 +180,15 @@ public class UpdateElementPositionCommandTest extends AbstractGraphCommandTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testOutOfBoundsFail() {
-        when(candidate.getContent()).thenReturn(new ViewImpl<>(mock(Object.class),
-                                                               Bounds.create(0d, 0d, 100d, 100d)));
+    public void testOutOfBoundsWarn() {
+        ViewImpl<Object> view = new ViewImpl<>(mock(Object.class),
+                                               Bounds.create(0d, 0d, 100d, 100d));
+        when(candidate.getContent()).thenReturn(view);
         tested = new UpdateElementPositionCommand(candidate,
                                                   Point2D.create(550d, 550d));
         CommandResult<RuleViolation> result = tested.execute(graphCommandExecutionContext);
-        assertEquals(CommandResult.Type.ERROR, result.getType());
-        verify(content, never()).setBounds(any(Bounds.class));
+        assertEquals(CommandResult.Type.WARNING, result.getType());
+        assertEquals(view.getBounds().getUpperLeft(), Bound.create(550d, 550d));
+        assertEquals(view.getBounds().getLowerRight(), Bound.create(650d, 650d));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnectionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnectionTest.java
@@ -26,7 +26,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -34,17 +33,18 @@ import static org.mockito.Mockito.when;
 public class MagnetConnectionTest {
 
     @Mock
-    private Element element;
+    private Element<? extends View<?>> element;
 
     @Mock
-    private Element element2;
+    private Element<? extends View<?>> element2;
 
     @Mock
-    private View<?> content;
+    private View content;
     @Mock
-    private View<?> content2;
+    private View content2;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUp() {
         Bounds bounds = Bounds.create(10d, 20d, 100d, 200d);
         when(element.getContent()).thenReturn(content);
@@ -65,8 +65,8 @@ public class MagnetConnectionTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testForElement() {
-        MagnetConnection m1 = MagnetConnection.Builder.forElement(element);
+    public void testAtCenter() {
+        MagnetConnection m1 = MagnetConnection.Builder.atCenter(element);
 
         assertEquals(45,
                      m1.getLocation().getX(),
@@ -81,30 +81,30 @@ public class MagnetConnectionTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testForElementWithReferenceRight() {
+    public void testForTargetARight() {
         Bounds bounds2 = Bounds.create(20d, 30d, 200d, 300d);
         when(element2.getContent()).thenReturn(content2);
         when(content2.getBounds()).thenReturn(bounds2);
 
-        MagnetConnection m1 = MagnetConnection.Builder.forElement(element, element2);
-        assertNull(m1.getLocation());
+        MagnetConnection m1 = MagnetConnection.Builder.forTarget(element, element2);
+        assertEquals(Point2D.create(90, 90), m1.getLocation());
         assertEquals(MagnetConnection.MAGNET_RIGHT,
                      m1.getMagnetIndex().getAsInt());
-        assertFalse(m1.isAuto());
+        assertTrue(m1.isAuto());
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testForElementWithReferenceLeft() {
+    public void testForTargetAtLeft() {
         Bounds bounds2 = Bounds.create(5d, 10d, 200d, 300d);
         when(element2.getContent()).thenReturn(content2);
         when(content2.getBounds()).thenReturn(bounds2);
 
-        MagnetConnection m1 = MagnetConnection.Builder.forElement(element, element2);
-        assertNull(m1.getLocation());
+        MagnetConnection m1 = MagnetConnection.Builder.forTarget(element, element2);
+        assertEquals(Point2D.create(0, 90), m1.getLocation());
         assertEquals(MagnetConnection.MAGNET_LEFT,
                      m1.getMagnetIndex().getAsInt());
-        assertFalse(m1.isAuto());
+        assertTrue(m1.isAuto());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ControlPointValidationsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/ControlPointValidationsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.graph.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.cannotControlPointsBeUpdated;
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.checkAddControlPoint;
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.checkDeleteControlPoint;
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.checkUpdateControlPoint;
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.isAddingControlPointIndexForbidden;
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.isControlPointIndexInvalid;
+import static org.kie.workbench.common.stunner.core.graph.util.ControlPointValidations.isControlPointInvalid;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ControlPointValidationsTest {
+
+    private ControlPoint controlPoint;
+    private ControlPoint[] controlPoints;
+
+    @Before
+    public void setup() {
+        controlPoint = ControlPoint.build(0, 0);
+        controlPoints = new ControlPoint[]{controlPoint};
+    }
+
+    @Test
+    public void testInvalidIndexes() {
+        assertFalse(isControlPointIndexInvalid.test(0));
+        assertFalse(isControlPointIndexInvalid.test(1));
+        assertFalse(isControlPointIndexInvalid.test(1425));
+        assertTrue(isControlPointIndexInvalid.test(-1));
+        assertTrue(isControlPointIndexInvalid.test(-4543));
+    }
+
+    @Test
+    public void testInvalidControlPoint() {
+        assertFalse(isControlPointInvalid.test(controlPoint));
+        controlPoint.setLocation(null);
+        assertTrue(isControlPointInvalid.test(controlPoint));
+    }
+
+    @Test
+    public void testInvalidControlPointAddIndex() {
+        assertFalse(isAddingControlPointIndexForbidden.test(controlPoints, 1));
+        assertFalse(isAddingControlPointIndexForbidden.test(controlPoints, 0));
+        assertTrue(isAddingControlPointIndexForbidden.test(controlPoints, 2));
+        assertTrue(isAddingControlPointIndexForbidden.test(controlPoints, 3));
+        assertFalse(isAddingControlPointIndexForbidden.test(null, 0));
+        assertTrue(isAddingControlPointIndexForbidden.test(null, 1));
+        assertTrue(isAddingControlPointIndexForbidden.test(null, 2));
+        assertTrue(isAddingControlPointIndexForbidden.test(null, 3));
+    }
+
+    @Test
+    public void testCannotUpdateControlPoints() {
+        ControlPoint controlPoint2 = ControlPoint.build(1, 1);
+        ControlPoint[] controlPoints2 = new ControlPoint[]{controlPoint2};
+        assertFalse(cannotControlPointsBeUpdated.test(controlPoints, controlPoints2));
+        controlPoints2 = new ControlPoint[0];
+        assertTrue(cannotControlPointsBeUpdated.test(controlPoints, controlPoints2));
+        assertTrue(cannotControlPointsBeUpdated.test(controlPoints, null));
+        assertTrue(cannotControlPointsBeUpdated.test(null, controlPoints2));
+    }
+
+    @Test
+    public void testValidCheckAddControlPoint() {
+        ControlPoint cp = ControlPoint.build(1, 1);
+        checkAddControlPoint(controlPoints, cp, 0);
+        checkAddControlPoint(controlPoints, cp, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCheckAddControlPoint() {
+        ControlPoint cp = ControlPoint.build(1, 1);
+        checkAddControlPoint(controlPoints, cp, 2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCheckAddControlPoint2() {
+        ControlPoint cp = ControlPoint.build(1, 1);
+        checkAddControlPoint(controlPoints, cp, 3);
+    }
+
+    @Test
+    public void testValidCheckDeleteControlPoint() {
+        checkDeleteControlPoint(controlPoints, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCheckDeleteControlPoint() {
+        checkDeleteControlPoint(controlPoints, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCheckDeleteControlPoint2() {
+        checkDeleteControlPoint(controlPoints, 2);
+    }
+
+    @Test
+    public void testValidCheckUpdateControlPoints() {
+        ControlPoint controlPoint2 = ControlPoint.build(1, 1);
+        ControlPoint[] controlPoints2 = new ControlPoint[]{controlPoint2};
+        checkUpdateControlPoint(controlPoints, controlPoints2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCheckUpdateControlPoints() {
+        ControlPoint[] controlPoints2 = new ControlPoint[0];
+        checkUpdateControlPoint(controlPoints, controlPoints2);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/ConnectorCardinalityEvaluationHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/ConnectorCardinalityEvaluationHandlerTest.java
@@ -156,7 +156,7 @@ public class ConnectorCardinalityEvaluationHandlerTest extends AbstractGraphRule
         RuleViolations violations = tested.evaluate(RULE_IN_MAX_1,
                                                     context);
         assertNotNull(violations);
-        assertTrue(violations.violations(RuleViolation.Type.ERROR).iterator().hasNext());
+        assertTrue(violations.violations(RuleViolation.Type.WARNING).iterator().hasNext());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/EdgeCardinalityEvaluationHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/rule/handler/impl/EdgeCardinalityEvaluationHandlerTest.java
@@ -138,7 +138,7 @@ public class EdgeCardinalityEvaluationHandlerTest {
         RuleViolations violations = tested.evaluate(RULE_IN_MAX_1,
                                                     context);
         assertNotNull(violations);
-        assertTrue(violations.violations(RuleViolation.Type.ERROR).iterator().hasNext());
+        assertTrue(violations.violations(RuleViolation.Type.WARNING).iterator().hasNext());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/AssociationPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/AssociationPropertyWriter.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
 
-import java.util.List;
-
 import org.eclipse.bpmn2.Association;
 import org.eclipse.bpmn2.AssociationDirection;
 import org.eclipse.bpmn2.di.BPMNEdge;
@@ -46,7 +44,7 @@ public class AssociationPropertyWriter extends BasePropertyWriter {
             Connection sourceConnection = connector.getSourceConnection().get();
             Connection targetConnection = connector.getTargetConnection().get();
 
-            List<ControlPoint> controlPoints = connector.getControlPoints();
+            ControlPoint[] controlPoints = connector.getControlPoints();
             bpmnEdge = PropertyWriterUtils.createBPMNEdge(source,
                                                           target,
                                                           sourceConnection,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SequenceFlowPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SequenceFlowPropertyWriter.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties;
 
-import java.util.List;
-
 import org.eclipse.bpmn2.FlowNode;
 import org.eclipse.bpmn2.FormalExpression;
 import org.eclipse.bpmn2.SequenceFlow;
@@ -65,7 +63,7 @@ public class SequenceFlowPropertyWriter extends PropertyWriter {
         setAutoConnectionSource(sourceConnection);
         setAutoConnectionTarget(targetConnection);
 
-        List<ControlPoint> controlPoints = connector.getControlPoints();
+        ControlPoint[] controlPoints = connector.getControlPoints();
         bpmnEdge = PropertyWriterUtils.createBPMNEdge(source, target, sourceConnection, controlPoints, targetConnection);
         bpmnEdge.setBpmnElement(sequenceFlow);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/util/PropertyWriterUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/util/PropertyWriterUtils.java
@@ -35,7 +35,7 @@ public class PropertyWriterUtils {
     public static BPMNEdge createBPMNEdge(BasePropertyWriter source,
                                           BasePropertyWriter target,
                                           Connection sourceConnection,
-                                          List<ControlPoint> mid,
+                                          ControlPoint[] mid,
                                           Connection targetConnection) {
         BPMNEdge bpmnEdge = di.createBPMNEdge();
         bpmnEdge.setId(Ids.bpmnEdge(source.getShape().getId(),
@@ -57,11 +57,12 @@ public class PropertyWriterUtils {
         List<Point> waypoints = bpmnEdge.getWaypoint();
         waypoints.add(sourcePoint);
 
-        mid.stream()
-                .map(pt -> pointOf(
-                        pt.getLocation().getX(),
-                        pt.getLocation().getY()))
-                .forEach(waypoints::add);
+        if (null != mid) {
+            for (ControlPoint controlPoint : mid) {
+                waypoints.add(pointOf(controlPoint.getLocation().getX(),
+                                      controlPoint.getLocation().getY()));
+            }
+        }
 
         waypoints.add(targetPoint);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/parser/EdgeParser.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/marshall/json/parser/EdgeParser.java
@@ -75,11 +75,12 @@ public class EdgeParser extends ElementParser<Edge<View, Node>> {
         dockersParser.addParser(createDockerObjectParser(viewConnector.getSourceConnection()));
 
         //inserting ControlPoints
-        viewConnector.getControlPoints().stream()
-                .sequential()
-                .map(ControlPoint::getLocation)
-                .map(this::createDockerObjectParser)
-                .forEach(dockersParser::addParser);
+        final ControlPoint[] controlPoints = viewConnector.getControlPoints();
+        if (null != controlPoints) {
+            for (ControlPoint controlPoint : controlPoints) {
+                dockersParser.addParser(createDockerObjectParser(controlPoint.getLocation()));
+            }
+        }
 
         //insert target
         dockersParser.addParser(createDockerObjectParser(viewConnector.getTargetConnection()));
@@ -93,14 +94,14 @@ public class EdgeParser extends ElementParser<Edge<View, Node>> {
 
     private ObjectParser createDockerObjectParser(Point2D location) {
         return (Objects.nonNull(location) ? createDockerObjectParser(Double.valueOf(location.getX()).intValue(),
-                                                Double.valueOf(location.getY()).intValue())
+                                                                     Double.valueOf(location.getY()).intValue())
                 : createDockerObjectParser(-1, -1));
     }
 
     private ObjectParser createDockerObjectParser(final int x, final int y) {
         return new ObjectParser("")
-                .addParser(new IntegerFieldParser("x",x))
-                .addParser(new IntegerFieldParser("y",y));
+                .addParser(new IntegerFieldParser("x", x))
+                .addParser(new IntegerFieldParser("y", y));
     }
 
     private void appendConnAuto(final Connection connection,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/associations/AssociationPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/associations/AssociationPropertyWriterTest.java
@@ -16,9 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.associations;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.bpmn2.Association;
 import org.eclipse.bpmn2.AssociationDirection;
 import org.eclipse.bpmn2.BaseElement;
@@ -83,20 +80,17 @@ public class AssociationPropertyWriterTest {
         BPMNShape targetShape = mockShape(TARGET_SHAPE_ID, 10, 10, 4, 4);
         when(sourceWriter.getShape()).thenReturn(sourceShape);
         when(targetWriter.getShape()).thenReturn(targetShape);
-
-        List<ControlPoint> controlPoints = new ArrayList<>();
-        controlPoints.add(new ControlPoint(Point2D.create(3,3),0));
-        controlPoints.add(new ControlPoint(Point2D.create(4,4),0));
-        controlPoints.add(new ControlPoint(Point2D.create(5,5),0));
-
-        ViewConnector <? extends BPMNViewDefinition> connector = mockConnector(1, 1, 10, 10, controlPoints);
-
+        ControlPoint[] controlPoints = new ControlPoint[]{
+                new ControlPoint(Point2D.create(3, 3)),
+                new ControlPoint(Point2D.create(4, 4)),
+                new ControlPoint(Point2D.create(5, 5))
+        };
+        ViewConnector<? extends BPMNViewDefinition> connector = mockConnector(1, 1, 10, 10, controlPoints);
         associationWriter.setSource(sourceWriter);
         associationWriter.setTarget(targetWriter);
         associationWriter.setConnection(connector);
 
         assertNotNull(associationWriter.getEdge());
-
         assertEquals(association, associationWriter.getEdge().getBpmnElement());
         assertEquals("edge_SOURCE_SHAPE_ID_to_TARGET_SHAPE_ID", associationWriter.getEdge().getId());
         assertWaypoint(2, 2, 0, associationWriter.getEdge().getWaypoint());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SequenceFlowPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SequenceFlowPropertyWriterTest.java
@@ -125,14 +125,14 @@ public class SequenceFlowPropertyWriterTest {
         ViewConnectorImpl<SequenceFlow> connector = makeConnector();
         connector.setSourceConnection(MagnetConnection.Builder.at(1, 2));
         connector.setTargetConnection(MagnetConnection.Builder.at(2, 3));
-        connector.setControlPoints(asList(
+        connector.setControlPoints(new ControlPoint[]{
                 ControlPoint.build(Point2D.create(
                         sx + 100,
                         sy + 100)),
                 ControlPoint.build(Point2D.create(
                         sx + 150,
                         sy + 150))
-        ));
+        });
         p.setConnection(connector);
 
         BPMNEdge edge = p.getEdge();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/util/PropertyWriterUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/util/PropertyWriterUtilsTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.properties.util;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -71,14 +70,13 @@ public class PropertyWriterUtilsTest {
         BPMNShape targetShape = mockShape(TARGET_SHAPE_ID, 10, 10, 4, 4);
         when(sourceWriter.getShape()).thenReturn(sourceShape);
         when(targetWriter.getShape()).thenReturn(targetShape);
-
         Connection sourceConnection = mockConnection(1, 1);
         Connection targetConnection = mockConnection(10, 10);
-
-        List<ControlPoint> controlPoints = new ArrayList<>();
-        controlPoints.add(new ControlPoint(Point2D.create(3,3),0));
-        controlPoints.add(new ControlPoint(Point2D.create(4,4),0));
-        controlPoints.add(new ControlPoint(Point2D.create(5,5),0));
+        ControlPoint[] controlPoints = new ControlPoint[]{
+                new ControlPoint(Point2D.create(3, 3)),
+                new ControlPoint(Point2D.create(4, 4)),
+                new ControlPoint(Point2D.create(5, 5))
+        };
 
         BPMNEdge edge = PropertyWriterUtils.createBPMNEdge(sourceWriter, targetWriter, sourceConnection, controlPoints, targetConnection);
 
@@ -115,7 +113,7 @@ public class PropertyWriterUtilsTest {
     }
 
     @SuppressWarnings("unchecked")
-    public static ViewConnector<? extends BPMNViewDefinition> mockConnector(double sourceX, double sourceY, double targetX, double targetY, List<ControlPoint> controlPoints) {
+    public static ViewConnector<? extends BPMNViewDefinition> mockConnector(double sourceX, double sourceY, double targetX, double targetY, ControlPoint[] controlPoints) {
         ViewConnector<? extends BPMNViewDefinition> connector = mock(ViewConnector.class);
         Connection sourceConnection = mockConnection(sourceX, sourceY);
         Connection targetConnection = mockConnection(targetX, targetY);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/BPMNCreateNodeAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/BPMNCreateNodeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,29 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.client.components.toolbox.actions;
+package org.kie.workbench.common.stunner.bpmn.client.canvas.controls;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.bpmn.definition.BaseGateway;
+import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
 import org.kie.workbench.common.stunner.core.client.api.ClientFactoryManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.GeneralCreateNodeAction;
 import org.kie.workbench.common.stunner.core.client.session.Session;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 @Dependent
+@BPMN
 public class BPMNCreateNodeAction extends GeneralCreateNodeAction {
 
     @Inject
@@ -42,5 +50,26 @@ public class BPMNCreateNodeAction extends GeneralCreateNodeAction {
               selectionEvent,
               sessionCommandManager,
               canvasCommandFactory);
+    }
+
+    @Override
+    protected MagnetConnection buildConnectionBetween(final Node<View<?>, Edge> sourceNode,
+                                                      final Node<View<?>, Edge> targetNode) {
+        final MagnetConnection connection = super.buildConnectionBetween(sourceNode, targetNode);
+        connection.setAuto(isAutoMagnetConnection(sourceNode, targetNode));
+        return connection;
+    }
+
+    public static boolean isAutoMagnetConnection(final Node<View<?>, Edge> sourceNode,
+                                                 final Node<View<?>, Edge> targetNode) {
+        final Object sourceDefinition = null != sourceNode ? sourceNode.getContent().getDefinition() : null;
+        final Object targetDefinition = null != targetNode ? targetNode.getContent().getDefinition() : null;
+        final boolean isSourceGateway = isGateway(sourceDefinition);
+        final boolean isTargetGateway = isGateway(targetDefinition);
+        return !(isSourceGateway || isTargetGateway);
+    }
+
+    private static boolean isGateway(final Object bean) {
+        return null != bean && bean instanceof BaseGateway;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendEmbeddedSubprocessShortcut.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendEmbeddedSubprocessShortcut.java
@@ -39,7 +39,7 @@ public class AppendEmbeddedSubprocessShortcut extends AbstractAppendNodeShortcut
     @Inject
     public AppendEmbeddedSubprocessShortcut(final ToolboxDomainLookups toolboxDomainLookups,
                                             final DefinitionsCacheRegistry definitionsCacheRegistry,
-                                            final GeneralCreateNodeAction generalCreateNodeAction) {
+                                            final @BPMN GeneralCreateNodeAction generalCreateNodeAction) {
         super(toolboxDomainLookups, definitionsCacheRegistry, generalCreateNodeAction);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendNoneEndEventShortcut.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendNoneEndEventShortcut.java
@@ -39,7 +39,7 @@ public class AppendNoneEndEventShortcut extends AbstractAppendNodeShortcut {
     @Inject
     public AppendNoneEndEventShortcut(final ToolboxDomainLookups toolboxDomainLookups,
                                       final DefinitionsCacheRegistry definitionsCacheRegistry,
-                                      final GeneralCreateNodeAction generalCreateNodeAction) {
+                                      final @BPMN GeneralCreateNodeAction generalCreateNodeAction) {
         super(toolboxDomainLookups, definitionsCacheRegistry, generalCreateNodeAction);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendNoneTaskShortcut.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendNoneTaskShortcut.java
@@ -39,7 +39,7 @@ public class AppendNoneTaskShortcut extends AbstractAppendNodeShortcut {
     @Inject
     public AppendNoneTaskShortcut(final ToolboxDomainLookups toolboxDomainLookups,
                                   final DefinitionsCacheRegistry definitionsCacheRegistry,
-                                  final GeneralCreateNodeAction generalCreateNodeAction) {
+                                  final @BPMN GeneralCreateNodeAction generalCreateNodeAction) {
         super(toolboxDomainLookups, definitionsCacheRegistry, generalCreateNodeAction);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendParallelGatewayShortcut.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/keyboard/shortcut/AppendParallelGatewayShortcut.java
@@ -39,7 +39,7 @@ public class AppendParallelGatewayShortcut extends AbstractAppendNodeShortcut {
     @Inject
     public AppendParallelGatewayShortcut(final ToolboxDomainLookups toolboxDomainLookups,
                                          final DefinitionsCacheRegistry definitionsCacheRegistry,
-                                         final GeneralCreateNodeAction generalCreateNodeAction) {
+                                         final @BPMN GeneralCreateNodeAction generalCreateNodeAction) {
         super(toolboxDomainLookups, definitionsCacheRegistry, generalCreateNodeAction);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/BPMNCreateNodeActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/canvas/controls/BPMNCreateNodeActionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.canvas.controls;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
+import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
+import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.bpmn.client.canvas.controls.BPMNCreateNodeAction.isAutoMagnetConnection;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BPMNCreateNodeActionTest {
+
+    private Node gatewayNode;
+    private Node eventNode;
+    private Node taskNode;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() {
+        gatewayNode = new NodeImpl<>("gNode");
+        gatewayNode.setContent(new ViewImpl<>(new ParallelGateway(),
+                                              Bounds.createEmpty()));
+        taskNode = new NodeImpl<>("tNode");
+        taskNode.setContent(new ViewImpl<>(new UserTask(),
+                                           Bounds.createEmpty()));
+        eventNode = new NodeImpl<>("eNode");
+        eventNode.setContent(new ViewImpl<>(new StartNoneEvent(),
+                                            Bounds.createEmpty()));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testIsAutoConnection() {
+        assertFalse(isAutoMagnetConnection(gatewayNode, taskNode));
+        assertFalse(isAutoMagnetConnection(gatewayNode, eventNode));
+        assertFalse(isAutoMagnetConnection(taskNode, gatewayNode));
+        assertFalse(isAutoMagnetConnection(eventNode, gatewayNode));
+        assertFalse(isAutoMagnetConnection(gatewayNode, gatewayNode));
+        assertTrue(isAutoMagnetConnection(taskNode, taskNode));
+        assertTrue(isAutoMagnetConnection(eventNode, taskNode));
+        assertTrue(isAutoMagnetConnection(taskNode, eventNode));
+        assertTrue(isAutoMagnetConnection(eventNode, eventNode));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-backend/src/main/java/org/kie/workbench/common/stunner/cm/backend/CaseManagementDirectDiagramMarshaller.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-backend/src/main/java/org/kie/workbench/common/stunner/cm/backend/CaseManagementDirectDiagramMarshaller.java
@@ -150,8 +150,8 @@ public class CaseManagementDirectDiagramMarshaller extends BaseDirectDiagramMars
         targetNode.getInEdges().add(edge);
 
         ViewConnector<SequenceFlow> content = (ViewConnector<SequenceFlow>) edge.getContent();
-        content.setSourceConnection(MagnetConnection.Builder.forElement(sourceNode));
-        content.setTargetConnection(MagnetConnection.Builder.forElement(targetNode));
+        content.setSourceConnection(MagnetConnection.Builder.atCenter(sourceNode));
+        content.setTargetConnection(MagnetConnection.Builder.atCenter(targetNode));
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/pom.xml
@@ -190,6 +190,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.ahome-it</groupId>
+      <artifactId>ahome-tooling-common</artifactId>
+    </dependency>
+
     <!-- Test scope -->
     <dependency>
       <groupId>junit</groupId>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/command/CaseManagementCanvasCommandFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/command/CaseManagementCanvasCommandFactory.java
@@ -25,9 +25,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.client.lienzo.canvas.command.LienzoCanvasCommandFactory;
 import org.kie.workbench.common.stunner.cm.qualifiers.CaseManagementEditor;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -39,7 +39,7 @@ import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.V
 
 @ApplicationScoped
 @CaseManagementEditor
-public class CaseManagementCanvasCommandFactory extends DefaultCanvasCommandFactory {
+public class CaseManagementCanvasCommandFactory extends LienzoCanvasCommandFactory {
 
     @Inject
     public CaseManagementCanvasCommandFactory(final ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementColorMapBackedPicker.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementColorMapBackedPicker.java
@@ -19,26 +19,16 @@ import java.util.Optional;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.wires.PickerPart;
-import com.ait.lienzo.client.core.shape.wires.WiresLayer;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
 import com.ait.lienzo.client.core.util.ScratchPad;
-import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import org.kie.workbench.common.stunner.cm.client.shape.view.CaseManagementShapeView;
 
 public class CaseManagementColorMapBackedPicker extends ColorMapBackedPicker {
 
-    public CaseManagementColorMapBackedPicker(final WiresLayer layer,
+    public CaseManagementColorMapBackedPicker(final ScratchPad scratchPad,
                                               final PickerOptions options) {
-        super(layer,
-              options);
-    }
-
-    public CaseManagementColorMapBackedPicker(final NFastArrayList<WiresShape> shapes,
-                                              final ScratchPad scratchPad,
-                                              final PickerOptions options) {
-        super(shapes,
-              scratchPad,
+        super(scratchPad,
               options);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControl.java
@@ -23,6 +23,7 @@ import com.ait.lienzo.client.core.shape.wires.WiresLayer;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresContainmentControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresLayerIndex;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresParentPickerControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresContainmentControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerControlImpl;
@@ -36,9 +37,9 @@ public class CaseManagementContainmentControl implements WiresContainmentControl
     private final WiresContainmentControlImpl containmentControl;
     private final CaseManagementContainmentStateHolder state;
 
-    public CaseManagementContainmentControl(final WiresParentPickerControlImpl parentPickerControl,
+    public CaseManagementContainmentControl(final WiresParentPickerControl parentPickerControl,
                                             final CaseManagementContainmentStateHolder state) {
-        this(new WiresContainmentControlImpl(parentPickerControl),
+        this(new WiresContainmentControlImpl(() -> parentPickerControl),
              state);
     }
 
@@ -69,7 +70,7 @@ public class CaseManagementContainmentControl implements WiresContainmentControl
         state.setOriginalIndex(getShapeIndex());
         state.setGhost(Optional.ofNullable(((CaseManagementShapeView) getShape()).getGhost()));
 
-        final WiresParentPickerControl.Index index = containmentControl.getParentPickerControl().getIndex();
+        final WiresLayerIndex index = containmentControl.getParentPickerControl().getIndex();
         index.clear();
         if (state.getGhost().isPresent()) {
             index.exclude(state.getGhost().get());
@@ -91,8 +92,9 @@ public class CaseManagementContainmentControl implements WiresContainmentControl
         if (ghost.isPresent() && null != getParent() && null != getParent().getGroup()) {
             if (getWiresManager().getContainmentAcceptor().containmentAllowed(getParent(),
                                                                               new WiresShape[]{getShape()})) {
-                final double mouseX = containmentControl.getParentPickerControl().getShapeLocationControl().getMouseStartX() + dx;
-                final double mouseY = containmentControl.getParentPickerControl().getShapeLocationControl().getMouseStartY() + dy;
+                final WiresParentPickerControlImpl parentPickerControl = (WiresParentPickerControlImpl) containmentControl.getParentPickerControl();
+                final double mouseX = parentPickerControl.getMouseStartX() + dx;
+                final double mouseY = parentPickerControl.getMouseStartY() + dy;
                 final Point2D parentAbsLoc = getParent().getGroup().getComputedLocation();
                 final Point2D mouseRelativeLoc = new Point2D(mouseX - parentAbsLoc.getX(),
                                                              mouseY - parentAbsLoc.getY());
@@ -102,7 +104,7 @@ public class CaseManagementContainmentControl implements WiresContainmentControl
                                                    getParent(),
                                                    mouseRelativeLoc);
 
-                containmentControl.getParentPickerControl().rebuildPicker();
+                containmentControl.getParentPickerControl().getIndex().build(getWiresManager().getLayer());
             }
         }
 
@@ -198,11 +200,11 @@ public class CaseManagementContainmentControl implements WiresContainmentControl
     }
 
     private WiresContainer getParent() {
-        return containmentControl.getParent();
+        return containmentControl.getParentPickerControl().getParent();
     }
 
     private WiresShape getShape() {
-        return containmentControl.getShape();
+        return containmentControl.getParentPickerControl().getShape();
     }
 
     private WiresManager getWiresManager() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControl.java
@@ -71,7 +71,6 @@ public class CaseManagementContainmentControl implements WiresContainmentControl
         state.setGhost(Optional.ofNullable(((CaseManagementShapeView) getShape()).getGhost()));
 
         final WiresLayerIndex index = containmentControl.getParentPickerControl().getIndex();
-        index.clear();
         if (state.getGhost().isPresent()) {
             index.exclude(state.getGhost().get());
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControl.java
@@ -112,8 +112,8 @@ public class CaseManagementContainmentControl implements WiresContainmentControl
     }
 
     @Override
-    public boolean onMoveComplete() {
-        return containmentControl.onMoveComplete();
+    public void onMoveComplete() {
+        containmentControl.onMoveComplete();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementControlFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementControlFactory.java
@@ -26,11 +26,15 @@ import com.ait.lienzo.client.core.shape.wires.handlers.WiresCompositeControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectionControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresControlFactory;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresLayerIndex;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeHighlight;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresColorMapIndex;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresConnectionControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresConnectorControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeHighlightImpl;
+import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
+import com.ait.lienzo.client.core.util.ScratchPad;
 import org.kie.workbench.common.stunner.cm.qualifiers.CaseManagementEditor;
 
 @ApplicationScoped
@@ -59,6 +63,16 @@ public class CaseManagementControlFactory implements WiresControlFactory {
     @Override
     public WiresShapeHighlight<PickerPart.ShapePart> newShapeHighlight(WiresManager wiresManager) {
         return new WiresShapeHighlightImpl(wiresManager.getDockingAcceptor().getHotspotSize());
+    }
+
+    @Override
+    public WiresLayerIndex newIndex(WiresManager manager) {
+        final ScratchPad scratchPad = manager.getLayer().getLayer().getScratchPad();
+        final ColorMapBackedPicker.PickerOptions pickerOptions =
+                new ColorMapBackedPicker.PickerOptions(false, 0);
+        final CaseManagementColorMapBackedPicker picker = new CaseManagementColorMapBackedPicker(scratchPad,
+                                                                                                 pickerOptions);
+        return new WiresColorMapIndex(picker);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementShapeControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementShapeControl.java
@@ -16,13 +16,13 @@
 
 package org.kie.workbench.common.stunner.cm.client.wires;
 
-import com.ait.lienzo.client.core.shape.wires.WiresLayer;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresLayerIndex;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresParentPickerControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresMagnetsControlImpl;
-import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerCachedControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeControlImpl;
-import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
+import com.ait.tooling.common.api.java.util.function.Supplier;
 import org.kie.workbench.common.stunner.client.lienzo.wires.DelegateWiresShapeControl;
 
 public class CaseManagementShapeControl
@@ -32,12 +32,14 @@ public class CaseManagementShapeControl
 
     public CaseManagementShapeControl(final WiresShape shape,
                                       final CaseManagementContainmentStateHolder state) {
-        final ColorMapBackedPicker.PickerOptions pickerOptions =
-                new ColorMapBackedPicker.PickerOptions(false,
-                                                       0);
-        final WiresParentPickerCachedControl parentPicker =
-                new WiresParentPickerCachedControl(new CaseManagementShapeLocationControl(shape),
-                                                   new CaseManagementColorMapBackedPickerProvider(pickerOptions));
+        final WiresParentPickerControl parentPicker =
+                new WiresParentPickerControlImpl(new CaseManagementShapeLocationControl(shape),
+                                                 new Supplier<WiresLayerIndex>() {
+                                                     @Override
+                                                     public WiresLayerIndex get() {
+                                                         return shapeControl.getIndex().get();
+                                                     }
+                                                 });
         shapeControl = new WiresShapeControlImpl(parentPicker,
                                                  new WiresMagnetsControlImpl(shape),
                                                  null,
@@ -47,18 +49,5 @@ public class CaseManagementShapeControl
     @Override
     public WiresShapeControlImpl getDelegate() {
         return shapeControl;
-    }
-
-    public static class CaseManagementColorMapBackedPickerProvider extends WiresParentPickerControlImpl.ColorMapBackedPickerProviderImpl {
-
-        public CaseManagementColorMapBackedPickerProvider(final ColorMapBackedPicker.PickerOptions pickerOptions) {
-            super(pickerOptions);
-        }
-
-        @Override
-        public ColorMapBackedPicker get(WiresLayer layer) {
-            return new CaseManagementColorMapBackedPicker(layer,
-                                                          getOptions());
-        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementColorMapBackedPickerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementColorMapBackedPickerTest.java
@@ -67,9 +67,7 @@ public class CaseManagementColorMapBackedPickerTest {
         when(scratchPad.getContext()).thenReturn(context2D);
         final NFastArrayList<WiresShape> shapesToSkip = new NFastArrayList<>();
         shapesToSkip.add(shapeToSkip);
-        this.picker = spy(new TestCaseManagementColorMapBackedPicker(new NFastArrayList<>(),
-                                                                     scratchPad,
-                                                                     shapesToSkip));
+        this.picker = spy(new TestCaseManagementColorMapBackedPicker(scratchPad));
     }
 
     @Test
@@ -116,11 +114,8 @@ public class CaseManagementColorMapBackedPickerTest {
 
     private class TestCaseManagementColorMapBackedPicker extends CaseManagementColorMapBackedPicker {
 
-        public TestCaseManagementColorMapBackedPicker(final NFastArrayList<WiresShape> shapes,
-                                                      final ScratchPad scratchPad,
-                                                      final NFastArrayList<WiresShape> shapesToSkip) {
-            super(shapes,
-                  scratchPad,
+        public TestCaseManagementColorMapBackedPicker(final ScratchPad scratchPad) {
+            super(scratchPad,
                   new PickerOptions(false,
                                     0));
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControlTest.java
@@ -146,6 +146,7 @@ public class CaseManagementContainmentControlTest {
         verify(state, times(1)).setOriginalParent(eq(Optional.empty()));
         verify(parent, never()).logicallyReplace(any(CaseManagementShapeView.class),
                                                  any(CaseManagementShapeView.class));
+        verify(index, never()).clear();
     }
 
     @Test
@@ -160,6 +161,7 @@ public class CaseManagementContainmentControlTest {
         verify(state, times(1)).setOriginalParent(eq(Optional.of(parent)));
         verify(parent, times(1)).logicallyReplace(eq(shape),
                                                   eq(ghost));
+        verify(index, never()).clear();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementContainmentControlTest.java
@@ -26,11 +26,10 @@ import com.ait.lienzo.client.core.shape.wires.ILayoutHandler;
 import com.ait.lienzo.client.core.shape.wires.WiresContainer;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
-import com.ait.lienzo.client.core.shape.wires.handlers.WiresParentPickerControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresLayerIndex;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresContainmentControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeLocationControlImpl;
-import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
@@ -57,10 +56,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class CaseManagementContainmentControlTest {
-
-    private static ColorMapBackedPicker.PickerOptions PICKER_OPTIONS =
-            new ColorMapBackedPicker.PickerOptions(false,
-                                                   0d);
 
     @Mock
     private WiresManager wiresManager;
@@ -90,7 +85,7 @@ public class CaseManagementContainmentControlTest {
     private CaseManagementShapeView ghost;
 
     @Mock
-    private WiresParentPickerControl.Index index;
+    private WiresLayerIndex index;
 
     private CaseManagementContainmentControl control;
 
@@ -109,9 +104,9 @@ public class CaseManagementContainmentControlTest {
         when(shape.getWiresManager()).thenReturn(wiresManager);
         doReturn(ghost).when(shape).getGhost();
         when(wiresManager.getContainmentAcceptor()).thenReturn(containmentAcceptor);
-        when(parentPickerControl.getPickerOptions()).thenReturn(PICKER_OPTIONS);
-        when(parentPickerControl.getShapeLocationControl()).thenReturn(shapeLocationControl);
         when(parentPickerControl.getIndex()).thenReturn(index);
+        when(parentPickerControl.getShape()).thenReturn(shape);
+        when(parentPickerControl.getParent()).thenReturn(parent);
         when(containmentControl.getParentPickerControl()).thenReturn(parentPickerControl);
         when(containmentControl.getShape()).thenReturn(shape);
         when(containmentControl.getParent()).thenReturn(parent);
@@ -140,7 +135,7 @@ public class CaseManagementContainmentControlTest {
     @Test
     public void testOnMoveStartButNoCMShape() {
         final WiresShape aShape = mock(WiresShape.class);
-        when(containmentControl.getShape()).thenReturn(aShape);
+        when(parentPickerControl.getShape()).thenReturn(aShape);
         final double x = 15.5d;
         final double y = 21.63d;
         control.onMoveStart(x, y);
@@ -181,7 +176,6 @@ public class CaseManagementContainmentControlTest {
         verify(parentLayoutHandler, never()).add(any(WiresShape.class),
                                                  any(WiresContainer.class),
                                                  any(Point2D.class));
-        verify(parentPickerControl, never()).rebuildPicker();
     }
 
     @Test
@@ -198,7 +192,6 @@ public class CaseManagementContainmentControlTest {
         verify(parentLayoutHandler, times(1)).add(eq(ghost),
                                                   eq(parent),
                                                   eq(new Point2D(x, y)));
-        verify(parentPickerControl, times(1)).rebuildPicker();
         verify(containmentAcceptor, never()).acceptContainment(any(WiresContainer.class),
                                                                any(WiresShape[].class));
     }
@@ -295,14 +288,14 @@ public class CaseManagementContainmentControlTest {
 
     @Test
     public void testGetShapeIndex_noShape() throws Exception {
-        when(containmentControl.getShape()).thenReturn(null);
+        when(parentPickerControl.getShape()).thenReturn(null);
         OptionalInt result = control.getShapeIndex();
         assertFalse(result.isPresent());
     }
 
     @Test
     public void testGetShapeIndex_noParent() throws Exception {
-        when(containmentControl.getParent()).thenReturn(null);
+        when(parentPickerControl.getParent()).thenReturn(null);
         OptionalInt result = control.getShapeIndex();
         assertFalse(result.isPresent());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementShapeControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/wires/CaseManagementShapeControlTest.java
@@ -22,10 +22,9 @@ import com.ait.lienzo.client.core.shape.wires.WiresLayer;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresContainmentControl;
-import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerCachedControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeControlImpl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeLocationControlImpl;
-import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
 import com.ait.lienzo.client.core.util.ScratchPad;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
@@ -34,8 +33,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -71,7 +68,7 @@ public class CaseManagementShapeControlTest {
         when(shape.getWiresManager()).thenReturn(wiresManager);
         when(wiresManager.getLayer()).thenReturn(wiresLayer);
         when(wiresLayer.getLayer()).thenReturn(layer);
-        when(wiresLayer.getChildShapes()).thenReturn(new NFastArrayList<WiresShape>());
+        when(wiresLayer.getChildShapes()).thenReturn(new NFastArrayList<>());
         when(layer.getScratchPad()).thenReturn(scratchPad);
         when(scratchPad.getContext()).thenReturn(context);
         tested = new CaseManagementShapeControl(shape,
@@ -80,16 +77,10 @@ public class CaseManagementShapeControlTest {
 
     @Test
     public void checkRightDelegates() {
-        final WiresShapeControlImpl delegate = (WiresShapeControlImpl) tested.getDelegate();
-        final ColorMapBackedPicker.PickerOptions pickerOptions = delegate.getParentPickerControl().getPickerOptions();
-        assertFalse(pickerOptions.isHotspotsEnabled());
-        assertEquals(0d, pickerOptions.getHotspotWidth(), 0d);
-        final WiresParentPickerCachedControl parentPickerControl = delegate.getParentPickerControl();
+        final WiresShapeControlImpl delegate = tested.getDelegate();
+        final WiresParentPickerControlImpl parentPickerControl = (WiresParentPickerControlImpl) delegate.getParentPickerControl();
         final WiresShapeLocationControlImpl shapeLocationControl = parentPickerControl.getShapeLocationControl();
         assertTrue(shapeLocationControl instanceof CaseManagementShapeLocationControl);
-        parentPickerControl.rebuildPicker();
-        final ColorMapBackedPicker picker = parentPickerControl.getPicker();
-        assertTrue(picker instanceof CaseManagementColorMapBackedPicker);
         final WiresContainmentControl containmentControl = delegate.getContainmentControl();
         assertTrue(containmentControl instanceof CaseManagementContainmentControl);
         assertNull(delegate.getDockingControl());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/widgets/Notifications.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/widgets/Notifications.java
@@ -42,6 +42,7 @@ public class Notifications implements IsWidget {
         View setColumnSortHandler(final ColumnSortEvent.ListHandler<Notification> sortHandler);
 
         View addColumn(final com.google.gwt.user.cellview.client.Column<Notification, String> column,
+                       final double pixelsWidth,
                        final String name);
 
         View removeColumn(final int index);
@@ -57,7 +58,6 @@ public class Notifications implements IsWidget {
     private final NotificationsObserver notificationsObserver;
 
     final ListDataProvider<Notification> logsProvider = new ListDataProvider<Notification>();
-    private boolean notifyErrors = true;
 
     @Inject
     public Notifications(final View view,
@@ -71,10 +71,6 @@ public class Notifications implements IsWidget {
         view.init(this);
         notificationsObserver.onNotification(this::add);
         buildViewColumns();
-    }
-
-    public void setNotifyErrors(boolean notifyErrors) {
-        this.notifyErrors = notifyErrors;
     }
 
     @Override
@@ -120,18 +116,21 @@ public class Notifications implements IsWidget {
         final com.google.gwt.user.cellview.client.Column<Notification, String> typeColumn = createTypeColumn(sortHandler);
         if (typeColumn != null) {
             view.addColumn(typeColumn,
-                           "Type");
+                           100,
+                           "Severity");
         }
         // Log element's UUID.
         final com.google.gwt.user.cellview.client.Column<Notification, String> contextColumn = createContextColumn(sortHandler);
         if (contextColumn != null) {
             view.addColumn(contextColumn,
+                           300,
                            "Context");
         }
         // Log's message.
         final com.google.gwt.user.cellview.client.Column<Notification, String> messageColumn = createMessageColumn(sortHandler);
         if (messageColumn != null) {
             view.addColumn(messageColumn,
+                           600,
                            "Message");
         }
     }
@@ -186,7 +185,7 @@ public class Notifications implements IsWidget {
     @SuppressWarnings("unchecked")
     private String getNotificationSourceMessage(final Notification notification) {
         return notification.getSource().isPresent() ?
-                notification.getSource().toString() :
+                notification.getSource().get().toString() :
                 "-- No source --";
     }
 
@@ -200,7 +199,7 @@ public class Notifications implements IsWidget {
     @SuppressWarnings("unchecked")
     private String getNotificationTypeMessage(final Notification notification) {
         return notification.getType() != null ?
-                notification.getType().name() :
-                "-- No type --";
+                "[" + notification.getType().name() + "]" :
+                "[ ]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/widgets/NotificationsView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/widgets/NotificationsView.java
@@ -83,12 +83,13 @@ public class NotificationsView extends Composite implements Notifications.View {
     @Override
     @SuppressWarnings("unchecked")
     public Notifications.View addColumn(final Column<Notification, String> column,
+                                        final double pixelsWidth,
                                         final String name) {
         logsGrid.addColumn(column,
                            name);
         logsGrid.setColumnWidth(column,
-                                5,
-                                Style.Unit.PCT);
+                                pixelsWidth,
+                                Style.Unit.PX);
         return this;
     }
 


### PR DESCRIPTION
Hey @hasys @tiagodolphine 

The goals for this commit is to fix several issues at once: 
* [JBPM-8118](https://issues.jboss.org/browse/JBPM-8118)
* [JBPM-8182](https://issues.jboss.org/browse/JBPM-8182)
* [JBPM-8105](https://issues.jboss.org/browse/JBPM-8105)
* [JBPM-8158](https://issues.jboss.org/browse/JBPM-8158)
* [JBPM-8235](https://issues.jboss.org/browse/JBPM-8235)
* ~~[JBPM-7099](https://issues.jboss.org/browse/JBPM-7099)~~ _Finally not fixed here, see [comment](https://github.com/kiegroup/kie-wb-common/pull/2451#issuecomment-462953019)_


Some notes about what this commit does:
- Refactor due to new lienzo's `WiresLayerIndex` stuff (see https://github.com/kiegroup/lienzo-core/pull/88)
- Fix undo/redo issues due to bad composite command undo direction (RequestCommandManager)
- Refactor `toString` methods for all canvas commands (logging was terrible!)
- Improve client "dev" commands logging
- Refactored commands & components related to Control Points - @tiagodolphine I did this because of different reasons: 
-- To delete the `isCanvasCommandFirst` stuff in `AbstractCanvasGraphCommand`. It was difficult to follow on top of abstract commands, which are not easy as well... so I tried some different approach
-- To avoid [this change](https://github.com/kiegroup/kie-wb-common/pull/2035/files#diff-914d5b1cceaa40ab6aa47bbc1c760e70L219), as it brakes other stuff, like containment or docking.  The assumption is that the undo direction when using the `RequestCommandManager` is `reverse`
-- Also now the Stunner's `IControlPointsAcceptor` implementation just fires a single command when user adds a new CP and also drags it on the same mouse operation. It was firing two different commands before, which must be reverted in `forward` direction, and well it's fine.. but it was getting difficult to integrate with the `RequestCommandManager`, which defaults to a `reverse` direction
-- Finally noticed that the model for CPs was a bit confusing.. the CPs for an instance where handled by a `List`, but  also each CP was declaring an `index` field. Also some additional computation was being done (and tested) to manage this. Not sure if there was some reason for it, probably I could be missing something, but tried to simplify it, by removing the `index` from the CP class and refactoring the `List` into an `array`, so order is implicit.. does that makes sense?

Soo please as for this PR you should check containment, docking (single & multiple nodes) and also play around with control points.

Assembly:
https://github.com/kiegroup/lienzo-core/pull/88
https://github.com/kiegroup/lienzo-tests/pull/63

Thanks!!