### PR TITLE
JBPM-6454 Stunner - rethink text wrapping and fonts for nodes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/shape/def/DMNDecisionServiceSVGShapeDefImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/shape/def/DMNDecisionServiceSVGShapeDefImpl.java
@@ -73,8 +73,11 @@ public class DMNDecisionServiceSVGShapeDefImpl implements DMNDecisionServiceSVGS
                 .fontSize(bean -> bean.getFontSet().getFontSize().getValue())
                 .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE)
                 .strokeAlpha(bean -> 0.0d)
-                .position(bean -> HasTitle.Position.TOP)
-                .positionYOffset(bean -> Y_OFFSET)
+                .verticalAlignment(bean -> HasTitle.VerticalAlignment.TOP)
+                .horizontalAlignment(bean -> HasTitle.HorizontalAlignment.CENTER)
+                .referencePosition(bean -> HasTitle.ReferencePosition.INSIDE)
+                .orientation(bean -> HasTitle.Orientation.HORIZONTAL)
+                .margin(HasTitle.VerticalAlignment.TOP, Y_OFFSET)
                 .build();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlers.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/shape/view/handlers/DMNViewHandlers.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.shape.view.handlers;
 import org.kie.workbench.common.dmn.api.definition.DMNDefinition;
 import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
@@ -46,6 +47,10 @@ public class DMNViewHandlers {
                     .fontColor(bean -> bean.getFontSet().getFontColour().getValue())
                     .fontSize(bean -> bean.getFontSet().getFontSize().getValue())
                     .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE)
+                    .verticalAlignment(bean -> HasTitle.VerticalAlignment.MIDDLE)
+                    .horizontalAlignment(bean -> HasTitle.HorizontalAlignment.CENTER)
+                    .referencePosition(bean -> HasTitle.ReferencePosition.INSIDE)
+                    .orientation(bean -> HasTitle.Orientation.HORIZONTAL)
                     .strokeColor(bean -> null)
                     .strokeAlpha(bean -> 0.0)
                     .strokeSize(bean -> 0.0);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/def/DMNDecisionServiceSVGShapeDefImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/shape/def/DMNDecisionServiceSVGShapeDefImplTest.java
@@ -20,6 +20,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Maps;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionService;
 import org.kie.workbench.common.dmn.api.property.dimensions.GeneralRectangleDimensionsSet;
 import org.kie.workbench.common.dmn.client.resources.DMNDecisionServiceSVGViewFactory;
