### PR TITLE
RHPAM-1892 - Ad Hoc Subprocess: Signal end node is not allowed

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/AdHocSubprocess.java
@@ -47,7 +47,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@CanContain(roles = {"cm_activity", "cm_stage", "IntermediateEventsMorph", "GatewaysMorph"})
+@CanContain(roles = {"cm_activity", "cm_stage", "IntermediateEventsMorph", "GatewaysMorph", "EndEventsMorph"})
 @CanDock(roles = {"IntermediateEventOnSubprocessBoundary"})
 @Definition(graphFactory = NodeFactory.class)
 @Morph(base = BaseSubprocess.class)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/AdHocSubprocess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-api/src/main/java/org/kie/workbench/common/stunner/cm/definition/AdHocSubprocess.java
@@ -46,7 +46,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 
 @Portable
 @Bindable
-@CanContain(roles = {"cm_activity", "IntermediateEventsMorph", "GatewaysMorph"})
+@CanContain(roles = {"cm_activity", "IntermediateEventsMorph", "GatewaysMorph", "EndEventsMorph"})
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(
         startElement = "general",


### PR DESCRIPTION
https://issues.jboss.org/browse/RHPAM-1892

Ad Hoc Subprocess Nodes supports End Nodes containment.