### PR TITLE
[JBPM-7974] kie-server not removed from the controller view if server is killed or crashes  (7.18.x)

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
@@ -19,6 +19,8 @@
     <java.module.name>org.kie.wb.common.server.ui.backend</java.module.name>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
     <jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</jboss.home>
+    <jboss.home.instance1>${project.build.directory}/instance1/wildfly-${version.org.jboss.errai.wildfly}</jboss.home.instance1>
+    <jboss.home.instance2>${project.build.directory}/instance2/wildfly-${version.org.jboss.errai.wildfly}</jboss.home.instance2>
   </properties>
 
   <dependencies>
@@ -386,6 +388,22 @@
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}</outputDirectory>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.wildfly</groupId>
+                  <artifactId>wildfly-dist</artifactId>
+                  <version>${version.org.jboss.errai.wildfly}</version>
+                  <type>zip</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/instance1</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.wildfly</groupId>
+                  <artifactId>wildfly-dist</artifactId>
+                  <version>${version.org.jboss.errai.wildfly}</version>
+                  <type>zip</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/instance2</outputDirectory>
+                </artifactItem>
               </artifactItems>
             </configuration>
           </execution>
@@ -411,6 +429,40 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-resources-instance1</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${jboss.home.instance1}/standalone/configuration</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>src/test/config</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-resources-instance2</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${jboss.home.instance2}/standalone/configuration</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>src/test/config</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -419,12 +471,26 @@
         <configuration>
           <systemPropertyVariables>
             <jboss.home>${jboss.home}</jboss.home>
+            <jboss.home.instance1>${jboss.home.instance1}</jboss.home.instance1>
+            <jboss.home.instance2>${jboss.home.instance2}</jboss.home.instance2>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
           <redirectTestOutputToFile>false</redirectTestOutputToFile>
         </configuration>
         <executions>
           <execution>
