### PR TITLE
DROOLS-3702: [Stunner] Arrows are incorrectly positioned when save-open diagram

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshaller.java
@@ -509,7 +509,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                 final View<?> sourceView = (View<?>) sourceNode.getContent();
                 final double xSource = xOfBound(upperLeftBound(sourceView));
                 final double ySource = yOfBound(upperLeftBound(sourceView));
-                connectionContent.setSourceConnection(MagnetConnection.Builder.at(source.getX() - xSource, source.getY() - ySource)); // Stunner connection x,y is relative to shape
+                connectionContent.setSourceConnection(MagnetConnection.Builder.at(source.getX() - xSource, source.getY() - ySource).setAuto(true)); // Stunner connection x,y is relative to shape
             }
             Point target = e.getWaypoint().get(e.getWaypoint().size() - 1);
             final Node targetNode = edge.getTargetNode();
@@ -517,7 +517,7 @@ public class DMNMarshaller implements DiagramMarshaller<Graph, Metadata, Diagram
                 final View<?> targetView = (View<?>) targetNode.getContent();
                 final double xTarget = xOfBound(upperLeftBound(targetView));
                 final double yTarget = yOfBound(upperLeftBound(targetView));
-                connectionContent.setTargetConnection(MagnetConnection.Builder.at(target.getX() - xTarget, target.getY() - yTarget)); // Stunner connection x,y is relative to shape
+                connectionContent.setTargetConnection(MagnetConnection.Builder.at(target.getX() - xTarget, target.getY() - yTarget).setAuto(true)); // Stunner connection x,y is relative to shape
             }
             if (e.getWaypoint().size() > 2) {
                 connectionContent.setControlPoints(e.getWaypoint()

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -140,6 +140,7 @@ import org.kie.workbench.common.stunner.core.graph.command.impl.GraphCommandFact
 import org.kie.workbench.common.stunner.core.graph.content.Bound;
 import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
 import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
@@ -799,6 +800,14 @@ public class DMNMarshallerTest {
         Point2D controlPointLocation = connectionContent.getControlPoints()[0].getLocation();
         assertEquals(398.61898612976074d, controlPointLocation.getX(), 0.1d);
         assertEquals(116.99999809265137d, controlPointLocation.getY(), 0.1d);
+
+        final Connection sourceConnection = connectionContent.getSourceConnection().get();
+        assertTrue(sourceConnection instanceof MagnetConnection);
+        assertTrue(((MagnetConnection) sourceConnection).isAuto());
+
+        final Connection targetConnection = connectionContent.getTargetConnection().get();
+        assertTrue(targetConnection instanceof MagnetConnection);
+        assertTrue(((MagnetConnection) targetConnection).isAuto());
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/GeneralCreateNodeActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/GeneralCreateNodeActionTest.java
@@ -124,7 +124,7 @@ public class GeneralCreateNodeActionTest {
         final Node targetNode = mock(Node.class);
         final View targetElementContent = mock(View.class);
         doReturn(targetElementContent).when(targetNode).getContent();
-        doReturn(Bounds.create(0d, 0d, 100d, 100d)).when(targetElementContent).getBounds();
+        doReturn(Bounds.create(-100d, 0d, 0d, 100d)).when(targetElementContent).getBounds();
         doReturn(targetNode).when(targetNodeElement).asNode();
         final String targetNodeUuid = "target-uuid";
         doReturn(targetNodeUuid).when(targetNode).getUUID();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnectionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnectionTest.java
@@ -81,8 +81,36 @@ public class MagnetConnectionTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testForTargetARight() {
-        Bounds bounds2 = Bounds.create(20d, 30d, 200d, 300d);
+    public void testForTargetAtTop() {
+        Bounds bounds2 = Bounds.create(0d, -100d, 200d, 0d);
+        when(element2.getContent()).thenReturn(content2);
+        when(content2.getBounds()).thenReturn(bounds2);
+
+        MagnetConnection m1 = MagnetConnection.Builder.forTarget(element, element2);
+        assertEquals(Point2D.create(45, 0), m1.getLocation());
+        assertEquals(MagnetConnection.MAGNET_TOP,
+                     m1.getMagnetIndex().getAsInt());
+        assertTrue(m1.isAuto());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testForTargetAtBottom() {
+        Bounds bounds2 = Bounds.create(0d, 210d, 200d, 310d);
+        when(element2.getContent()).thenReturn(content2);
+        when(content2.getBounds()).thenReturn(bounds2);
+
+        MagnetConnection m1 = MagnetConnection.Builder.forTarget(element, element2);
+        assertEquals(Point2D.create(45, 180), m1.getLocation());
+        assertEquals(MagnetConnection.MAGNET_BOTTOM,
+                     m1.getMagnetIndex().getAsInt());
+        assertTrue(m1.isAuto());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testForTargetAtRight() {
+        Bounds bounds2 = Bounds.create(120d, 30d, 200d, 300d);
         when(element2.getContent()).thenReturn(content2);
         when(content2.getBounds()).thenReturn(bounds2);
 
@@ -96,7 +124,7 @@ public class MagnetConnectionTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testForTargetAtLeft() {
-        Bounds bounds2 = Bounds.create(5d, 10d, 200d, 300d);
+        Bounds bounds2 = Bounds.create(-40d, 10d, 0d, 300d);
         when(element2.getContent()).thenReturn(content2);
         when(content2.getBounds()).thenReturn(bounds2);
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3702

This fixes the issue reported by @danielzhe and the preview when authoring.

It improves on the `MagnetConnector.Builder.forTarget(..)` method to be less naive and considers target nodes above or below the source. The old implementation simply checked for left or right that was OK for BPMN as most diagrams run from left to right whereas DMN is top to bottom.

However please note the preview does not appear to honour the "auto" setting on the connection. This is not a regression caused by this PR but is in `master` too. I've included @romartin and @hasys on the review for BPMN.