### PR TITLE
JBPM-8030: JDK11 JAXB ClassNotFound exception in kie-wb-common-forms

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
@@ -87,6 +87,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
It seems that on jdk11 the javax.xml has been removed, so adding the missing dep so the test can pass.

@jomarko @wmedvede could you please take a look?