### PR TITLE
BAPL-1148: upgraded to jboss-jaxrs-api_2.1_spec

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-distribution/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-distribution/pom.xml
@@ -64,7 +64,11 @@
           <groupId>org.ow2.asm</groupId>
           <artifactId>asm-all</artifactId>
         </exclusion>
-      </exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.ws.rs</groupId>
+          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+        </exclusion>
+    </exclusions>
     </dependency>
     <!-- GUVNOR ALA Dependencies -->
     <dependency>
@@ -81,7 +85,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>javax.ws.rs</groupId>
@@ -107,7 +111,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>javax.ws.rs</groupId>

--- a/kie-wb-common-ala/kie-wb-common-ala-services-api/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-services-api/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
@@ -239,6 +239,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
added exclusion of duplicated class brought in by resteasy
upgraded to jboss-jaxrs-api_2.1_spec left over