### PR TITLE
DROOLS-3590/DROOLS-3589: [DMN Designer] Data Types - When users create a Data Type, they must be able to perform shortcut operations in the last created DT /  Shortcut tooltip remains opened in some scenarios

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
@@ -49,7 +49,7 @@ public class DataTypeList {
 
     private final DataTypeStackHash dataTypeStackHash;
 
-    private List<Consumer<DataTypeListItem>> dataTypeListItemUpdateCallbacks = new ArrayList<>();
+    private Consumer<DataTypeListItem> onDataTypeListItemUpdate = (e) -> { /* Nothing. */ };
 
     private List<DataTypeListItem> items;
 
@@ -196,7 +196,7 @@ public class DataTypeList {
         view.addSubItem(listItem);
 
         listItem.enableEditMode();
-        fireListItemUpdateCallbacks(listItem);
+        fireOnDataTypeListItemUpdateCallback(listItem);
     }
 
     void insertBelow(final DataType dataType,
@@ -251,16 +251,16 @@ public class DataTypeList {
         findItemByDataTypeHash(dataTypeHash).ifPresent(DataTypeListItem::enableEditMode);
     }
 
-    public void registerDataTypeListItemUpdateCallback(final Consumer<DataTypeListItem> consumer) {
-        dataTypeListItemUpdateCallbacks.add(consumer);
+    public void registerDataTypeListItemUpdateCallback(final Consumer<DataTypeListItem> onDataTypeListItemUpdate) {
+        this.onDataTypeListItemUpdate = onDataTypeListItemUpdate;
     }
 
-    void fireListItemUpdateCallbacks(final String dataTypeHash) {
-        findItemByDataTypeHash(dataTypeHash).ifPresent(this::fireListItemUpdateCallbacks);
+    void fireOnDataTypeListItemUpdateCallback(final String dataTypeHash) {
+        findItemByDataTypeHash(dataTypeHash).ifPresent(this::fireOnDataTypeListItemUpdateCallback);
     }
 
-    private void fireListItemUpdateCallbacks(final DataTypeListItem listItem) {
-        dataTypeListItemUpdateCallbacks.forEach(itemConsumer -> itemConsumer.accept(listItem));
+    private void fireOnDataTypeListItemUpdateCallback(final DataTypeListItem listItem) {
+        onDataTypeListItemUpdate.accept(listItem);
     }
 
     Optional<DataTypeListItem> findItemByDataTypeHash(final String dataTypeHash) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -47,6 +48,8 @@ public class DataTypeList {
     private final DataTypeSearchBar searchBar;
 
     private final DataTypeStackHash dataTypeStackHash;
+
+    private List<Consumer<DataTypeListItem>> dataTypeListItemUpdateCallbacks = new ArrayList<>();
 
     private List<DataTypeListItem> items;
 
@@ -193,15 +196,16 @@ public class DataTypeList {
         view.addSubItem(listItem);
 
         listItem.enableEditMode();
+        fireListItemUpdateCallbacks(listItem);
     }
 
-    public void insertBelow(final DataType dataType,
-                            final DataType reference) {
+    void insertBelow(final DataType dataType,
+                     final DataType reference) {
         view.insertBelow(makeListItem(dataType), reference);
     }
 
-    public void insertAbove(final DataType dataType,
-                            final DataType reference) {
+    void insertAbove(final DataType dataType,
+                     final DataType reference) {
         view.insertAbove(makeListItem(dataType), reference);
     }
 
@@ -245,6 +249,18 @@ public class DataTypeList {
 
     public void enableEditMode(final String dataTypeHash) {
         findItemByDataTypeHash(dataTypeHash).ifPresent(DataTypeListItem::enableEditMode);
+    }
+
+    public void registerDataTypeListItemUpdateCallback(final Consumer<DataTypeListItem> consumer) {
+        dataTypeListItemUpdateCallbacks.add(consumer);
+    }
+
+    void fireListItemUpdateCallbacks(final String dataTypeHash) {
+        findItemByDataTypeHash(dataTypeHash).ifPresent(this::fireListItemUpdateCallbacks);
+    }
+
+    private void fireListItemUpdateCallbacks(final DataTypeListItem listItem) {
+        dataTypeListItemUpdateCallbacks.forEach(itemConsumer -> itemConsumer.accept(listItem));
     }
 
     Optional<DataTypeListItem> findItemByDataTypeHash(final String dataTypeHash) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -241,7 +241,7 @@ public class DataTypeListItem {
             final String referenceDataTypeHash = dataTypeList.calculateParentHash(dataType);
             dataTypeList.refreshItemsByUpdatedDataTypes(persist(dataType));
             closeEditMode();
-            dataTypeList.fireListItemUpdateCallbacks(getNewDataTypeHash(dataType, referenceDataTypeHash));
+            dataTypeList.fireOnDataTypeListItemUpdateCallback(getNewDataTypeHash(dataType, referenceDataTypeHash));
         };
     }
 
@@ -442,7 +442,7 @@ public class DataTypeListItem {
 
     void enableEditModeAndUpdateCallbacks(final String dataTypeHash) {
         dataTypeList.enableEditMode(dataTypeHash);
-        dataTypeList.fireListItemUpdateCallbacks(dataTypeHash);
+        dataTypeList.fireOnDataTypeListItemUpdateCallback(dataTypeHash);
     }
 
     String getNewDataTypeHash(final DataType newDataType,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -238,8 +238,10 @@ public class DataTypeListItem {
 
     Command doSaveAndCloseEditMode(final DataType dataType) {
         return () -> {
+            final String referenceDataTypeHash = dataTypeList.calculateParentHash(dataType);
             dataTypeList.refreshItemsByUpdatedDataTypes(persist(dataType));
             closeEditMode();
+            dataTypeList.fireListItemUpdateCallbacks(getNewDataTypeHash(dataType, referenceDataTypeHash));
         };
     }
 
@@ -405,7 +407,7 @@ public class DataTypeListItem {
             dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes);
         }
 
-        dataTypeList.enableEditMode(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+        enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
     }
 
     public void insertFieldBelow() {
@@ -422,7 +424,7 @@ public class DataTypeListItem {
             dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes);
         }
 
-        dataTypeList.enableEditMode(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+        enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
     }
 
     public void insertNestedField() {
@@ -433,9 +435,14 @@ public class DataTypeListItem {
         final DataType newDataType = newDataType();
         final String referenceDataTypeHash = dataTypeList.calculateHash(getDataType());
         final List<DataType> updatedDataTypes = newDataType.create(getDataType(), NESTED);
-
         dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes);
-        dataTypeList.enableEditMode(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+
+        enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+    }
+
+    void enableEditModeAndUpdateCallbacks(final String dataTypeHash) {
+        dataTypeList.enableEditMode(dataTypeHash);
+        dataTypeList.fireListItemUpdateCallbacks(dataTypeHash);
     }
 
     String getNewDataTypeHash(final DataType newDataType,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.html
@@ -16,9 +16,9 @@
 
 <div data-field="view" class="list-group-item">
     <div class="list-view-pf-actions">
-        <button data-type-field="edit-button" class="btn btn-sm btn-default" data-i18n-key="Edit" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom"></button>
-        <button data-type-field="save-button" class="btn btn-sm btn-default" data-i18n-key="Save" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom"></button>
-        <button data-type-field="close-button" class="btn btn-sm btn-default close-button" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom">✖</button>
+        <button data-type-field="edit-button" class="btn btn-sm btn-default" data-i18n-key="Edit" data-toggle="tooltip" data-delay="500" data-placement="bottom"></button>
+        <button data-type-field="save-button" class="btn btn-sm btn-default" data-i18n-key="Save" data-toggle="tooltip" data-delay="500" data-placement="bottom"></button>
+        <button data-type-field="close-button" class="btn btn-sm btn-default close-button" data-toggle="tooltip" data-delay="500" data-placement="bottom">✖</button>
         <div data-type-field="kebab-menu" class="dropdown-kebab-container">
             <div class="dropdown pull-right dropdown-kebab-pf">
                 <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
@@ -26,18 +26,18 @@
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right">
                     <li>
-                        <a data-type-field="remove-button" href="#" data-i18n-key="Remove" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom"></a>
+                        <a data-type-field="remove-button" href="#" data-i18n-key="Remove" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
                     </li>
                     <li role="separator" class="divider"></li>
                     <li>
-                        <a data-type-field="insert-field-above" href="#" data-i18n-key="InsertFieldAbove" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom"></a>
+                        <a data-type-field="insert-field-above" href="#" data-i18n-key="InsertFieldAbove" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
                     </li>
                     <li>
-                        <a data-type-field="insert-field-below" href="#" data-i18n-key="InsertFieldBelow" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom"></a>
+                        <a data-type-field="insert-field-below" href="#" data-i18n-key="InsertFieldBelow" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
                     </li>
                     <li role="separator" class="divider"></li>
                     <li>
-                        <a data-type-field="insert-nested-field" href="#" data-i18n-key="InsertNestedField" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom"></a>
+                        <a data-type-field="insert-nested-field" href="#" data-i18n-key="InsertNestedField" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
                     </li>
                     <!-- TODO: https://issues.jboss.org/browse/DROOLS-3083 -->
                     <!--<li role="separator" class="divider"></li>-->
@@ -51,7 +51,7 @@
     <div class="list-view-pf-main-info">
         <div class="list-view-pf-body">
             <span class="nesting-level"></span>
-            <span data-type-field="arrow-button" class="icon expand-icon fa fa-caret-down" data-toggle="tooltip" data-container="body" data-delay="500" data-placement="bottom">
+            <span data-type-field="arrow-button" class="icon expand-icon fa fa-caret-down" data-toggle="tooltip" data-delay="500" data-placement="right">
                 <span class="data-type-icon fa fa-object-group"></span>
             </span>
             <div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.editors.types.shortcuts;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -45,6 +46,7 @@ public class DataTypeListShortcuts {
 
     public void init(final DataTypeList dataTypeList) {
         this.dataTypeList = dataTypeList;
+        this.dataTypeList.registerDataTypeListItemUpdateCallback(getDataTypeListItemConsumer());
     }
 
     void onArrowDown() {
@@ -122,6 +124,10 @@ public class DataTypeListShortcuts {
 
     public void reset() {
         view.reset();
+    }
+
+    Consumer<DataTypeListItem> getDataTypeListItemConsumer() {
+        return dataTypeListItem -> view.highlight(dataTypeListItem.getElement());
     }
 
     public interface View extends HasPresenter<DataTypeListShortcuts> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.client.editors.types.shortcuts;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -46,7 +45,7 @@ public class DataTypeListShortcuts {
 
     public void init(final DataTypeList dataTypeList) {
         this.dataTypeList = dataTypeList;
-        this.dataTypeList.registerDataTypeListItemUpdateCallback(getDataTypeListItemConsumer());
+        this.dataTypeList.registerDataTypeListItemUpdateCallback(this::onDataTypeListItemUpdate);
     }
 
     void onArrowDown() {
@@ -83,7 +82,7 @@ public class DataTypeListShortcuts {
             getVisibleDataTypeListItems().forEach(DataTypeListItem::disableEditMode);
         }
 
-        view.reset();
+        reset();
     }
 
     void onCtrlBackspace() {
@@ -91,7 +90,7 @@ public class DataTypeListShortcuts {
     }
 
     void onCtrlS() {
-        getFocusedDataTypeListItem().ifPresent(DataTypeListItem::saveAndCloseEditMode);
+        getCurrentDataTypeListItem().ifPresent(DataTypeListItem::saveAndCloseEditMode);
     }
 
     void onCtrlB() {
@@ -118,16 +117,16 @@ public class DataTypeListShortcuts {
         return view.getCurrentDataTypeListItem();
     }
 
-    private Optional<DataTypeListItem> getFocusedDataTypeListItem() {
-        return view.getFocusedDataTypeListItem();
+    void focusIn() {
+        view.focusIn();
     }
 
     public void reset() {
         view.reset();
     }
 
-    Consumer<DataTypeListItem> getDataTypeListItemConsumer() {
-        return dataTypeListItem -> view.highlight(dataTypeListItem.getElement());
+    private void onDataTypeListItemUpdate(final DataTypeListItem dataTypeListItem) {
+        view.highlight(dataTypeListItem.getElement());
     }
 
     public interface View extends HasPresenter<DataTypeListShortcuts> {
@@ -138,8 +137,6 @@ public class DataTypeListShortcuts {
 
         Optional<DataTypeListItem> getCurrentDataTypeListItem();
 
-        Optional<DataTypeListItem> getFocusedDataTypeListItem();
-
         Optional<Element> getFirstDataTypeRow();
 
         Optional<Element> getNextDataTypeRow();
@@ -147,5 +144,7 @@ public class DataTypeListShortcuts {
         Optional<Element> getPrevDataTypeRow();
 
         void highlight(final Element element);
+
+        void focusIn();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
@@ -76,7 +76,9 @@ public class DataTypeShortcuts {
     }
 
     void clickListener(final Event event) {
-        if (!tabContentContainsTarget(event)) {
+        if (tabContentContainsTarget(event)) {
+            listShortcuts.focusIn();
+        } else {
             listShortcuts.reset();
         }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeList;
 
 import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 import static com.google.gwt.dom.client.BrowserEvents.KEYDOWN;
+import static org.uberfire.client.views.pfly.selectpicker.JQuery.$;
 
 @ApplicationScoped
 public class DataTypeShortcuts {
@@ -74,8 +75,10 @@ public class DataTypeShortcuts {
         removeEventListener(CLICK, CLICK_LISTENER);
     }
 
-    void clickListener(final Event e) {
-        listShortcuts.reset();
+    void clickListener(final Event event) {
+        if (!tabContentContainsTarget(event)) {
+            listShortcuts.reset();
+        }
     }
 
     void keyDownListener(final Event e) {
@@ -154,7 +157,7 @@ public class DataTypeShortcuts {
     }
 
     boolean isSearchBarTarget(final KeyboardEvent event) {
-        final Element element = (Element) event.target;
+        final Element element = getTarget(event);
         return Objects.equals(element.getAttribute("data-field"), "search-bar");
     }
 
@@ -163,8 +166,18 @@ public class DataTypeShortcuts {
     }
 
     boolean isTargetElementAnInput(final KeyboardEvent event) {
-        final Element element = (Element) event.target;
+        final Element element = getTarget(event);
         return element instanceof HTMLInputElement;
+    }
+
+    private boolean tabContentContainsTarget(final Event event) {
+        final Element target = getTarget(event);
+        final Element tabContent = getTabContent();
+        return $.contains(tabContent, target);
+    }
+
+    private Element getTabContent() {
+        return querySelector(".tab-content");
     }
 
     boolean isDropdownOpened() {
@@ -187,5 +200,9 @@ public class DataTypeShortcuts {
     void removeEventListener(final String type,
                              final EventListener eventListener) {
         DomGlobal.document.removeEventListener(type, eventListener);
+    }
+
+    private Element getTarget(final Event e) {
+        return (Element) e.target;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -410,14 +410,19 @@ public class DataTypeListItemTest {
 
         final DataType dataType = spy(makeDataType());
         final List<DataType> updatedDataTypes = singletonList(makeDataType());
+        final String referenceDataTypeHash = "referenceDataTypeHash";
+        final String newDataTypeHash = "newDataTypeHash";
 
         doReturn(updatedDataTypes).when(listItem).persist(dataType);
         doReturn(dataType).when(listItem).getDataType();
+        doReturn(newDataTypeHash).when(listItem).getNewDataTypeHash(dataType, referenceDataTypeHash);
+        when(dataTypeList.calculateParentHash(dataType)).thenReturn(referenceDataTypeHash);
 
         listItem.doSaveAndCloseEditMode(dataType).execute();
 
         verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
         verify(listItem).closeEditMode();
+        verify(dataTypeList).fireListItemUpdateCallbacks(newDataTypeHash);
     }
 
     @Test
@@ -703,8 +708,8 @@ public class DataTypeListItemTest {
         listItem.insertFieldAbove();
 
         verify(listItem).closeEditMode();
+        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
         verify(dataTypeList).insertAbove(newDataType, reference);
-        verify(dataTypeList).enableEditMode(newDataTypeHash);
     }
 
     @Test
@@ -727,8 +732,8 @@ public class DataTypeListItemTest {
         listItem.insertFieldAbove();
 
         verify(listItem).closeEditMode();
+        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
         verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
-        verify(dataTypeList).enableEditMode(newDataTypeHash);
     }
 
     @Test
@@ -751,8 +756,8 @@ public class DataTypeListItemTest {
         listItem.insertFieldBelow();
 
         verify(listItem).closeEditMode();
+        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
         verify(dataTypeList).insertBelow(newDataType, reference);
-        verify(dataTypeList).enableEditMode(newDataTypeHash);
     }
 
     @Test
@@ -775,8 +780,8 @@ public class DataTypeListItemTest {
         listItem.insertFieldBelow();
 
         verify(listItem).closeEditMode();
+        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
         verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
-        verify(dataTypeList).enableEditMode(newDataTypeHash);
     }
 
     @Test
@@ -798,7 +803,7 @@ public class DataTypeListItemTest {
         listItem.insertNestedField();
 
         verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
-        verify(dataTypeList).enableEditMode(newDataTypeHash);
+        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
     }
 
     @Test
@@ -859,6 +864,17 @@ public class DataTypeListItemTest {
         listItem.refreshConstraintComponent();
 
         verify(dataTypeConstraintComponent).enable();
+    }
+
+    @Test
+    public void testEnableEditModeAndUpdateCallbacks() {
+
+        final String dataTypeHash = "dataTypeHash";
+
+        listItem.enableEditModeAndUpdateCallbacks(dataTypeHash);
+
+        verify(dataTypeList).enableEditMode(dataTypeHash);
+        verify(dataTypeList).fireListItemUpdateCallbacks(dataTypeHash);
     }
 
     private DataType makeDataType() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -422,7 +422,7 @@ public class DataTypeListItemTest {
 
         verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
         verify(listItem).closeEditMode();
-        verify(dataTypeList).fireListItemUpdateCallbacks(newDataTypeHash);
+        verify(dataTypeList).fireOnDataTypeListItemUpdateCallback(newDataTypeHash);
     }
 
     @Test
@@ -874,7 +874,7 @@ public class DataTypeListItemTest {
         listItem.enableEditModeAndUpdateCallbacks(dataTypeHash);
 
         verify(dataTypeList).enableEditMode(dataTypeHash);
-        verify(dataTypeList).fireListItemUpdateCallbacks(dataTypeHash);
+        verify(dataTypeList).fireOnDataTypeListItemUpdateCallback(dataTypeHash);
     }
 
     private DataType makeDataType() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLElement;
@@ -77,6 +78,9 @@ public class DataTypeListTest {
 
     @Mock
     private DataTypeSearchBar searchBar;
+
+    @Mock
+    private Consumer<DataTypeListItem> listItemConsumer;
 
     private DataTypeStore dataTypeStore;
 
@@ -549,6 +553,20 @@ public class DataTypeListTest {
         dataTypeList.enableEditMode(dataTypeHash);
 
         verify(listItem).enableEditMode();
+    }
+
+    @Test
+    public void testFireListItemUpdateCallbacks() {
+
+        final String dataTypeHash = "tCity.name";
+        final DataTypeListItem listItem = mock(DataTypeListItem.class);
+
+        doReturn(Optional.of(listItem)).when(dataTypeList).findItemByDataTypeHash(dataTypeHash);
+
+        dataTypeList.registerDataTypeListItemUpdateCallback(listItemConsumer);
+        dataTypeList.fireListItemUpdateCallbacks(dataTypeHash);
+
+        verify(listItemConsumer).accept(listItem);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
@@ -564,7 +564,7 @@ public class DataTypeListTest {
         doReturn(Optional.of(listItem)).when(dataTypeList).findItemByDataTypeHash(dataTypeHash);
 
         dataTypeList.registerDataTypeListItemUpdateCallback(listItemConsumer);
-        dataTypeList.fireListItemUpdateCallbacks(dataTypeHash);
+        dataTypeList.fireOnDataTypeListItemUpdateCallback(dataTypeHash);
 
         verify(listItemConsumer).accept(listItem);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
@@ -18,9 +18,11 @@ package org.kie.workbench.common.dmn.client.editors.types.shortcuts;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +31,11 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListIt
 import org.mockito.Mock;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,8 +52,23 @@ public class DataTypeListShortcutsTest {
 
     @Before
     public void setup() {
-        shortcuts = new DataTypeListShortcuts(view);
+        shortcuts = spy(new DataTypeListShortcuts(view));
         shortcuts.init(dataTypeList);
+    }
+
+    @Test
+    public void testInit() {
+
+        final Consumer<DataTypeListItem> consumer = (e) -> { /* Nothing. */ };
+        doReturn(consumer).when(shortcuts).getDataTypeListItemConsumer();
+
+        shortcuts.init(dataTypeList);
+
+        final DataTypeList actualDataTypeList = shortcuts.getDataTypeList();
+        final DataTypeList expectedDataTypeList = shortcuts.getDataTypeList();
+
+        assertEquals(expectedDataTypeList, actualDataTypeList);
+        verify(expectedDataTypeList).registerDataTypeListItemUpdateCallback(eq(consumer));
     }
 
     @Test
@@ -195,5 +216,18 @@ public class DataTypeListShortcutsTest {
         shortcuts.onCtrlD();
 
         verify(listItem).insertFieldBelow();
+    }
+
+    @Test
+    public void testGetDataTypeListItemConsumer() {
+
+        final DataTypeListItem listItem = mock(DataTypeListItem.class);
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+
+        when(listItem.getElement()).thenReturn(htmlElement);
+
+        shortcuts.getDataTypeListItemConsumer().accept(listItem);
+
+        verify(view).highlight(htmlElement);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcutsTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.uberfire.client.views.pfly.selectpicker.JQuery;
 
 import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 import static com.google.gwt.dom.client.BrowserEvents.KEYDOWN;
@@ -107,8 +108,37 @@ public class DataTypeShortcutsTest {
     }
 
     @Test
-    public void testClickListener() {
-        shortcuts.clickListener(mock(Event.class));
+    public void testClickListenerWhenTabContentContainsTarget() {
+
+        final Event target = mock(Event.class);
+        final Element targetElement = mock(Element.class);
+        final Element tabContentElement = mock(Element.class);
+        final JQuery jQuery = mock(JQuery.class);
+
+        JQuery.$ = jQuery;
+        target.target = targetElement;
+        doReturn(tabContentElement).when(shortcuts).querySelector(".tab-content");
+        when(jQuery.contains(tabContentElement, targetElement)).thenReturn(true);
+
+        shortcuts.clickListener(target);
+
+        verify(listShortcuts, never()).reset();
+    }
+
+    @Test
+    public void testClickListenerWhenTabContentDoesNotContainTarget() {
+
+        final Event target = mock(Event.class);
+        final Element targetElement = mock(Element.class);
+        final Element tabContentElement = mock(Element.class);
+        final JQuery jQuery = mock(JQuery.class);
+
+        JQuery.$ = jQuery;
+        target.target = targetElement;
+        doReturn(tabContentElement).when(shortcuts).querySelector(".tab-content");
+        when(jQuery.contains(tabContentElement, targetElement)).thenReturn(false);
+
+        shortcuts.clickListener(target);
 
         verify(listShortcuts).reset();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcutsTest.java
@@ -122,6 +122,7 @@ public class DataTypeShortcutsTest {
 
         shortcuts.clickListener(target);
 
+        verify(listShortcuts).focusIn();
         verify(listShortcuts, never()).reset();
     }
 
@@ -141,6 +142,7 @@ public class DataTypeShortcutsTest {
         shortcuts.clickListener(target);
 
         verify(listShortcuts).reset();
+        verify(listShortcuts, never()).focusIn();
     }
 
     @Test


### PR DESCRIPTION
See:
- [DROOLS-3590](https://issues.jboss.org/browse/DROOLS-3590): [DMN Designer] Data Types - When users create a Data Type, they must be able to perform shortcut operations in the last created DT
- [DROOLS-3589](https://issues.jboss.org/browse/DROOLS-3589): [DMN Designer] Data Types - Shortcut tooltip remains opened in some scenarios

---

**DROOLS-3590**

![2019-02-11 19 21 20](https://user-images.githubusercontent.com/1079279/52594626-1d391200-2e33-11e9-8b5b-25bcb622a74a.gif)

---

**DROOLS-3589**

Before:
![2019-02-06 18 28 15](https://user-images.githubusercontent.com/1079279/52594650-2a560100-2e33-11e9-8a97-45e65fdfdc78.gif)

After:
![2019-02-11 18 56 30](https://user-images.githubusercontent.com/1079279/52594656-2de98800-2e33-11e9-956d-f9720ac9ddf8.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/630
- https://github.com/kiegroup/kie-wb-common/pull/2466
