### PR TITLE
DROOLS-3725: [DMN Designer] Included Models - Error when a file with included models is saved

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverter.java
@@ -41,6 +41,9 @@ public final class ImportConverter {
         result.setId(new Id(id != null ? id : UUID.randomUUID().toString()));
         result.setName(new Name(name));
         result.setDescription(DescriptionPropertyConverter.wbFromDMN(description));
+
+        dmn.getNsContext().forEach((key, value) -> result.getNsContext().put(key, value));
+
         return result;
     }
 
@@ -58,6 +61,9 @@ public final class ImportConverter {
         result.setName(wb.getName().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(wb.getDescription()));
         result.setAdditionalAttributes(additionalAttributes);
+
+        wb.getNsContext().forEach((key, value) -> result.getNsContext().put(key, value));
+
         return result;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ImportConverterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.definition.v1_1;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.kie.dmn.model.v1_2.TImport;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImportConverterTest {
+
+    @Test
+    public void testWbFromDMN() {
+
+        final org.kie.dmn.model.api.Import dmn = new TImport();
+        final String key = "drools";
+        final String value = "http://www.drools.org/kie/dmn/1.1";
+        dmn.getNsContext().put(key, value);
+
+        final org.kie.workbench.common.dmn.api.definition.v1_1.Import anImport = ImportConverter.wbFromDMN(dmn);
+        final Map<String, String> nsContext = anImport.getNsContext();
+
+        assertEquals(1, nsContext.size());
+        assertEquals(value, nsContext.get(key));
+    }
+
+    @Test
+    public void testDmnFromWb() {
+
+        final org.kie.workbench.common.dmn.api.definition.v1_1.Import wb = new org.kie.workbench.common.dmn.api.definition.v1_1.Import();
+        final String key = "drools";
+        final String value = "http://www.drools.org/kie/dmn/1.1";
+        wb.getNsContext().put(key, value);
+
+        final org.kie.dmn.model.api.Import anImport = ImportConverter.dmnFromWb(wb);
+        final Map<String, String> nsContext = anImport.getNsContext();
+
+        assertEquals(1, nsContext.size());
+        assertEquals(value, nsContext.get(key));
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3725

---

Before:
![2019-03-07 21 09 53](https://user-images.githubusercontent.com/1079279/53998864-147ce880-4120-11e9-995d-935871b0f672.gif)

After:
![2019-03-07 21 04 34](https://user-images.githubusercontent.com/1079279/53998876-21014100-4120-11e9-875e-20dd5814bb55.gif)

---

The error was happening because the property `xmlns:drools` (from the `import` element) was being discarded (PS.: this property was added by a third party editor).
```xml
<semantic:import
  namespace="http://www.treasuretech.com/definitions/789456123459789"
  name="model-test"
  treasure:fileId="123456789123456798"
  treasure:fileName="karreiro/dmn-tests/model-test"
  importType="http://www.omg.org/spec/DMN/20180521/MODEL/"
  drools:modelName="model-test"
  xmlns:drools="http://www.drools.org/kie/dmn/1.1"/>
```

