### PR TITLE
Make kie-wb-common-library-spaces-screen module inherit version from its parent

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/pom.xml
@@ -11,7 +11,6 @@
 
   <packaging>jar</packaging>
   <artifactId>kie-wb-common-library-spaces-screen</artifactId>
-  <version>7.21.0-SNAPSHOT</version>
   <name>Kie Workbench - Common - Library - Spaces Screen</name>
   <description>Kie Workbench - Common - Library - Spaces Screen</description>
 


### PR DESCRIPTION
Using custom tags causes errors on release builds because the version update script doesn't update these custom versions anymore.