### PR TITLE
AF-1875-Add string cut for breadcrumb Links and toolbar title

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryView.less
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/LibraryView.less
@@ -119,6 +119,10 @@
         float:left;
         font-size: 1.5em;
         margin-right: 1em;
+        text-overflow: ellipsis !important;
+        overflow: hidden;
+        white-space: nowrap;
+        max-width: 1030px;
     }
 
     // Add space to left of kebab; have to override specificity


### PR DESCRIPTION
Added string cut for Toolbar title to avoid breaking html layout due long names