### PR TITLE
AF-1674: Role-based access to branches in the Workbench. Fix for Stunner standalone webapp screens

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionPropertiesScreen.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionPropertiesScreen.java
@@ -15,8 +15,6 @@
  */
 package org.kie.workbench.common.stunner.standalone.client.screens;
 
-import java.util.function.Consumer;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -29,7 +27,6 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.forms.client.event.FormPropertiesOpened;
 import org.kie.workbench.common.stunner.forms.client.widgets.FormPropertiesWidget;
 import org.uberfire.client.annotations.WorkbenchContextId;
-import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
@@ -39,7 +36,6 @@ import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
-import org.uberfire.workbench.model.menu.Menus;
 
 /**
  * This screen wraps the FormsProperties widget.
@@ -83,10 +79,6 @@ public class SessionPropertiesScreen extends AbstractSessionScreen {
     @OnClose
     public void onClose() {
         close();
-    }
-
-    @WorkbenchMenu
-    public void getMenus(final Consumer<Menus> menusConsumer) {
     }
 
     @WorkbenchPartTitle

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionTreeExplorerScreen.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/screens/SessionTreeExplorerScreen.java
@@ -15,8 +15,6 @@
  */
 package org.kie.workbench.common.stunner.standalone.client.screens;
 
-import java.util.function.Consumer;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -27,7 +25,6 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.client.widgets.explorer.tree.TreeExplorer;
 import org.uberfire.client.annotations.WorkbenchContextId;
-import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
@@ -36,7 +33,6 @@ import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
-import org.uberfire.workbench.model.menu.Menus;
 
 // TODO: I18n.
 @Dependent
@@ -80,10 +76,6 @@ public class SessionTreeExplorerScreen extends AbstractSessionScreen {
     @OnClose
     public void onClose() {
         close();
-    }
-
-    @WorkbenchMenu
-    public void getMenus(final Consumer<Menus> menusConsumer) {
     }
 
     @WorkbenchPartTitle


### PR DESCRIPTION
AppFormer correctly handles `WorkbenchActivity` implementations with no menus.

Stunner standalone showcase webapp was incorrectly providing an empty `@WorkbenchMenu` method (that should either not exist, or should invoke the `Consumer` with `null`). Since the affected screens do not have menus it was perfectly safe to simply remove the `@WorkbenchMenu` methods.  