### PR TITLE
 JBPM-8378: Undo command is shared between windows

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/registration/RegisterChangedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/registration/RegisterChangedEvent.java
@@ -16,8 +16,12 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.event.registration;
 
-import org.uberfire.workbench.events.UberFireEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.AbstractCanvasHandlerEvent;
 
-public class RegisterChangedEvent implements UberFireEvent {
+public class RegisterChangedEvent extends AbstractCanvasHandlerEvent<CanvasHandler> {
 
+    public RegisterChangedEvent(CanvasHandler canvasHandler) {
+        super(canvasHandler);
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
@@ -110,10 +110,12 @@ public class RedoSessionCommand extends AbstractClientSessionCommand<EditorSessi
     void onCommandExecuted(final @Observes CanvasCommandExecutedEvent commandExecutedEvent) {
         checkNotNull("commandExecutedEvent",
                      commandExecutedEvent);
-        if (null != commandExecutedEvent.getCommand()) {
-            redoCommandHandler.onCommandExecuted(commandExecutedEvent.getCommand());
+        if (getSession().getCanvasHandler().equals(commandExecutedEvent.getCanvasHandler())) {
+            if (null != commandExecutedEvent.getCommand()) {
+                redoCommandHandler.onCommandExecuted(commandExecutedEvent.getCommand());
+            }
+            checkState();
         }
-        checkState();
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
@@ -64,6 +64,7 @@ public class RedoSessionCommand extends AbstractClientSessionCommand<EditorSessi
     public void bind(final EditorSession session) {
         super.bind(session);
         session.getKeyboardControl().addKeyShortcutCallback(this::onKeyDownEvent);
+        redoCommandHandler.setSession(getSession());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
@@ -100,7 +100,9 @@ public class UndoSessionCommand extends AbstractClientSessionCommand<EditorSessi
     void onCommandAdded(final @Observes RegisterChangedEvent registerChangedEvent) {
         checkNotNull("registerChangedEvent",
                      registerChangedEvent);
-        checkState();
+        if (registerChangedEvent.getCanvasHandler().equals(getCanvasHandler())) {
+            checkState();
+        }
     }
 
     private void checkState() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
@@ -21,7 +21,6 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
-import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -41,14 +40,11 @@ import static org.kie.workbench.common.stunner.core.client.canvas.controls.keybo
 @Default
 public class UndoSessionCommand extends AbstractClientSessionCommand<EditorSession> {
 
-    private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
 
     @Inject
-    public UndoSessionCommand(final SessionManager sessionManager,
-                              final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager) {
+    public UndoSessionCommand(final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager) {
         super(false);
-        this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
     }
 
@@ -106,9 +102,8 @@ public class UndoSessionCommand extends AbstractClientSessionCommand<EditorSessi
     }
 
     private void checkState() {
-        final EditorSession session = getSession();
-        if (null != session && session.equals(sessionManager.getCurrentSession())) {
-            setEnabled(!session.getCommandRegistry().getCommandHistory().isEmpty());
+        if (getSession() != null) {
+            setEnabled(!getSession().getCommandRegistry().getCommandHistory().isEmpty());
             fire();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
@@ -65,7 +65,7 @@ public class DefaultEditorSession
     private final CanvasCommandManager<AbstractCanvasHandler> canvasCommandManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
     private final SessionCommandManager<AbstractCanvasHandler> requestCommandManager;
-    private final CommandRegistry<org.kie.workbench.common.stunner.core.command.Command<AbstractCanvasHandler, CanvasViolation>> commandRegistry;
+    private final ClientCommandRegistry<org.kie.workbench.common.stunner.core.command.Command<AbstractCanvasHandler, CanvasViolation>> commandRegistry;
 
     @Inject
     public DefaultEditorSession(final ManagedSession session,
@@ -86,6 +86,7 @@ public class DefaultEditorSession
                 .onCanvasHandlerControlRegistered(this::onCanvasHandlerControlRegistered)
                 .onCanvasControlDestroyed(AbstractSession::onControlDestroyed)
                 .onCanvasHandlerControlDestroyed(AbstractSession::onControlDestroyed);
+        commandRegistry.setSession(getSession());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
@@ -22,6 +22,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandlerImpl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandUndoneEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -122,5 +123,46 @@ public class RedoSessionCommandTest extends BaseSessionCommandKeyboardTest {
         command.onCommandUndoExecuted(event);
 
         verify(redoCommandHandler, times(0)).onUndoCommandExecuted(event.getCommand());
+    }
+
+    @Test
+    public void testOnCommandExecutedSuccess() {
+        RedoSessionCommand command = spy(new RedoSessionCommand(sessionCommandManager, redoCommandHandler));
+
+        doCallRealMethod().when(command).onCommandExecuted(any(CanvasCommandExecutedEvent.class));
+        doCallRealMethod().when(command).bind(any(EditorSession.class));
+
+
+
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+        when(keyboardControl.addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class))).thenReturn(keyboardControl);
+        ((AbstractClientSessionCommand) command).bind(session);
+
+        CanvasCommandExecutedEvent event = new CanvasCommandExecutedEvent(canvasHandler,
+                                                                          new CompositeCommand(true),
+                                                                          null);
+        command.onCommandExecuted(event);
+        verify(redoCommandHandler, times(1)).onCommandExecuted(event.getCommand());
+    }
+
+    public void testOnCommandExecutedFails() {
+        RedoSessionCommand command = spy(new RedoSessionCommand(sessionCommandManager, redoCommandHandler));
+
+        doCallRealMethod().when(command).onCommandExecuted(any(CanvasCommandExecutedEvent.class));
+        doCallRealMethod().when(command).bind(any(EditorSession.class));
+
+
+
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(session.getKeyboardControl()).thenReturn(keyboardControl);
+        when(keyboardControl.addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class))).thenReturn(keyboardControl);
+        ((AbstractClientSessionCommand) command).bind(session);
+
+        CanvasCommandExecutedEvent event = new CanvasCommandExecutedEvent(canvasHandler,
+                                                                          new CompositeCommand(true),
+                                                                          null);
+        command.onCommandExecuted(event);
+        verify(redoCommandHandler, times(0)).onCommandExecuted(event.getCommand());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
@@ -82,7 +82,7 @@ public class UndoSessionCommandTest extends BaseSessionCommandKeyboardTest {
 
     @Override
     protected AbstractClientSessionCommand<EditorSession> getCommand() {
-        return new UndoSessionCommand(sessionManager, sessionCommandManager);
+        return new UndoSessionCommand(sessionCommandManager);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -60,6 +61,9 @@ public class UndoSessionCommandTest extends BaseSessionCommandKeyboardTest {
     private CommandResult commandResult;
 
     @Mock
+    private SessionManager sessionManager;
+
+    @Mock
     private org.uberfire.mvp.Command statusCallback;
 
     private List commandHistory;
@@ -72,11 +76,13 @@ public class UndoSessionCommandTest extends BaseSessionCommandKeyboardTest {
         commandHistory = new ArrayList<>();
         when(commandRegistry.getCommandHistory()).thenReturn(commandHistory);
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        when(session.getCommandRegistry()).thenReturn(commandRegistry);
+        when(sessionManager.getCurrentSession()).thenReturn(session);
     }
 
     @Override
     protected AbstractClientSessionCommand<EditorSession> getCommand() {
-        return new UndoSessionCommand(sessionCommandManager);
+        return new UndoSessionCommand(sessionManager, sessionCommandManager);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommandTest.java
@@ -132,15 +132,28 @@ public class UndoSessionCommandTest extends BaseSessionCommandKeyboardTest {
         command.bind(session);
         command.listen(statusCallback);
 
-        ((UndoSessionCommand) command).onCommandAdded(new RegisterChangedEvent());
+        ((UndoSessionCommand) command).onCommandAdded(new RegisterChangedEvent(canvasHandler));
         assertFalse(command.isEnabled());
 
         commandHistory.add(mock(Command.class));
 
-        ((UndoSessionCommand) command).onCommandAdded(new RegisterChangedEvent());
+        ((UndoSessionCommand) command).onCommandAdded(new RegisterChangedEvent(canvasHandler));
         assertTrue(command.isEnabled());
         verify(statusCallback,
                atLeastOnce()).execute();
+        verify(commandRegistry,
+               never()).clear();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnCommandExecutedCheckWrongSession() {
+        command.bind(session);
+        command.listen(statusCallback);
+
+        assertFalse(command.isEnabled());
+        verify(statusCallback,
+               never()).execute();
         verify(commandRegistry,
                never()).clear();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
@@ -18,11 +18,11 @@ package org.kie.workbench.common.stunner.core.command.util;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 
 /**
@@ -44,7 +44,7 @@ import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry
 @Dependent
 public class RedoCommandHandler<C extends Command> {
 
-    private final CommandRegistry<C> registry;
+    private final ClientCommandRegistry<C> registry;
 
     protected RedoCommandHandler() {
         this(null);
@@ -86,6 +86,10 @@ public class RedoCommandHandler<C extends Command> {
         final C last = registry.peek();
         return commandManager.execute(context,
                                       last);
+    }
+
+    public void setSession(ClientSession clientSession) {
+        registry.setSession(clientSession);
     }
 
     public boolean isEnabled() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/ClientCommandRegistry.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/ClientCommandRegistry.java
@@ -21,6 +21,7 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 
 /**
@@ -33,6 +34,8 @@ public class ClientCommandRegistry<C extends Command> extends CommandRegistryImp
 
     private Event<RegisterChangedEvent> registerChangedEvent;
 
+    private ClientSession session;
+
     @Inject
     public ClientCommandRegistry(Event<RegisterChangedEvent> registerChangedEvent) {
         this.registerChangedEvent = registerChangedEvent;
@@ -44,19 +47,23 @@ public class ClientCommandRegistry<C extends Command> extends CommandRegistryImp
     @Override
     public void register(final C command) {
         super.register(command);
-        registerChangedEvent.fire(new RegisterChangedEvent());
+        registerChangedEvent.fire(new RegisterChangedEvent(session.getCanvasHandler()));
     }
 
     @Override
     public void clear() {
         super.clear();
-        registerChangedEvent.fire(new RegisterChangedEvent());
+        registerChangedEvent.fire(new RegisterChangedEvent(session.getCanvasHandler()));
     }
 
     @Override
     public C pop() {
         C command = super.pop();
-        registerChangedEvent.fire(new RegisterChangedEvent());
+        registerChangedEvent.fire(new RegisterChangedEvent(session.getCanvasHandler()));
         return command;
+    }
+
+    public void setSession(ClientSession session) {
+        this.session = session;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandlerTest.java
@@ -20,7 +20,9 @@ import javax.enterprise.event.Event;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
@@ -54,6 +56,12 @@ public class RedoCommandHandlerTest {
     private ClientCommandRegistry clientCommandRegistry;
 
     @Mock
+    private ClientSession session;
+
+    @Mock
+    private CanvasHandler canvasHandler;
+
+    @Mock
     private Event<RegisterChangedEvent> registerChangedEvent;
 
     private RedoCommandHandler tested;
@@ -62,12 +70,16 @@ public class RedoCommandHandlerTest {
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         this.tested = new RedoCommandHandler(clientCommandRegistry);
+        when(session.getCanvasHandler()).thenReturn(canvasHandler);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testUndoCommandExecuted() {
-        ClientCommandRegistry realRegistry = spy(new ClientCommandRegistry(registerChangedEvent));
+        ClientCommandRegistry clientCommandRegistry = new ClientCommandRegistry(registerChangedEvent);
+        clientCommandRegistry.setSession(session);
+
+        ClientCommandRegistry realRegistry = spy(clientCommandRegistry);
         RedoCommandHandler tested = new RedoCommandHandler(realRegistry);
         assertTrue(tested.onUndoCommandExecuted(command1));
         verify(realRegistry).register(eq(command1));
@@ -109,7 +121,10 @@ public class RedoCommandHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testExecuteJustRecentRedoCommand() {
-        RedoCommandHandler tested = new RedoCommandHandler(spy(new ClientCommandRegistry(registerChangedEvent)));
+        ClientCommandRegistry clientCommandRegistry = new ClientCommandRegistry(registerChangedEvent);
+        clientCommandRegistry.setSession(session);
+
+        RedoCommandHandler tested = new RedoCommandHandler(spy(clientCommandRegistry));
         assertTrue(tested.onUndoCommandExecuted(command1));
         assertFalse(tested.onCommandExecuted(command1));
         assertFalse(tested.isEnabled());
@@ -118,7 +133,10 @@ public class RedoCommandHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testExecuteRemoveRedoCommands() {
-        RedoCommandHandler tested = new RedoCommandHandler(spy(new ClientCommandRegistry(registerChangedEvent)));
+        ClientCommandRegistry clientCommandRegistry = new ClientCommandRegistry(registerChangedEvent);
+        clientCommandRegistry.setSession(session);
+
+        RedoCommandHandler tested = new RedoCommandHandler(spy(clientCommandRegistry));
         Command command3 = mock(Command.class);
         assertTrue(tested.onUndoCommandExecuted(command1));
         assertTrue(tested.onUndoCommandExecuted(command2));


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/JBPM-8378

Here i don't like the way i am providing the ClientSession to ClientCommandRegistry, but i can't Inject ClientSession because errai can't resolv the interface to type and i can't inject ManagedSession because of cyclic deps. ManagedSession belongs to kie-wb-common-stunner-client-common and depends on kie-wb-common-stunner-core-common.