+          	<id>default</id>
+          	<goals>
+          	   <goal>integration-test</goal>
+          	</goals>
+          	<configuration>
+          		<excludes>
+          		   <exclude>**/**</exclude>
+          		</excludes>
+          	</configuration>
+          </execution>
+          <execution>
+            <id>wildfly-embedded-rest</id>
             <goals>
               <goal>integration-test</goal>
             </goals>
@@ -469,6 +535,21 @@
             </configuration>
           </execution>
           <execution>
+            <id>wildfly-multinode</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/StandaloneControllerMultinodeIT</include>
+              </includes>
+              <systemPropertyVariables>
+                <arquillian.launch>wildfly-multinode</arquillian.launch>
+              </systemPropertyVariables>
+              <summaryFile>target/failsafe-reports/failsafe-summary-wildfly-multinode.xml</summaryFile>
+            </configuration>
+          </execution>
+          <execution>
             <id>verify</id>
             <goals>
               <goal>verify</goal>
@@ -478,6 +559,7 @@
                 <summaryFile>target/failsafe-reports/failsafe-summary-wildfly-embedded-rest.xml</summaryFile>
                 <summaryFile>target/failsafe-reports/failsafe-summary-wildfly-embedded-websocket.xml</summaryFile>
                 <summaryFile>target/failsafe-reports/failsafe-summary-wildfly-standalone-websocket.xml</summaryFile>
+                <summaryFile>target/failsafe-reports/failsafe-summary-wildfly-multinode.xml</summaryFile>
               </summaryFiles>
             </configuration>
           </execution>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/HealthCheckControllerBootstrap.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/HealthCheckControllerBootstrap.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.server.management.backend;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.server.controller.impl.KieServerHealthCheckControllerImpl;
+import org.kie.workbench.common.screens.server.management.backend.utils.EmbeddedController;
+import org.uberfire.commons.services.cdi.Startup;
+
+@Startup
+@ApplicationScoped
+@EmbeddedController
+public class HealthCheckControllerBootstrap {
+
+    @Inject
+    @EmbeddedController
+    private KieServerHealthCheckControllerImpl controller;
+
+    @PostConstruct
+    public void init() {
+        controller.start();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        controller.stop();
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerEmbeddedControllerProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerEmbeddedControllerProducer.java
@@ -16,12 +16,15 @@
 
 package org.kie.workbench.common.screens.server.management.backend;
 
+import java.util.concurrent.ExecutorService;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
 import org.kie.server.controller.api.service.NotificationService;
 import org.kie.server.controller.api.service.RuleCapabilitiesService;
 import org.kie.server.controller.api.storage.KieServerTemplateStorage;
+import org.kie.server.controller.impl.KieServerHealthCheckControllerImpl;
 import org.kie.server.controller.impl.KieServerInstanceManager;
 import org.kie.server.controller.impl.service.RuleCapabilitiesServiceImpl;
 import org.kie.server.controller.impl.service.RuntimeManagementServiceImpl;
@@ -32,6 +35,7 @@ import org.kie.server.controller.rest.RestSpecManagementServiceImpl;
 import org.kie.workbench.common.screens.server.management.backend.utils.EmbeddedController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.commons.concurrent.Managed;
 
 @ApplicationScoped
 @EmbeddedController
@@ -115,4 +119,19 @@ public class KieServerEmbeddedControllerProducer {
         controller.setTemplateStorage(kieServerTemplateStorage);
         return controller;
     }
+
+    @Produces
+    @EmbeddedController
+    public KieServerHealthCheckControllerImpl produceKieServerHealthCheckController(
+                                                                                final @EmbeddedController NotificationService notificationService,
+                                                                                final @EmbeddedController KieServerTemplateStorage kieServerTemplateStorage,
+                                                                                final @Managed ExecutorService executorService) {
+        LOGGER.debug("Creating KieServerHealthCheckController...");
+        final KieServerHealthCheckControllerImpl controller = new KieServerHealthCheckControllerImpl();
+        controller.setNotificationService(notificationService);
+        controller.setTemplateStorage(kieServerTemplateStorage);
+        controller.setExecutorService(executorService);
+        return controller;
+    }
+
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerStandaloneControllerProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerStandaloneControllerProducer.java
@@ -26,7 +26,10 @@ import org.kie.workbench.common.screens.server.management.backend.utils.Standalo
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.kie.workbench.common.screens.server.management.utils.ControllerUtils.*;
+import static org.kie.workbench.common.screens.server.management.utils.ControllerUtils.getControllerPassword;
+import static org.kie.workbench.common.screens.server.management.utils.ControllerUtils.getControllerToken;
+import static org.kie.workbench.common.screens.server.management.utils.ControllerUtils.getControllerURL;
+import static org.kie.workbench.common.screens.server.management.utils.ControllerUtils.getControllerUser;
 
 @ApplicationScoped
 @StandaloneController

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/AbstractAutoControllerIT.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/AbstractAutoControllerIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.server.management.backend;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.server.controller.api.model.spec.ServerTemplateList;
+import org.kie.server.controller.client.KieServerControllerClient;
+import org.kie.workbench.common.screens.server.management.service.SpecManagementService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractAutoControllerIT extends AbstractControllerIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAutoControllerIT.class);
+
+    @Inject
+    SpecManagementService specManagementService;
+
+    KieServerControllerClient client;
+
+    @After
+    public void closeControllerClient() {
+        if (client != null) {
+            try {
+                LOGGER.info("Closing Kie Server Management Controller client");
+                client.close();
+            } catch (IOException e) {
+                LOGGER.warn("Error trying to close Kie Server Management Controller Client: {}",
+                            e.getMessage(),
+                            e);
+            }
+        }
+    }
+
+    @Test
+    @OperateOnDeployment("workbench")
+    public void testSpecManagementService() throws Exception {
+        final ServerTemplateList serverTemplateList = specManagementService.listServerTemplates();
+        assertServerTemplateList(serverTemplateList);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/EmbeddedControllerIT.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/EmbeddedControllerIT.java
@@ -45,12 +45,16 @@ import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(Arquillian.class)
-public class EmbeddedControllerIT extends AbstractControllerIT {
+public class EmbeddedControllerIT extends AbstractAutoControllerIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedControllerIT.class);
 

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/StandaloneControllerIT.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/StandaloneControllerIT.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.screens.server.management.backend;
 
 import java.net.URI;
 import java.net.URL;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -36,10 +37,12 @@ import org.junit.runner.RunWith;
 import org.kie.server.controller.client.KieServerControllerClientFactory;
 import org.kie.server.controller.client.exception.KieServerControllerHTTPClientException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
-public class StandaloneControllerIT extends AbstractControllerIT {
+public class StandaloneControllerIT extends AbstractAutoControllerIT {
 
     @Deployment(name = "kie-server-controller", order = 1, testable = false)
     public static WebArchive createKieServerControllerWarDeployment() {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/StandaloneControllerMultinodeIT.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/StandaloneControllerMultinodeIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.server.management.backend;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.client.jaxrs.BasicAuthentication;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.controller.api.model.events.ContainerSpecUpdated;
+import org.kie.server.controller.api.model.events.ServerInstanceConnected;
+import org.kie.server.controller.api.model.events.ServerInstanceDeleted;
+import org.kie.server.controller.api.model.events.ServerInstanceDisconnected;
+import org.kie.server.controller.api.model.events.ServerInstanceUpdated;
+import org.kie.server.controller.api.model.events.ServerTemplateDeleted;
+import org.kie.server.controller.api.model.events.ServerTemplateUpdated;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
+import org.kie.server.controller.client.KieServerControllerClientFactory;
+import org.kie.server.controller.client.event.EventHandler;
+import org.kie.server.controller.client.websocket.WebSocketKieServerControllerClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class StandaloneControllerMultinodeIT extends AbstractControllerIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneControllerMultinodeIT.class);
+
+    public static final String PRIMARY_NODE = "wildfly-node1";
+    public static final String SECONDARY_NODE = "wildfly-node2";
+    public static final String KIE_SERVER_ID = "wildfly-multinode-kie-server";
+
+
+    @Deployment(name = "workbench", order = 2)
+    @TargetsContainer(PRIMARY_NODE)
+    public static WebArchive createWorkbenchWarDeployment() {
+        return createWorkbenchWar();
+    }
+
+    @Deployment(name = "kie-server", order = 3, testable = false)
+    @TargetsContainer(SECONDARY_NODE)
+    public static WebArchive createKieServerWarDeployment() {
+        return createKieServerWar();
+    }
+
+    @ArquillianResource
+    private ContainerController controller;
+
+    @Before
+    public void before() {
+
+        if (controller.isStarted(SECONDARY_NODE)) {
+            controller.stop(SECONDARY_NODE);
+        }
+        controller.start(SECONDARY_NODE);
+    }
+
+    @After
+    public void after() {
+        if (controller.isStarted(SECONDARY_NODE)) {
+            controller.stop(SECONDARY_NODE);
+        }
+    }
+
+    /**
+     * This creates a multiinstance node where
+     * instance 1 deploys the workbench
+     * instance 2 deploys kie-server
+     * after checking that the instance 2 manual is instantiated and working
+     * it kills the server (only working in linux for now) -> on windows it will stop the app server gracefully
+     * instance 2 is killed and the health check detects the problem
+     * notifies back to the test that the kie server is disconnected (CountDownLatch in the EventHandler)
+     */
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("workbench")
+    public void testAvailableRestEndpoint(final @ArquillianResource URL baseURL,
+                                          final @ArquillianResource @OperateOnDeployment("kie-server") URL baseServerURL) throws Exception {
+        String url = new URL(baseURL, "websocket/controller").toExternalForm();
+        
+        URL serverUrl = new URL(baseServerURL, "services/rest/server");
+        CountDownLatch serverDown = new CountDownLatch(1);
+        EventHandler customWSEventHandler = new EventHandler () {
+
+            @Override
+            public void onServerInstanceConnected(ServerInstanceConnected serverInstanceConnected) {
+                LOGGER.info("onServerInstanceConnected :" + serverInstanceConnected);
+            }
+
+            @Override
+            public void onServerInstanceDeleted(ServerInstanceDeleted serverInstanceDeleted) {       
+                LOGGER.info("onServerInstanceDeleted :" + serverInstanceDeleted);
+            }
+
+            @Override
+            public void onServerInstanceDisconnected(ServerInstanceDisconnected serverInstanceDisconnected) {
+                LOGGER.info("onServerInstanceDisconnected :" + serverInstanceDisconnected);
+                serverDown.countDown();
+            }
+
+            @Override
+            public void onServerTemplateDeleted(ServerTemplateDeleted serverTemplateDeleted) {
+                LOGGER.info("onServerTemplateDeleted :" + serverTemplateDeleted);
+            }
+
+            @Override
+            public void onServerTemplateUpdated(ServerTemplateUpdated serverTemplateUpdated) {
+                LOGGER.info("onServerTemplateUpdated :" + serverTemplateUpdated);
+            }
+
+            @Override
+            public void onServerInstanceUpdated(ServerInstanceUpdated serverInstanceUpdated) {
+                LOGGER.info("onServerInstanceUpdated :" + serverInstanceUpdated);
+            }
+
+            @Override
+            public void onContainerSpecUpdated(ContainerSpecUpdated containerSpecUpdated) {   
+                LOGGER.info("onContainerSpecUpdated :" + containerSpecUpdated);
+            }
+            
+        };
+
+        try (WebSocketKieServerControllerClient client = (WebSocketKieServerControllerClient) KieServerControllerClientFactory.newWebSocketClient(url,
+                                                                                                                                                  USER,
+                                                                                                                                                  PASSWORD,
+                                                                                                                                                  customWSEventHandler)) {
+
+            assertTrue(ping(serverUrl));
+            // get all the instances connected to the controller
+            ServerInstanceKeyList list = client.getServerInstances(KIE_SERVER_ID);
+
+            assertEquals(1, list.getServerInstanceKeys().length);
+
+            // kill the secondary node
+            controller.kill(SECONDARY_NODE);
+
+            serverDown.await(100, TimeUnit.SECONDS);
+
+            assertFalse(ping(serverUrl));
+
+            list = client.getServerInstances(KIE_SERVER_ID);
+
+            assertEquals(0, list.getServerInstanceKeys().length);
+
+        }
+    }
+
+    private boolean ping(URL url) {
+        try {
+            Client client = ClientBuilder.newClient().register(new BasicAuthentication(USER,
+                                                                                       PASSWORD));
+            WebTarget target = client.target(URI.create(url.toExternalForm()));
+
+            Response response = target.request().accept(MediaType.APPLICATION_XML).get();
+
+            return response.getStatus() == 200;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/arquillian/DefaultLinuxKillProcessor.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/arquillian/DefaultLinuxKillProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.server.management.backend.arquillian;
+
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.ServerKillProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultLinuxKillProcessor implements ServerKillProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLinuxKillProcessor.class);
+
+    private static final long TIMEOUT = 1000;
+
+    @Override
+    public void kill(Container container) throws Exception {
+        String osName = System.getProperty("os.name", "");
+        String killSequence = null;
+        Process p = null;
+
+        if (osName.toLowerCase().contains("linux")) {
+            killSequence = "kill -9 `ps aux | grep -v 'grep' | grep 'jboss.home.dir=[jbossHome] ' | sed -re '1,$s/[ \\t]+/ /g' | cut -d ' ' -f 2`";
+            killSequence = killSequence.replace("[jbossHome]", container.getContainerConfiguration().getContainerProperties()
+                                                                        .get("jbossHome"));
+            p = Runtime.getRuntime().exec(new String[]{"sh", "-c", killSequence});
+            executeKill(p, killSequence);
+        } else {
+            container.stop();
+        }
+    }
+
+    private void executeKill(Process p, String logKillSequence) throws Exception {
+        LOGGER.info("Issuing kill sequence (on " + System.getProperty("os.name") + "): " + logKillSequence);
+        p.waitFor();
+        if (p.exitValue() != 0) {
+            throw new RuntimeException("Kill sequence failed => server not killed. (Exit value of killing process: " + p.exitValue() + " OS=" + System.getProperty("os.name") + ")");
+        }
+        Thread.sleep(TIMEOUT);
+        LOGGER.info("Kill sequence successfully completed. \n");
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/arquillian/ServerExtension.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/arquillian/ServerExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.server.management.backend.arquillian;
+
+import org.jboss.arquillian.container.spi.ServerKillProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class ServerExtension implements LoadableExtension {
+
+   @Override
+   public void register(ExtensionBuilder builder) {
+        builder.service(ServerKillProcessor.class, DefaultLinuxKillProcessor.class);
+   }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.kie.workbench.common.screens.server.management.backend.arquillian.ServerExtension

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/resources/arquillian.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/resources/arquillian.xml
@@ -13,10 +13,43 @@
     </configuration>
   </container>
 
+  
+  <group qualifier="wildfly-multinode">
+	  <container qualifier="wildfly-node1" default="true">
+	    <configuration>
+	      <property name="jbossHome">${jboss.home.instance1}</property>
+	      <property name="javaVmArguments">-Xmx1500m -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false -Dorg.kie.server.mode=REGULAR
+	        -Dorg.kie.server.location=http://localhost:8230/kie-server/services/rest/server
+	        -Dorg.kie.server.user=admin 
+	        -Dorg.kie.server.pwd=admin 
+	      </property>
+	      <property name="serverConfig">standalone-full.xml</property>
+	    </configuration>
+	  </container>
+	  <container qualifier="wildfly-node2" mode="manual">
+	    <configuration>
+	      <property name="jbossHome">${jboss.home.instance2}</property>
+	      <property name="javaVmArguments">-Xmx1500m -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false -Djboss.socket.binding.port-offset=150  -Dorg.kie.server.mode=REGULAR
+	      	-Dorg.kie.server.controller=http://localhost:8080/workbench/rest/controller 
+	      	-Dorg.kie.server.controller.pwd=admin 
+	      	-Dorg.kie.server.controller.user=admin 
+	      	-Dorg.kie.server.id=wildfly-multinode-kie-server 
+	      </property>
+	      <property name="managementPort">10140</property>
+	      <property name="serverConfig">standalone-full.xml</property>
+	    </configuration>
+	  </container>
+  </group>
+
+  
+
   <container qualifier="wildfly-embedded-rest">
     <configuration>
       <property name="jbossHome">${jboss.home}</property>
-      <property name="javaVmArguments">-Xmx1500m -Dorg.kie.server.id=it-test-kie-server -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.repo=target/ -Dorg.kie.server.controller=http://localhost:8080/workbench/rest/controller -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false  -Dorg.kie.server.mode=PRODUCTION</property>
+      <property name="javaVmArguments">-Xmx1500m -Dorg.kie.server.id=it-test-kie-server -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.repo=target/ -Dorg.kie.server.controller=http://localhost:8080/workbench/rest/controller -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false  -Dorg.kie.server.mode=PRODUCTION
+	        -Dorg.kie.server.user=admin 
+	        -Dorg.kie.server.pwd=admin 
+      </property>
       <property name="serverConfig">standalone-full.xml</property>
     </configuration>
   </container>
@@ -24,7 +57,10 @@
   <container qualifier="wildfly-embedded-websocket">
     <configuration>
       <property name="jbossHome">${jboss.home}</property>
-      <property name="javaVmArguments">-Xmx1500m -Dorg.kie.server.id=it-test-kie-server -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.repo=target/ -Dorg.kie.server.controller=ws://localhost:8080/workbench/websocket/controller -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false -Dorg.kie.server.mode=PRODUCTION</property>
+      <property name="javaVmArguments">-Xmx1500m -Dorg.kie.server.id=it-test-kie-server -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.repo=target/ -Dorg.kie.server.controller=ws://localhost:8080/workbench/websocket/controller -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false -Dorg.kie.server.mode=PRODUCTION
+      	    -Dorg.kie.server.user=admin 
+	        -Dorg.kie.server.pwd=admin 
+	  </property>
       <property name="serverConfig">standalone-full.xml</property>
     </configuration>
   </container>
@@ -32,7 +68,10 @@
   <container qualifier="wildfly-standalone-websocket">
     <configuration>
       <property name="jbossHome">${jboss.home}</property>
-      <property name="javaVmArguments">-Xmx1500m -Dorg.kie.server.id=it-test-kie-server -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.repo=target/ -Dorg.kie.server.controller=ws://localhost:8080/kie-server-controller/websocket/controller -Dorg.kie.workbench.controller=ws://localhost:8080/kie-server-controller/websocket/controller -Dorg.kie.server.controller.templatefile=target/template_store.xml -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false  -Dorg.kie.server.mode=PRODUCTION</property>
+      <property name="javaVmArguments">-Xmx1500m -Dorg.kie.server.id=it-test-kie-server -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.repo=target/ -Dorg.kie.server.controller=ws://localhost:8080/kie-server-controller/websocket/controller -Dorg.kie.workbench.controller=ws://localhost:8080/kie-server-controller/websocket/controller -Dorg.kie.server.controller.templatefile=target/template_store.xml -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false -Dorg.kie.server.mode=PRODUCTION
+            -Dorg.kie.server.user=admin 
+	        -Dorg.kie.server.pwd=admin 
+      </property>
       <property name="serverConfig">standalone-full.xml</property>
     </configuration>
   </container>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
@@ -30,6 +30,7 @@ import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.controller.api.model.events.ServerInstanceUpdated;
 import org.kie.server.controller.api.model.runtime.Container;
 import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerConfig;
@@ -126,6 +127,12 @@ public class ContainerPresenter {
             load(containerSpecSelected.getContainerSpecKey());
         } else {
             logger.warn("Illegal event argument.");
+        }
+    }
+
+    public void onInstanceUpdated(@Observes ServerInstanceUpdated instanceUpdated) {
+        if (instanceUpdated != null && containerSpec.getServerTemplateKey().getId().equals(instanceUpdated.getServerInstance().getServerTemplateId())) {
+            load(containerSpec);
         }
     }
 

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/navigation/template/ServerTemplatePresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/navigation/template/ServerTemplatePresenter.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.screens.server.management.client.navigation.tem
 
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -229,6 +230,7 @@ public class ServerTemplatePresenter {
         if ( serverInstanceDeleted != null &&
                 serverInstanceDeleted.getServerInstanceId() != null ) {
             serverInstances.remove( serverInstanceDeleted.getServerInstanceId() );
+            serverTemplateListRefreshEvent.fire(new ServerTemplateListRefresh(serverInstanceDeleted.getServerInstanceId()));
         } else {
             logger.warn( "Illegal event argument." );
         }


### PR DESCRIPTION
fixes some problem during refreshing in the UI
added alive ping to check whether servers are alive

cherry picked from (#2285)

depends on https://github.com/kiegroup/droolsjbpm-integration/pull/1772