### PR TITLE
DROOLS-3896: [DMN Designer] Editing a merged header cell positions editor at the wrong location

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/handlers/EditableHeaderGridWidgetEditCellMouseEventHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/handlers/EditableHeaderGridWidgetEditCellMouseEventHandler.java
@@ -65,9 +65,21 @@ public class EditableHeaderGridWidgetEditCellMouseEventHandler extends DefaultGr
                                     final int uiHeaderRowIndex,
                                     final int uiHeaderColumnIndex,
                                     final AbstractNodeMouseEvent event) {
-        //Get column information
-        final double cx = relativeLocation.getX();
+        //Lookup Header block start
         final BaseGridRendererHelper rendererHelper = gridWidget.getRendererHelper();
+        final List<GridColumn<?>> gridColumns = gridWidget.getModel().getColumns();
+        final List<GridColumn.HeaderMetaData> columnHeaderMetaData = gridColumns.get(uiHeaderColumnIndex).getHeaderMetaData();
+        if (Objects.isNull(columnHeaderMetaData) || columnHeaderMetaData.isEmpty()) {
+            return false;
+        }
+        final GridColumn.HeaderMetaData headerMetaData = columnHeaderMetaData.get(uiHeaderRowIndex);
+        final int blockStartColumnIndex = ColumnIndexUtilities.getHeaderBlockStartColumnIndex(gridColumns,
+                                                                                              headerMetaData,
+                                                                                              uiHeaderRowIndex,
+                                                                                              uiHeaderColumnIndex);
+
+        //Get column information
+        final double cx = rendererHelper.getColumnOffset(blockStartColumnIndex) + gridColumns.get(blockStartColumnIndex).getWidth() / 2;
         final BaseGridRendererHelper.ColumnInformation ci = rendererHelper.getColumnInformation(cx);
         final GridColumn<?> column = ci.getColumn();
         if (column == null) {
@@ -85,7 +97,7 @@ public class EditableHeaderGridWidgetEditCellMouseEventHandler extends DefaultGr
         //Get rendering information
         final Point2D gridWidgetComputedLocation = gridWidget.getComputedLocation();
         final BaseGridRendererHelper.RenderingInformation ri = rendererHelper.getRenderingInformation();
-        final EditableHeaderMetaData headerMetaData = (EditableHeaderMetaData) column.getHeaderMetaData().get(uiHeaderRowIndex);
+        final EditableHeaderMetaData editableHeaderMetaData = (EditableHeaderMetaData) column.getHeaderMetaData().get(uiHeaderRowIndex);
         final GridBodyCellEditContext context = CellContextUtilities.makeHeaderCellRenderContext(gridWidget,
                                                                                                  ri,
                                                                                                  ci,
@@ -93,7 +105,7 @@ public class EditableHeaderGridWidgetEditCellMouseEventHandler extends DefaultGr
                                                                                                  uiHeaderRowIndex);
 
         if (isHeaderSelectionValid(gridWidget)) {
-            if (Objects.equals(headerMetaData.getSupportedEditAction(), GridCellEditAction.getSupportedEditAction(event))) {
+            if (Objects.equals(editableHeaderMetaData.getSupportedEditAction(), GridCellEditAction.getSupportedEditAction(event))) {
                 headerMetaData.edit(context);
                 return true;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/handlers/EditableHeaderGridWidgetEditCellMouseEventHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/handlers/EditableHeaderGridWidgetEditCellMouseEventHandler.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.dmn.client.widgets.grid.handlers;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.ait.lienzo.client.core.event.AbstractNodeMouseEvent;
 import com.ait.lienzo.client.core.types.Point2D;
@@ -28,13 +27,9 @@ import org.kie.workbench.common.dmn.client.widgets.grid.columns.EditableHeaderMe
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.EditableHeaderUtilities;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellEditAction;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.util.CellContextUtilities;
-import org.uberfire.ext.wires.core.grids.client.util.ColumnIndexUtilities;
-import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.DefaultGridWidgetEditCellMouseEventHandler;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
 public class EditableHeaderGridWidgetEditCellMouseEventHandler extends DefaultGridWidgetEditCellMouseEventHandler {
 
@@ -65,86 +60,32 @@ public class EditableHeaderGridWidgetEditCellMouseEventHandler extends DefaultGr
                                     final int uiHeaderRowIndex,
                                     final int uiHeaderColumnIndex,
                                     final AbstractNodeMouseEvent event) {
-        //Lookup Header block start
-        final BaseGridRendererHelper rendererHelper = gridWidget.getRendererHelper();
         final List<GridColumn<?>> gridColumns = gridWidget.getModel().getColumns();
-        final List<GridColumn.HeaderMetaData> columnHeaderMetaData = gridColumns.get(uiHeaderColumnIndex).getHeaderMetaData();
-        if (Objects.isNull(columnHeaderMetaData) || columnHeaderMetaData.isEmpty()) {
-            return false;
-        }
-        final GridColumn.HeaderMetaData headerMetaData = columnHeaderMetaData.get(uiHeaderRowIndex);
-        final int blockStartColumnIndex = ColumnIndexUtilities.getHeaderBlockStartColumnIndex(gridColumns,
-                                                                                              headerMetaData,
-                                                                                              uiHeaderRowIndex,
-                                                                                              uiHeaderColumnIndex);
+        final GridColumn<?> gridColumn = gridColumns.get(uiHeaderColumnIndex);
+        final List<GridColumn.HeaderMetaData> gridColumnHeaderMetaData = gridColumn.getHeaderMetaData();
 
-        //Get column information
-        final double cx = rendererHelper.getColumnOffset(blockStartColumnIndex) + gridColumns.get(blockStartColumnIndex).getWidth() / 2;
-        final BaseGridRendererHelper.ColumnInformation ci = rendererHelper.getColumnInformation(cx);
-        final GridColumn<?> column = ci.getColumn();
-        if (column == null) {
-            return false;
-        }
-        if (!EditableHeaderUtilities.hasEditableHeader(column)) {
+        if (Objects.isNull(gridColumnHeaderMetaData) || gridColumnHeaderMetaData.isEmpty()) {
             return false;
         }
 
-        if (!EditableHeaderUtilities.isEditableHeader(column,
+        if (!EditableHeaderUtilities.hasEditableHeader(gridColumn)) {
+            return false;
+        }
+
+        if (!EditableHeaderUtilities.isEditableHeader(gridColumn,
                                                       uiHeaderRowIndex)) {
             return false;
         }
 
-        //Get rendering information
-        final Point2D gridWidgetComputedLocation = gridWidget.getComputedLocation();
-        final BaseGridRendererHelper.RenderingInformation ri = rendererHelper.getRenderingInformation();
-        final EditableHeaderMetaData editableHeaderMetaData = (EditableHeaderMetaData) column.getHeaderMetaData().get(uiHeaderRowIndex);
-        final GridBodyCellEditContext context = CellContextUtilities.makeHeaderCellRenderContext(gridWidget,
-                                                                                                 ri,
-                                                                                                 ci,
-                                                                                                 relativeLocation.add(gridWidgetComputedLocation),
-                                                                                                 uiHeaderRowIndex);
+        final EditableHeaderMetaData editableHeaderMetaData = (EditableHeaderMetaData) gridColumn.getHeaderMetaData().get(uiHeaderRowIndex);
 
-        if (isHeaderSelectionValid(gridWidget)) {
-            if (Objects.equals(editableHeaderMetaData.getSupportedEditAction(), GridCellEditAction.getSupportedEditAction(event))) {
-                headerMetaData.edit(context);
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private boolean isHeaderSelectionValid(final GridWidget gridWidget) {
-        final GridData gridData = gridWidget.getModel();
-        final List<GridData.SelectedCell> selectedHeaderCells = gridData.getSelectedHeaderCells();
-
-        //No selections (should not happen) then cannot edit the header cell
-        if (selectedHeaderCells.isEmpty()) {
-            return false;
-        }
-
-        //Single selection, then can edit header cell
-        if (selectedHeaderCells.size() == 1) {
+        if (Objects.equals(editableHeaderMetaData.getSupportedEditAction(),
+                           GridCellEditAction.getSupportedEditAction(event))) {
+            final Point2D gridWidgetComputedLocation = gridWidget.getComputedLocation();
+            CellContextUtilities.editSelectedCell(gridWidget, relativeLocation.add(gridWidgetComputedLocation));
             return true;
         }
 
-        //Check if all selected cell MetaData are equal
-        final GridColumn.HeaderMetaData firstSelectedCellMetaData = getSelectedCellMetaData(gridData,
-                                                                                            selectedHeaderCells.get(0));
-        return selectedHeaderCells
-                .stream()
-                .map(selectedCell -> getSelectedCellMetaData(gridData, selectedCell))
-                .collect(Collectors.toList())
-                .stream()
-                .allMatch(selectedCell -> Objects.equals(selectedCell, firstSelectedCellMetaData));
-    }
-
-    private GridColumn.HeaderMetaData getSelectedCellMetaData(final GridData gridData,
-                                                              final GridData.SelectedCell selectedCell) {
-        final int _headerColumnIndex = ColumnIndexUtilities.findUiColumnIndex(gridData.getColumns(),
-                                                                              selectedCell.getColumnIndex());
-        final GridColumn<?> gridColumn = gridData.getColumns().get(_headerColumnIndex);
-        final List<GridColumn.HeaderMetaData> gridColumnMetaData = gridColumn.getHeaderMetaData();
-        return gridColumnMetaData.get(selectedCell.getRowIndex());
+        return false;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/handlers/EditableHeaderGridWidgetEditCellMouseEventHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/handlers/EditableHeaderGridWidgetEditCellMouseEventHandlerTest.java
@@ -194,29 +194,40 @@ public class EditableHeaderGridWidgetEditCellMouseEventHandlerTest {
 
         uiModel.selectHeaderCell(0, 0);
 
-        assertHeaderCellEdited();
+        assertHeaderCellEdited(0);
     }
 
     @Test
-    public void testHandleHeaderCell_EditableMergedColumns_EditableRow_ClickEvent() {
-        final GridColumn gridColumn2 = mock(GridColumn.class);
-        uiModel.appendColumn(gridColumn2);
+    public void testHandleHeaderCell_EditableMergedColumns_EditableRow_Column0_ClickEvent() {
+        setupAdditionalColumn();
+
+        assertHeaderCellEdited(0);
+    }
+
+    @Test
+    public void testHandleHeaderCell_EditableMergedColumns_EditableRow_Column1_ClickEvent() {
+        setupAdditionalColumn();
+
+        assertHeaderCellEdited(1);
+    }
+
+    private void setupAdditionalColumn() {
+        final GridColumn additionalGridColumn = mock(GridColumn.class);
+        uiModel.appendColumn(additionalGridColumn);
         when(gridColumn.getHeaderMetaData()).thenReturn(Collections.singletonList(editableHeaderMetaData));
-        when(gridColumn2.getHeaderMetaData()).thenReturn(Collections.singletonList(editableHeaderMetaData));
         when(gridColumn.getIndex()).thenReturn(0);
-        when(gridColumn2.getIndex()).thenReturn(1);
+        when(additionalGridColumn.getHeaderMetaData()).thenReturn(Collections.singletonList(editableHeaderMetaData));
+        when(additionalGridColumn.getIndex()).thenReturn(1);
 
         uiModel.selectHeaderCell(0, 0);
         uiModel.selectHeaderCell(0, 1);
-
-        assertHeaderCellEdited();
     }
 
-    private void assertHeaderCellEdited() {
+    private void assertHeaderCellEdited(final int uiHeaderColumnIndex) {
         assertThat(handler.handleHeaderCell(gridWidget,
                                             relativeLocation,
                                             0,
-                                            0,
+                                            uiHeaderColumnIndex,
                                             clickEvent)).isTrue();
 
         verify(editableHeaderMetaData).edit(gridBodyCellEditContextCaptor.capture());


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3896

@jomarko this was not a regression after all but an existing bug.. please note you won't be able to test that entries in the `TextBox` are flushed to the UI when the `TextBox` looses the focus until the remainder of your DOM Factory PRs are complete and merged (as, at the moment, your change to `destroyResources()` means the text is not flushed).