### PR TITLE
DROOLS-3656: [DMN Designer] Select logic type missing entries

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlImpl.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.controls.container;
 
+import java.util.Optional;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -26,18 +28,20 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanv
 @Dependent
 public class CellEditorControlImpl extends AbstractCanvasControl<AbstractCanvas> implements CellEditorControl {
 
-    private CellEditorControlsView view;
     private CellEditorControls editorControls;
 
+    public CellEditorControlImpl() {
+        //CDI proxy
+    }
+
     @Inject
-    public CellEditorControlImpl(final CellEditorControlsView view) {
-        this.view = view;
+    public CellEditorControlImpl(final CellEditorControls editorControls) {
+        this.editorControls = editorControls;
     }
 
     @Override
     public void bind(final DMNSession session) {
-        this.editorControls = new CellEditorControls(session::getGridPanel,
-                                                     view);
+        this.editorControls.setGridPanelSupplier(Optional.of(session::getGridPanel));
     }
 
     @Override
@@ -46,8 +50,7 @@ public class CellEditorControlImpl extends AbstractCanvasControl<AbstractCanvas>
 
     @Override
     protected void doDestroy() {
-        view = null;
-        editorControls = null;
+        this.editorControls.setGridPanelSupplier(Optional.empty());
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlsView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlsView.java
@@ -17,12 +17,12 @@
 package org.kie.workbench.common.dmn.client.widgets.grid.controls.container;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorControls;
-import org.uberfire.client.mvp.UberElement;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 
-public interface CellEditorControlsView extends org.jboss.errai.ui.client.local.api.IsElement,
-                                                UberElement<CellEditorControlsView.Presenter> {
+public interface CellEditorControlsView extends org.jboss.errai.ui.client.local.api.IsElement {
 
     void show(final HasCellEditorControls.Editor<?> editor,
               final Optional<String> editorTitle,
@@ -33,15 +33,13 @@ public interface CellEditorControlsView extends org.jboss.errai.ui.client.local.
 
     interface Presenter {
 
+        void setGridPanelSupplier(final Optional<Supplier<DMNGridPanel>> gridPanelSupplier);
+
         void show(final HasCellEditorControls.Editor<?> editor,
                   final Optional<String> editorTitle,
                   final int x,
                   final int y);
 
         void hide();
-
-        int getTransformedX(final int x);
-
-        int getTransformedY(final int y);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlsViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlsViewImpl.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.enterprise.context.Dependent;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import com.google.gwt.dom.client.BrowserEvents;
@@ -40,7 +40,7 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorControls;
 
 @Templated
-@Dependent
+@ApplicationScoped
 public class CellEditorControlsViewImpl implements CellEditorControlsView {
 
     private static final String CONTAINER_CLASS = "kie-dmn-cell-editor-controls";
@@ -66,8 +66,6 @@ public class CellEditorControlsViewImpl implements CellEditorControlsView {
     private Optional<HasCellEditorControls.Editor> activeEditor = Optional.empty();
 
     private Optional<ElementWrapperWidget<?>> elementWrapperWidget = Optional.empty();
-
-    private Presenter presenter;
 
     public CellEditorControlsViewImpl() {
         //CDI proxy
@@ -122,11 +120,6 @@ public class CellEditorControlsViewImpl implements CellEditorControlsView {
     }
 
     @Override
-    public void init(final Presenter presenter) {
-        this.presenter = presenter;
-    }
-
-    @Override
     public void show(final HasCellEditorControls.Editor<?> editor,
                      final Optional<String> editorTitle,
                      final int x,
@@ -134,11 +127,9 @@ public class CellEditorControlsViewImpl implements CellEditorControlsView {
         DOMUtil.removeAllChildren(cellEditorControlsContainer);
         cellEditorControlsContainer.appendChild(editor.getElement());
 
-        final int tx = presenter.getTransformedX(x);
-        final int ty = presenter.getTransformedY(y);
         final CSSStyleDeclaration style = getElement().getStyle();
-        style.setProperty("left", tx + "px");
-        style.setProperty("top", ty + "px");
+        style.setProperty("left", x + "px");
+        style.setProperty("top", y + "px");
 
         activeEditor = Optional.of(editor);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/CellEditorControlsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/CellEditorControlsTest.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellE
 import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 import org.mockito.Mock;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -58,8 +57,9 @@ public class CellEditorControlsTest {
 
     @Before
     public void setup() {
-        this.controls = new CellEditorControls(() -> gridPanel,
-                                               view);
+        this.controls = new CellEditorControls(view);
+
+        this.controls.setGridPanelSupplier(Optional.of(() -> gridPanel));
 
         doReturn(viewport).when(gridPanel).getViewport();
         doReturn(transform).when(viewport).getTransform();
@@ -67,12 +67,20 @@ public class CellEditorControlsTest {
 
     @Test
     public void testShow() {
+        doReturn(0.5).when(transform).getScaleX();
+        doReturn(-100.0).when(transform).getTranslateX();
+        doReturn(-50).when(gridPanel).getAbsoluteLeft();
+
+        doReturn(0.25).when(transform).getScaleY();
+        doReturn(-200.0).when(transform).getTranslateY();
+        doReturn(-75).when(gridPanel).getAbsoluteTop();
+
         controls.show(editor, EDITOR_TITLE, 10, 20);
 
         verify(view).show(eq(editor),
                           eq(EDITOR_TITLE),
-                          eq(10),
-                          eq(20));
+                          eq(-145),
+                          eq(-270));
     }
 
     @Test
@@ -80,27 +88,5 @@ public class CellEditorControlsTest {
         controls.hide();
 
         verify(view).hide();
-    }
-
-    @Test
-    public void testGetTransformedX() {
-        doReturn(0.5).when(transform).getScaleX();
-        doReturn(-100.0).when(transform).getTranslateX();
-        doReturn(-50).when(gridPanel).getAbsoluteLeft();
-
-        final int tx = controls.getTransformedX(10);
-
-        assertThat(tx).isEqualTo(-145);
-    }
-
-    @Test
-    public void testGetTransformedY() {
-        doReturn(0.25).when(transform).getScaleY();
-        doReturn(-200.0).when(transform).getTranslateY();
-        doReturn(-75).when(gridPanel).getAbsoluteTop();
-
-        final int ty = controls.getTransformedY(20);
-
-        assertThat(ty).isEqualTo(-270);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlImplTest.java
@@ -16,15 +16,25 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.controls.container;
 
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class CellEditorControlImplTest {
@@ -33,37 +43,45 @@ public class CellEditorControlImplTest {
     private DMNSession session;
 
     @Mock
-    private CellEditorControlsView view;
+    private DMNGridPanel gridPanel;
+
+    @Mock
+    private CellEditorControls editorControls;
+
+    @Captor
+    private ArgumentCaptor<Optional<Supplier<DMNGridPanel>>> gridPanelSupplierArgumentCaptor;
 
     private CellEditorControlImpl control;
 
     @Before
     public void setup() {
-        this.control = new CellEditorControlImpl(view);
+        this.control = new CellEditorControlImpl(editorControls);
+
+        when(session.getGridPanel()).thenReturn(gridPanel);
     }
 
     @Test
     public void testBind() {
         control.bind(session);
 
-        assertNotNull(control.getCellEditorControls());
-    }
+        verify(editorControls).setGridPanelSupplier(gridPanelSupplierArgumentCaptor.capture());
 
-    @Test
-    public void testDoInit() {
-        assertNull(control.getCellEditorControls());
-
-        control.doInit();
-
-        assertNull(control.getCellEditorControls());
+        final Optional<Supplier<DMNGridPanel>> gridPanelSupplier = gridPanelSupplierArgumentCaptor.getValue();
+        assertTrue(gridPanelSupplier.isPresent());
+        assertEquals(gridPanel, gridPanelSupplier.get().get());
     }
 
     @Test
     public void testDoDestroy() {
         control.bind(session);
 
+        reset(editorControls);
+
         control.doDestroy();
 
-        assertNull(control.getCellEditorControls());
+        verify(editorControls).setGridPanelSupplier(gridPanelSupplierArgumentCaptor.capture());
+
+        final Optional<Supplier<DMNGridPanel>> gridPanelSupplier = gridPanelSupplierArgumentCaptor.getValue();
+        assertFalse(gridPanelSupplier.isPresent());
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3656

The issue was much the same as my previous PR.. when multiple DMN files are open each was getting its own `CellEditorControlsView` added to the HTML `body` which lead to Bootstrap binding popovers to the wrong element. This PR ensures all editors share a single instance attached to `body`.

Please note I could not replicate without first merging #2483 as I was unable to have multiple editors simultaneously open. With the referenced PR merged locally I could successfully replicate the issue - and tested my fix. 