### PR TITLE
 JBPM-7826 - Speedup new marshaller tests for Tasks

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
@@ -426,22 +426,6 @@
       <scope>test</scope>
     </dependency>
 
-
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- Tuned memory management for the maven-sure-plugin to avoid OutOfMemory in UserTaskTest -->
-      <!-- TODO review as part of the UserTaskTest optimizations -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration combine.self="override">
-          <forkCount>1</forkCount>
-          <argLine>-Xmx1536m -Dfile.encoding=UTF-8</argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
@@ -128,30 +128,30 @@ public abstract class BPMNDiagramMarshallerBase {
     private static final String BPMN_DEF_SET_ID = BindableAdapterUtils.getDefinitionSetId(BPMNDefinitionSet.class);
 
     @Mock
-    private DefinitionManager definitionManager;
+    private static DefinitionManager definitionManager;
     @Mock
-    private AdapterManager adapterManager;
+    private static AdapterManager adapterManager;
     @Mock
-    private AdapterRegistry adapterRegistry;
+    private static AdapterRegistry adapterRegistry;
     @Mock
-    private RuleManager rulesManager;
+    private static RuleManager rulesManager;
     @Mock
-    private CloneManager cloneManager;
+    private static CloneManager cloneManager;
     @Mock
-    private FactoryManager applicationFactoryManager;
+    private static FactoryManager applicationFactoryManager;
     @Spy
-    protected GraphCommandManager commandManager =
+    protected static GraphCommandManager commandManager =
             new GraphCommandManagerImpl(null, null, null);
 
-    private EdgeFactory<Object> connectionEdgeFactory;
-    private NodeFactory<Object> viewNodeFactory;
-    private GraphFactory bpmnGraphFactory;
-    private TestScopeModelFactory testScopeModelFactory;
-    private TaskTypeMorphDefinition taskMorphDefinition;
+    private static EdgeFactory<Object> connectionEdgeFactory;
+    private static NodeFactory<Object> viewNodeFactory;
+    private static GraphFactory bpmnGraphFactory;
+    private static TestScopeModelFactory testScopeModelFactory;
+    private static TaskTypeMorphDefinition taskMorphDefinition;
 
-    protected BPMNDiagramMarshaller oldMarshaller;
-    protected BPMNDirectDiagramMarshaller newMarshaller;
-    protected WorkItemDefinitionMockRegistry workItemDefinitionMockRegistry;
+    protected static BPMNDiagramMarshaller oldMarshaller;
+    protected static BPMNDirectDiagramMarshaller newMarshaller;
+    protected static WorkItemDefinitionMockRegistry workItemDefinitionMockRegistry;
 
     @SuppressWarnings("unchecked")
     protected void init() {
@@ -350,7 +350,7 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private void mockAdapterRegistry(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
+    private static void mockAdapterRegistry(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
         when(adapterRegistry.getDefinitionSetAdapter(any(Class.class))).thenReturn(definitionSetAdapter);
         when(adapterRegistry.getDefinitionAdapter(any(Class.class))).thenReturn(definitionAdapter);
         when(adapterRegistry.getPropertySetAdapter(any(Class.class))).thenReturn(propertySetAdapter);
@@ -358,19 +358,19 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private void mockAdapterManager(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
+    private static void mockAdapterManager(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
         when(adapterManager.forDefinitionSet()).thenReturn(definitionSetAdapter);
         when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
         when(adapterManager.forPropertySet()).thenReturn(propertySetAdapter);
         when(adapterManager.forProperty()).thenReturn(propertyAdapter);
     }
 
-    protected void assertDiagram(Diagram<Graph, Metadata> diagram, int nodesSize) {
+    protected static void assertDiagram(Diagram<Graph, Metadata> diagram, int nodesSize) {
         assertEquals(nodesSize, getNodes(diagram).size());
     }
 
     @SuppressWarnings("unchecked")
-    protected List<Node> getNodes(Diagram<Graph, Metadata> diagram) {
+    protected static List<Node> getNodes(Diagram<Graph, Metadata> diagram) {
         Graph graph = diagram.getGraph();
         assertNotNull(graph);
         Iterator<Node> nodesIterable = graph.nodes().iterator();
@@ -379,24 +379,24 @@ public abstract class BPMNDiagramMarshallerBase {
         return nodes;
     }
 
-    protected Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, String fileName) throws Exception {
+    protected static Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, String fileName) throws Exception {
         return Unmarshalling.unmarshall(marshaller, fileName);
     }
 
-    protected Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, InputStream is) throws Exception {
+    protected static Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, InputStream is) throws Exception {
         return Unmarshalling.unmarshall(marshaller, is);
     }
 
-    protected Definitions convertToDefinitions(Diagram<Graph, Metadata> d) {
+    protected static Definitions convertToDefinitions(Diagram<Graph, Metadata> d) {
         return new DefinitionsConverter(d.getGraph())
                 .toDefinitions();
     }
 
-    protected InputStream getStream(String data) {
+    protected static InputStream getStream(String data) {
         return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
     }
 
-    private void assertNodeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
+    private static void assertNodeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
         Map<String, Node<View, ?>> oldNodes = asNodeMap(oldDiagram.getGraph().nodes());
         Map<String, Node<View, ?>> newNodes = asNodeMap(newDiagram.getGraph().nodes());
 
@@ -431,7 +431,7 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, Node<View, ?>> asNodeMap(Iterable nodes) {
+    private static Map<String, Node<View, ?>> asNodeMap(Iterable nodes) {
         Map<String, Node<View, ?>> oldNodes = new HashMap<>();
         nodes.forEach(n -> {
             Node n1 = (Node) n;
@@ -440,13 +440,13 @@ public abstract class BPMNDiagramMarshallerBase {
         return oldNodes;
     }
 
-    protected void assertDiagramEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
+    protected static void assertDiagramEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
         assertNodeEquals(oldDiagram, newDiagram, fileName);
         assertEdgeEquals(oldDiagram, newDiagram, fileName);
     }
 
     @SuppressWarnings("unchecked")
-    private void assertEdgeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
+    private static void assertEdgeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
         Set<Edge> oldEdges = asEdgeSet(oldDiagram.getGraph().nodes());
         Set<Edge> newEdges = asEdgeSet(newDiagram.getGraph().nodes());
 
@@ -501,7 +501,7 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private Set<Edge> asEdgeSet(Iterable nodes) {
+    private static Set<Edge> asEdgeSet(Iterable nodes) {
         Set<Edge> oldEdges = new HashSet<>();
         nodes.forEach(n -> {
             oldEdges.addAll(((Node<?, Edge>) n).getOutEdges());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/BPMNDiagramMarshallerBase.java
@@ -128,30 +128,30 @@ public abstract class BPMNDiagramMarshallerBase {
     private static final String BPMN_DEF_SET_ID = BindableAdapterUtils.getDefinitionSetId(BPMNDefinitionSet.class);
 
     @Mock
-    private static DefinitionManager definitionManager;
+    private DefinitionManager definitionManager;
     @Mock
-    private static AdapterManager adapterManager;
+    private AdapterManager adapterManager;
     @Mock
-    private static AdapterRegistry adapterRegistry;
+    private AdapterRegistry adapterRegistry;
     @Mock
-    private static RuleManager rulesManager;
+    private RuleManager rulesManager;
     @Mock
-    private static CloneManager cloneManager;
+    private CloneManager cloneManager;
     @Mock
-    private static FactoryManager applicationFactoryManager;
+    private FactoryManager applicationFactoryManager;
     @Spy
-    protected static GraphCommandManager commandManager =
+    protected GraphCommandManager commandManager =
             new GraphCommandManagerImpl(null, null, null);
 
-    private static EdgeFactory<Object> connectionEdgeFactory;
-    private static NodeFactory<Object> viewNodeFactory;
-    private static GraphFactory bpmnGraphFactory;
-    private static TestScopeModelFactory testScopeModelFactory;
-    private static TaskTypeMorphDefinition taskMorphDefinition;
+    private EdgeFactory<Object> connectionEdgeFactory;
+    private NodeFactory<Object> viewNodeFactory;
+    private GraphFactory bpmnGraphFactory;
+    private TestScopeModelFactory testScopeModelFactory;
+    private TaskTypeMorphDefinition taskMorphDefinition;
 
-    protected static BPMNDiagramMarshaller oldMarshaller;
-    protected static BPMNDirectDiagramMarshaller newMarshaller;
-    protected static WorkItemDefinitionMockRegistry workItemDefinitionMockRegistry;
+    protected BPMNDiagramMarshaller oldMarshaller;
+    protected BPMNDirectDiagramMarshaller newMarshaller;
+    protected WorkItemDefinitionMockRegistry workItemDefinitionMockRegistry;
 
     @SuppressWarnings("unchecked")
     protected void init() {
@@ -350,7 +350,7 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private static void mockAdapterRegistry(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
+    private void mockAdapterRegistry(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
         when(adapterRegistry.getDefinitionSetAdapter(any(Class.class))).thenReturn(definitionSetAdapter);
         when(adapterRegistry.getDefinitionAdapter(any(Class.class))).thenReturn(definitionAdapter);
         when(adapterRegistry.getPropertySetAdapter(any(Class.class))).thenReturn(propertySetAdapter);
@@ -358,19 +358,19 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private static void mockAdapterManager(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
+    private void mockAdapterManager(BackendDefinitionAdapter definitionAdapter, BackendDefinitionSetAdapter definitionSetAdapter, BackendPropertySetAdapter propertySetAdapter, BackendPropertyAdapter propertyAdapter) {
         when(adapterManager.forDefinitionSet()).thenReturn(definitionSetAdapter);
         when(adapterManager.forDefinition()).thenReturn(definitionAdapter);
         when(adapterManager.forPropertySet()).thenReturn(propertySetAdapter);
         when(adapterManager.forProperty()).thenReturn(propertyAdapter);
     }
 
-    protected static void assertDiagram(Diagram<Graph, Metadata> diagram, int nodesSize) {
+    protected void assertDiagram(Diagram<Graph, Metadata> diagram, int nodesSize) {
         assertEquals(nodesSize, getNodes(diagram).size());
     }
 
     @SuppressWarnings("unchecked")
-    protected static List<Node> getNodes(Diagram<Graph, Metadata> diagram) {
+    protected List<Node> getNodes(Diagram<Graph, Metadata> diagram) {
         Graph graph = diagram.getGraph();
         assertNotNull(graph);
         Iterator<Node> nodesIterable = graph.nodes().iterator();
@@ -379,24 +379,24 @@ public abstract class BPMNDiagramMarshallerBase {
         return nodes;
     }
 
-    protected static Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, String fileName) throws Exception {
+    protected Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, String fileName) throws Exception {
         return Unmarshalling.unmarshall(marshaller, fileName);
     }
 
-    protected static Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, InputStream is) throws Exception {
+    protected Diagram<Graph, Metadata> unmarshall(DiagramMarshaller<Graph, Metadata, Diagram<Graph, Metadata>> marshaller, InputStream is) throws Exception {
         return Unmarshalling.unmarshall(marshaller, is);
     }
 
-    protected static Definitions convertToDefinitions(Diagram<Graph, Metadata> d) {
+    protected Definitions convertToDefinitions(Diagram<Graph, Metadata> d) {
         return new DefinitionsConverter(d.getGraph())
                 .toDefinitions();
     }
 
-    protected static InputStream getStream(String data) {
+    protected InputStream getStream(String data) {
         return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static void assertNodeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
+    private void assertNodeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
         Map<String, Node<View, ?>> oldNodes = asNodeMap(oldDiagram.getGraph().nodes());
         Map<String, Node<View, ?>> newNodes = asNodeMap(newDiagram.getGraph().nodes());
 
@@ -431,7 +431,7 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, Node<View, ?>> asNodeMap(Iterable nodes) {
+    private Map<String, Node<View, ?>> asNodeMap(Iterable nodes) {
         Map<String, Node<View, ?>> oldNodes = new HashMap<>();
         nodes.forEach(n -> {
             Node n1 = (Node) n;
@@ -440,13 +440,13 @@ public abstract class BPMNDiagramMarshallerBase {
         return oldNodes;
     }
 
-    protected static void assertDiagramEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
+    protected void assertDiagramEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
         assertNodeEquals(oldDiagram, newDiagram, fileName);
         assertEdgeEquals(oldDiagram, newDiagram, fileName);
     }
 
     @SuppressWarnings("unchecked")
-    private static void assertEdgeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
+    private void assertEdgeEquals(Diagram<Graph, Metadata> oldDiagram, Diagram<Graph, Metadata> newDiagram, String fileName) {
         Set<Edge> oldEdges = asEdgeSet(oldDiagram.getGraph().nodes());
         Set<Edge> newEdges = asEdgeSet(newDiagram.getGraph().nodes());
 
@@ -501,7 +501,7 @@ public abstract class BPMNDiagramMarshallerBase {
     }
 
     @SuppressWarnings("unchecked")
-    private static Set<Edge> asEdgeSet(Iterable nodes) {
+    private Set<Edge> asEdgeSet(Iterable nodes) {
         Set<Edge> oldEdges = new HashSet<>();
         nodes.forEach(n -> {
             oldEdges.addAll(((Node<?, Edge>) n).getOutEdges());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/AssociationsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/AssociationsTest.java
@@ -53,6 +53,7 @@ public class AssociationsTest extends BPMNDiagramMarshallerBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void parseAssociations() throws Exception {
         Diagram<Graph, Metadata> d = unmarshall(newMarshaller, BPMN_FILE_PATH);
         Node<View<UserTask>, ?> node = d.getGraph().getNode(TASK_ID);
@@ -63,7 +64,7 @@ public class AssociationsTest extends BPMNDiagramMarshallerBase {
     }
 
     @Test
-    public void marshallUnassignedDeclaration() throws Exception {
+    public void marshallUnassignedDeclaration() {
         String id = "PARENT";
         String decl = "||Foo:String||";
         StartEvent startEvent = bpmn2.createStartEvent();
@@ -83,8 +84,6 @@ public class AssociationsTest extends BPMNDiagramMarshallerBase {
     @Test
     public void marshallAssociations() throws Exception {
         Diagram<Graph, Metadata> d = unmarshall(newMarshaller, BPMN_FILE_PATH);
-        Node<View<UserTask>, ?> node = d.getGraph().getNode(TASK_ID);
-        UserTask definition = node.getContent().getDefinition();
 
         DefinitionsConverter definitionsConverter =
                 new DefinitionsConverter(d.getGraph());
@@ -100,7 +99,7 @@ public class AssociationsTest extends BPMNDiagramMarshallerBase {
         assertEquals("<![CDATA[HELLO]]>", findAssignment(associations, "Body"));
     }
 
-    public String findVar(List<DataInputAssociation> associations, String varName) {
+    private String findVar(List<DataInputAssociation> associations, String varName) {
         return associations.stream()
                 .filter(a -> {
                     DataInput in = (DataInput) a.getTargetRef();
@@ -114,7 +113,7 @@ public class AssociationsTest extends BPMNDiagramMarshallerBase {
                 .get();
     }
 
-    public String findAssignment(List<DataInputAssociation> associations, String varName) {
+    private String findAssignment(List<DataInputAssociation> associations, String varName) {
         return associations.stream()
                 .filter(a -> {
                     DataInput in = (DataInput) a.getTargetRef();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
@@ -80,7 +80,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     private final Marshaller marshallerType;
 
-    public BusinessRuleTaskTest(Marshaller marshallerType) {
+    public BusinessRuleTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
         this.marshallerType = marshallerType;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
@@ -26,6 +26,9 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOSe
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.BusinessRuleTaskExecutionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleLanguage;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.ScriptTypeValue;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -79,10 +82,55 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
 
     private final Marshaller marshallerType;
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
 
     public BusinessRuleTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
         this.marshallerType = marshallerType;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Ignore("Test is ignored, Business Rule Task has properties that are not supported by the old marshallers.")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
@@ -26,9 +26,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOSe
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.BusinessRuleTaskExecutionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleLanguage;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.ScriptTypeValue;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -94,7 +91,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Task01 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Business Rule Task.\");";
@@ -113,10 +110,9 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
         final String RULE_FLOW_GROUP = "Group01";
         final String TASK_DATA_INPUT_OUTPUT = "|input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                   FILLED_TOP_LEVEL_TASK_JAVA_ID,
                                                                   ZERO_INCOME_EDGES,
                                                                   HAS_NO_OUTCOME_EDGE);
@@ -135,7 +131,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                         FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                         ZERO_INCOME_EDGES,
                                                                         HAS_NO_OUTCOME_EDGE);
@@ -154,7 +150,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                   FILLED_TOP_LEVEL_TASK_MVEL_ID,
                                                                   ZERO_INCOME_EDGES,
                                                                   HAS_NO_OUTCOME_EDGE);
@@ -176,11 +172,10 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(diagram,
+        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                              EMPTY_TOP_LEVEL_TASK_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -202,7 +197,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Task10 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task10 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Business Rule Task.\");";
@@ -221,10 +216,9 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
         final String RULE_FLOW_GROUP = "Group01";
         final String TASK_DATA_INPUT_OUTPUT = "|input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                          FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                          ZERO_INCOME_EDGES,
                                                                          HAS_NO_OUTCOME_EDGE);
@@ -243,7 +237,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                                FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                                ZERO_INCOME_EDGES,
                                                                                HAS_NO_OUTCOME_EDGE);
@@ -262,7 +256,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                          FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                          ZERO_INCOME_EDGES,
                                                                          HAS_NO_OUTCOME_EDGE);
@@ -284,11 +278,10 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        BusinessRuleTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                     EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -310,7 +303,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Task02 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Business Rule Task.\");";
@@ -329,10 +322,9 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
         final String RULE_FLOW_GROUP = "Group01";
         final String TASK_DATA_INPUT_OUTPUT = "|input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                   FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID,
                                                                   ONE_INCOME_EDGE,
                                                                   HAS_OUTCOME_EDGE);
@@ -351,7 +343,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                         FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                         ONE_INCOME_EDGE,
                                                                         HAS_OUTCOME_EDGE);
@@ -370,7 +362,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                   FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID,
                                                                   ONE_INCOME_EDGE,
                                                                   HAS_OUTCOME_EDGE);
@@ -392,11 +384,10 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(diagram,
+        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                              EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -418,11 +409,10 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        BusinessRuleTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                     EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -444,7 +434,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Task11 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task11 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Business Rule Task.\");";
@@ -463,10 +453,9 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
         final String RULE_FLOW_GROUP = "Group01";
         final String TASK_DATA_INPUT_OUTPUT = "|input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                          FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                          ONE_INCOME_EDGE,
                                                                          HAS_OUTCOME_EDGE);
@@ -485,7 +474,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                                FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                                ONE_INCOME_EDGE,
                                                                                HAS_OUTCOME_EDGE);
@@ -504,7 +493,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                          FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                          ONE_INCOME_EDGE,
                                                                          HAS_OUTCOME_EDGE);
@@ -526,7 +515,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Task03 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Business Rule Task.\");";
@@ -545,10 +534,9 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
         final String RULE_FLOW_GROUP = "Group01";
         final String TASK_DATA_INPUT_OUTPUT = "|input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                   FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID,
                                                                   TWO_INCOME_EDGES,
                                                                   HAS_OUTCOME_EDGE);
@@ -567,7 +555,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                         FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                         TWO_INCOME_EDGES,
                                                                         HAS_OUTCOME_EDGE);
@@ -586,7 +574,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        BusinessRuleTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                   FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID,
                                                                   TWO_INCOME_EDGES,
                                                                   HAS_OUTCOME_EDGE);
@@ -608,11 +596,10 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(diagram,
+        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                              EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -634,11 +621,10 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        BusinessRuleTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                     EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -660,7 +646,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Task12 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task12 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Business Rule Task.\");";
@@ -679,10 +665,9 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
         final String RULE_FLOW_GROUP = "Group01";
         final String TASK_DATA_INPUT_OUTPUT = "|input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                          FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                          TWO_INCOME_EDGES,
                                                                          HAS_OUTCOME_EDGE);
@@ -701,7 +686,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                                FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                                TWO_INCOME_EDGES,
                                                                                HAS_OUTCOME_EDGE);
@@ -720,7 +705,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
                                            AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        BusinessRuleTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        BusinessRuleTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                          FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                          TWO_INCOME_EDGES,
                                                                          HAS_OUTCOME_EDGE);
@@ -741,13 +726,12 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
     }
 
     @Test
-    public void testUnmarshallDMNRuleLanguageProperties() throws Exception {
+    public void testUnmarshallDMNRuleLanguageProperties() {
         final String DMN_LANGUAGE_TASK_NAME = "DMN Task";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(diagram,
+        BusinessRuleTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                              DMN_RULE_LANGUAGE_TASK_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -776,7 +760,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -784,7 +768,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -792,7 +776,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -800,7 +784,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -808,7 +792,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
@@ -816,14 +800,14 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
     }
 
     @Test
-    public void testMarshallDMNRuleLanguageProperties() throws Exception {
+    public void testMarshallDMNRuleLanguageProperties() {
         checkTaskMarshalling(DMN_RULE_LANGUAGE_TASK_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
@@ -81,7 +81,7 @@ public class BusinessRuleTaskTest extends Task<BusinessRuleTask> {
     private final Marshaller marshallerType;
 
     public BusinessRuleTaskTest(Marshaller marshallerType) {
-        super(marshallerType);
+        super(marshallerType, marshallers());
         this.marshallerType = marshallerType;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/EmailServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/EmailServiceTaskTest.java
@@ -20,9 +20,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -75,7 +72,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Email task01 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Email task01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Email Task.\");";
@@ -93,10 +90,9 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
         final String TASK_DATA_INPUT_OUTPUT = "|Body:String,From:String,Subject:String,To:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_JAVA_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -110,7 +106,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ZERO_INCOME_EDGES,
                                                                    HAS_NO_OUTCOME_EDGE);
@@ -124,7 +120,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_MVEL_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -145,11 +141,10 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TOP_LEVEL_TASK_ID,
                                                         ZERO_INCOME_EDGES,
                                                         HAS_NO_OUTCOME_EDGE);
@@ -167,7 +162,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Email task10 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Email task10 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Email Task.\");";
@@ -185,10 +180,9 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
         final String TASK_DATA_INPUT_OUTPUT = "|Body:String,From:String,Subject:String,To:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -202,7 +196,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ZERO_INCOME_EDGES,
                                                                           HAS_NO_OUTCOME_EDGE);
@@ -216,7 +210,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -237,11 +231,10 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                                ZERO_INCOME_EDGES,
                                                                HAS_NO_OUTCOME_EDGE);
@@ -258,7 +251,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Email task02 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Email task02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Email Task.\");";
@@ -276,10 +269,9 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
         final String TASK_DATA_INPUT_OUTPUT = "|Body:String,From:String,Subject:String,To:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -293,7 +285,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ONE_INCOME_EDGE,
                                                                    HAS_OUTCOME_EDGE);
@@ -307,7 +299,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -328,11 +320,10 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                         ONE_INCOME_EDGE,
                                                         HAS_OUTCOME_EDGE);
@@ -353,11 +344,10 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                                ONE_INCOME_EDGE,
                                                                HAS_OUTCOME_EDGE);
@@ -374,7 +364,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Email task11 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Email task11 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Email Task.\");";
@@ -392,10 +382,9 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
         final String TASK_DATA_INPUT_OUTPUT = "|Body:String,From:String,Subject:String,To:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -409,7 +398,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ONE_INCOME_EDGE,
                                                                           HAS_OUTCOME_EDGE);
@@ -423,7 +412,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -440,7 +429,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Email task03 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Email task03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Email Task.\");";
@@ -458,10 +447,9 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
         final String TASK_DATA_INPUT_OUTPUT = "|Body:String,From:String,Subject:String,To:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -475,7 +463,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    TWO_INCOME_EDGES,
                                                                    HAS_OUTCOME_EDGE);
@@ -489,7 +477,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -510,11 +498,10 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                         TWO_INCOME_EDGES,
                                                         HAS_OUTCOME_EDGE);
@@ -535,11 +522,10 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                                TWO_INCOME_EDGES,
                                                                HAS_OUTCOME_EDGE);
@@ -556,7 +542,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Email task12 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Email task12 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Email Task.\");";
@@ -574,10 +560,9 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
         final String TASK_DATA_INPUT_OUTPUT = "|Body:String,From:String,Subject:String,To:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -591,7 +576,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           TWO_INCOME_EDGES,
                                                                           HAS_OUTCOME_EDGE);
@@ -605,7 +590,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -622,7 +607,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -630,7 +615,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -638,7 +623,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -646,7 +631,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -654,7 +639,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
@@ -662,7 +647,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/EmailServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/EmailServiceTaskTest.java
@@ -66,7 +66,7 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
 
-    public EmailServiceTaskTest(Marshaller marshallerType) {
+    public EmailServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/EmailServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/EmailServiceTaskTest.java
@@ -20,6 +20,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -65,6 +68,12 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
     private static final boolean IS_NOT_ASYNC = false;
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
+
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
 
     public EmailServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
@@ -603,6 +612,46 @@ public class EmailServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.
                                       IS_ASYNC,
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/LogServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/LogServiceTaskTest.java
@@ -66,7 +66,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
 
-    public LogServiceTaskTest(Marshaller marshallerType) {
+    public LogServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/LogServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/LogServiceTaskTest.java
@@ -20,6 +20,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -65,6 +68,12 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
     private static final boolean IS_NOT_ASYNC = false;
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
+
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
 
     public LogServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
@@ -603,6 +612,46 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       IS_ASYNC,
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/LogServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/LogServiceTaskTest.java
@@ -20,9 +20,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -75,7 +72,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Log task01 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Log task01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Log Task.\");";
@@ -93,10 +90,9 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Message:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_JAVA_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -110,7 +106,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ZERO_INCOME_EDGES,
                                                                    HAS_NO_OUTCOME_EDGE);
@@ -124,7 +120,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_MVEL_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -145,11 +141,10 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TOP_LEVEL_TASK_ID,
                                                         ZERO_INCOME_EDGES,
                                                         HAS_NO_OUTCOME_EDGE);
@@ -167,7 +162,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Log task10 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Log task10 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Log Task.\");";
@@ -185,10 +180,9 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Message:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -202,7 +196,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ZERO_INCOME_EDGES,
                                                                           HAS_NO_OUTCOME_EDGE);
@@ -216,7 +210,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -237,11 +231,10 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                                ZERO_INCOME_EDGES,
                                                                HAS_NO_OUTCOME_EDGE);
@@ -258,7 +251,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Log task02 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Log task02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Log Task.\");";
@@ -276,10 +269,9 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Message:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -293,7 +285,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ONE_INCOME_EDGE,
                                                                    HAS_OUTCOME_EDGE);
@@ -307,7 +299,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -328,11 +320,10 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                         ONE_INCOME_EDGE,
                                                         HAS_OUTCOME_EDGE);
@@ -353,11 +344,10 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                                ONE_INCOME_EDGE,
                                                                HAS_OUTCOME_EDGE);
@@ -374,7 +364,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Log task11 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Log task11 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Log Task.\");";
@@ -392,10 +382,9 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Message:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -409,7 +398,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ONE_INCOME_EDGE,
                                                                           HAS_OUTCOME_EDGE);
@@ -423,7 +412,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -440,7 +429,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Log task03 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Log task03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Log Task.\");";
@@ -458,10 +447,9 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Message:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -475,7 +463,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    TWO_INCOME_EDGES,
                                                                    HAS_OUTCOME_EDGE);
@@ -489,7 +477,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -510,11 +498,10 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                         TWO_INCOME_EDGES,
                                                         HAS_OUTCOME_EDGE);
@@ -535,11 +522,10 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                                TWO_INCOME_EDGES,
                                                                HAS_OUTCOME_EDGE);
@@ -556,7 +542,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Log task12 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Log task12 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Log Task.\");";
@@ -574,10 +560,9 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Message:String,input:String||output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -591,7 +576,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           TWO_INCOME_EDGES,
                                                                           HAS_OUTCOME_EDGE);
@@ -605,7 +590,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -622,7 +607,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -630,7 +615,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -638,7 +623,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -646,7 +631,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -654,7 +639,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
@@ -662,7 +647,7 @@ public class LogServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
@@ -20,6 +20,9 @@ import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.EmptyTaskExecutionSet;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -44,8 +47,54 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     private static final int AMOUNT_OF_NODES_IN_DIAGRAM = 36;
 
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
+
     public NoneTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
+    }
+
+    @Override
+    synchronized Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    synchronized Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
@@ -20,9 +20,6 @@ import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.EmptyTaskExecutionSet;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -53,14 +50,13 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME = "Task01 name ~!@#$%^&*()_+`-={}[]:\"|;'\\<>?,./";
         final String TASK_DOCUMENTATION = "Task01 doc\n ~!@#$%^&*()_+`1234567890-={}[]:\"|;'\\<>?,./";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask filledTopLevelTask = getTaskNodeById(diagram,
+        NoneTask filledTopLevelTask = getTaskNodeById(getDiagram(),
                                                       FILLED_TOP_LEVEL_TASK_ID,
                                                       ZERO_INCOME_EDGES,
                                                       HAS_NO_OUTCOME_EDGE);
@@ -70,11 +66,10 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask emptyTopLevelTask = getTaskNodeById(diagram,
+        NoneTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                      EMPTY_TOP_LEVEL_TASK_ID,
                                                      ZERO_INCOME_EDGES,
                                                      HAS_NO_OUTCOME_EDGE);
@@ -84,14 +79,13 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME = "Task03 name ~!@#$%^&*()_+`-={}[]:\"|;'\\<>?,./";
         final String TASK_DOCUMENTATION = "Task03 doc\n ~!@#$%^&*()_+`1234567890-={}[]:\"|;'\\<>?,./";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask filledSubprocessLevelTask = getTaskNodeById(diagram,
+        NoneTask filledSubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                              FILLED_SUBPROCESS_LEVEL_TASK_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -101,11 +95,10 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        NoneTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                             EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                             ZERO_INCOME_EDGES,
                                                             HAS_NO_OUTCOME_EDGE);
@@ -115,14 +108,13 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME = "Task02 name ~!@#$%^&*()_+`-={}[]:\"|;'\\<>?,./";
         final String TASK_DOCUMENTATION = "Task02 doc\n ~!@#$%^&*()_+`1234567890-={}[]:\"|;'\\<>?,./";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask filledTopLevelTask = getTaskNodeById(diagram,
+        NoneTask filledTopLevelTask = getTaskNodeById(getDiagram(),
                                                       FILLED_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                       ONE_INCOME_EDGE,
                                                       HAS_OUTCOME_EDGE);
@@ -132,11 +124,10 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask emptyTopLevelTask = getTaskNodeById(diagram,
+        NoneTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                      EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                      ONE_INCOME_EDGE,
                                                      HAS_OUTCOME_EDGE);
@@ -146,11 +137,10 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        NoneTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                             EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                             ONE_INCOME_EDGE,
                                                             HAS_OUTCOME_EDGE);
@@ -160,14 +150,13 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME = "Task04 name ~!@#$%^&*()_+`-={}[]:\"|;'\\<>?,./";
         final String TASK_DOCUMENTATION = "Task04 doc\n ~!@#$%^&*()_+`1234567890-={}[]:\"|;'\\<>?,./";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask filledSubprocessLevelTask = getTaskNodeById(diagram,
+        NoneTask filledSubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -177,14 +166,13 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME = "Task05 name ~!@#$%^&*()_+`-={}[]:\"|;'\\<>?,./";
         final String TASK_DOCUMENTATION = "Task05 doc\n ~!@#$%^&*()_+`1234567890-={}[]:\"|;'\\<>?,./";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask filledTopLevelTask = getTaskNodeById(diagram,
+        NoneTask filledTopLevelTask = getTaskNodeById(getDiagram(),
                                                       FILLED_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                       TWO_INCOME_EDGES,
                                                       HAS_OUTCOME_EDGE);
@@ -194,11 +182,10 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask filledTopLevelTask = getTaskNodeById(diagram,
+        NoneTask filledTopLevelTask = getTaskNodeById(getDiagram(),
                                                       EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                       TWO_INCOME_EDGES,
                                                       HAS_OUTCOME_EDGE);
@@ -208,11 +195,10 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        NoneTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                             EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                             TWO_INCOME_EDGES,
                                                             HAS_OUTCOME_EDGE);
@@ -222,14 +208,13 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME = "Task06 name ~!@#$%^&*()_+`-={}[]:\"|;'\\<>?,./";
         final String TASK_DOCUMENTATION = "Task06 doc\n ~!@#$%^&*()_+`1234567890-={}[]:\"|;'\\<>?,./";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        NoneTask filledSubprocessLevelTask = getTaskNodeById(diagram,
+        NoneTask filledSubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
@@ -45,7 +45,7 @@ public class NoneTaskTest extends Task<NoneTask> {
     private static final int AMOUNT_OF_NODES_IN_DIAGRAM = 36;
 
     public NoneTaskTest(Marshaller marshallerType) {
-        super(marshallerType);
+        super(marshallerType, marshallers());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/NoneTaskTest.java
@@ -44,7 +44,7 @@ public class NoneTaskTest extends Task<NoneTask> {
 
     private static final int AMOUNT_OF_NODES_IN_DIAGRAM = 36;
 
-    public NoneTaskTest(Marshaller marshallerType) {
+    public NoneTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
@@ -65,7 +65,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
 
-    public RestServiceTaskTest(Marshaller marshallerType) {
+    public RestServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
@@ -19,6 +19,9 @@ package org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshallin
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -64,6 +67,12 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
     private static final boolean IS_NOT_ASYNC = false;
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
+
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
 
     public RestServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
@@ -578,6 +587,46 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       IS_ASYNC,
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/RestServiceTaskTest.java
@@ -19,9 +19,6 @@ package org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshallin
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -74,7 +71,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Rest task01 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Rest task01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Rest Task.\");";
@@ -92,10 +89,9 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
         final String TASK_DATA_INPUT_OUTPUT = "|ConnectTimeout:String,ContentData:String,Method:String,Password:String,ReadTimeout:String,Url:String,Username:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_JAVA_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -109,7 +105,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ZERO_INCOME_EDGES,
                                                                    HAS_NO_OUTCOME_EDGE);
@@ -123,7 +119,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_MVEL_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -140,11 +136,10 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TOP_LEVEL_TASK_ID,
                                                         ZERO_INCOME_EDGES,
                                                         HAS_NO_OUTCOME_EDGE);
@@ -162,7 +157,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Rest task10 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Rest task10 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Rest Task.\");";
@@ -180,10 +175,9 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
         final String TASK_DATA_INPUT_OUTPUT = "|ConnectTimeout:String,ContentData:String,Method:String,Password:String,ReadTimeout:String,Url:String,Username:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -197,7 +191,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ZERO_INCOME_EDGES,
                                                                           HAS_NO_OUTCOME_EDGE);
@@ -211,7 +205,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -228,11 +222,10 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                                ZERO_INCOME_EDGES,
                                                                HAS_NO_OUTCOME_EDGE);
@@ -249,7 +242,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Rest task02 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Rest task02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Rest Task.\");";
@@ -267,10 +260,9 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
         final String TASK_DATA_INPUT_OUTPUT = "|ConnectTimeout:String,ContentData:String,Method:String,Password:String,ReadTimeout:String,Url:String,Username:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -284,7 +276,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ONE_INCOME_EDGE,
                                                                    HAS_OUTCOME_EDGE);
@@ -298,7 +290,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -315,11 +307,10 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                         ONE_INCOME_EDGE,
                                                         HAS_OUTCOME_EDGE);
@@ -336,11 +327,10 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                                ONE_INCOME_EDGE,
                                                                HAS_OUTCOME_EDGE);
@@ -357,7 +347,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Rest task11 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Rest task11 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Rest Task.\");";
@@ -375,10 +365,9 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
         final String TASK_DATA_INPUT_OUTPUT = "|ConnectTimeout:String,ContentData:String,Method:String,Password:String,ReadTimeout:String,Url:String,Username:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -392,7 +381,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ONE_INCOME_EDGE,
                                                                           HAS_OUTCOME_EDGE);
@@ -406,7 +395,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -423,7 +412,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Rest task03 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Rest task03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Rest Task.\");";
@@ -441,10 +430,9 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
         final String TASK_DATA_INPUT_OUTPUT = "|ConnectTimeout:String,ContentData:String,Method:String,Password:String,ReadTimeout:String,Url:String,Username:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -458,7 +446,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    TWO_INCOME_EDGES,
                                                                    HAS_OUTCOME_EDGE);
@@ -472,7 +460,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -489,11 +477,10 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                         TWO_INCOME_EDGES,
                                                         HAS_OUTCOME_EDGE);
@@ -510,11 +497,10 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                                TWO_INCOME_EDGES,
                                                                HAS_OUTCOME_EDGE);
@@ -531,7 +517,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Rest task12 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Rest task12 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from Rest Task.\");";
@@ -549,10 +535,9 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
         final String TASK_DATA_INPUT_OUTPUT = "|ConnectTimeout:String,ContentData:String,Method:String,Password:String,ReadTimeout:String,Url:String,Username:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -566,7 +551,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           TWO_INCOME_EDGES,
                                                                           HAS_OUTCOME_EDGE);
@@ -580,7 +565,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -597,7 +582,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -605,7 +590,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -613,7 +598,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -621,7 +606,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -629,7 +614,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
@@ -637,7 +622,7 @@ public class RestServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.b
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
@@ -20,6 +20,9 @@ import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.ScriptTaskExecutionSet;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -66,6 +69,12 @@ public class ScriptTaskTest extends Task<ScriptTask> {
     private static final String TASK_SCRIPT_MVEL_LANGUAGE = "mvel";
     private static final boolean IS_ASYNC = true;
     private static final boolean IS_NOT_ASYNC = false;
+
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
 
     public ScriptTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
@@ -381,6 +390,46 @@ public class ScriptTaskTest extends Task<ScriptTask> {
                                                                    HAS_OUTCOME_EDGE);
         assertGeneralSet(filledSubprocessLevelTaskMvel.getGeneral(), TASK_NAME_MVEL, TASK_DOCUMENTATION_MVEL);
         assertScriptTaskExecutionSet(filledSubprocessLevelTaskMvel.getExecutionSet(), TASK_SCRIPT_MVEL, TASK_SCRIPT_MVEL_LANGUAGE, IS_ASYNC);
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
@@ -20,9 +20,6 @@ import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.ScriptTaskExecutionSet;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -76,7 +73,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Task01 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_JAVA = "System.out.println(\"Called from Script Task.\");";
@@ -89,24 +86,23 @@ public class ScriptTaskTest extends Task<ScriptTask> {
         final String TASK_DOCUMENTATION_MVEL = "Task10 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_MVEL = "System.out.println(\"Called from Script Task.\");";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                             FILLED_TOP_LEVEL_TASK_JAVA_ID,
                                                             ZERO_INCOME_EDGES,
                                                             HAS_NO_OUTCOME_EDGE);
         assertGeneralSet(filledTopLevelTaskJava.getGeneral(), TASK_NAME_JAVA, TASK_DOCUMENTATION_JAVA);
         assertScriptTaskExecutionSet(filledTopLevelTaskJava.getExecutionSet(), TASK_SCRIPT_JAVA, TASK_SCRIPT_JAVA_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                   FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                   ZERO_INCOME_EDGES,
                                                                   HAS_NO_OUTCOME_EDGE);
         assertGeneralSet(filledTopLevelTaskJavascript.getGeneral(), TASK_NAME_JAVASCRIPT, TASK_DOCUMENTATION_JAVASCRIPT);
         assertScriptTaskExecutionSet(filledTopLevelTaskJavascript.getExecutionSet(), TASK_SCRIPT_JAVASCRIPT, TASK_SCRIPT_JAVASCRIPT_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                             FILLED_TOP_LEVEL_TASK_MVEL_ID,
                                                             ZERO_INCOME_EDGES,
                                                             HAS_NO_OUTCOME_EDGE);
@@ -116,11 +112,10 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledTopLevelTask = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TOP_LEVEL_TASK_ID,
                                                         ZERO_INCOME_EDGES,
                                                         HAS_NO_OUTCOME_EDGE);
@@ -130,7 +125,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Task03 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_JAVA = "System.out.println(\"Called from Script Task.\");";
@@ -143,24 +138,23 @@ public class ScriptTaskTest extends Task<ScriptTask> {
         final String TASK_DOCUMENTATION_MVEL = "Task16 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_MVEL = "System.out.println(\"Called from Script Task.\");";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                    FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                    ZERO_INCOME_EDGES,
                                                                    HAS_NO_OUTCOME_EDGE);
         assertGeneralSet(filledSubprocessLevelTaskJava.getGeneral(), TASK_NAME_JAVA, TASK_DOCUMENTATION_JAVA);
         assertScriptTaskExecutionSet(filledSubprocessLevelTaskJava.getExecutionSet(), TASK_SCRIPT_JAVA, TASK_SCRIPT_JAVA_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                          FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                          ZERO_INCOME_EDGES,
                                                                          HAS_NO_OUTCOME_EDGE);
         assertGeneralSet(filledSubprocessLevelTaskJavascript.getGeneral(), TASK_NAME_JAVASCRIPT, TASK_DOCUMENTATION_JAVASCRIPT);
         assertScriptTaskExecutionSet(filledSubprocessLevelTaskJavascript.getExecutionSet(), TASK_SCRIPT_JAVASCRIPT, TASK_SCRIPT_JAVASCRIPT_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                    FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                    ZERO_INCOME_EDGES,
                                                                    HAS_NO_OUTCOME_EDGE);
@@ -170,11 +164,10 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                    EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                                    ZERO_INCOME_EDGES,
                                                                    HAS_NO_OUTCOME_EDGE);
@@ -184,7 +177,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Task02 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_JAVA = "System.out.println(\"Called from Script Task.\");";
@@ -197,24 +190,23 @@ public class ScriptTaskTest extends Task<ScriptTask> {
         final String TASK_DOCUMENTATION_MVEL = "Task11 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_MVEL = "System.out.println(\"Called from Script Task.\");";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                             FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID,
                                                             ONE_INCOME_EDGE,
                                                             HAS_OUTCOME_EDGE);
         assertGeneralSet(filledTopLevelTaskJava.getGeneral(), TASK_NAME_JAVA, TASK_DOCUMENTATION_JAVA);
         assertScriptTaskExecutionSet(filledTopLevelTaskJava.getExecutionSet(), TASK_SCRIPT_JAVA, TASK_SCRIPT_JAVA_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                   FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                   ONE_INCOME_EDGE,
                                                                   HAS_OUTCOME_EDGE);
         assertGeneralSet(filledTopLevelTaskJavascript.getGeneral(), TASK_NAME_JAVASCRIPT, TASK_DOCUMENTATION_JAVASCRIPT);
         assertScriptTaskExecutionSet(filledTopLevelTaskJavascript.getExecutionSet(), TASK_SCRIPT_JAVASCRIPT, TASK_SCRIPT_JAVASCRIPT_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                             FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID,
                                                             ONE_INCOME_EDGE,
                                                             HAS_OUTCOME_EDGE);
@@ -224,11 +216,10 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledTopLevelTask = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                         ONE_INCOME_EDGE,
                                                         HAS_OUTCOME_EDGE);
@@ -238,11 +229,10 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                    EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                                    ONE_INCOME_EDGE,
                                                                    HAS_OUTCOME_EDGE);
@@ -252,7 +242,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Task04 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task04 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_JAVA = "System.out.println(\"Called from Script Task.\");";
@@ -265,24 +255,23 @@ public class ScriptTaskTest extends Task<ScriptTask> {
         final String TASK_DOCUMENTATION_MVEL = "Task17 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_MVEL = "System.out.println(\"Called from Script Task.\");";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                    FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                    ONE_INCOME_EDGE,
                                                                    HAS_OUTCOME_EDGE);
         assertGeneralSet(filledSubprocessLevelTaskJava.getGeneral(), TASK_NAME_JAVA, TASK_DOCUMENTATION_JAVA);
         assertScriptTaskExecutionSet(filledSubprocessLevelTaskJava.getExecutionSet(), TASK_SCRIPT_JAVA, TASK_SCRIPT_JAVA_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                          FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                          ONE_INCOME_EDGE,
                                                                          HAS_OUTCOME_EDGE);
         assertGeneralSet(filledSubprocessLevelTaskJavascript.getGeneral(), TASK_NAME_JAVASCRIPT, TASK_DOCUMENTATION_JAVASCRIPT);
         assertScriptTaskExecutionSet(filledSubprocessLevelTaskJavascript.getExecutionSet(), TASK_SCRIPT_JAVASCRIPT, TASK_SCRIPT_JAVASCRIPT_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                    FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                    ONE_INCOME_EDGE,
                                                                    HAS_OUTCOME_EDGE);
@@ -292,7 +281,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Task05 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task05 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_JAVA = "System.out.println(\"Called from Script Task.\");";
@@ -305,24 +294,23 @@ public class ScriptTaskTest extends Task<ScriptTask> {
         final String TASK_DOCUMENTATION_MVEL = "Task12 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_MVEL = "System.out.println(\"Called from Script Task.\");";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                             FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID,
                                                             TWO_INCOME_EDGES,
                                                             HAS_OUTCOME_EDGE);
         assertGeneralSet(filledTopLevelTaskJava.getGeneral(), TASK_NAME_JAVA, TASK_DOCUMENTATION_JAVA);
         assertScriptTaskExecutionSet(filledTopLevelTaskJava.getExecutionSet(), TASK_SCRIPT_JAVA, TASK_SCRIPT_JAVA_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                   FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                   TWO_INCOME_EDGES,
                                                                   HAS_OUTCOME_EDGE);
         assertGeneralSet(filledTopLevelTaskJavascript.getGeneral(), TASK_NAME_JAVASCRIPT, TASK_DOCUMENTATION_JAVASCRIPT);
         assertScriptTaskExecutionSet(filledTopLevelTaskJavascript.getExecutionSet(), TASK_SCRIPT_JAVASCRIPT, TASK_SCRIPT_JAVASCRIPT_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                             FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID,
                                                             TWO_INCOME_EDGES,
                                                             HAS_OUTCOME_EDGE);
@@ -332,11 +320,10 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledTopLevelTask = getTaskNodeById(diagram,
+        ScriptTask filledTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                         TWO_INCOME_EDGES,
                                                         HAS_OUTCOME_EDGE);
@@ -346,11 +333,10 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                    EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                                    TWO_INCOME_EDGES,
                                                                    HAS_OUTCOME_EDGE);
@@ -360,7 +346,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Task06 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task06 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_JAVA = "System.out.println(\"Called from Script Task.\");";
@@ -373,24 +359,23 @@ public class ScriptTaskTest extends Task<ScriptTask> {
         final String TASK_DOCUMENTATION_MVEL = "Task18 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_SCRIPT_MVEL = "System.out.println(\"Called from Script Task.\");";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                    FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                    TWO_INCOME_EDGES,
                                                                    HAS_OUTCOME_EDGE);
         assertGeneralSet(filledSubprocessLevelTaskJava.getGeneral(), TASK_NAME_JAVA, TASK_DOCUMENTATION_JAVA);
         assertScriptTaskExecutionSet(filledSubprocessLevelTaskJava.getExecutionSet(), TASK_SCRIPT_JAVA, TASK_SCRIPT_JAVA_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                          FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                          TWO_INCOME_EDGES,
                                                                          HAS_OUTCOME_EDGE);
         assertGeneralSet(filledSubprocessLevelTaskJavascript.getGeneral(), TASK_NAME_JAVASCRIPT, TASK_DOCUMENTATION_JAVASCRIPT);
         assertScriptTaskExecutionSet(filledSubprocessLevelTaskJavascript.getExecutionSet(), TASK_SCRIPT_JAVASCRIPT, TASK_SCRIPT_JAVASCRIPT_LANGUAGE, IS_ASYNC);
 
-        ScriptTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ScriptTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                    FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                    TWO_INCOME_EDGES,
                                                                    HAS_OUTCOME_EDGE);
@@ -400,7 +385,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -408,7 +393,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -416,7 +401,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -424,7 +409,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -432,7 +417,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
@@ -440,7 +425,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
@@ -67,7 +67,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
     private static final boolean IS_ASYNC = true;
     private static final boolean IS_NOT_ASYNC = false;
 
-    public ScriptTaskTest(Marshaller marshallerType) {
+    public ScriptTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ScriptTaskTest.java
@@ -68,7 +68,7 @@ public class ScriptTaskTest extends Task<ScriptTask> {
     private static final boolean IS_NOT_ASYNC = false;
 
     public ScriptTaskTest(Marshaller marshallerType) {
-        super(marshallerType);
+        super(marshallerType, marshallers());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
@@ -44,7 +44,7 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
     }
 
     ServiceTask(Marshaller marshallerType) {
-        super(marshallerType);
+        super(marshallerType, marshallers());
     }
 
     @Ignore("Test is ignored, because does not make sense, since there is only new Marhsaller tested.")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
@@ -43,7 +43,7 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
         });
     }
 
-    ServiceTask(Marshaller marshallerType) {
+    ServiceTask(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
     }
 
@@ -53,13 +53,13 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
     public void testMigration() {
     }
 
-    protected void assertServiceTaskExecutionSet(ServiceTaskExecutionSet executionSet,
-                                                 String onEntryActionScriptValue,
-                                                 String onEntryActionScriptLanguage,
-                                                 String onExitActionScriptValue,
-                                                 String onExitActionScriptLanguage,
-                                                 boolean isAsync,
-                                                 boolean adHocAutostart) {
+    void assertServiceTaskExecutionSet(ServiceTaskExecutionSet executionSet,
+                                       String onEntryActionScriptValue,
+                                       String onEntryActionScriptLanguage,
+                                       String onExitActionScriptValue,
+                                       String onExitActionScriptLanguage,
+                                       boolean isAsync,
+                                       boolean adHocAutostart) {
         assertNotNull(executionSet);
         assertNotNull(executionSet.getOnEntryAction());
         assertNotNull(executionSet.getOnExitAction());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTask.java
@@ -94,42 +94,42 @@ public abstract class ServiceTask<T extends BaseServiceTask> extends Task<T> {
     // The test is already defined in parent Task test class.
     @Test
     @Override
-    public void testMarshallTopLevelTaskEmptyProperties() throws Exception {
+    public void testMarshallTopLevelTaskEmptyProperties() {
         checkTaskMarshalling(getEmptyTopLevelTaskId(), ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
     }
 
     // The test is already defined in parent Task test class.
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
         checkTaskMarshalling(getEmptySubprocessLevelTaskOneIncomeId(), ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
     }
 
     // The test is already defined in parent Task test class.
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
         checkTaskMarshalling(getEmptySubprocessLevelTaskTwoIncomesId(), TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
     }
 
     // The test is already defined in parent Task test class.
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeEmptyProperties() {
         checkTaskMarshalling(getEmptyTopLevelTaskOneIncomeId(), ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
     }
 
     // The test is already defined in parent Task test class.
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesEmptyProperties() {
         checkTaskMarshalling(getEmptyTopLevelTaskTwoIncomesId(), TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
     }
 
     // The test is already defined in parent Task test class.
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskEmptyProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskEmptyProperties() {
         checkTaskMarshalling(getEmptySubprocessLevelTaskId(), ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/ServiceTaskTest.java
@@ -43,6 +43,7 @@ public class ServiceTaskTest extends BPMNDiagramMarshallerBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testBasicUnmarshall() throws Exception {
         Diagram<Graph, Metadata> d = unmarshall(newMarshaller, BPMN_SERVICE_TASK_PROPERTIES_FILE_PATH);
         Node<View<ServiceTask>, ?> node = d.getGraph().getNode(SERVICE_TASK_ID);
@@ -70,6 +71,7 @@ public class ServiceTaskTest extends BPMNDiagramMarshallerBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testBasicBidi() throws Exception {
         Diagram<Graph, Metadata> d = unmarshall(newMarshaller, BPMN_SERVICE_TASK_PROPERTIES_FILE_PATH);
         String marshall = newMarshaller.marshall(d);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/Task.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/Task.java
@@ -54,22 +54,22 @@ public abstract class Task<T extends BaseTask> extends BPMNDiagramMarshallerBase
         });
     }
 
-    private static Diagram<Graph, Metadata> old_diagram;
-    private static Diagram<Graph, Metadata> old_roundTripDiagram;
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
 
-    private static Diagram<Graph, Metadata> new_diagram;
-    private static Diagram<Graph, Metadata> new_roundTripDiagram;
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
 
     private static Class clazz = null;
 
     private Marshaller currentMarshaller;
 
-    Task(Marshaller marshallerType, List<Object[]> marshallers) {
-        super.init();
+    Task(Marshaller marshallerType, List<Object[]> marshallers) throws Exception {
 
         currentMarshaller = marshallerType;
 
         if (this.getClass() != clazz) {
+            super.init();
             for (Object[] o : marshallers) {
                 if (o.length > 0) {
                     if (o[0] == NEW) {
@@ -84,22 +84,14 @@ public abstract class Task<T extends BaseTask> extends BPMNDiagramMarshallerBase
         }
     }
 
-    private void marshallDiagramWithNewMarshaller() {
-        try {
-            new_diagram = unmarshall(newMarshaller, getBpmnTaskFilePath());
-            new_roundTripDiagram = unmarshall(newMarshaller, getStream(newMarshaller.marshall(new_diagram)));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+    private void marshallDiagramWithNewMarshaller() throws Exception {
+        newDiagram = unmarshall(newMarshaller, getBpmnTaskFilePath());
+        newRoundTripDiagram = unmarshall(newMarshaller, getStream(newMarshaller.marshall(newDiagram)));
     }
 
-    private void marshallDiagramWithOldMarshaller() {
-        try {
-            old_diagram = unmarshall(oldMarshaller, getBpmnTaskFilePath());
-            old_roundTripDiagram = unmarshall(oldMarshaller, getStream(oldMarshaller.marshall(old_diagram)));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+    private void marshallDiagramWithOldMarshaller() throws Exception {
+        oldDiagram = unmarshall(oldMarshaller, getBpmnTaskFilePath());
+        oldRoundTripDiagram = unmarshall(oldMarshaller, getStream(oldMarshaller.marshall(oldDiagram)));
     }
 
     @Test
@@ -108,7 +100,7 @@ public abstract class Task<T extends BaseTask> extends BPMNDiagramMarshallerBase
         // assertEquals(oldDiagram.getGraph(), newDiagram.getGraph());
 
         // Let's check nodes only.
-        assertDiagramEquals(old_diagram, new_diagram, getBpmnTaskFilePath());
+        assertDiagramEquals(oldDiagram, newDiagram, getBpmnTaskFilePath());
     }
 
     @Test
@@ -200,9 +192,9 @@ public abstract class Task<T extends BaseTask> extends BPMNDiagramMarshallerBase
     public Diagram<Graph, Metadata> getDiagram() {
         switch (currentMarshaller) {
             case OLD:
-                return old_diagram;
+                return oldDiagram;
             case NEW:
-                return new_diagram;
+                return newDiagram;
             default:
                 throw new IllegalArgumentException("Unexpected value, Marshaller can be NEW or OLD.");
         }
@@ -211,9 +203,9 @@ public abstract class Task<T extends BaseTask> extends BPMNDiagramMarshallerBase
     public Diagram<Graph, Metadata> getRoundTripDiagram() {
         switch (currentMarshaller) {
             case OLD:
-                return old_roundTripDiagram;
+                return oldRoundTripDiagram;
             case NEW:
-                return new_roundTripDiagram;
+                return newRoundTripDiagram;
             default:
                 throw new IllegalArgumentException("Unexpected value, Marshaller can be NEW or OLD.");
         }
@@ -268,7 +260,6 @@ public abstract class Task<T extends BaseTask> extends BPMNDiagramMarshallerBase
         return getTaskType().cast(node.getContent().getDefinition());
     }
 
-    @SuppressWarnings("unchecked")
     void checkTaskMarshalling(String nodeID, int amountOfIncomeEdges, boolean hasOutcomeEdge) {
         Diagram<Graph, Metadata> initialDiagram = getDiagram();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/Task.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/Task.java
@@ -64,14 +64,22 @@ public abstract class Task<T extends BaseTask> extends BPMNDiagramMarshallerBase
 
     private Marshaller currentMarshaller;
 
-    Task(Marshaller marshallerType) {
+    Task(Marshaller marshallerType, List<Object[]> marshallers) {
         super.init();
 
         currentMarshaller = marshallerType;
 
         if (this.getClass() != clazz) {
-            marshallDiagramWithNewMarshaller();
-            marshallDiagramWithOldMarshaller();
+            for (Object[] o : marshallers) {
+                if (o.length > 0) {
+                    if (o[0] == NEW) {
+                        marshallDiagramWithNewMarshaller();
+                    }
+                    if (o[0] == OLD) {
+                        marshallDiagramWithOldMarshaller();
+                    }
+                }
+            }
             clazz = this.getClass();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
@@ -87,7 +87,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     private final Marshaller _marshallerType;
 
-    public UserTaskTest(Marshaller marshallerType) {
+    public UserTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
         this._marshallerType = marshallerType;
     }
@@ -95,6 +95,7 @@ public class UserTaskTest extends Task<UserTask> {
     @Test
     @SuppressWarnings("unchecked")
     public void RHBA607() throws Exception {
+        super.init();
         final String BPMN_USER_TASK_PROPERTIES_FILE_PATH =
                 "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/userTaskProperties.bpmn";
         final String DIAGRAM_ID = "_pfJ-8O50EeiVSc03Fghuww";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
@@ -93,6 +93,7 @@ public class UserTaskTest extends Task<UserTask> {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void RHBA607() throws Exception {
         final String BPMN_USER_TASK_PROPERTIES_FILE_PATH =
                 "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/userTaskProperties.bpmn";
@@ -106,24 +107,23 @@ public class UserTaskTest extends Task<UserTask> {
         assertTrue(declarationList.getDeclarations().isEmpty());
     }
 
-    @Ignore("Test is ignored, because new and old marshaler User Task nodes will differ anyway. Because different " +
+    @Ignore("Test is ignored, because new and old marshaller User Task nodes will differ anyway. Because different " +
             "properties supported by them")
     @Test
-    public void testMigration() throws Exception {
+    public void testMigration() {
     }
 
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
         // cannot be empty
         final String TASK_NAME = "Task_1";
         // cannot be empty
         final String TASK_TASK_NAME = "Task";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask emptyTopLevelTask = getTaskNodeById(diagram,
+        UserTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                      EMPTY_TOP_LEVEL_TASK_ID,
                                                      ZERO_INCOME_EDGES,
                                                      HAS_NO_OUTCOME_EDGE);
@@ -151,16 +151,15 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
         // cannot be empty
         final String TASK_NAME = "Task_2";
         // cannot be empty
         final String TASK_TASK_NAME = "Task";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask emptyTopLevelTask = getTaskNodeById(diagram,
+        UserTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                      EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                      ONE_INCOME_EDGE,
                                                      HAS_OUTCOME_EDGE);
@@ -188,16 +187,15 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
         // cannot be empty
         final String TASK_NAME = "Task_3";
         // cannot be empty
         final String TASK_TASK_NAME = "Task";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask emptyTopLevelTask = getTaskNodeById(diagram,
+        UserTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                      EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                      TWO_INCOME_EDGES,
                                                      HAS_OUTCOME_EDGE);
@@ -225,7 +223,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Task01 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_TASK_NAME_JAVA = "Task01ImplExecName";
@@ -271,10 +269,9 @@ public class UserTaskTest extends Task<UserTask> {
         final String TASK_CONTENT_MVEL = "Content example. Top level. MVEL.";
         final String SLA_DUE_DATE = "25/12/1983";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                           FILLED_TOP_LEVEL_TASK_JAVA_ID,
                                                           ZERO_INCOME_EDGES,
                                                           HAS_NO_OUTCOME_EDGE);
@@ -298,7 +295,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVA,
                                    SLA_DUE_DATE);
 
-        UserTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                 FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                 ZERO_INCOME_EDGES,
                                                                 HAS_NO_OUTCOME_EDGE);
@@ -322,7 +319,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVASCRIPT,
                                    SLA_DUE_DATE);
 
-        UserTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                           FILLED_TOP_LEVEL_TASK_MVEL_ID,
                                                           ZERO_INCOME_EDGES,
                                                           HAS_NO_OUTCOME_EDGE);
@@ -349,7 +346,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Task02 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_TASK_NAME_JAVA = "Task02ImplExecName";
@@ -395,10 +392,9 @@ public class UserTaskTest extends Task<UserTask> {
         final String TASK_CONTENT_MVEL = "Content example. Top level. One income. MVEL.";
         final String SLA_DUE_DATE = "25/12/1983";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                           FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID,
                                                           ONE_INCOME_EDGE,
                                                           HAS_OUTCOME_EDGE);
@@ -422,7 +418,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVA,
                                    SLA_DUE_DATE);
 
-        UserTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                 FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                 ONE_INCOME_EDGE,
                                                                 HAS_OUTCOME_EDGE);
@@ -446,7 +442,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVASCRIPT,
                                    SLA_DUE_DATE);
 
-        UserTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                           FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID,
                                                           ONE_INCOME_EDGE,
                                                           HAS_OUTCOME_EDGE);
@@ -473,7 +469,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Task03 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_TASK_NAME_JAVA = "Task03ImplExecName";
@@ -519,10 +515,9 @@ public class UserTaskTest extends Task<UserTask> {
         final String TASK_CONTENT_MVEL = "Content example. Top level. Two incomes. MVEL.";
         final String SLA_DUE_DATE = "25/12/1983";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                           FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID,
                                                           TWO_INCOME_EDGES,
                                                           HAS_OUTCOME_EDGE);
@@ -546,7 +541,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVA,
                                    SLA_DUE_DATE);
 
-        UserTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                 FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                 TWO_INCOME_EDGES,
                                                                 HAS_OUTCOME_EDGE);
@@ -570,7 +565,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVASCRIPT,
                                    SLA_DUE_DATE);
 
-        UserTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        UserTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                           FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID,
                                                           TWO_INCOME_EDGES,
                                                           HAS_OUTCOME_EDGE);
@@ -597,16 +592,15 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
         // cannot be empty
         final String TASK_NAME = "Task_4";
         // cannot be empty
         final String TASK_TASK_NAME = "Task";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        UserTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                             EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                             ZERO_INCOME_EDGES,
                                                             HAS_NO_OUTCOME_EDGE);
@@ -634,16 +628,15 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
         // cannot be empty
         final String TASK_NAME = "Task_5";
         // cannot be empty
         final String TASK_TASK_NAME = "Task";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        UserTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                             EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                             ONE_INCOME_EDGE,
                                                             HAS_OUTCOME_EDGE);
@@ -671,16 +664,15 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
         // cannot be empty
         final String TASK_NAME = "Task_6";
         // cannot be empty
         final String TASK_TASK_NAME = "Task";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        UserTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                             EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                             TWO_INCOME_EDGES,
                                                             HAS_OUTCOME_EDGE);
@@ -708,7 +700,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "Task10 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task10 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_TASK_NAME_JAVA = "Task10ImplExecName";
@@ -754,10 +746,9 @@ public class UserTaskTest extends Task<UserTask> {
         final String TASK_CONTENT_MVEL = "Content example. Sub-Process level. MVEL.";
         final String SLA_DUE_DATE = "25/12/1983";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                  FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                  ZERO_INCOME_EDGES,
                                                                  HAS_NO_OUTCOME_EDGE);
@@ -781,7 +772,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVA,
                                    SLA_DUE_DATE);
 
-        UserTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                        FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                        ZERO_INCOME_EDGES,
                                                                        HAS_NO_OUTCOME_EDGE);
@@ -805,7 +796,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVASCRIPT,
                                    SLA_DUE_DATE);
 
-        UserTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                  FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                  ZERO_INCOME_EDGES,
                                                                  HAS_NO_OUTCOME_EDGE);
@@ -832,7 +823,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "Task11 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task11 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_TASK_NAME_JAVA = "Task11ImplExecName";
@@ -878,10 +869,9 @@ public class UserTaskTest extends Task<UserTask> {
         final String TASK_CONTENT_MVEL = "Content example. Sub-Process level. One income. MVEL.";
         final String SLA_DUE_DATE = "25/12/1983";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                  FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                  ONE_INCOME_EDGE,
                                                                  HAS_OUTCOME_EDGE);
@@ -905,7 +895,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVA,
                                    SLA_DUE_DATE);
 
-        UserTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                        FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                        ONE_INCOME_EDGE,
                                                                        HAS_OUTCOME_EDGE);
@@ -929,7 +919,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVASCRIPT,
                                    SLA_DUE_DATE);
 
-        UserTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                  FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                  ONE_INCOME_EDGE,
                                                                  HAS_OUTCOME_EDGE);
@@ -956,7 +946,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "Task12 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "Task12 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_TASK_NAME_JAVA = "Task12ImplExecName";
@@ -1002,10 +992,9 @@ public class UserTaskTest extends Task<UserTask> {
         final String TASK_CONTENT_MVEL = "Content example. Sub-Process level. Two incomes. MVEL.";
         final String SLA_DUE_DATE = "25/12/1983";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        UserTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                  FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                  TWO_INCOME_EDGES,
                                                                  HAS_OUTCOME_EDGE);
@@ -1029,7 +1018,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVA,
                                    SLA_DUE_DATE);
 
-        UserTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                        FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                        TWO_INCOME_EDGES,
                                                                        HAS_OUTCOME_EDGE);
@@ -1053,7 +1042,7 @@ public class UserTaskTest extends Task<UserTask> {
                                    TASK_CONTENT_JAVASCRIPT,
                                    SLA_DUE_DATE);
 
-        UserTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        UserTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                  FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                  TWO_INCOME_EDGES,
                                                                  HAS_OUTCOME_EDGE);
@@ -1080,7 +1069,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -1088,7 +1077,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -1096,7 +1085,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -1104,7 +1093,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -1112,7 +1101,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
@@ -1120,7 +1109,7 @@ public class UserTaskTest extends Task<UserTask> {
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
@@ -87,6 +87,12 @@ public class UserTaskTest extends Task<UserTask> {
 
     private final Marshaller _marshallerType;
 
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
+
     public UserTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType, marshallers());
         this._marshallerType = marshallerType;
@@ -106,6 +112,46 @@ public class UserTaskTest extends Task<UserTask> {
         ProcessVariables processVariables = processData.getProcessVariables();
         DeclarationList declarationList = DeclarationList.fromString(processVariables.getValue());
         assertTrue(declarationList.getDeclarations().isEmpty());
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Ignore("Test is ignored, because new and old marshaller User Task nodes will differ anyway. Because different " +

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/UserTaskTest.java
@@ -88,7 +88,7 @@ public class UserTaskTest extends Task<UserTask> {
     private final Marshaller _marshallerType;
 
     public UserTaskTest(Marshaller marshallerType) {
-        super(marshallerType);
+        super(marshallerType, marshallers());
         this._marshallerType = marshallerType;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/WebServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/WebServiceTaskTest.java
@@ -20,6 +20,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -65,6 +68,12 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
     private static final boolean IS_NOT_ASYNC = false;
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
+
+    private static Diagram<Graph, Metadata> oldDiagram;
+    private static Diagram<Graph, Metadata> oldRoundTripDiagram;
+
+    private static Diagram<Graph, Metadata> newDiagram;
+    private static Diagram<Graph, Metadata> newRoundTripDiagram;
 
     public WebServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
@@ -603,6 +612,46 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       IS_ASYNC,
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskMvel.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldDiagram() {
+        return oldDiagram;
+    }
+
+    @Override
+    void setOldDiagram(Diagram<Graph, Metadata> diagram) {
+        oldDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getOldRoundTripDiagram() {
+        return oldRoundTripDiagram;
+    }
+
+    @Override
+    void setOldRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        oldRoundTripDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewDiagram() {
+        return newDiagram;
+    }
+
+    @Override
+    void setNewDiagram(Diagram<Graph, Metadata> diagram) {
+        newDiagram = diagram;
+    }
+
+    @Override
+    Diagram<Graph, Metadata> getNewRoundTripDiagram() {
+        return newRoundTripDiagram;
+    }
+
+    @Override
+    void setNewRoundTripDiagram(Diagram<Graph, Metadata> diagram) {
+        newRoundTripDiagram = diagram;
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/WebServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/WebServiceTaskTest.java
@@ -20,9 +20,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.Marshaller;
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
-import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.graph.Graph;
 
 public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.backend.service.diagram.marshalling.tasks.ServiceTask<ServiceTask> {
 
@@ -75,7 +72,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "WebService task01 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "WebService task01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from WebService Task.\");";
@@ -93,10 +90,9 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Endpoint:String,Interface:String,Mode:String,Namespace:String,Operation:String,Parameter:String,Url:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_JAVA_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -110,7 +106,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ZERO_INCOME_EDGES,
                                                                    HAS_NO_OUTCOME_EDGE);
@@ -124,7 +120,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TOP_LEVEL_TASK_MVEL_ID,
                                                              ZERO_INCOME_EDGES,
                                                              HAS_NO_OUTCOME_EDGE);
@@ -145,11 +141,10 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelEmptyTaskProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelEmptyTaskProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TOP_LEVEL_TASK_ID,
                                                         ZERO_INCOME_EDGES,
                                                         HAS_NO_OUTCOME_EDGE);
@@ -167,7 +162,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskFilledProperties() {
         final String TASK_NAME_JAVA = "WebService task10 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "WebService task10 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from WebService Task.\");";
@@ -185,10 +180,9 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Endpoint:String,Interface:String,Mode:String,Namespace:String,Operation:String,Parameter:String,Url:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -202,7 +196,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ZERO_INCOME_EDGES,
                                                                           HAS_NO_OUTCOME_EDGE);
@@ -216,7 +210,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ZERO_INCOME_EDGES,
                                                                     HAS_NO_OUTCOME_EDGE);
@@ -237,11 +231,10 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_SUBPROCESS_LEVEL_TASK_ID,
                                                                ZERO_INCOME_EDGES,
                                                                HAS_NO_OUTCOME_EDGE);
@@ -258,7 +251,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "WebService task02 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "WebService task02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from WebService Task.\");";
@@ -276,10 +269,9 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Endpoint:String,Interface:String,Mode:String,Namespace:String,Operation:String,Parameter:String,Url:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -293,7 +285,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    ONE_INCOME_EDGE,
                                                                    HAS_OUTCOME_EDGE);
@@ -307,7 +299,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID,
                                                              ONE_INCOME_EDGE,
                                                              HAS_OUTCOME_EDGE);
@@ -328,11 +320,10 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_ONE_INCOME_TOP_LEVEL_TASK_ID,
                                                         ONE_INCOME_EDGE,
                                                         HAS_OUTCOME_EDGE);
@@ -353,11 +344,10 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskOneIncomeEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_ONE_INCOME_SUBPROCESS_LEVEL_TASK_ID,
                                                                ONE_INCOME_EDGE,
                                                                HAS_OUTCOME_EDGE);
@@ -374,7 +364,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         final String TASK_NAME_JAVA = "WebService task11 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "WebService task11 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from WebService Task.\");";
@@ -392,10 +382,9 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Endpoint:String,Interface:String,Mode:String,Namespace:String,Operation:String,Parameter:String,Url:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -409,7 +398,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           ONE_INCOME_EDGE,
                                                                           HAS_OUTCOME_EDGE);
@@ -423,7 +412,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     ONE_INCOME_EDGE,
                                                                     HAS_OUTCOME_EDGE);
@@ -440,7 +429,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallTopLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "WebService task03 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "WebService task03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from WebService Task.\");";
@@ -458,10 +447,9 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Endpoint:String,Interface:String,Mode:String,Namespace:String,Operation:String,Parameter:String,Url:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledTopLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJava = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -475,7 +463,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                    FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID,
                                                                    TWO_INCOME_EDGES,
                                                                    HAS_OUTCOME_EDGE);
@@ -489,7 +477,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledTopLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledTopLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                              FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID,
                                                              TWO_INCOME_EDGES,
                                                              HAS_OUTCOME_EDGE);
@@ -510,11 +498,10 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallTopLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptyTopLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptyTopLevelTask = getTaskNodeById(getDiagram(),
                                                         EMPTY_TWO_INCOMES_TOP_LEVEL_TASK_ID,
                                                         TWO_INCOME_EDGES,
                                                         HAS_OUTCOME_EDGE);
@@ -535,11 +522,10 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
             "https://issues.jboss.org/browse/JBPM-7726")
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() throws Exception {
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesEmptyProperties() {
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask emptySubprocessLevelTask = getTaskNodeById(diagram,
+        ServiceTask emptySubprocessLevelTask = getTaskNodeById(getDiagram(),
                                                                EMPTY_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_ID,
                                                                TWO_INCOME_EDGES,
                                                                HAS_OUTCOME_EDGE);
@@ -556,7 +542,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testUnmarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         final String TASK_NAME_JAVA = "WebService task12 name ~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./";
         final String TASK_DOCUMENTATION_JAVA = "WebService task12 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String TASK_ON_ENTRY_ACTION_JAVA = "System.out.println(\"On Entry Action from WebService Task.\");";
@@ -574,10 +560,9 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
         final String TASK_DATA_INPUT_OUTPUT = "|Endpoint:String,Interface:String,Mode:String,Namespace:String,Operation:String,Parameter:String,Url:String,input:String||Result:java.lang.Object,output:String|[din]processGlobalVar->input,[dout]output->processGlobalVar";
 
-        Diagram<Graph, Metadata> diagram = unmarshall(marshaller, BPMN_TASK_FILE_PATH);
-        assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
+        assertDiagram(getDiagram(), AMOUNT_OF_NODES_IN_DIAGRAM);
 
-        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJava = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -591,7 +576,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJava.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskJavascript = getTaskNodeById(getDiagram(),
                                                                           FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID,
                                                                           TWO_INCOME_EDGES,
                                                                           HAS_OUTCOME_EDGE);
@@ -605,7 +590,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
                                       AD_HOC_AUTOSTART);
         assertDataIOSet(filledSubprocessLevelTaskJavascript.getDataIOSet(), TASK_DATA_INPUT_OUTPUT);
 
-        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(diagram,
+        ServiceTask filledSubprocessLevelTaskMvel = getTaskNodeById(getDiagram(),
                                                                     FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID,
                                                                     TWO_INCOME_EDGES,
                                                                     HAS_OUTCOME_EDGE);
@@ -622,7 +607,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TOP_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -630,7 +615,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskFilledProperties() {
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVA_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_SUBPROCESS_LEVEL_TASK_MVEL_ID, ZERO_INCOME_EDGES, HAS_NO_OUTCOME_EDGE);
@@ -638,7 +623,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_TOP_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -646,7 +631,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskOneIncomeFilledProperties() {
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVA_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_ONE_INCOME_SUBPROCESS_LEVEL_TASK_MVEL_ID, ONE_INCOME_EDGE, HAS_OUTCOME_EDGE);
@@ -654,7 +639,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallTopLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_TOP_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
@@ -662,7 +647,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
 
     @Test
     @Override
-    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() throws Exception {
+    public void testMarshallSubprocessLevelTaskTwoIncomesFilledProperties() {
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVA_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_JAVASCRIPT_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);
         checkTaskMarshalling(FILLED_TWO_INCOMES_SUBPROCESS_LEVEL_TASK_MVEL_ID, TWO_INCOME_EDGES, HAS_OUTCOME_EDGE);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/WebServiceTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/WebServiceTaskTest.java
@@ -66,7 +66,7 @@ public class WebServiceTaskTest extends org.kie.workbench.common.stunner.bpmn.ba
     private static final boolean AD_HOC_AUTOSTART = true;
     private static final boolean NOT_AD_HOC_AUTOSTART = false;
 
-    public WebServiceTaskTest(Marshaller marshallerType) {
+    public WebServiceTaskTest(Marshaller marshallerType) throws Exception {
         super(marshallerType);
     }
 


### PR DESCRIPTION
Hi @romartin, @wmedvede, @tiagodolphine, @LuboTerifaj,

there is a refactoring of new marshalling tests. It affects only Task tests because it is the most slow part of all tests and we handle different nodes in different way, so we need a lot of copy-pasting or global refactoring. I think global refactoring is a good way to go, but it's better to do it as part of Old marshaller tests removal task (or even after it).

**What changed**: Diagram is parsed only twice for the test class - once by the Old marshaller and once by the New marshaller. Before refactoring diagram was parsed for every single method separately, sometimes even two or three times.

### Some numbers:
Task tests **before** refactoring (on my local machine):
![screenshot from 2019-02-21 13-29-07](https://user-images.githubusercontent.com/1477262/53169164-cc68ac80-35dc-11e9-89c4-3ec15bbc2b4f.png)
Task tests **after** refactoring (on my local machine):
![screenshot from 2019-02-21 12-37-28](https://user-images.githubusercontent.com/1477262/53169200-e2766d00-35dc-11e9-88c1-4d76f67e54b0.png)
All marshalling tests including all old tests **before** refactoring (on my local machine):
![screenshot from 2019-02-21 12-11-05](https://user-images.githubusercontent.com/1477262/53169239-fd48e180-35dc-11e9-8aa5-96143814894a.png)
All marshalling tests including all old tests **after** refactoring (on my local machine):
![screenshot from 2019-02-21 12-34-26](https://user-images.githubusercontent.com/1477262/53169262-08037680-35dd-11e9-909d-76ab8ec05eb2.png)

As you can see **ALL** marshalling tests **after** refactoring running almost two times faster than new marshalling **TASK** tests **before** refactoring.

@wmedvede, @tiagodolphine: I didn't investigate memory leaks too much, but looks like tests failed before due to memory leaks. After refactoring tests passing always without any OutOfMemory issues even without @wmedvede's configuration fix.