@@ -103,8 +104,9 @@ public class DMNDecisionServiceSVGShapeDefImplTest {
         final FontHandler<DecisionService, SVGShapeView> handler = shapeDef.newFontHandler();
         handler.handle(decisionService, shapeView);
 
-        verify(shapeView).setTitlePosition(HasTitle.Position.TOP);
-        verify(shapeView).setTitleYOffsetPosition(DMNDecisionServiceSVGShapeDefImpl.Y_OFFSET);
+        verify(shapeView).setTitlePosition(HasTitle.VerticalAlignment.TOP, HasTitle.HorizontalAlignment.CENTER,
+                                           HasTitle.ReferencePosition.INSIDE, HasTitle.Orientation.HORIZONTAL);
+        verify(shapeView).setMargins(new Maps.Builder().put(HasTitle.VerticalAlignment.TOP, 20.0).build());
         verify(shapeView).setTextWrapper(TextWrapperStrategy.TRUNCATE);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/TextWrapperProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/TextWrapperProvider.java
@@ -17,13 +17,12 @@
 package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
 
 import com.ait.lienzo.client.core.shape.ITextWrapper;
-
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.shape.TextBoundsAndLineBreaksWrap;
 import com.ait.lienzo.client.core.shape.TextBoundsWrap;
+import com.ait.lienzo.client.core.shape.TextLineBreakTruncateWrapper;
 import com.ait.lienzo.client.core.shape.TextLineBreakWrap;
 import com.ait.lienzo.client.core.shape.TextNoWrap;
-import com.ait.lienzo.client.core.shape.TextTruncateWrapper;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 
@@ -42,10 +41,11 @@ public final class TextWrapperProvider {
                 return new TextNoWrap(text);
 
             case TRUNCATE:
-                return new TextTruncateWrapper(text, new BoundingBox(0,
-                                                                     0,
-                                                                     1,
-                                                                     1));
+                return new TextLineBreakTruncateWrapper(text, new BoundingBox());
+
+            case TRUNCATE_WITH_LINE_BREAK:
+                return new TextLineBreakTruncateWrapper(text, new BoundingBox());
+
             default:
                 return new TextBoundsWrap(text);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
@@ -144,7 +144,7 @@ public class WiresConnectorViewExt<T>
     }
 
     @Override
-    public T setTextSizeConstraints(final SizeConstraints sizeConstraints) {
+    public T setTextSizeConstraints(final Size sizeConstraints) {
         // Do not apply here...
         return cast();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
@@ -69,7 +69,7 @@ public class WiresConnectorViewExt<T>
     }
 
     protected void init(final ViewEventType[] supportedEventTypes) {
-        this.label = Optional.empty();
+        this.label = createLabel("");
         this.textRotationDegrees = 0;
         this.eventHandlerManager = new ViewEventHandlerManager(getLine().asShape(),
                                                                getLine().asShape(),
@@ -119,15 +119,10 @@ public class WiresConnectorViewExt<T>
     @Override
     @SuppressWarnings("unchecked")
     public T setTitle(final String title) {
-        if (null == title || title.trim().length() == 0) {
-            destroyLabel();
-        } else {
-            if (!label.isPresent()) {
-                label = Optional.of(createLabel(title));
-            }
-            label.get().configure(text -> text.setText(title));
-        }
-        return cast();
+        return Optional.ofNullable(title)
+                .map(t -> label.map(l -> l.configure(text -> text.setText(t))))
+                .map(l -> cast())
+                .orElse(cast());
     }
 
     @Override
@@ -216,6 +211,12 @@ public class WiresConnectorViewExt<T>
     }
 
     @Override
+    public T setTitleStrokeAlpha(double alpha) {
+        label.ifPresent(l -> l.configure(text -> text.setStrokeAlpha(alpha)));
+        return cast();
+    }
+
+    @Override
     public void destroy() {
         super.destroy();
         // Clear registered event handlers.
@@ -226,8 +227,8 @@ public class WiresConnectorViewExt<T>
         destroyLabel();
     }
 
-    protected WiresConnectorLabel createLabel(final String title) {
-        return WiresConnectorLabelFactory.newLabelOnFirstSegment(title, this);
+    protected Optional<WiresConnectorLabel> createLabel(final String title) {
+        return Optional.of(WiresConnectorLabelFactory.newLabelOnFirstSegment(title, this));
     }
 
     private void destroyLabel() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
 
+import java.util.Map;
 import java.util.Optional;
 
 import com.ait.lienzo.client.core.shape.AbstractDirectionalMultiPointShape;
@@ -130,8 +131,20 @@ public class WiresConnectorViewExt<T>
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public T setTitlePosition(final Position position) {
+    public T setMargins(final Map<Enum, Double> margins) {
+        // Do not apply here...
+        return cast();
+    }
+
+    @Override
+    public T setTitlePosition(final VerticalAlignment verticalAlignment, final HorizontalAlignment horizontalAlignment,
+                              final ReferencePosition referencePosition, final Orientation orientation) {
+        // Do not apply here...
+        return cast();
+    }
+
+    @Override
+    public T setTextSizeConstraints(final SizeConstraints sizeConstraints) {
         // Do not apply here...
         return cast();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -378,7 +378,8 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     }
 
     private void addTextAsChild() {
-        labelContainerLayout = Optional.of(this.addLabel(textViewDecorator.getView(), textViewDecorator.getLabelLayout()));
+        labelContainerLayout = Optional.of(this.addLabel(textViewDecorator.getView(),
+                                                         textViewDecorator.getLabelLayout()));
         // Ensure text element is listening for events.
         textViewDecorator.getView().setListening(true);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -88,10 +88,6 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
         setTextViewDecorator(new WiresTextDecorator(() -> eventHandlerManager, this));
     }
 
-    protected ViewEventHandlerManager getEventHandlerManager() {
-        return this.eventHandlerManager;
-    }
-
     void setTextViewDecorator(final WiresTextDecorator textViewDecorator) {
         this.textViewDecorator = textViewDecorator;
     }
@@ -128,7 +124,7 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     }
 
     @Override
-    public T setTextSizeConstraints(final SizeConstraints sizeConstraints) {
+    public T setTextSizeConstraints(final Size sizeConstraints) {
         textViewDecorator.setTextSizeConstraints(sizeConstraints);
         return cast();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -194,16 +194,16 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     }
 
     @Override
-    public T setTitleStrokeAlpha(final double strokeAlpha){
+    public T setTitleStrokeAlpha(final double strokeAlpha) {
         textViewDecorator.setTitleStrokeAlpha(strokeAlpha);
         return cast();
     }
 
     @Override
-    public T setTextWrapper(final TextWrapperStrategy wrapperStrategy){
+    public T setTextWrapper(final TextWrapperStrategy wrapperStrategy) {
         textViewDecorator.setTextWrapper(wrapperStrategy);
         labelContainerLayout.ifPresent(LabelContainerLayout::execute);
-        return(cast());
+        return (cast());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
 
+import java.util.Map;
+import java.util.Optional;
+
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Shape;
 import com.ait.lienzo.client.core.shape.wires.IControlHandle;
@@ -24,6 +27,7 @@ import com.ait.lienzo.client.core.shape.wires.LayoutContainer;
 import com.ait.lienzo.client.core.shape.wires.WiresLayoutContainer;
 import com.ait.lienzo.client.core.shape.wires.event.AbstractWiresDragEvent;
 import com.ait.lienzo.client.core.shape.wires.event.AbstractWiresResizeEvent;
+import com.ait.lienzo.client.core.shape.wires.layout.label.LabelContainerLayout;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.LinearGradient;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -58,9 +62,10 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
 
     private ViewEventHandlerManager eventHandlerManager;
     private WiresTextDecorator textViewDecorator;
-    private Type fillGradientType = null;
-    private String fillGradientStartColor = null;
-    private String fillGradientEndColor = null;
+    private Type fillGradientType;
+    private String fillGradientStartColor;
+    private String fillGradientEndColor;
+    private Optional<LabelContainerLayout> labelContainerLayout = Optional.empty();
 
     public WiresShapeViewExt(final ViewEventType[] supportedEventTypes,
                              final MultiPath path) {
@@ -80,8 +85,7 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
 
     protected void setEventHandlerManager(final ViewEventHandlerManager eventHandlerManager) {
         this.eventHandlerManager = eventHandlerManager;
-        setTextViewDecorator(new WiresTextDecorator(() -> eventHandlerManager, getPath().getBoundingBox()));
-        addTextAsChild();
+        setTextViewDecorator(new WiresTextDecorator(() -> eventHandlerManager, this));
     }
 
     protected ViewEventHandlerManager getEventHandlerManager() {
@@ -106,16 +110,26 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     @SuppressWarnings("unchecked")
     public T setTitle(final String title) {
         textViewDecorator.setTitle(title);
+        addTextAsChild();
         return cast();
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public T setTitlePosition(final Position position) {
-        if (textViewDecorator.setTitlePosition(position)) {
-            removeChild(textViewDecorator.getView());
-            addTextAsChild();
-        }
+    public T setMargins(final Map<Enum, Double> margins) {
+        textViewDecorator.setMargins(margins);
+        return cast();
+    }
+
+    @Override
+    public T setTitlePosition(final VerticalAlignment verticalAlignment, final HorizontalAlignment horizontalAlignment,
+                              final ReferencePosition referencePosition, final Orientation orientation) {
+        textViewDecorator.setTitlePosition(verticalAlignment, horizontalAlignment, referencePosition, orientation);
+        return cast();
+    }
+
+    @Override
+    public T setTextSizeConstraints(final SizeConstraints sizeConstraints) {
+        textViewDecorator.setTextSizeConstraints(sizeConstraints);
         return cast();
     }
 
@@ -188,6 +202,7 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     @Override
     public T setTextWrapper(final TextWrapperStrategy wrapperStrategy){
         textViewDecorator.setTextWrapper(wrapperStrategy);
+        labelContainerLayout.ifPresent(LabelContainerLayout::execute);
         return(cast());
     }
 
@@ -358,15 +373,22 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
 
     protected void rebuildTextBoundaries(final double width,
                                          final double height) {
-        textViewDecorator.resize(width,
-                                 height);
+        textViewDecorator.setTextBoundaries(width, height);
+    }
+
+    @Override
+    public void setTextBoundaries(final double width, final double height) {
+        rebuildTextBoundaries(width, height);
     }
 
     private void addTextAsChild() {
-        this.addChild(textViewDecorator.getView(),
-                      textViewDecorator.getLayout());
+        labelContainerLayout = Optional.of(this.addLabel(textViewDecorator.getView(), textViewDecorator.getLabelLayout()));
         // Ensure text element is listening for events.
         textViewDecorator.getView().setListening(true);
+    }
+
+    public Optional<LabelContainerLayout> getLabelContainerLayout() {
+        return labelContainerLayout;
     }
 
     private IControlHandle.ControlHandleType translate(final ControlPointType type) {
@@ -403,7 +425,6 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
         HandlerRegistration r0 = addWiresResizeStartHandler(wiresResizeStartEvent -> {
             final ResizeEvent event = buildResizeEvent(wiresResizeStartEvent);
             resizeHandler.start(event);
-            rebuildTextBoundaries(event.getWidth(), event.getHeight());
         });
         HandlerRegistration r1 = addWiresResizeStepHandler(wiresResizeStepEvent -> {
             final ResizeEvent event = buildResizeEvent(wiresResizeStepEvent);
@@ -413,7 +434,6 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
         HandlerRegistration r2 = addWiresResizeEndHandler(wiresResizeEndEvent -> {
             final ResizeEvent event = buildResizeEvent(wiresResizeEndEvent);
             resizeHandler.end(event);
-            rebuildTextBoundaries(event.getWidth(), event.getHeight());
         });
         return new HandlerRegistration[]{r0, r1, r2};
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -88,6 +88,10 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
         setTextViewDecorator(new WiresTextDecorator(() -> eventHandlerManager, this));
     }
 
+    protected ViewEventHandlerManager getEventHandlerManager() {
+        return this.eventHandlerManager;
+    }
+
     void setTextViewDecorator(final WiresTextDecorator textViewDecorator) {
         this.textViewDecorator = textViewDecorator;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,23 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
 
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
-import com.ait.lienzo.client.core.shape.Group;
-import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.ITextWrapper;
 import com.ait.lienzo.client.core.shape.ITextWrapperWithBoundaries;
-import com.ait.lienzo.client.core.shape.Line;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.shape.TextBoundsWrap;
-import com.ait.lienzo.client.core.shape.wires.LayoutContainer;
+import com.ait.lienzo.client.core.shape.wires.layout.direction.DirectionLayout;
+import com.ait.lienzo.client.core.shape.wires.layout.direction.DirectionLayout.Direction;
+import com.ait.lienzo.client.core.shape.wires.layout.label.LabelContainerLayout;
+import com.ait.lienzo.client.core.shape.wires.layout.label.LabelLayout;
+import com.ait.lienzo.client.core.shape.wires.layout.size.SizeConstraints.Type;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.shared.core.types.TextAlign;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -38,6 +45,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.TextEnterEv
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewHandler;
+import org.kie.workbench.common.stunner.core.graph.util.Exceptions;
 
 /**
  * A helper class for handling the wires shapes' text primitive
@@ -47,7 +55,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewHandler
  * type, can be reused for shapes or connectors.
  * <p>
  */
-public class WiresTextDecorator {
+public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
 
     // Default text attribute values.
     private static final double TEXT_ALPHA = 1d;
@@ -57,29 +65,24 @@ public class WiresTextDecorator {
     private static final String TEXT_STROKE_COLOR = "#000000";
     private static final double TEXT_STROKE_WIDTH = 0.5d;
     private static final TextAlign TEXT_ALIGN = TextAlign.CENTER;
-    private static final LayoutContainer.Layout TEXT_LAYOUT_ALIGN = LayoutContainer.Layout.CENTER;
 
     private final Supplier<ViewEventHandlerManager> eventHandlerManager;
-    private final Group textContainer = new Group();
     private ViewHandler<TextEnterEvent> textOverHandlerViewHandler;
     private ViewHandler<TextExitEvent> textOutEventViewHandler;
     private ViewHandler<TextClickEvent> textClickEventViewHandler;
     private ViewHandler<TextDoubleClickEvent> textDblClickEventViewHandler;
     private Text text;
     private ITextWrapper textWrapper;
-    private LayoutContainer.Layout currentTextLayout;
-    private double width;
-    private double height;
-
-    // WiresLayoutContainer lays out content based on the BoundingBox of the content. Therefore, even when the Text
-    // has its Location set to non-zero co-ordinates its BoundingBox does not change. This (almost invisible) Line is
-    // used to ensure the BoundingBox represents the positioning of the WiresTextDecorator
-    private Line textSpacer = new Line().setAlpha(0.1).setListening(false);
+    private LabelLayout labelLayout;
+    private Optional<SizeConstraints> sizeConstraints = Optional.empty();
+    private Map<Enum, Double> margins = Collections.emptyMap();
+    private WiresShapeViewExt<WiresShapeViewExt> shape;
 
     public WiresTextDecorator(final Supplier<ViewEventHandlerManager> eventHandlerManager,
-                              final BoundingBox boundingBox) {
+                              final WiresShapeViewExt shape) {
         this.eventHandlerManager = eventHandlerManager;
-        initialize(boundingBox);
+        this.shape = shape;
+        initialize();
     }
 
     public void setTextClickHandler(final ViewHandler<TextClickEvent> textClickEventViewHandler) {
@@ -98,7 +101,7 @@ public class WiresTextDecorator {
         this.textOutEventViewHandler = textOutEventViewHandler;
     }
 
-    private void initialize(final BoundingBox boundingBox) {
+    private void initialize() {
         this.text = new Text("")
                 .setAlpha(TEXT_ALPHA)
                 .setFontFamily(TEXT_FONT_FAMILY)
@@ -108,19 +111,12 @@ public class WiresTextDecorator {
                 .setStrokeWidth(TEXT_STROKE_WIDTH)
                 .setTextAlign(TEXT_ALIGN)
                 .setDraggable(false);
-        this.textWrapper = new TextBoundsWrap(text,
-                                              new BoundingBox(0,
-                                                              0,
-                                                              1,
-                                                              1));
+        this.textWrapper = new TextBoundsWrap(text, shape.getPath().getBoundingBox());
         this.text.setWrapper(textWrapper);
-        this.currentTextLayout = TEXT_LAYOUT_ALIGN;
-        textContainer.add(text);
-        textContainer.add(textSpacer);
         // Ensure path bounds are available on the selection context.
         text.setFillBoundsForSelection(true);
         initializeHandlers();
-        resize(boundingBox.getWidth(), boundingBox.getHeight());
+        setTextBoundaries(shape.getPath().getBoundingBox());
     }
 
     private void initializeHandlers() {
@@ -191,34 +187,19 @@ public class WiresTextDecorator {
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitle(final String title) {
+    public WiresTextDecorator setTitle(final String title) {
         if (null == title) {
             text.setText(null);
         } else {
             text.setText(title.trim());
         }
+        return this;
     }
 
-    @SuppressWarnings("unchecked")
-    public boolean setTitlePosition(final HasTitle.Position position) {
-        LayoutContainer.Layout layout = LayoutContainer.Layout.CENTER;
-        switch (position) {
-            case BOTTOM:
-                layout = LayoutContainer.Layout.BOTTOM;
-                break;
-            case TOP:
-                layout = LayoutContainer.Layout.TOP;
-                break;
-            case LEFT:
-                layout = LayoutContainer.Layout.LEFT;
-                break;
-            case RIGHT:
-                layout = LayoutContainer.Layout.RIGHT;
-                break;
-        }
-        final boolean changed = !currentTextLayout.equals(layout);
-        this.currentTextLayout = layout;
-        return changed;
+    @Override
+    public WiresTextDecorator setMargins(final Map<Enum, Double> margins) {
+        this.margins = margins;
+        return this;
     }
 
     public void setTitleXOffsetPosition(final double xOffset) {
@@ -230,50 +211,74 @@ public class WiresTextDecorator {
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitleRotation(final double degrees) {
+    public WiresTextDecorator setTitleRotation(final double degrees) {
         text.setRotationDegrees(degrees);
+        return this;
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitleStrokeColor(final String color) {
+    public WiresTextDecorator setTitleStrokeColor(final String color) {
         text.setStrokeColor(color);
+        return this;
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitleFontFamily(final String fontFamily) {
+    public WiresTextDecorator setTitleFontFamily(final String fontFamily) {
         text.setFontFamily(fontFamily);
+        return this;
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitleFontSize(final double fontSize) {
+    public WiresTextDecorator setTitleFontSize(final double fontSize) {
         text.setFontSize(fontSize);
+        return this;
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitleFontColor(final String fillColor) {
+    public WiresTextDecorator setTitleFontColor(final String fillColor) {
         text.setFillColor(fillColor);
+        return this;
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitleAlpha(final double alpha) {
+    public WiresTextDecorator setTitleAlpha(final double alpha) {
         text.setAlpha(alpha);
+        return this;
     }
 
     @SuppressWarnings("unchecked")
-    public void setTitleStrokeWidth(final double strokeWidth) {
+    public WiresTextDecorator setTitleStrokeWidth(final double strokeWidth) {
         text.setStrokeWidth(strokeWidth);
+        return this;
     }
 
-    public void setTitleStrokeAlpha(final double strokeAlpha) {
+    public WiresTextDecorator setTitleStrokeAlpha(final double strokeAlpha) {
         text.setStrokeAlpha(strokeAlpha);
+        return this;
     }
 
-    public void setTextWrapper(final TextWrapperStrategy strategy) {
+    public WiresTextDecorator setTextWrapper(final TextWrapperStrategy strategy) {
 
         final ITextWrapper wrapper = getTextWrapper(strategy);
         this.textWrapper = wrapper;
         text.setWrapper(textWrapper);
-        updateTextBoundaries();
+        update();
+        return this;
+    }
+
+    @Override
+    public WiresTextDecorator setTitleXOffsetPosition(final Double xOffset) {
+        return this;
+    }
+
+    @Override
+    public WiresTextDecorator setTitleYOffsetPosition(final Double yOffset) {
+        return this;
+    }
+
+    @Override
+    public void setTextBoundaries(final double width, final double height) {
+        setTextBoundaries(new BoundingBox(0, 0, width, height));
     }
 
     ITextWrapper getTextWrapper(final TextWrapperStrategy strategy) {
@@ -281,27 +286,67 @@ public class WiresTextDecorator {
     }
 
     @SuppressWarnings("unchecked")
-    public void moveTitleToTop() {
-        textContainer.moveToTop();
+    public WiresTextDecorator moveTitleToTop() {
+        text.moveToTop();
+        return this;
     }
 
-    public IPrimitive<?> getView() {
-        return textContainer;
+    public Text getView() {
+        return text;
     }
 
-    public LayoutContainer.Layout getLayout() {
-        return currentTextLayout;
+    /**
+     * Returns the label layout based on the model
+     * @return
+     */
+    public LabelLayout getLabelLayout() {
+        return Optional.ofNullable(labelLayout)
+                .orElseGet(() -> new LabelLayout.Builder().horizontalAlignment(
+                        DirectionLayout.HorizontalAlignment.CENTER)
+                        .verticalAlignment(DirectionLayout.VerticalAlignment.MIDDLE)
+                        .orientation(DirectionLayout.Orientation.HORIZONTAL)
+                        .referencePosition(DirectionLayout.ReferencePosition.INSIDE)
+                        .sizeConstraints(getDefaultSizeConstraints())
+                        .build());
+    }
+
+    private com.ait.lienzo.client.core.shape.wires.layout.size.SizeConstraints getDefaultSizeConstraints() {
+        return new com.ait.lienzo.client.core.shape.wires.layout.size.SizeConstraints(100, 100,
+                                                                                      Type.PERCENTAGE);
+    }
+
+    private <T extends Enum<T>> T convertEnum(Enum<?> input, Class<T> outputType) {
+        return Exceptions.swallow(() -> Enum.valueOf(outputType, input.name()), null);
+    }
+
+    public WiresTextDecorator setTitlePosition(final HasTitle.VerticalAlignment verticalAlignment, final HasTitle.HorizontalAlignment horizontalAlignment,
+                                               final HasTitle.ReferencePosition referencePosition, final HasTitle.Orientation orientation) {
+        labelLayout = new LabelLayout.Builder()
+                .horizontalAlignment(convertEnum(horizontalAlignment, DirectionLayout.HorizontalAlignment.class))
+                .verticalAlignment(convertEnum(verticalAlignment, DirectionLayout.VerticalAlignment.class))
+                .orientation(convertEnum(orientation, DirectionLayout.Orientation.class))
+                .referencePosition(convertEnum(referencePosition, DirectionLayout.ReferencePosition.class))
+                .margins(margins.entrySet().stream().map(e ->
+                                                                 new SimpleEntry<>(Optional
+                                                                                           .<Direction>ofNullable(convertEnum(e.getKey(), DirectionLayout.VerticalAlignment.class))
+                                                                                           .orElse(convertEnum(e.getKey(), DirectionLayout.HorizontalAlignment.class)),
+                                                                                   e.getValue())).collect(Collectors.toMap(Entry::getKey, Entry::getValue)))
+                .sizeConstraints(sizeConstraints
+                                         .map(s -> new com.ait.lienzo.client.core.shape.wires.layout.size.SizeConstraints(s.getWidth(),
+                                                                                                                          s.getHeight(), convertEnum(s.getType(), Type.class)))
+                                         .orElse(getDefaultSizeConstraints()))
+                .build();
+        return this;
+    }
+
+    @Override
+    public WiresTextDecorator setTextSizeConstraints(final SizeConstraints sizeConstraints) {
+        this.sizeConstraints = Optional.ofNullable(sizeConstraints);
+        return this;
     }
 
     public void update() {
-        updateTextBoundaries();
-    }
-
-    public void resize(final double width,
-                       final double height) {
-        this.width = width;
-        this.height = height;
-        update();
+        setTextBoundaries(shape.getPath().getBoundingBox());
     }
 
     public void destroy() {
@@ -309,14 +354,13 @@ public class WiresTextDecorator {
             text.removeFromParent();
             this.text = null;
         }
-        textContainer.destroy();
         deregisterHandler(textOverHandlerViewHandler);
         deregisterHandler(textOutEventViewHandler);
         deregisterHandler(textClickEventViewHandler);
         deregisterHandler(textDblClickEventViewHandler);
         eventHandlerManager.get().destroy();
         textWrapper = null;
-        currentTextLayout = null;
+
     }
 
     private void deregisterHandler(final ViewHandler<?> handler) {
@@ -330,45 +374,19 @@ public class WiresTextDecorator {
         return null != text && text.trim().length() > 0;
     }
 
-    void updateTextBoundaries() {
-        setTextBoundaries(new BoundingBox(0,
-                                          0,
-                                          width,
-                                          height));
-    }
+
 
     void setTextBoundaries(BoundingBox boundaries) {
+        //update position
+        shape.getLabelContainerLayout().ifPresent(LabelContainerLayout::execute);
+
         if (!(textWrapper instanceof ITextWrapperWithBoundaries)) {
             return;
         }
 
-        final ITextWrapperWithBoundaries textWrapperWithBoundaries = (ITextWrapperWithBoundaries) textWrapper;
-
-        switch (getLayout()) {
-            case LEFT:
-                if (null != boundaries) {
-                    textWrapperWithBoundaries.setWrapBoundaries(new BoundingBox(boundaries.getMinY(),
-                                                                                boundaries.getMaxX(),
-                                                                                boundaries.getMaxY(),
-                                                                                boundaries.getMaxX()));
-                }
-                break;
-
-            case RIGHT:
-                if (null != boundaries) {
-                    textWrapperWithBoundaries.setWrapBoundaries(new BoundingBox(boundaries.getMinY(),
-                                                                                boundaries.getMaxX(),
-                                                                                boundaries.getMaxY(),
-                                                                                boundaries.getMaxX()));
-                }
-                break;
-
-            case TOP:
-            case CENTER:
-            case BOTTOM:
-            default:
-                textWrapperWithBoundaries.setWrapBoundaries(boundaries);
-                break;
-        }
+        //update wrapping boundaries
+        ((ITextWrapperWithBoundaries) textWrapper).setWrapBoundaries(() -> shape.getLabelContainerLayout()
+                .map(labelContainerLayout -> labelContainerLayout.getMaxSize(text))
+                .orElse(boundaries));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -203,14 +203,6 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
         return this;
     }
 
-    public void setTitleXOffsetPosition(final double xOffset) {
-        this.text.setX(xOffset);
-    }
-
-    public void setTitleYOffsetPosition(final double yOffset) {
-        this.text.setY(yOffset);
-    }
-
     @SuppressWarnings("unchecked")
     public WiresTextDecorator setTitleRotation(final double degrees) {
         text.setRotationDegrees(degrees);
@@ -269,11 +261,13 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
 
     @Override
     public WiresTextDecorator setTitleXOffsetPosition(final Double xOffset) {
+        this.text.setX(xOffset);
         return this;
     }
 
     @Override
     public WiresTextDecorator setTitleYOffsetPosition(final Double yOffset) {
+        this.text.setY(yOffset);
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -360,7 +360,6 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
         deregisterHandler(textDblClickEventViewHandler);
         eventHandlerManager.get().destroy();
         textWrapper = null;
-
     }
 
     private void deregisterHandler(final ViewHandler<?> handler) {
@@ -374,8 +373,6 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
         return null != text && text.trim().length() > 0;
     }
 
-
-
     void setTextBoundaries(BoundingBox boundaries) {
         //update position
         shape.getLabelContainerLayout().ifPresent(LabelContainerLayout::execute);
@@ -385,8 +382,9 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
         }
 
         //update wrapping boundaries
-        ((ITextWrapperWithBoundaries) textWrapper).setWrapBoundaries(() -> shape.getLabelContainerLayout()
-                .map(labelContainerLayout -> labelContainerLayout.getMaxSize(text))
-                .orElse(boundaries));
+        ((ITextWrapperWithBoundaries) textWrapper)
+                .setWrapBoundaries(shape.getLabelContainerLayout()
+                                           .map(labelContainerLayout -> labelContainerLayout.getMaxSize(text))
+                                           .orElse(boundaries));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -377,8 +377,6 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
     }
 
     void setTextBoundaries(BoundingBox boundaries) {
-        //update position
-        shape.getLabelContainerLayout().ifPresent(LabelContainerLayout::execute);
         //update text wrapper boundaries
         Optional.ofNullable(textWrapper)
                 .filter(wrapper -> wrapper instanceof ITextWrapperWithBoundaries)
@@ -387,5 +385,8 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
                         .setWrapBoundaries(shape.getLabelContainerLayout()
                                                    .map(layout -> layout.getMaxSize(text))
                                                    .orElse(boundaries)));
+
+        //update position
+        shape.getLabelContainerLayout().ifPresent(LabelContainerLayout::execute);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -24,10 +24,12 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.ITextWrapper;
 import com.ait.lienzo.client.core.shape.ITextWrapperWithBoundaries;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.shape.TextBoundsWrap;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.layout.direction.DirectionLayout;
 import com.ait.lienzo.client.core.shape.wires.layout.direction.DirectionLayout.Direction;
 import com.ait.lienzo.client.core.shape.wires.layout.label.LabelContainerLayout;
@@ -283,7 +285,16 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
     @SuppressWarnings("unchecked")
     public WiresTextDecorator moveTitleToTop() {
         text.moveToTop();
+        moveShapeChildrenToFront();
         return this;
+    }
+
+    private void moveShapeChildrenToFront() {
+        shape.getChildShapes()
+                .toList()
+                .stream()
+                .map(WiresShape::getGroup)
+                .forEach(Group::moveToTop);
     }
 
     public Text getView() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/AbstractWiresShapeViewText.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/AbstractWiresShapeViewText.java
@@ -19,15 +19,24 @@ package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.shape.wires.layout.direction.DirectionLayout;
 import com.ait.lienzo.client.core.shape.wires.layout.label.LabelLayout;
+import org.junit.Test;
 import org.mockito.Mock;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public abstract class AbstractWiresShapeViewText {
+public abstract class AbstractWiresShapeViewText<T extends WiresShapeViewExt<T>> {
+
+    public static final String TITLE = "Title";
 
     protected Text text;
 
     protected LabelLayout layout;
+
+    protected T tested;
 
     @Mock
     protected WiresTextDecorator textDecorator;
@@ -40,7 +49,25 @@ public abstract class AbstractWiresShapeViewText {
                 .referencePosition(DirectionLayout.ReferencePosition.INSIDE)
                 .build();
         when(textDecorator.getView()).thenReturn(text);
-        when(textDecorator.getView()).thenReturn(text);
         when(textDecorator.getLabelLayout()).thenReturn(layout);
+        this.tested = spy(createInstance());
+        this.tested.setTextViewDecorator(textDecorator);
+
+        verify(tested, never()).addLabel(any(), any());
+    }
+
+    public abstract T createInstance();
+
+    @Test
+    public void testTitle() {
+        tested.setTitle(TITLE);
+        verify(textDecorator).setTitle(TITLE);
+        verify(tested).addLabel(text, layout);
+    }
+
+    @Test
+    public void testNullTitle() {
+        //setTitle should not throw an exception when called with a null argument
+        tested.setTitle(null);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/AbstractWiresShapeViewText.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/AbstractWiresShapeViewText.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
+
+import com.ait.lienzo.client.core.shape.Text;
+import com.ait.lienzo.client.core.shape.wires.layout.direction.DirectionLayout;
+import com.ait.lienzo.client.core.shape.wires.layout.label.LabelLayout;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractWiresShapeViewText {
+
+    protected Text text;
+
+    protected LabelLayout layout;
+
+    @Mock
+    protected WiresTextDecorator textDecorator;
+
+    public void setUp() {
+        this.text = new Text("test");
+        this.layout = new LabelLayout.Builder()
+                .horizontalAlignment(DirectionLayout.HorizontalAlignment.CENTER)
+                .verticalAlignment(DirectionLayout.VerticalAlignment.MIDDLE)
+                .referencePosition(DirectionLayout.ReferencePosition.INSIDE)
+                .build();
+        when(textDecorator.getView()).thenReturn(text);
+        when(textDecorator.getView()).thenReturn(text);
+        when(textDecorator.getLabelLayout()).thenReturn(layout);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeViewTest.java
@@ -23,12 +23,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.WiresScalableContainer;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
-import org.mockito.Mock;
 
 import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class DecoratedShapeViewTest {
+public class DecoratedShapeViewTest extends AbstractWiresShapeViewText {
 
     private static ViewEventType[] viewEventTypes = {};
     private final static MultiPath PATH = new MultiPath();
@@ -36,15 +35,13 @@ public class DecoratedShapeViewTest {
     private final double width = 5;
     private final double height = 5;
 
-    @Mock
-    private WiresTextDecorator textDecorator;
-
     private WiresScalableContainer container;
 
     private DecoratedShapeView<WiresShapeViewExt> tested;
 
     @Before
     public void setup() throws Exception {
+        super.setUp();
         container = new WiresScalableContainer();
         this.tested = new DecoratedShapeView<>(viewEventTypes,
                                                container,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/DecoratedShapeViewTest.java
@@ -37,24 +37,20 @@ public class DecoratedShapeViewTest extends AbstractWiresShapeViewText {
 
     private WiresScalableContainer container;
 
-    private DecoratedShapeView<WiresShapeViewExt> tested;
 
     @Before
     public void setup() throws Exception {
-        super.setUp();
         container = new WiresScalableContainer();
-        this.tested = new DecoratedShapeView<>(viewEventTypes,
-                                               container,
-                                               PATH,
-                                               width,
-                                               height);
-        this.tested.setTextViewDecorator(textDecorator);
+        super.setUp();
     }
 
-    @Test
-    public void testTitle() {
-        //setTitle should not throw an exception when called with a null argument
-        tested.setTitle(null);
+    @Override
+    public WiresShapeViewExt createInstance() {
+        return  new DecoratedShapeView<>(viewEventTypes,
+                                         container,
+                                         PATH,
+                                         width,
+                                         height);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/TextWrapperProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/TextWrapperProviderTest.java
@@ -20,6 +20,7 @@ import com.ait.lienzo.client.core.shape.ITextWrapper;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.shape.TextBoundsAndLineBreaksWrap;
 import com.ait.lienzo.client.core.shape.TextBoundsWrap;
+import com.ait.lienzo.client.core.shape.TextLineBreakTruncateWrapper;
 import com.ait.lienzo.client.core.shape.TextLineBreakWrap;
 import com.ait.lienzo.client.core.shape.TextNoWrap;
 import com.ait.lienzo.client.core.shape.TextTruncateWrapper;
@@ -65,5 +66,11 @@ public class TextWrapperProviderTest {
     public void testBounds() {
         final ITextWrapper wrapper = TextWrapperProvider.get(TextWrapperStrategy.BOUNDS, text);
         assertTrue(wrapper instanceof TextBoundsWrap);
+    }
+
+    @Test
+    public void testTruncateWithLineBreak() {
+        final ITextWrapper wrapper = TextWrapperProvider.get(TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK, text);
+        assertTrue(wrapper instanceof TextLineBreakTruncateWrapper);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExtTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExtTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext;
 
+import java.util.Optional;
+
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.MultiPathDecorator;
@@ -79,8 +81,8 @@ public class WiresConnectorViewExtTest {
                                            HEAD_DECORATOR,
                                            TAIL_DECORATOR) {
             @Override
-            protected WiresConnectorLabel createLabel(String title) {
-                return WiresConnectorViewExtTest.this.label;
+            protected Optional<WiresConnectorLabel> createLabel(String title) {
+                return Optional.of(WiresConnectorViewExtTest.this.label);
             }
         };
         tested.setControl(connectorControl);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExtTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExtTest.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.ShapeViewSu
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -76,23 +77,24 @@ public class WiresConnectorViewExtTest {
             ((Consumer) invocation.getArguments()[0]).accept(labelText);
             return label;
         }).when(label).configure(any(Consumer.class));
-        tested = new WiresConnectorViewExt(ShapeViewSupportedEvents.DESKTOP_CONNECTOR_EVENT_TYPES,
-                                           line,
-                                           HEAD_DECORATOR,
-                                           TAIL_DECORATOR) {
+        tested = spy(new WiresConnectorViewExt(ShapeViewSupportedEvents.DESKTOP_CONNECTOR_EVENT_TYPES,
+                                               line,
+                                               HEAD_DECORATOR,
+                                               TAIL_DECORATOR) {
             @Override
             protected Optional<WiresConnectorLabel> createLabel(String title) {
                 return Optional.of(WiresConnectorViewExtTest.this.label);
             }
-        };
+        });
         tested.setControl(connectorControl);
         layer.add(tested.getGroup());
     }
 
     @Test
     public void testLabel() {
-        tested.setTitle("some label");
+        assertNotNull(tested.label);
         assertTrue(tested.label.isPresent());
+        tested.setTitle("some label");
         verify(labelText, times(1)).setText(eq("some label"));
         tested.setTitleAlpha(0.1d);
         verify(labelText, times(1)).setAlpha(eq(0.1d));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
@@ -32,20 +32,15 @@ public class WiresShapeViewExtTest extends AbstractWiresShapeViewText {
     private static ViewEventType[] viewEventTypes = {};
     private final static MultiPath PATH = new MultiPath();
 
-    private WiresShapeViewExt<WiresShapeViewExt> tested;
-
     @Before
     public void setup() throws Exception {
         super.setUp();
-        this.tested = new WiresShapeViewExt<>(viewEventTypes,
-                                              PATH);
-        this.tested.setTextViewDecorator(textDecorator);
     }
 
-    @Test
-    public void testTitle() {
-        //setTitle should not thrown an exception when called with a null argument
-        tested.setTitle(null);
+    @Override
+    public WiresShapeViewExt createInstance() {
+        return new WiresShapeViewExt<>(viewEventTypes,
+                                       PATH);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
@@ -96,6 +96,11 @@ public class WiresShapeViewExtTest {
         testSetTextWrapperStrategy(TextWrapperStrategy.TRUNCATE);
     }
 
+    @Test
+    public void testSetTextWrapperTruncateWithLineBreak() {
+        testSetTextWrapperStrategy(TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK);
+    }
+
     private void testSetTextWrapperStrategy(final TextWrapperStrategy wrapperStrategy) {
         tested.setTextWrapper(wrapperStrategy);
         verify(textDecorator).setTextWrapper(wrapperStrategy);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
@@ -23,23 +23,20 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
-import org.mockito.Mock;
 
 import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class WiresShapeViewExtTest {
+public class WiresShapeViewExtTest extends AbstractWiresShapeViewText {
 
     private static ViewEventType[] viewEventTypes = {};
     private final static MultiPath PATH = new MultiPath();
-
-    @Mock
-    private WiresTextDecorator textDecorator;
 
     private WiresShapeViewExt<WiresShapeViewExt> tested;
 
     @Before
     public void setup() throws Exception {
+        super.setUp();
         this.tested = new WiresShapeViewExt<>(viewEventTypes,
                                               PATH);
         this.tested.setTextViewDecorator(textDecorator);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecoratorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecoratorTest.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 
 import com.ait.lienzo.client.core.shape.ITextWrapper;
 import com.ait.lienzo.client.core.shape.ITextWrapperWithBoundaries;
+import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.shape.TextBoundsWrap;
 import com.ait.lienzo.client.core.types.BoundingBox;
@@ -58,15 +59,23 @@ public class WiresTextDecoratorTest {
     private final BoundingBox bb = new BoundingBox(new Point2D(0, 0),
                                                    new Point2D(100, 100));
 
+    @Mock
+    private WiresShapeViewExt shape;
+
+    @Mock
+    private MultiPath path;
+
     @Before
     public void setup() {
         when(eventHandlerManager.get()).thenReturn(manager);
+        when(shape.getPath()).thenReturn(path);
+        when(path.getBoundingBox()).thenReturn(bb);
     }
 
     @Test
     public void ensureThatWrapBoundariesAreSet() {
 
-        final WiresTextDecorator decorator = new WiresTextDecorator(eventHandlerManager, bb);
+        final WiresTextDecorator decorator = new WiresTextDecorator(eventHandlerManager, shape);
         final Text text = (Text) decorator.getView().asGroup().getChildNodes().get(0);
         final BoundingBox wrapBoundaries = ((TextBoundsWrap) text.getWrapper()).getWrapBoundaries();
 
@@ -79,9 +88,9 @@ public class WiresTextDecoratorTest {
     @Test
     public void ensureThatResizeUpdatesTheNode() {
         final WiresTextDecorator decorator = mock(WiresTextDecorator.class);
-        doCallRealMethod().when(decorator).resize(anyDouble(), anyDouble());
+        doCallRealMethod().when(decorator).setTextBoundaries(anyDouble(), anyDouble());
 
-        decorator.resize(0, 0);
+        decorator.setTextBoundaries(0, 0);
         verify(decorator).update();
     }
 
@@ -91,7 +100,7 @@ public class WiresTextDecoratorTest {
         doCallRealMethod().when(decorator).update();
 
         decorator.update();
-        verify(decorator).updateTextBoundaries();
+        verify(decorator).setTextBoundaries(any(BoundingBox.class));
     }
 
     @Test
@@ -120,7 +129,7 @@ public class WiresTextDecoratorTest {
     }
 
     private void testSetTextWrapperStrategy(final TextWrapperStrategy wrapperStrategy) {
-        final WiresTextDecorator decorator = spy(new WiresTextDecorator(eventHandlerManager, bb));
+        final WiresTextDecorator decorator = spy(new WiresTextDecorator(eventHandlerManager, shape));
         final Text text = (Text) decorator.getView().asGroup().getChildNodes().get(0);
         final ITextWrapper expectedWrapper = TextWrapperProvider.get(wrapperStrategy, text);
 
@@ -128,13 +137,13 @@ public class WiresTextDecoratorTest {
 
         decorator.setTextWrapper(wrapperStrategy);
 
-        verify(decorator).updateTextBoundaries();
+        verify(decorator).setTextBoundaries(any(BoundingBox.class));
         assertEquals(expectedWrapper.getClass(), text.getWrapper().getClass());
     }
 
     @Test
     public void ensureSetWrapBoundariesIsCalled(){
-        final WiresTextDecorator decorator = spy(new WiresTextDecorator(eventHandlerManager, bb));
+        final WiresTextDecorator decorator = spy(new WiresTextDecorator(eventHandlerManager, shape));
         doCallRealMethod().when(decorator).setTextWrapper(any());
         doReturn(textWrapperWithBoundaries).when(decorator).getTextWrapper(any());
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecoratorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecoratorTest.java
@@ -128,6 +128,11 @@ public class WiresTextDecoratorTest {
         testSetTextWrapperStrategy(TextWrapperStrategy.TRUNCATE);
     }
 
+    @Test
+    public void testSetTextWrapperTruncateWithLineBreak() {
+        testSetTextWrapperStrategy(TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK);
+    }
+
     private void testSetTextWrapperStrategy(final TextWrapperStrategy wrapperStrategy) {
         final WiresTextDecorator decorator = spy(new WiresTextDecorator(eventHandlerManager, shape));
         final Text text = (Text) decorator.getView().asGroup().getChildNodes().get(0);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/TextWrapperStrategy.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/TextWrapperStrategy.java
@@ -40,5 +40,10 @@ public enum TextWrapperStrategy {
     /**
      * Wraps when exceeds the width. Truncates when the text exceeds the width and height appending "...".
      */
-    TRUNCATE
+    TRUNCATE,
+
+    /**
+     * Same as {@link TextWrapperStrategy#TRUNCATE} but consider line break.
+     */
+    TRUNCATE_WITH_LINE_BREAK
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
@@ -52,7 +52,7 @@ public interface HasTitle<T> {
         VERTICAL
     }
 
-    class SizeConstraints {
+    class Size {
 
         public enum SizeType {
             PERCENTAGE,
@@ -63,7 +63,7 @@ public interface HasTitle<T> {
         private double width;
         private SizeType type;
 
-        public SizeConstraints(final double width, final double height, final SizeType type) {
+        public Size(final double width, final double height, final SizeType type) {
             this.width = width;
             this.height = height;
             this.type = type;
@@ -82,7 +82,7 @@ public interface HasTitle<T> {
         }
     }
 
-    T setTextSizeConstraints(final SizeConstraints sizeConstraints);
+    T setTextSizeConstraints(final Size sizeConstraints);
 
     T setTitlePosition(final VerticalAlignment verticalAlignment,
                        final HorizontalAlignment horizontalAlignment,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
@@ -22,14 +22,6 @@ import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 
 public interface HasTitle<T> {
 
-    enum Position {
-        CENTER,
-        LEFT,
-        RIGHT,
-        TOP,
-        BOTTOM
-    }
-
     enum HorizontalAlignment {
         RIGHT,
         CENTER,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.core.client.shape.view;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 
@@ -71,6 +72,26 @@ public interface HasTitle<T> {
 
         public SizeType getType() {
             return type;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Size size = (Size) o;
+            return Double.compare(size.height, height) == 0 &&
+                    Double.compare(size.width, width) == 0 &&
+                    type == size.type;
+        }
+
+        @Override
+        public int hashCode() {
+
+            return Objects.hash(height, width, type);
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.client.shape.view;
 
+import java.util.Map;
+
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 
 public interface HasTitle<T> {
@@ -28,9 +30,68 @@ public interface HasTitle<T> {
         BOTTOM
     }
 
+    enum HorizontalAlignment {
+        RIGHT,
+        CENTER,
+        LEFT
+    }
+
+    enum VerticalAlignment {
+        TOP,
+        MIDDLE,
+        BOTTOM
+    }
+
+    enum ReferencePosition {
+        INSIDE,
+        OUTSIDE
+    }
+
+    enum Orientation {
+        HORIZONTAL,
+        VERTICAL
+    }
+
+    class SizeConstraints {
+
+        public enum SizeType {
+            PERCENTAGE,
+            RAW
+        }
+
+        private double height;
+        private double width;
+        private SizeType type;
+
+        public SizeConstraints(final double width, final double height, final SizeType type) {
+            this.width = width;
+            this.height = height;
+            this.type = type;
+        }
+
+        public double getHeight() {
+            return height;
+        }
+
+        public double getWidth() {
+            return width;
+        }
+
+        public SizeType getType() {
+            return type;
+        }
+    }
+
+    T setTextSizeConstraints(final SizeConstraints sizeConstraints);
+
+    T setTitlePosition(final VerticalAlignment verticalAlignment,
+                       final HorizontalAlignment horizontalAlignment,
+                       final ReferencePosition referencePosition,
+                       final Orientation orientation);
+
     T setTitle(final String title);
 
-    T setTitlePosition(final Position position);
+    T setMargins(final Map<Enum, Double> margins);
 
     T setTitleXOffsetPosition(final Double xOffset);
 
@@ -59,4 +120,8 @@ public interface HasTitle<T> {
     T setTitleStrokeColor(final String color);
 
     T moveTitleToTop();
+
+    default void setTextBoundaries(final double width, final double height) {
+
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/AbstractElementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/AbstractElementShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,11 +53,11 @@ public abstract class AbstractElementShape<W, C extends View<W>, E extends Eleme
                            final E element,
                            final MutationContext mutationContext) {
         getShapeHandlersDef()
-                .titleHandler()
-                .ifPresent(h -> h.accept(title, getShapeView()));
-        getShapeHandlersDef()
                 .fontHandler()
                 .ifPresent(h -> h.accept(getDefinition(element), getShapeView()));
+        getShapeHandlersDef()
+                .titleHandler()
+                .ifPresent(h -> h.accept(title, getShapeView()));
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/AbstractElementShape.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/impl/AbstractElementShape.java
@@ -52,9 +52,11 @@ public abstract class AbstractElementShape<W, C extends View<W>, E extends Eleme
     public void applyTitle(final String title,
                            final E element,
                            final MutationContext mutationContext) {
+        //first set the font properties
         getShapeHandlersDef()
                 .fontHandler()
                 .ifPresent(h -> h.accept(getDefinition(element), getShapeView()));
+        //after set the title
         getShapeHandlersDef()
                 .titleHandler()
                 .ifPresent(h -> h.accept(title, getShapeView()));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
@@ -26,7 +26,7 @@ import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Horizont
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Position;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeViewHandler;
@@ -57,7 +57,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
     private Function<W, HasTitle.HorizontalAlignment> horizontalAlignmentProvider;
     private Function<W, HasTitle.ReferencePosition> referencePositionProvider;
     private Function<W, HasTitle.Orientation> orientationProvider;
-    private final Function<W, SizeConstraints> sizeConstraintsProvider;
+    private final Function<W, Size> sizeConstraintsProvider;
     private final Map<Enum, Double> margins;
 
     FontHandler(final Function<W, Double> alphaProvider, final Function<W, String> fontFamilyProvider,
@@ -71,7 +71,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
                 final Function<W, HorizontalAlignment> horizontalAlignmentProvider,
                 final Function<W, ReferencePosition> referencePositionProvider,
                 final Function<W, Orientation> orientationProvider,
-                final Function<W, SizeConstraints> sizeConstraintsProvider,
+                final Function<W, Size> sizeConstraintsProvider,
                 final Map<Enum, Double> margins) {
         this.alphaProvider = alphaProvider;
         this.fontFamilyProvider = fontFamilyProvider;
@@ -110,7 +110,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             final Double positionYOffset = positionYOffsetProvider.apply(element);
             final Double rotation = rotationProvider.apply(element);
             final TextWrapperStrategy wrapperStrategy = textWrapperStrategyProvider.apply(element);
-            final SizeConstraints sizeConstraints = sizeConstraintsProvider.apply(element);
+            final Size sizeConstraints = sizeConstraintsProvider.apply(element);
             final VerticalAlignment verticalAlignment = verticalAlignmentProvider.apply(element);
             final HorizontalAlignment horizontalAlignment = horizontalAlignmentProvider.apply(element);
             final ReferencePosition referencePosition = referencePositionProvider.apply(element);
@@ -197,7 +197,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
         private Function<W, HasTitle.HorizontalAlignment> horizontalAlignmentProvider;
         private Function<W, HasTitle.ReferencePosition> referencePositionProvider;
         private Function<W, HasTitle.Orientation> orientationProvider;
-        private Function<W, HasTitle.SizeConstraints> sizeConstraintsProvider;
+        private Function<W, Size> sizeConstraintsProvider;
         private final Map<Enum, Double> margins = new HashMap<>();
 
         public Builder() {
@@ -300,7 +300,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             return this;
         }
 
-        public Builder<W, V> textSizeConstraints(Function<W, SizeConstraints> provider) {
+        public Builder<W, V> textSizeConstraints(Function<W, Size> provider) {
             this.sizeConstraintsProvider = provider;
             return this;
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
@@ -18,7 +18,10 @@ package org.kie.workbench.common.stunner.core.client.shape.view.handler;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
@@ -176,7 +179,9 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             }
         }
 
-        hasTitle.setTitlePosition(verticalAlignment, horizontalAlignment, referencePosition, currentOrientation);
+        if(Stream.of(verticalAlignment, horizontalAlignment, referencePosition, currentOrientation).allMatch(Objects::nonNull)) {
+            hasTitle.setTitlePosition(verticalAlignment, horizontalAlignment, referencePosition, currentOrientation);
+        }
     }
 
     public static class Builder<W, V extends ShapeView> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.core.client.shape.view.handler;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -179,7 +178,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             }
         }
 
-        if(Stream.of(verticalAlignment, horizontalAlignment, referencePosition, currentOrientation).allMatch(Objects::nonNull)) {
+        if (Stream.of(verticalAlignment, horizontalAlignment, referencePosition, currentOrientation).allMatch(Objects::nonNull)) {
             hasTitle.setTitlePosition(verticalAlignment, horizontalAlignment, referencePosition, currentOrientation);
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
@@ -61,6 +61,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
     private Function<W, HasTitle.Orientation> orientationProvider;
     private final Function<W, Size> sizeConstraintsProvider;
     private final Map<Enum, Double> margins;
+    private final Function<W,Map<Enum, Double>> marginsProvider;
 
     FontHandler(final Function<W, Double> alphaProvider, final Function<W, String> fontFamilyProvider,
                 final Function<W, String> fontColorProvider, final Function<W, Double> fontSizeProvider,
@@ -74,7 +75,8 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
                 final Function<W, ReferencePosition> referencePositionProvider,
                 final Function<W, Orientation> orientationProvider,
                 final Function<W, Size> sizeConstraintsProvider,
-                final Map<Enum, Double> margins) {
+                final Map<Enum, Double> margins,
+                final Function<W,Map<Enum, Double>> marginsProvider) {
         this.alphaProvider = alphaProvider;
         this.fontFamilyProvider = fontFamilyProvider;
         this.fontColorProvider = fontColorProvider;
@@ -93,6 +95,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
         this.orientationProvider = orientationProvider;
         this.sizeConstraintsProvider = sizeConstraintsProvider;
         this.margins = margins;
+        this.marginsProvider = marginsProvider;
     }
 
     @Override
@@ -107,7 +110,6 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             final String strokeColor = strokeColorProvider.apply(element);
             final Double strokeSize = strokeSizeProvider.apply(element);
             final Double strokeAlpha = strokeAlphaProvider.apply(element);
-            final HasTitle.Position position = positionProvider.apply(element);
             final Double positionXOffset = positionXOffsetProvider.apply(element);
             final Double positionYOffset = positionYOffsetProvider.apply(element);
             final Double rotation = rotationProvider.apply(element);
@@ -116,7 +118,8 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             final VerticalAlignment verticalAlignment = verticalAlignmentProvider.apply(element);
             final HorizontalAlignment horizontalAlignment = horizontalAlignmentProvider.apply(element);
             final ReferencePosition referencePosition = referencePositionProvider.apply(element);
-            Orientation orientation = orientationProvider.apply(element);
+            final Orientation orientation = orientationProvider.apply(element);
+            final Map<Enum, Double> margins = marginsProvider.apply(element);
 
             if (fontFamily != null && fontFamily.trim().length() > 0) {
                 hasTitle.setTitleFontFamily(fontFamily);
@@ -154,7 +157,11 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
 
             hasTitle.setTextSizeConstraints(sizeConstraints);
 
-            hasTitle.setMargins(margins);
+            if(margins != null){
+                this.margins.putAll(margins);
+            }
+
+            hasTitle.setMargins(this.margins);
 
             applyTextPosition(hasTitle, rotation, verticalAlignment, horizontalAlignment, referencePosition,
                               orientation);
@@ -203,6 +210,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
         private Function<W, HasTitle.Orientation> orientationProvider;
         private Function<W, Size> sizeConstraintsProvider;
         private final Map<Enum, Double> margins = new HashMap<>();
+        private Function<W,Map<Enum, Double>> marginsProvider;
 
         public Builder() {
             this.alphaProvider = value -> null;
@@ -222,6 +230,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             this.referencePositionProvider = value -> null;
             this.orientationProvider = value -> null;
             this.sizeConstraintsProvider = value -> null;
+            this.marginsProvider = value -> null;
         }
 
         public Builder<W, V> alpha(Function<W, Double> alphaProvider) {
@@ -314,6 +323,12 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             return this;
         }
 
+        public Builder<W, V> margins(Function<W, Map<Enum, Double>> marginsProvider) {
+
+            this.marginsProvider = marginsProvider;
+            return this;
+        }
+
         public FontHandler<W, V> build() {
             return new FontHandler<>(alphaProvider,
                                      fontFamilyProvider,
@@ -332,7 +347,8 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
                                      referencePositionProvider,
                                      orientationProvider,
                                      sizeConstraintsProvider,
-                                     margins);
+                                     margins,
+                                     marginsProvider);
         }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.client.shape.view.handler;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -26,7 +27,6 @@ import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Position;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
@@ -50,7 +50,6 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
     private final Function<W, String> strokeColorProvider;
     private final Function<W, Double> strokeSizeProvider;
     private final Function<W, Double> strokeAlphaProvider;
-    private final Function<W, HasTitle.Position> positionProvider;
     private final Function<W, Double> positionXOffsetProvider;
     private final Function<W, Double> positionYOffsetProvider;
     private final Function<W, Double> rotationProvider;
@@ -61,13 +60,17 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
     private Function<W, HasTitle.Orientation> orientationProvider;
     private final Function<W, Size> sizeConstraintsProvider;
     private final Map<Enum, Double> margins;
-    private final Function<W,Map<Enum, Double>> marginsProvider;
+    private final Function<W, Map<Enum, Double>> marginsProvider;
 
-    FontHandler(final Function<W, Double> alphaProvider, final Function<W, String> fontFamilyProvider,
-                final Function<W, String> fontColorProvider, final Function<W, Double> fontSizeProvider,
-                final Function<W, String> strokeColorProvider, final Function<W, Double> strokeSizeProvider,
-                final Function<W, Double> strokeAlphaProvider, final Function<W, Position> positionProvider,
-                final Function<W, Double> positionXOffsetProvider, final Function<W, Double> positionYOffsetProvider,
+    FontHandler(final Function<W, Double> alphaProvider,
+                final Function<W, String> fontFamilyProvider,
+                final Function<W, String> fontColorProvider,
+                final Function<W, Double> fontSizeProvider,
+                final Function<W, String> strokeColorProvider,
+                final Function<W, Double> strokeSizeProvider,
+                final Function<W, Double> strokeAlphaProvider,
+                final Function<W, Double> positionXOffsetProvider,
+                final Function<W, Double> positionYOffsetProvider,
                 final Function<W, Double> rotationProvider,
                 final Function<W, TextWrapperStrategy> textWrapperStrategyProvider,
                 final Function<W, VerticalAlignment> verticalAlignmentProvider,
@@ -76,7 +79,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
                 final Function<W, Orientation> orientationProvider,
                 final Function<W, Size> sizeConstraintsProvider,
                 final Map<Enum, Double> margins,
-                final Function<W,Map<Enum, Double>> marginsProvider) {
+                final Function<W, Map<Enum, Double>> marginsProvider) {
         this.alphaProvider = alphaProvider;
         this.fontFamilyProvider = fontFamilyProvider;
         this.fontColorProvider = fontColorProvider;
@@ -84,7 +87,6 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
         this.strokeColorProvider = strokeColorProvider;
         this.strokeSizeProvider = strokeSizeProvider;
         this.strokeAlphaProvider = strokeAlphaProvider;
-        this.positionProvider = positionProvider;
         this.positionXOffsetProvider = positionXOffsetProvider;
         this.positionYOffsetProvider = positionYOffsetProvider;
         this.rotationProvider = rotationProvider;
@@ -155,13 +157,14 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
                 hasTitle.setTextWrapper(wrapperStrategy);
             }
 
-            hasTitle.setTextSizeConstraints(sizeConstraints);
-
-            if(margins != null){
-                this.margins.putAll(margins);
+            if (!this.margins.isEmpty()) {
+                hasTitle.setMargins(this.margins);
+                Optional.ofNullable(margins).ifPresent(m -> this.margins.putAll(m));
             }
 
-            hasTitle.setMargins(this.margins);
+            if (sizeConstraints != null) {
+                hasTitle.setTextSizeConstraints(sizeConstraints);
+            }
 
             applyTextPosition(hasTitle, rotation, verticalAlignment, horizontalAlignment, referencePosition,
                               orientation);
@@ -199,7 +202,6 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
         private Function<W, String> strokeColorProvider;
         private Function<W, Double> strokeSizeProvider;
         private Function<W, Double> strokeAlphaProvider;
-        private Function<W, HasTitle.Position> positionProvider;
         private Function<W, Double> positionXOffsetProvider;
         private Function<W, Double> positionYOffsetProvider;
         private Function<W, Double> rotationProvider;
@@ -210,7 +212,7 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
         private Function<W, HasTitle.Orientation> orientationProvider;
         private Function<W, Size> sizeConstraintsProvider;
         private final Map<Enum, Double> margins = new HashMap<>();
-        private Function<W,Map<Enum, Double>> marginsProvider;
+        private Function<W, Map<Enum, Double>> marginsProvider;
 
         public Builder() {
             this.alphaProvider = value -> null;
@@ -219,7 +221,6 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
             this.fontSizeProvider = value -> null;
             this.strokeColorProvider = value -> null;
             this.strokeSizeProvider = value -> null;
-            this.positionProvider = value -> null;
             this.positionXOffsetProvider = value -> null;
             this.positionYOffsetProvider = value -> null;
             this.rotationProvider = value -> null;
@@ -265,11 +266,6 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
 
         public Builder<W, V> strokeAlpha(Function<W, Double> provider) {
             this.strokeAlphaProvider = provider;
-            return this;
-        }
-
-        public Builder<W, V> position(Function<W, HasTitle.Position> provider) {
-            this.positionProvider = provider;
             return this;
         }
 
@@ -337,7 +333,6 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
                                      strokeColorProvider,
                                      strokeSizeProvider,
                                      strokeAlphaProvider,
-                                     positionProvider,
                                      positionXOffsetProvider,
                                      positionYOffsetProvider,
                                      rotationProvider,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/handler/FontHandler.java
@@ -157,9 +157,9 @@ public class FontHandler<W, V extends ShapeView> implements ShapeViewHandler<W, 
                 hasTitle.setTextWrapper(wrapperStrategy);
             }
 
+            Optional.ofNullable(margins).ifPresent(m -> this.margins.putAll(m));
             if (!this.margins.isEmpty()) {
                 hasTitle.setMargins(this.margins);
-                Optional.ofNullable(margins).ifPresent(m -> this.margins.putAll(m));
             }
 
             if (sizeConstraints != null) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
@@ -82,7 +82,7 @@ public class ShapeViewExtStub
     }
 
     @Override
-    public Object setTextSizeConstraints(final SizeConstraints sizeConstraints) {
+    public Object setTextSizeConstraints(final Size sizeConstraints) {
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.core.client.shape;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
@@ -74,7 +75,19 @@ public class ShapeViewExtStub
     }
 
     @Override
-    public Object setTitlePosition(final Position position) {
+    public Object setTitlePosition(final VerticalAlignment verticalAlignment,
+                                   final HorizontalAlignment horizontalAlignment, final ReferencePosition referencePosition,
+                                   final Orientation orientation) {
+        return this;
+    }
+
+    @Override
+    public Object setTextSizeConstraints(final SizeConstraints sizeConstraints) {
+        return this;
+    }
+
+    @Override
+    public Object setMargins(final Map<Enum, Double> margins) {
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/NodeShapeImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/impl/NodeShapeImplTest.java
@@ -33,10 +33,12 @@ import org.kie.workbench.common.stunner.core.graph.content.Bound;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -77,6 +79,9 @@ public class NodeShapeImplTest {
 
     private ShapeViewExtStub view;
     private NodeShapeImpl<Object, ShapeViewDef<Object, ShapeView>, ShapeView> tested;
+
+    @Mock
+    private MutationContext context;
 
     @Before
     public void setup() throws Exception {
@@ -130,5 +135,13 @@ public class NodeShapeImplTest {
         tested.applyState(ShapeState.INVALID);
         verify(shapeStateHandler,
                times(1)).applyState(eq(ShapeState.INVALID));
+    }
+
+    @Test
+    public void testTitle() {
+        final InOrder order = inOrder(titleHandler, fontHandler);
+        tested.applyTitle("title", element, context);
+        order.verify(fontHandler).accept(definition, view);
+        order.verify(titleHandler).accept("title", view);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/FontHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/FontHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,6 @@ public class FontHandlerTest {
         verify(view).setTitleFontSize(eq(10.5d));
         verify(view).setTitleAlpha(eq(0.7d));
         verify(view).setTitleRotation(eq(180d));
-        verify(view).setTitlePosition(eq(HasTitle.Position.TOP));
         verify(view).setTitleXOffsetPosition(eq(X_OFFSET));
         verify(view).setTitleYOffsetPosition(eq(Y_OFFSET));
         verify(view).setTextWrapper(TextWrapperStrategy.NO_WRAP);
@@ -107,7 +106,6 @@ public class FontHandlerTest {
         verify(view, never()).setTitleFontSize(anyDouble());
         verify(view, never()).setTitleAlpha(anyDouble());
         verify(view, never()).setTitleRotation(anyDouble());
-        verify(view, never()).setTitlePosition(any(HasTitle.Position.class));
         verify(view, never()).setTitleXOffsetPosition(anyDouble());
         verify(view, never()).setTitleYOffsetPosition(anyDouble());
         verify(view, never()).setTextWrapper(any());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/FontHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/FontHandlerTest.java
@@ -71,6 +71,7 @@ public class FontHandlerTest {
                 .orientation(o -> HasTitle.Orientation.VERTICAL)
                 .margin(HasTitle.HorizontalAlignment.LEFT, 10d)
                 .margin(HasTitle.VerticalAlignment.TOP, 10d)
+                .margins(o -> new Maps.Builder<Enum, Double>().put(HasTitle.HorizontalAlignment.RIGHT, 50d).build())
                 .textSizeConstraints(o -> SIZE_CONSTRAINTS)
                 .build();
         final Object bean = mock(Object.class);
@@ -91,6 +92,7 @@ public class FontHandlerTest {
         verify(view).setMargins(new Maps.Builder()
                                         .put(HasTitle.VerticalAlignment.TOP, 10d)
                                         .put(HasTitle.HorizontalAlignment.LEFT, 10d)
+                                        .put(HasTitle.HorizontalAlignment.RIGHT, 50d)
                                         .build());
         verify(view).setTextSizeConstraints(SIZE_CONSTRAINTS);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/FontHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/view/FontHandlerTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.client.shape.view;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Maps;
 import org.kie.workbench.common.stunner.core.client.shape.ShapeViewExtStub;
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
@@ -39,6 +40,7 @@ public class FontHandlerTest {
     private static final double X_OFFSET = 10.0;
 
     private static final double Y_OFFSET = 20.0;
+    public static final HasTitle.Size SIZE_CONSTRAINTS = new HasTitle.Size(50d, 50d, HasTitle.Size.SizeType.PERCENTAGE);
 
     private FontHandler<Object, ShapeViewExtStub> tested;
 
@@ -60,10 +62,16 @@ public class FontHandlerTest {
                 .textWrapperStrategy(o -> TextWrapperStrategy.NO_WRAP)
                 .fontSize(o -> 10.5d)
                 .alpha(o -> 0.7d)
-                .rotation(o -> 180d)
-                .position(o -> HasTitle.Position.TOP)
+                .rotation(o -> 270d)
                 .positionXOffset(o -> X_OFFSET)
                 .positionYOffset(o -> Y_OFFSET)
+                .verticalAlignment(o -> HasTitle.VerticalAlignment.TOP)
+                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.LEFT)
+                .referencePosition(o -> HasTitle.ReferencePosition.OUTSIDE)
+                .orientation(o -> HasTitle.Orientation.VERTICAL)
+                .margin(HasTitle.HorizontalAlignment.LEFT, 10d)
+                .margin(HasTitle.VerticalAlignment.TOP, 10d)
+                .textSizeConstraints(o -> SIZE_CONSTRAINTS)
                 .build();
         final Object bean = mock(Object.class);
         tested.handle(bean, view);
@@ -74,10 +82,17 @@ public class FontHandlerTest {
         verify(view).setTitleFontFamily(eq("fontFamily"));
         verify(view).setTitleFontSize(eq(10.5d));
         verify(view).setTitleAlpha(eq(0.7d));
-        verify(view).setTitleRotation(eq(180d));
+        verify(view).setTitleRotation(eq(270d));
         verify(view).setTitleXOffsetPosition(eq(X_OFFSET));
         verify(view).setTitleYOffsetPosition(eq(Y_OFFSET));
         verify(view).setTextWrapper(TextWrapperStrategy.NO_WRAP);
+        verify(view).setTitlePosition(HasTitle.VerticalAlignment.TOP, HasTitle.HorizontalAlignment.LEFT,
+                                      HasTitle.ReferencePosition.OUTSIDE, HasTitle.Orientation.VERTICAL);
+        verify(view).setMargins(new Maps.Builder()
+                                        .put(HasTitle.VerticalAlignment.TOP, 10d)
+                                        .put(HasTitle.HorizontalAlignment.LEFT, 10d)
+                                        .build());
+        verify(view).setTextSizeConstraints(SIZE_CONSTRAINTS);
     }
 
     @Test
@@ -92,9 +107,15 @@ public class FontHandlerTest {
                 .textWrapperStrategy(o -> null)
                 .alpha(o -> null)
                 .rotation(o -> null)
-                .position(o -> null)
                 .positionXOffset(o -> null)
                 .positionYOffset(o -> null)
+                .verticalAlignment(o -> null)
+                .horizontalAlignment(o -> null)
+                .referencePosition(o -> null)
+                .orientation(o -> null)
+                .margins(o -> null)
+                .textSizeConstraints(o -> null)
+
                 .build();
         final Object bean = mock(Object.class);
         tested.handle(bean, view);
@@ -109,5 +130,8 @@ public class FontHandlerTest {
         verify(view, never()).setTitleXOffsetPosition(anyDouble());
         verify(view, never()).setTitleYOffsetPosition(anyDouble());
         verify(view, never()).setTextWrapper(any());
+        verify(view, never()).setTitlePosition(any(), any(), any(), any());
+        verify(view, never()).setMargins(any());
+        verify(view, never()).setTextSizeConstraints(any());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/BaseSubProcessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/BaseSubProcessConverter.java
@@ -135,7 +135,7 @@ public abstract class BaseSubProcessConverter<A extends BaseAdHocSubprocess<P, S
         A definition = node.getContent().getDefinition();
         AdHocSubProcessPropertyReader p = delegate.propertyReaderFactory.of(subProcess);
 
-        definition.setGeneral(new BPMNGeneralSet(new Name(subProcess.getName()),
+        definition.setGeneral(new BPMNGeneralSet(new Name(p.getName()),
                                                  new Documentation(p.getDocumentation())
         ));
 
@@ -161,7 +161,7 @@ public abstract class BaseSubProcessConverter<A extends BaseAdHocSubprocess<P, S
         EmbeddedSubprocess definition = node.getContent().getDefinition();
         SubProcessPropertyReader p = delegate.propertyReaderFactory.of(subProcess);
 
-        definition.setGeneral(new BPMNGeneralSet(new Name(subProcess.getName()),
+        definition.setGeneral(new BPMNGeneralSet(new Name(p.getName()),
                                                  new Documentation(p.getDocumentation())
         ));
 
@@ -190,7 +190,7 @@ public abstract class BaseSubProcessConverter<A extends BaseAdHocSubprocess<P, S
         EventSubprocess definition = node.getContent().getDefinition();
         SubProcessPropertyReader p = delegate.propertyReaderFactory.of(subProcess);
 
-        definition.setGeneral(new BPMNGeneralSet(new Name(subProcess.getName()),
+        definition.setGeneral(new BPMNGeneralSet(new Name(p.getName()),
                                                  new Documentation(p.getDocumentation())
         ));
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/CatchingIntermediateEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/CatchingIntermediateEventShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ import org.kie.workbench.common.stunner.bpmn.definition.IntermediateMessageEvent
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateSignalEventCatching;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateTimerEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
@@ -80,7 +84,10 @@ public class CatchingIntermediateEventShapeDef
     @Override
     public FontHandler<BaseCatchingIntermediateEvent, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(event -> HasTitle.Position.BOTTOM)
+                .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
+                .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
+                .referencePosition(bean -> ReferencePosition.OUTSIDE)
+                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/CatchingIntermediateEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/CatchingIntermediateEventShapeDef.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.IntermediateTimerEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size.SizeType;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
@@ -87,7 +87,8 @@ public class CatchingIntermediateEventShapeDef
                 .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
                 .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                 .referencePosition(bean -> ReferencePosition.OUTSIDE)
-                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
+                .textSizeConstraints(bean -> new HasTitle.Size(400, 100, SizeType.PERCENTAGE))
+                .margin(VerticalAlignment.BOTTOM, 5d)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/EndEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/EndEventShapeDef.java
@@ -32,7 +32,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size.SizeType;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
@@ -83,7 +83,8 @@ public class EndEventShapeDef
                 .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
                 .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                 .referencePosition(bean -> ReferencePosition.OUTSIDE)
-                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
+                .textSizeConstraints(bean -> new HasTitle.Size(400, 100, SizeType.PERCENTAGE))
+                .margin(VerticalAlignment.BOTTOM, 5d)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/EndEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/EndEventShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,10 @@ import org.kie.workbench.common.stunner.bpmn.definition.EndNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.EndSignalEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.EndTerminateEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
@@ -76,7 +80,10 @@ public class EndEventShapeDef
     @Override
     public FontHandler<BaseEndEvent, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(event -> HasTitle.Position.BOTTOM)
+                .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
+                .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
+                .referencePosition(bean -> ReferencePosition.OUTSIDE)
+                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/GatewayShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/GatewayShapeDef.java
@@ -28,7 +28,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size.SizeType;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
@@ -86,7 +86,8 @@ public class GatewayShapeDef
                 .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
                 .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                 .referencePosition(bean -> ReferencePosition.OUTSIDE)
-                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
+                .textSizeConstraints(bean -> new HasTitle.Size(400, 100, SizeType.PERCENTAGE))
+                .margin(VerticalAlignment.BOTTOM, 5d)
                 .build();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/GatewayShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/GatewayShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ import org.kie.workbench.common.stunner.bpmn.definition.BaseGateway;
 import org.kie.workbench.common.stunner.bpmn.definition.ExclusiveGateway;
 import org.kie.workbench.common.stunner.bpmn.definition.InclusiveGateway;
 import org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
+import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.svg.client.shape.factory.SVGShapeViewResources;
@@ -72,5 +78,15 @@ public class GatewayShapeDef
     public Glyph getGlyph(final Class<? extends BaseGateway> type,
                           final String defId) {
         return GLYPHS.get(type);
+    }
+
+    @Override
+    public FontHandler<BaseGateway, SVGShapeView> newFontHandler() {
+        return newFontHandlerBuilder()
+                .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
+                .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
+                .referencePosition(bean -> ReferencePosition.OUTSIDE)
+                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
+                .build();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/LaneShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/LaneShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import java.util.Optional;
 import org.kie.workbench.common.stunner.bpmn.client.resources.BPMNGlyphFactory;
 import org.kie.workbench.common.stunner.bpmn.client.resources.BPMNSVGViewFactory;
 import org.kie.workbench.common.stunner.bpmn.definition.Lane;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
@@ -33,7 +34,8 @@ public class LaneShapeDef extends BaseDimensionedShapeDef
     @Override
     public FontHandler<Lane, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(c -> HasTitle.Position.LEFT)
+                .horizontalAlignment(bean -> HorizontalAlignment.LEFT)
+                .orientation(bean -> Orientation.VERTICAL)
                 .rotation(c -> 270d)
                 .build();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ServiceTaskShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ServiceTaskShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ import org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionC
 import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinitionRegistry;
 import org.kie.workbench.common.stunner.core.client.shape.ImageDataUriGlyph;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
+import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.svg.client.shape.view.SVGShapeView;
@@ -89,5 +91,12 @@ public class ServiceTaskShapeDef extends BaseDimensionedShapeDef
                         .getIconData();
         final String iconData = null != itemIconData ? itemIconData : WorkItemDefinitionClientUtils.getDefaultIconData();
         return iconDataGlyphGenerator.apply(iconData);
+    }
+
+    @Override
+    public FontHandler<ServiceTask, SVGShapeView> newFontHandler() {
+        return newFontHandlerBuilder()
+                .margin(HorizontalAlignment.LEFT, 50d)
+                .build();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ServiceTaskShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ServiceTaskShapeDef.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.stunner.svg.client.shape.view.SVGShapeView;
 public class ServiceTaskShapeDef extends BaseDimensionedShapeDef
         implements BPMNSvgShapeDef<ServiceTask> {
 
+    public static final double ICON_WIDTH = 30d;
     private final Supplier<WorkItemDefinitionRegistry> workItemDefinitionRegistry;
     private final Function<String, Glyph> iconDataGlyphGenerator;
 
@@ -96,7 +97,7 @@ public class ServiceTaskShapeDef extends BaseDimensionedShapeDef
     @Override
     public FontHandler<ServiceTask, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .margin(HorizontalAlignment.LEFT, 50d)
+                .margin(HorizontalAlignment.LEFT, ICON_WIDTH)
                 .build();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/StartEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/StartEventShapeDef.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.StartTimerEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size.SizeType;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
@@ -91,7 +91,8 @@ public class StartEventShapeDef
                 .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
                 .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                 .referencePosition(bean -> ReferencePosition.OUTSIDE)
-                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
+                .textSizeConstraints(bean -> new HasTitle.Size(400, 100, SizeType.PERCENTAGE))
+                .margin(VerticalAlignment.BOTTOM, 5d)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/StartEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/StartEventShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,10 @@ import org.kie.workbench.common.stunner.bpmn.definition.StartNoneEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.StartSignalEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.StartTimerEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
@@ -84,7 +88,10 @@ public class StartEventShapeDef
     @Override
     public FontHandler<BaseStartEvent, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(event -> HasTitle.Position.BOTTOM)
+                .verticalAlignment(bean -> VerticalAlignment.BOTTOM)
+                .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
+                .referencePosition(bean -> ReferencePosition.OUTSIDE)
+                .textSizeConstraints(bean -> new HasTitle.SizeConstraints(400, 100, SizeType.PERCENTAGE))
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/SubprocessShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/SubprocessShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.EmbeddedSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.EventSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.MultipleInstanceSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
@@ -58,18 +58,21 @@ public class SubprocessShapeDef extends BaseDimensionedShapeDef
                     .put(MultipleInstanceSubprocess.class, BPMNGlyphFactory.SUBPROCESS_MULTIPLE_INSTANCE)
                     .build();
 
-    private static HasTitle.Position getSubprocessTextPosition(final BaseSubprocess bean) {
-        if ((bean instanceof EmbeddedSubprocess) || (bean instanceof MultipleInstanceSubprocess) || (bean instanceof EventSubprocess) || (bean instanceof AdHocSubprocess)) {
-            return HasTitle.Position.TOP;
+    private static VerticalAlignment getSubprocessTextPosition(final BaseSubprocess bean) {
+        if ((bean instanceof EmbeddedSubprocess)
+                || (bean instanceof MultipleInstanceSubprocess)
+                || (bean instanceof EventSubprocess)
+                || (bean instanceof AdHocSubprocess)) {
+            return VerticalAlignment.TOP;
         } else {
-            return HasTitle.Position.CENTER;
+            return VerticalAlignment.MIDDLE;
         }
     }
 
     @Override
     public FontHandler<BaseSubprocess, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(SubprocessShapeDef::getSubprocessTextPosition)
+                .verticalAlignment(SubprocessShapeDef::getSubprocessTextPosition)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/TaskShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/TaskShapeDef.java
@@ -41,6 +41,8 @@ import org.kie.workbench.common.stunner.svg.client.shape.view.SVGShapeView;
 public class TaskShapeDef extends BaseDimensionedShapeDef
         implements BPMNSvgShapeDef<BaseTask> {
 
+    public static final double ICON_WIDTH = 35d;
+
     public static final SVGShapeViewResources<BaseTask, BPMNSVGViewFactory> VIEW_RESOURCES =
             new SVGShapeViewResources<BaseTask, BPMNSVGViewFactory>()
                     .put(NoneTask.class, BPMNSVGViewFactory::noneTask)
@@ -58,7 +60,7 @@ public class TaskShapeDef extends BaseDimensionedShapeDef
 
     private static final Map<Enum, Double> DEFAULT_TASK_MARGINS_WITH_ICON =
             new Maps.Builder<Enum, Double>()
-                    .put(HorizontalAlignment.LEFT, 50d)
+                    .put(HorizontalAlignment.LEFT, ICON_WIDTH)
                     .build();
 
     private static Map<Class<? extends BaseTask>, Map<Enum, Double>> taskMarginSuppliers =

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/TaskShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/TaskShapeDef.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
 import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+import org.kie.workbench.common.stunner.bpmn.workitem.ServiceTask;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
@@ -53,6 +54,20 @@ public class TaskShapeDef extends BaseDimensionedShapeDef
                     .put(UserTask.class, BPMNGlyphFactory.TASK_USER)
                     .put(ScriptTask.class, BPMNGlyphFactory.TASK_SCRIPT)
                     .put(BusinessRuleTask.class, BPMNGlyphFactory.TASK_BUSINESS_RULE)
+                    .build();
+
+    private static final Map<Enum, Double> DEFAULT_TASK_MARGINS_WITH_ICON =
+            new Maps.Builder<Enum, Double>()
+                    .put(HorizontalAlignment.LEFT, 50d)
+                    .build();
+
+    private static Map<Class<? extends BaseTask>, Map<Enum, Double>> taskMarginSuppliers =
+            new Maps.Builder()
+                    .put(NoneTask.class, null)
+                    .put(UserTask.class, DEFAULT_TASK_MARGINS_WITH_ICON)
+                    .put(ScriptTask.class, DEFAULT_TASK_MARGINS_WITH_ICON)
+                    .put(BusinessRuleTask.class, DEFAULT_TASK_MARGINS_WITH_ICON)
+                    .put(ServiceTask.class, DEFAULT_TASK_MARGINS_WITH_ICON)
                     .build();
 
     @Override
@@ -93,7 +108,7 @@ public class TaskShapeDef extends BaseDimensionedShapeDef
     @Override
     public FontHandler<BaseTask, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .margin(HorizontalAlignment.LEFT, 50d)
+                .margins(bean -> taskMarginSuppliers.getOrDefault(bean.getClass(), null))
                 .build();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/TaskShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/TaskShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
 import org.kie.workbench.common.stunner.bpmn.definition.NoneTask;
 import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.CompositeShapeViewHandler;
+import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.svg.client.shape.factory.SVGShapeViewResources;
@@ -86,5 +88,12 @@ public class TaskShapeDef extends BaseDimensionedShapeDef
     public Glyph getGlyph(final Class<? extends BaseTask> type,
                           final String defId) {
         return GLYPHS.get(type);
+    }
+
+    @Override
+    public FontHandler<BaseTask, SVGShapeView> newFontHandler() {
+        return newFontHandlerBuilder()
+                .margin(HorizontalAlignment.LEFT, 50d)
+                .build();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ThrowingIntermediateEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ThrowingIntermediateEventShapeDef.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.IntermediateCompensation
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateEscalationEventThrowing;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateMessageEventThrowing;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateSignalEventThrowing;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
@@ -52,8 +53,11 @@ public class ThrowingIntermediateEventShapeDef
     @Override
     public FontHandler<BaseThrowingIntermediateEvent, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                //.position(event -> HasTitle.Position.BOTTOM)
-                .positionYOffset(bean -> bean.getDimensionsSet().getRadius().getValue())
+                .verticalAlignment(bean -> HasTitle.VerticalAlignment.BOTTOM)
+                .horizontalAlignment(bean -> HasTitle.HorizontalAlignment.CENTER)
+                .referencePosition(bean -> HasTitle.ReferencePosition.OUTSIDE)
+                .textSizeConstraints(bean -> new HasTitle.Size(400, 100, HasTitle.Size.SizeType.PERCENTAGE))
+                .margin(HasTitle.VerticalAlignment.BOTTOM, 5d)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ThrowingIntermediateEventShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/def/ThrowingIntermediateEventShapeDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.IntermediateCompensation
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateEscalationEventThrowing;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateMessageEventThrowing;
 import org.kie.workbench.common.stunner.bpmn.definition.IntermediateSignalEventThrowing;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
@@ -53,7 +52,8 @@ public class ThrowingIntermediateEventShapeDef
     @Override
     public FontHandler<BaseThrowingIntermediateEvent, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(event -> HasTitle.Position.BOTTOM)
+                //.position(event -> HasTitle.Position.BOTTOM)
+                .positionYOffset(bean -> bean.getDimensionsSet().getRadius().getValue())
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/factory/BPMNShapeFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/factory/BPMNShapeFactory.java
@@ -95,6 +95,8 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.shapes.client.factory.BasicShapesFactory;
 import org.kie.workbench.common.stunner.svg.client.shape.factory.SVGShapeFactory;
 
+import static org.kie.workbench.common.stunner.bpmn.client.shape.view.handler.BPMNShapeViewHandlers.FontHandlerBuilder.getStrokeAlpha;
+
 @Dependent
 public class BPMNShapeFactory
         implements ShapeFactory<BPMNDefinition, Shape> {
@@ -126,7 +128,7 @@ public class BPMNShapeFactory
         this.basicShapesFactory = basicShapesFactory;
         this.svgShapeFactory = svgShapeFactory;
         this.delegateShapeFactory = delegateShapeFactory;
-        this.workItemDefinitionRegistry =  workItemDefinitionRegistry::get;
+        this.workItemDefinitionRegistry = workItemDefinitionRegistry::get;
         this.definitionUtils = definitionUtils;
         this.preferencesRegistries = preferencesRegistries;
     }
@@ -289,7 +291,8 @@ public class BPMNShapeFactory
                 .fontSize(c -> preferences.getTextFontSize())
                 .fontColor(c -> preferences.getTextFillColor())
                 .strokeColor(c -> preferences.getTextStrokeColor())
-                .strokeSize(c -> preferences.getTextStrokeWidth());
+                .strokeSize(c -> preferences.getTextStrokeWidth())
+                .strokeAlpha(c -> getStrokeAlpha(preferences.getTextStrokeWidth()));
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,13 @@
 package org.kie.workbench.common.stunner.bpmn.client.shape.view.handler;
 
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNViewDefinition;
+import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.TitleHandler;
@@ -34,7 +41,13 @@ public class BPMNShapeViewHandlers {
                     .fontColor(bean -> bean.getFontSet().getFontColor().getValue())
                     .fontSize(bean -> bean.getFontSet().getFontSize().getValue())
                     .strokeColor(bean -> bean.getFontSet().getFontBorderColor().getValue())
-                    .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue());
+                    .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
+                    .verticalAlignment(bean -> VerticalAlignment.MIDDLE)
+                    .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
+                    .referencePosition(bean -> ReferencePosition.INSIDE)
+                    .orientation(bean -> Orientation.HORIZONTAL)
+                    .textSizeConstraints(bean -> new SizeConstraints(100, 100, SizeType.PERCENTAGE))
+                    .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE);
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.shape.view.handler;
 
+import java.util.Optional;
+
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNViewDefinition;
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
@@ -42,12 +44,20 @@ public class BPMNShapeViewHandlers {
                     .fontSize(bean -> bean.getFontSet().getFontSize().getValue())
                     .strokeColor(bean -> bean.getFontSet().getFontBorderColor().getValue())
                     .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
+                    .strokeAlpha(bean -> getStrokeAlpha(bean.getFontSet().getFontBorderSize().getValue()))
                     .verticalAlignment(bean -> VerticalAlignment.MIDDLE)
                     .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                     .referencePosition(bean -> ReferencePosition.INSIDE)
                     .orientation(bean -> Orientation.HORIZONTAL)
                     .textSizeConstraints(bean -> new Size(100, 100, SizeType.PERCENTAGE))
                     .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK);
+        }
+
+        public static Double getStrokeAlpha(Double strokeWidth) {
+            return Optional.ofNullable(strokeWidth)
+                    .filter(value -> value > 0)
+                    .map(value -> 1.0)
+                    .orElse(0.0);
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
@@ -21,8 +21,8 @@ import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.SizeConstraints.SizeType;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size.SizeType;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
@@ -46,7 +46,7 @@ public class BPMNShapeViewHandlers {
                     .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                     .referencePosition(bean -> ReferencePosition.INSIDE)
                     .orientation(bean -> Orientation.HORIZONTAL)
-                    .textSizeConstraints(bean -> new SizeConstraints(100, 100, SizeType.PERCENTAGE))
+                    .textSizeConstraints(bean -> new Size(100, 100, SizeType.PERCENTAGE))
                     .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE);
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.stunner.bpmn.client.shape.view.handler;
 
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNViewDefinition;
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
-import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
@@ -43,14 +42,13 @@ public class BPMNShapeViewHandlers {
                     .fontSize(bean -> bean.getFontSet().getFontSize().getValue())
                     .strokeColor(bean -> bean.getFontSet().getFontBorderColor().getValue())
                     .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
-                    .textWrapperStrategy( bean  -> TextWrapperStrategy.TRUNCATE);
+                    .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK)
                     .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
                     .verticalAlignment(bean -> VerticalAlignment.MIDDLE)
                     .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                     .referencePosition(bean -> ReferencePosition.INSIDE)
                     .orientation(bean -> Orientation.HORIZONTAL)
-                    .textSizeConstraints(bean -> new Size(100, 100, SizeType.PERCENTAGE))
-                    .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE);
+                    .textSizeConstraints(bean -> new Size(100, 100, SizeType.PERCENTAGE));
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
@@ -42,13 +42,12 @@ public class BPMNShapeViewHandlers {
                     .fontSize(bean -> bean.getFontSet().getFontSize().getValue())
                     .strokeColor(bean -> bean.getFontSet().getFontBorderColor().getValue())
                     .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
-                    .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK)
-                    .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
                     .verticalAlignment(bean -> VerticalAlignment.MIDDLE)
                     .horizontalAlignment(bean -> HorizontalAlignment.CENTER)
                     .referencePosition(bean -> ReferencePosition.INSIDE)
                     .orientation(bean -> Orientation.HORIZONTAL)
-                    .textSizeConstraints(bean -> new Size(100, 100, SizeType.PERCENTAGE));
+                    .textSizeConstraints(bean -> new Size(100, 100, SizeType.PERCENTAGE))
+                    .textWrapperStrategy(bean -> TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK);
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlers.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.bpmn.client.shape.view.handler;
 
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNViewDefinition;
 import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
+import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
@@ -41,6 +42,8 @@ public class BPMNShapeViewHandlers {
                     .fontColor(bean -> bean.getFontSet().getFontColor().getValue())
                     .fontSize(bean -> bean.getFontSet().getFontSize().getValue())
                     .strokeColor(bean -> bean.getFontSet().getFontBorderColor().getValue())
+                    .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
+                    .textWrapperStrategy( bean  -> TextWrapperStrategy.TRUNCATE);
                     .strokeSize(bean -> bean.getFontSet().getFontBorderSize().getValue())
                     .verticalAlignment(bean -> VerticalAlignment.MIDDLE)
                     .horizontalAlignment(bean -> HorizontalAlignment.CENTER)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -676,10 +676,11 @@
 #text {
     opacity: 1;
     font-family: Open Sans;
+    font-weight: normal;
     font-size: 12px;
     fill: #000000;
     stroke: #393f44;
-    stroke-width: 1px;
+    stroke-width: 0px;
     text-align: left;
     align: left;
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/factory/BPMNShapeFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/factory/BPMNShapeFactoryTest.java
@@ -337,6 +337,7 @@ public class BPMNShapeFactoryTest {
         verify(sequenceFlowView).setTitleFontSize(BPMNTextPreferences.TEXT_FONT_SIZE);
         verify(sequenceFlowView).setTitleStrokeColor(BPMNTextPreferences.TEXT_STROKE_COLOR);
         verify(sequenceFlowView).setTitleStrokeWidth(BPMNTextPreferences.TEXT_STROKE_WIDTH);
+        verify(sequenceFlowView).setTitleStrokeAlpha(0);
 
         final long svgFactoryCallCount = factoryArgumentCaptor.getAllValues().stream()
                 .filter(this::isSvgShapeFactory)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlersTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlersTest.java
@@ -56,6 +56,6 @@ public class BPMNShapeViewHandlersTest {
     public void testFontHandler() {
         fontHandler.handle(task, text);
         verify(text).setTextWrapper(wrapper.capture());
-        assertEquals(wrapper.getValue(), TextWrapperStrategy.TRUNCATE);
+        assertEquals(wrapper.getValue(), TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlersTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlersTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.shape.view.handler;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNViewDefinition;
+import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+import org.kie.workbench.common.stunner.client.lienzo.shape.view.wires.ext.WiresShapeViewExt;
+import org.kie.workbench.common.stunner.core.client.shape.TextWrapperStrategy;
+import org.kie.workbench.common.stunner.core.client.shape.view.ShapeView;
+import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class BPMNShapeViewHandlersTest {
+
+    private UserTask task;
+
+    private FontHandler<BPMNViewDefinition, ShapeView> fontHandler;
+
+    @Mock
+    private WiresShapeViewExt text;
+
+    @Captor
+    private ArgumentCaptor<TextWrapperStrategy> wrapper;
+
+    @Before
+    public void setUp() {
+        task = new UserTask();
+        fontHandler = new BPMNShapeViewHandlers.FontHandlerBuilder<>().build();
+    }
+
+    @Test
+    public void testFontHandler() {
+        fontHandler.handle(task, text);
+        verify(text).setTextWrapper(wrapper.capture());
+        assertEquals(wrapper.getValue(), TextWrapperStrategy.TRUNCATE);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlersTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/shape/view/handler/BPMNShapeViewHandlersTest.java
@@ -31,6 +31,13 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.HorizontalAlignment;
+import static org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Orientation;
+import static org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.ReferencePosition;
+import static org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.Size;
+import static org.kie.workbench.common.stunner.core.client.shape.view.HasTitle.VerticalAlignment;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
@@ -46,9 +53,13 @@ public class BPMNShapeViewHandlersTest {
     @Captor
     private ArgumentCaptor<TextWrapperStrategy> wrapper;
 
+    @Captor
+    private ArgumentCaptor<Size> sizeConstraints;
+
     @Before
     public void setUp() {
         task = new UserTask();
+        task.getFontSet().getFontBorderSize().setValue(0.0);
         fontHandler = new BPMNShapeViewHandlers.FontHandlerBuilder<>().build();
     }
 
@@ -57,5 +68,16 @@ public class BPMNShapeViewHandlersTest {
         fontHandler.handle(task, text);
         verify(text).setTextWrapper(wrapper.capture());
         assertEquals(wrapper.getValue(), TextWrapperStrategy.TRUNCATE_WITH_LINE_BREAK);
+        verify(text).setTitleStrokeWidth(0);
+        verify(text).setTitleStrokeAlpha(0);
+        verify(text).setTitlePosition(VerticalAlignment.MIDDLE, HorizontalAlignment.CENTER,
+                                      ReferencePosition.INSIDE, Orientation.HORIZONTAL);
+        verify(text, never()).setMargins(anyMap());
+        verify(text).setTextSizeConstraints(sizeConstraints.capture());
+
+        final Size size = sizeConstraints.getValue();
+        assertEquals(size.getHeight(), 100, 0d);
+        assertEquals(size.getWidth(), 100, 0d);
+        assertEquals(size.getType(), Size.SizeType.PERCENTAGE);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgShapeDef.java
@@ -22,6 +22,8 @@ import java.util.function.BiConsumer;
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.BPMNShapeDef;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNViewDefinition;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGViewFactory;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.svg.client.shape.def.SVGShapeViewDef;
@@ -44,5 +46,20 @@ public interface CaseManagementSvgShapeDef<W extends BPMNViewDefinition>
 
     default Class<CaseManagementSVGViewFactory> getViewFactoryType() {
         return CaseManagementSVGViewFactory.class;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default Optional<BiConsumer<W, SVGShapeView>> fontHandler() {
+        return Optional.of(newFontHandler()::handle);
+    }
+
+    @Override
+    default FontHandler<W, SVGShapeView> newFontHandler() {
+        return newFontHandlerBuilder()
+                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.CENTER)
+                .verticalAlignment(o -> HasTitle.VerticalAlignment.MIDDLE)
+                .textSizeConstraints(o -> new HasTitle.Size(100, 100, HasTitle.Size.SizeType.PERCENTAGE))
+                .build();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgStageShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgStageShapeDef.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.stunner.cm.client.shape.def;
 import java.util.Optional;
 
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.BaseDimensionedShapeDef;
-import org.kie.workbench.common.stunner.bpmn.definition.BaseSubprocess;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGGlyphFactory;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGViewFactory;
 import org.kie.workbench.common.stunner.cm.definition.AdHocSubprocess;
@@ -31,14 +30,10 @@ import org.kie.workbench.common.stunner.svg.client.shape.view.SVGShapeView;
 public class CaseManagementSvgStageShapeDef extends BaseDimensionedShapeDef
         implements CaseManagementSvgShapeDef<AdHocSubprocess> {
 
-    private static HasTitle.Position getSubprocessTextPosition(final BaseSubprocess bean) {
-        return HasTitle.Position.CENTER;
-    }
-
     @Override
     public FontHandler<AdHocSubprocess, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(CaseManagementSvgStageShapeDef::getSubprocessTextPosition)
+                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.CENTER)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgStageShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgStageShapeDef.java
@@ -21,21 +21,12 @@ import org.kie.workbench.common.stunner.bpmn.client.shape.def.BaseDimensionedSha
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGGlyphFactory;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGViewFactory;
 import org.kie.workbench.common.stunner.cm.definition.AdHocSubprocess;
-import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
-import org.kie.workbench.common.stunner.core.client.shape.view.handler.FontHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.handler.SizeHandler;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.svg.client.shape.view.SVGShapeView;
 
 public class CaseManagementSvgStageShapeDef extends BaseDimensionedShapeDef
         implements CaseManagementSvgShapeDef<AdHocSubprocess> {
-
-    @Override
-    public FontHandler<AdHocSubprocess, SVGShapeView> newFontHandler() {
-        return newFontHandlerBuilder()
-                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.CENTER)
-                .build();
-    }
 
     @Override
     public SizeHandler<AdHocSubprocess, SVGShapeView> newSizeHandler() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgSubprocessShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgSubprocessShapeDef.java
@@ -47,19 +47,19 @@ public final class CaseManagementSvgSubprocessShapeDef extends BaseDimensionedSh
                     .put(CaseReusableSubprocess.class, CaseManagementSVGGlyphFactory.SUBCASE_GLYPH).build();
 
     @Override
-    public FontHandler<ReusableSubprocess, SVGShapeView> newFontHandler() {
-        return newFontHandlerBuilder()
-                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.CENTER)
-                .build();
-    }
-
-    @Override
     public SizeHandler<ReusableSubprocess, SVGShapeView> newSizeHandler() {
         return newSizeHandlerBuilder()
                 .width(e -> e.getDimensionsSet().getWidth().getValue())
                 .height(e -> e.getDimensionsSet().getHeight().getValue())
                 .minWidth(e -> 50d)
                 .minHeight(e -> 50d)
+                .build();
+    }
+
+    @Override
+    public FontHandler<ReusableSubprocess, SVGShapeView> newFontHandler() {
+        return newFontHandlerBuilder()
+                .margin(HasTitle.HorizontalAlignment.LEFT, 30d)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgSubprocessShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgSubprocessShapeDef.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import org.kie.soup.commons.util.Maps;
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.BaseDimensionedShapeDef;
-import org.kie.workbench.common.stunner.bpmn.definition.BaseSubprocess;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGGlyphFactory;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGViewFactory;
 import org.kie.workbench.common.stunner.cm.definition.CaseReusableSubprocess;
@@ -47,14 +46,10 @@ public final class CaseManagementSvgSubprocessShapeDef extends BaseDimensionedSh
                     .put(ProcessReusableSubprocess.class, CaseManagementSVGGlyphFactory.SUBPROCESS_GLYPH)
                     .put(CaseReusableSubprocess.class, CaseManagementSVGGlyphFactory.SUBCASE_GLYPH).build();
 
-    private static HasTitle.Position getSubprocessTextPosition(final BaseSubprocess bean) {
-        return HasTitle.Position.CENTER;
-    }
-
     @Override
     public FontHandler<ReusableSubprocess, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(CaseManagementSvgSubprocessShapeDef::getSubprocessTextPosition)
+                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.CENTER)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgUserTaskShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgUserTaskShapeDef.java
@@ -32,13 +32,6 @@ public final class CaseManagementSvgUserTaskShapeDef extends BaseDimensionedShap
         implements CaseManagementSvgShapeDef<UserTask> {
 
     @Override
-    public FontHandler<UserTask, SVGShapeView> newFontHandler() {
-        return newFontHandlerBuilder()
-                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.CENTER)
-                .build();
-    }
-
-    @Override
     public SizeHandler<UserTask, SVGShapeView> newSizeHandler() {
         return newSizeHandlerBuilder()
                 .width(e -> e.getDimensionsSet().getWidth().getValue())
@@ -52,6 +45,13 @@ public final class CaseManagementSvgUserTaskShapeDef extends BaseDimensionedShap
     public SVGShapeView<?> newViewInstance(final CaseManagementSVGViewFactory factory, final UserTask obj) {
         // user task should not be resizable in case modeler
         return newViewInstance(Optional.empty(), Optional.empty(), factory.task());
+    }
+
+    @Override
+    public FontHandler<UserTask, SVGShapeView> newFontHandler() {
+        return newFontHandlerBuilder()
+                .margin(HasTitle.HorizontalAlignment.LEFT, 30d)
+                .build();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgUserTaskShapeDef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/def/CaseManagementSvgUserTaskShapeDef.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.stunner.cm.client.shape.def;
 import java.util.Optional;
 
 import org.kie.workbench.common.stunner.bpmn.client.shape.def.BaseDimensionedShapeDef;
-import org.kie.workbench.common.stunner.bpmn.definition.BaseTask;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGGlyphFactory;
 import org.kie.workbench.common.stunner.cm.client.resources.CaseManagementSVGViewFactory;
 import org.kie.workbench.common.stunner.cm.definition.UserTask;
@@ -32,14 +31,10 @@ import org.kie.workbench.common.stunner.svg.client.shape.view.SVGShapeView;
 public final class CaseManagementSvgUserTaskShapeDef extends BaseDimensionedShapeDef
         implements CaseManagementSvgShapeDef<UserTask> {
 
-    private static HasTitle.Position getSubprocessTextPosition(final BaseTask bean) {
-        return HasTitle.Position.CENTER;
-    }
-
     @Override
     public FontHandler<UserTask, SVGShapeView> newFontHandler() {
         return newFontHandlerBuilder()
-                .position(CaseManagementSvgUserTaskShapeDef::getSubprocessTextPosition)
+                .horizontalAlignment(o -> HasTitle.HorizontalAlignment.CENTER)
                 .build();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeDefFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeDefFactory.java
@@ -78,6 +78,6 @@ public class CaseManagementShapeDefFactory implements ShapeDefFactory<BPMNDefini
     private Shape newCaseManagementShape(final Object instance, final CaseManagementSvgShapeDef svgShapeDef) {
         SVGShape shape = svgShapeFactory.newShape(instance, svgShapeDef);
         CaseManagementShapeView cmShapeView = (CaseManagementShapeView) shape.getShapeView();
-        return CaseManagementShapeCommand.create(instance.getClass(), cmShapeView);
+        return CaseManagementShapeCommand.create(instance, cmShapeView, svgShapeDef);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/test/java/org/kie/workbench/common/stunner/cm/client/shape/factory/CaseManagementShapeCommandTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.cm.client.shape.factory;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.cm.client.shape.CaseManagementShape;
+import org.kie.workbench.common.stunner.cm.client.shape.def.CaseManagementSvgDiagramShapeDef;
+import org.kie.workbench.common.stunner.cm.client.shape.def.CaseManagementSvgShapeDef;
+import org.kie.workbench.common.stunner.cm.client.shape.view.CaseManagementShapeView;
+import org.kie.workbench.common.stunner.cm.definition.CaseManagementDiagram;
+import org.kie.workbench.common.stunner.core.client.shape.view.HasTitle;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class CaseManagementShapeCommandTest {
+
+    private CaseManagementSvgShapeDef shapeDef;
+
+    private CaseManagementDiagram def;
+
+    @Mock
+    private CaseManagementShapeView shapeView;
+
+    @Before
+    public void setUp() {
+        def = new CaseManagementDiagram();
+        shapeDef = spy(new CaseManagementSvgDiagramShapeDef());
+    }
+
+    @Test
+    public void create() {
+        CaseManagementShape shape = CaseManagementShapeCommand.create(def, shapeView, shapeDef);
+        verify(shapeDef).fontHandler();
+        verify(shapeView).setTitlePosition(HasTitle.VerticalAlignment.MIDDLE,
+                                           HasTitle.HorizontalAlignment.CENTER,
+                                           HasTitle.ReferencePosition.INSIDE,
+                                           HasTitle.Orientation.HORIZONTAL);
+        verify(shapeView).setTextSizeConstraints(new HasTitle.Size(100, 100,
+                                                                   HasTitle.Size.SizeType.PERCENTAGE));
+    }
+}


### PR DESCRIPTION
- Text Wrapping for BPMN nodes
- Multi-line support
- New node label layout:
Vertical and Horizontal alignment
Position: outside/inside parent node
Orientation: vertical, horizontal
Margins

- Long text in tasks does not overlap icon of task type
- Events, Gateways, has labels on bottom-middle
- Removed the **bold** from labels

Assembly:
https://github.com/kiegroup/lienzo-core/pull/94
https://github.com/kiegroup/lienzo-tests/pull/73

@romartin 
@LuboTerifaj 