### PR TITLE
DROOLS-3897: [DMN Designer] Included Models - Temporally disable Included Models

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorPresenter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorPresenter.java
@@ -171,7 +171,7 @@ public class DecisionNavigatorPresenter {
 
     void setupView() {
         view.setupMainTree(treePresenter.getView());
-        view.setupDecisionComponents(decisionComponents.getView());
+        // TODO: {karreiro} Enable Included Models feature. # view.setupDecisionComponents(decisionComponents.getView());
     }
 
     public void refreshTreeView() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorView.html
@@ -33,7 +33,8 @@
             </div>
         </div>
     </div>
-    <div>
+    <!-- TODO: {karreiro} Enable Included Models feature. # class="hidden" -->
+    <div class="hidden">
         <div class="panel-group" id="decision-component-header">
             <div class="panel panel-default">
                 <div class="panel-heading" data-component="collapse-heading">

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorPresenterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/decision/DecisionNavigatorPresenterTest.java
@@ -136,7 +136,7 @@ public class DecisionNavigatorPresenterTest {
         presenter.setupView();
 
         verify(view).setupMainTree(treeView);
-        verify(view).setupDecisionComponents(decisionComponentsView);
+        // TODO: {karreiro} Enable Included Models feature. # verify(view).setupDecisionComponents(decisionComponentsView);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -171,7 +171,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         superInitialiseKieEditorForSession(diagram);
 
         kieView.getMultiPage().addPage(dataTypesPage);
-        kieView.getMultiPage().addPage(includedModelsPage);
+        // TODO: {karreiro} Enable Included Models feature. # kieView.getMultiPage().addPage(includedModelsPage);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -222,7 +222,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         diagramEditor.initialiseKieEditorForSession(diagram);
 
         verify(multiPage).addPage(dataTypesPage);
-        verify(multiPage).addPage(includedModelsPage);
+        // TODO: {karreiro} Enable Included Models feature. # verify(multiPage).addPage(includedModelsPage);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreen.java
@@ -171,7 +171,7 @@ public class SessionDiagramEditorScreen implements KieEditorWrapperView.KieEdito
         kieView.clear();
         kieView.addMainEditorPage(screenPanelView.asWidget());
         kieView.getMultiPage().addPage(dataTypesPage);
-        kieView.getMultiPage().addPage(includedModelsPage);
+        // TODO: {karreiro} Enable Included Models feature. # kieView.getMultiPage().addPage(includedModelsPage);
     }
 
     public void onDataTypePageNavTabActiveEvent(final @Observes DataTypePageTabActiveEvent event) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
@@ -175,7 +175,7 @@ public class SessionDiagramEditorScreenTest {
         verify(kieView).clear();
         verify(kieView).addMainEditorPage(screenPanelWidget);
         verify(multiPageEditor).addPage(dataTypesPage);
-        verify(multiPageEditor).addPage(includedModelsPage);
+        // TODO: {karreiro} Enable Included Models feature. # verify(multiPageEditor).addPage(includedModelsPage);
     }
 
     @Test


### PR DESCRIPTION
See: https://issues.jboss.org/browse/DROOLS-3897

---

![2019-04-16 22 32 05](https://user-images.githubusercontent.com/1079279/56254670-111e3a80-6098-11e9-8b71-ca784f9ee0b0.gif)

---

Disabling _Decision Components component_ and _Included Models tab_.