### PR TITLE
JBPM-8308: Add missing dependencies for JDK 11

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/pom.xml
@@ -152,6 +152,12 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-processing-engine/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-processing-engine/pom.xml
@@ -72,5 +72,15 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
@@ -87,6 +87,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/pom.xml
@@ -120,5 +120,10 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Missing dependencies for annotation and jaxb.