### PR TITLE
JBPM-8234 fix failing Marshalling tests

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/BaseFooTestBean1.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/BaseFooTestBean1.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.definition.adapter;
+
+public class BaseFooTestBean1 extends BaseFooTestBean2 {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/BaseFooTestBean2.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/BaseFooTestBean2.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.definition.adapter;
+
+import org.kie.workbench.common.stunner.core.definition.annotation.definition.Category;
+
+public class BaseFooTestBean2 {
+
+    @Category
+    public static final transient String category = "FooTest";
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/FooTestBeanBaseGrandParent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/FooTestBeanBaseGrandParent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.definition.adapter;
+
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
+
+@Definition(graphFactory = NodeFactory.class)
+public class FooTestBeanBaseGrandParent extends BaseFooTestBean2 {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/FooTestBeanBaseParent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/FooTestBeanBaseParent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.definition.adapter;
+
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
+
+@Definition(graphFactory = NodeFactory.class)
+public class FooTestBeanBaseParent extends BaseFooTestBean2 {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/FooTestBeanNoParent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/FooTestBeanNoParent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.backend.definition.adapter;
+
+import org.kie.workbench.common.stunner.core.definition.annotation.Definition;
+import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
+
+@Definition(graphFactory = NodeFactory.class)
+public class FooTestBeanNoParent {
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/definition/adapter/reflect/BackendDefinitionAdapterTest.java
@@ -23,12 +23,17 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.backend.definition.adapter.BaseFooTestBean2;
 import org.kie.workbench.common.stunner.core.backend.definition.adapter.FooTestBean;
+import org.kie.workbench.common.stunner.core.backend.definition.adapter.FooTestBeanBaseGrandParent;
+import org.kie.workbench.common.stunner.core.backend.definition.adapter.FooTestBeanBaseParent;
+import org.kie.workbench.common.stunner.core.backend.definition.adapter.FooTestBeanNoParent;
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
 import org.kie.workbench.common.stunner.core.factory.graph.NodeFactory;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
@@ -111,5 +116,31 @@ public class BackendDefinitionAdapterTest extends AbstractBackendAdapterTest {
     public void getPropertyByName() {
         final Optional<?> property = tested.getProperty(instance, FooTestBean.FOO_PROPERTY_NAME);
         assertEquals(property.get(), instance.fooProperty);
+    }
+
+    @Test
+    public void baseTypeGrandParentTest() {
+        String baseType = tested.getBaseType(FooTestBeanBaseGrandParent.class);
+        assertEquals(baseType, BaseFooTestBean2.class.getName());
+    }
+
+    @Test
+    public void baseTypeParentTest() {
+        String baseType = tested.getBaseType(FooTestBeanBaseParent.class);
+        assertEquals(baseType, BaseFooTestBean2.class.getName());
+    }
+
+    @Test
+    public void baseTypeNoParentTest() {
+        String baseType = tested.getBaseType(FooTestBeanNoParent.class);
+        assertEquals(baseType, null);
+    }
+
+    @Test
+    public void baseTypePrimitiveTest() {
+        String baseType = tested.getBaseType(int.class);
+        assertNull(baseType);
+        baseType = tested.getBaseType(double.class);
+        assertNull(baseType);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/BaseDirectDiagramMarshaller.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/BaseDirectDiagramMarshaller.java
@@ -132,7 +132,11 @@ public abstract class BaseDirectDiagramMarshaller implements DiagramMarshaller<G
 
     private String renderToString(Bpmn2Resource resource) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        resource.save(outputStream, new HashMap<>());
+        try {
+            resource.save(outputStream, new HashMap<>());
+        } finally {
+            outputStream.close();
+        }
         return StringEscapeUtils.unescapeHtml4(outputStream.toString("UTF-8"));
     }
 
@@ -141,9 +145,14 @@ public abstract class BaseDirectDiagramMarshaller implements DiagramMarshaller<G
                                                  final InputStream inputStream) throws IOException {
         LOG.debug("Starting diagram unmarshalling...");
 
-        // definition resolver provides utlities to access elements of the BPMN datamodel
-        DefinitionResolver definitionResolver = new DefinitionResolver(parseDefinitions(inputStream),
-                                                                       workItemDefinitionService.execute(metadata));
+        DefinitionResolver definitionResolver;
+        try {
+            // definition resolver provides utlities to access elements of the BPMN datamodel
+            definitionResolver = new DefinitionResolver(parseDefinitions(inputStream),
+                                                        workItemDefinitionService.execute(metadata));
+        } finally {
+            inputStream.close();
+        }
 
         metadata.setCanvasRootUUID(definitionResolver.getDefinitions().getId());
         metadata.setTitle(definitionResolver.getProcess().getName());
@@ -223,7 +232,11 @@ public abstract class BaseDirectDiagramMarshaller implements DiagramMarshaller<G
         options.put(JBPMBpmn2ResourceImpl.OPTION_PROCESS_DANGLING_HREF,
                     JBPMBpmn2ResourceImpl.OPTION_PROCESS_DANGLING_HREF_RECORD);
 
-        resource.load(inputStream, options);
+        try {
+            resource.load(inputStream, options);
+        } finally {
+            inputStream.close();
+        }
 
         final DocumentRoot root = (DocumentRoot) resource.getContents().get(0);
 


### PR DESCRIPTION
Fix errors on Marshalling tests. 

**Summary:**

TL;DR; 
The problem was at the` BackendDefinitionAdapter.getBaseType`. `UserTask` has changed its parent... now it is `BaseUserTask`, and before it was `BaseTask`, the adapter was just getting the first parent.

Details:
`BootstrapObjectBuilder.stencil` method was getting the Definition based on a given **oryxStencilId**, so sometimes it gets the `UserTask`, and the adapter was not returning the correct BaseType. If the return was any other Task, (BusinessRule, Script, None...) it worked... but this code is totally random. 
If you look at `BaseOryxIdMappings.getKey` this is the random part, it gets the map.entrySet from all the definition mapping and takes the first Definition that matches the **oryxStencilId**, randomly it was getting the UserTask(from the entrySet), and the adapter was not returning the correct BaseType, causing the errors.

Besides that, I closed some `InputStreams` that was not explicity closed on the new Marshhaler, but it seems not to help on the memory leaks during the tests.

@wmedvede 
@romartin 
@xiezhang7 
@hasys 
@manstis