### PR TITLE
JBPM-8207: Stunner - Redo command is shared between windows

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
@@ -22,6 +22,7 @@ import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandUndoneEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -118,10 +119,13 @@ public class RedoSessionCommand extends AbstractClientSessionCommand<EditorSessi
     void onCommandUndoExecuted(final @Observes CanvasCommandUndoneEvent commandUndoExecutedEvent) {
         checkNotNull("commandUndoExecutedEvent",
                      commandUndoExecutedEvent);
-        if (null != commandUndoExecutedEvent.getCommand()) {
-            redoCommandHandler.onUndoCommandExecuted(commandUndoExecutedEvent.getCommand());
+        CanvasHandler canvasHandler = commandUndoExecutedEvent.getCanvasHandler();
+        if (getSession().getCanvasHandler().equals(canvasHandler)) {
+            if (null != commandUndoExecutedEvent.getCommand()) {
+                redoCommandHandler.onUndoCommandExecuted(commandUndoExecutedEvent.getCommand());
+            }
+            checkState();
         }
-        checkState();
     }
 
     private void checkState() {


### PR DESCRIPTION
CanvasCommandUndoneEvent is firing from CanvasCommandManagerImpl for all subscribers and contains no context related info, as a result we have redu button active for all modeling workspaces. In RedoSessionCommand.onCommandUndoExecuted i added a check to be sure if this event belongs to this workspace. 

My suggestion is reduce it by adding uuid to this event. I am familiar with @Session annotation, maybe it сould reduce the scope but it seems to me that it won't. Any better ideas howto fix it?

@wmedvede @romartin 