### PR TITLE
JBPM-7968: Stunner - Node Selection Design

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateDefaultHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateDefaultHandler.java
@@ -25,7 +25,6 @@ import com.ait.lienzo.shared.core.types.ColorName;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.LienzoShapeView;
 import org.kie.workbench.common.stunner.client.lienzo.util.ShapeViewUserDataEncoder;
 import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
-import org.kie.workbench.common.stunner.core.client.shape.impl.ShapeStateAttributeHandler;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ShapeStateAttributeHandler.ShapeStateAttributes;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ShapeStateAttributesFactory;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ShapeStateHandler;
@@ -42,15 +41,7 @@ public class ShapeStateDefaultHandler
         private final Function<ShapeState, ShapeStateAttributes> stateAttributesProvider;
 
         RenderType(final Function<ShapeState, ShapeStateAttributes> stateAttributesProvider) {
-            this.stateAttributesProvider = state -> {
-                final ShapeStateAttributes attributes = stateAttributesProvider.apply(state);
-                if (isStateSelected(state)) {
-                    attributes
-                            .unset(ShapeStateAttributeHandler.ShapeStateAttribute.FILL_COLOR)
-                            .unset(ShapeStateAttributeHandler.ShapeStateAttribute.STROKE_COLOR);
-                }
-                return attributes;
-            };
+            this.stateAttributesProvider = stateAttributesProvider::apply;
         }
 
         public Function<ShapeState, ShapeStateAttributes> stateAttributesProvider() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateDefaultHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/impl/ShapeStateDefaultHandlerTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.shape.impl;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
@@ -26,6 +27,7 @@ import org.kie.workbench.common.stunner.client.lienzo.shape.view.LienzoShapeView
 import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ShapeStateAttributeHandler;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
@@ -38,6 +40,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,6 +60,9 @@ public class ShapeStateDefaultHandlerTest {
     @Mock
     private LienzoShapeView<?> backgroundShape;
 
+    @Captor
+    private ArgumentCaptor<Function<ShapeState, ShapeStateAttributeHandler.ShapeStateAttributes>> stateAttributesProviderCaptor;
+
     private ShapeStateDefaultHandler tested;
     private Command onComplete;
 
@@ -68,6 +74,40 @@ public class ShapeStateDefaultHandlerTest {
         }).when(handler).onComplete(any(Command.class));
         when(handler.getAttributesHandler()).thenReturn(delegateHandler);
         tested = new ShapeStateDefaultHandler(handler);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSelectedStateStroke() {
+        reset(delegateHandler);
+
+        when(handler.getShapeState()).thenReturn(ShapeState.SELECTED);
+
+        tested.setRenderType(ShapeStateDefaultHandler.RenderType.STROKE);
+
+        verify(delegateHandler).useAttributes(stateAttributesProviderCaptor.capture());
+
+        final Function<ShapeState, ShapeStateAttributeHandler.ShapeStateAttributes> stateAttributesProvider = stateAttributesProviderCaptor.getValue();
+        final ShapeStateAttributeHandler.ShapeStateAttributes attributes = stateAttributesProvider.apply(ShapeState.SELECTED);
+
+        assertNotNull(attributes.getValues().get(ShapeStateAttributeHandler.ShapeStateAttribute.STROKE_COLOR));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSelectedStateFill() {
+        reset(delegateHandler);
+
+        when(handler.getShapeState()).thenReturn(ShapeState.SELECTED);
+
+        tested.setRenderType(ShapeStateDefaultHandler.RenderType.FILL);
+
+        verify(delegateHandler).useAttributes(stateAttributesProviderCaptor.capture());
+
+        final Function<ShapeState, ShapeStateAttributeHandler.ShapeStateAttributes> stateAttributesProvider = stateAttributesProviderCaptor.getValue();
+        final ShapeStateAttributeHandler.ShapeStateAttributes attributes = stateAttributesProvider.apply(ShapeState.SELECTED);
+
+        assertNotNull(attributes.getValues().get(ShapeStateAttributeHandler.ShapeStateAttribute.FILL_COLOR));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeStateAttributesFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/ShapeStateAttributesFactory.java
@@ -22,7 +22,7 @@ import org.kie.workbench.common.stunner.core.client.shape.impl.ShapeStateAttribu
 
 public class ShapeStateAttributesFactory {
 
-    static final String COLOR_SELECTED = "#0000FF";
+    static final String COLOR_SELECTED = "#0088CE";
     static final String COLOR_HIGHLIGHT = "#3366CC";
     static final String COLOR_INVALID = "#FF0000";
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBPM-7968

This PR restores the (correct) blue border for _selected_ nodes. 

Added both @romartin and @hasys as reviewers since this affects all Stunner editors.

I checked BPMN, CM and DMN. All appear OK to me!