### PR TITLE
DROOLS-3633: [DMN Designer] Data Types - Constraints - Range - Checkboxes for include start and end value must be enabled by default

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/editors/types/RangeValue.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/editors/types/RangeValue.java
@@ -26,6 +26,8 @@ public class RangeValue {
     public RangeValue() {
         this.startValue = "";
         this.endValue = "";
+        this.includeStartValue = true;
+        this.includeEndValue = true;
     }
 
     public boolean getIncludeStartValue() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/editors/types/RangeValueTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/editors/types/RangeValueTest.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.dmn.api.editors.types;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RangeValueTest {
 
@@ -28,8 +28,8 @@ public class RangeValueTest {
         final RangeValue range = new RangeValue();
         assertEquals("", range.getStartValue());
         assertEquals("", range.getEndValue());
-        assertFalse(range.getIncludeStartValue());
-        assertFalse(range.getIncludeEndValue());
+        assertTrue(range.getIncludeStartValue());
+        assertTrue(range.getIncludeEndValue());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/range/DataTypeConstraintRangeTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/range/DataTypeConstraintRangeTest.java
@@ -126,8 +126,8 @@ public class DataTypeConstraintRangeTest {
         final RangeValue rangeValue = new RangeValue();
 
         constraintRange.loadConstraintValue(rangeValue);
-        verify(view).setIncludeStartValue(false);
-        verify(view).setIncludeEndValue(false);
+        verify(view).setIncludeStartValue(true);
+        verify(view).setIncludeEndValue(true);
         verify(view).setStartValue("");
         verify(view).setEndValue("");
 


### PR DESCRIPTION
DROOLS-3633: [DMN Designer] Data Types - Constraints - Range - Checkboxes for include start and end value must be enabled by default