### PR TITLE
JBPM-8432 API for Marshalling with a response to include error/warning messages

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingMessage.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingMessage.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.marshaller;
+
+import java.util.Objects;
+
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+
+public class MarshallingMessage implements DomainViolation {
+
+    private String elementUUID;
+    private int code;
+    private Type type;
+    private String message;
+
+    public String getElementUUID() {
+        return elementUUID;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public Type getViolationType() {
+        return type;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public MarshallingMessage(String elementUUID, int code, Type type, String message) {
+        this.elementUUID = elementUUID;
+        this.code = code;
+        this.type = type;
+        this.message = message;
+    }
+
+    public static MarshallingMessageBuilder builder(){
+        return new MarshallingMessageBuilder();
+    }
+
+    public static class MarshallingMessageBuilder {
+
+        private String elementUUID;
+        private int code;
+        private Type type = Type.ERROR;
+        private String message;
+
+        public MarshallingMessageBuilder elementUUID(String elementUUID) {
+            this.elementUUID = elementUUID;
+            return this;
+        }
+
+        public MarshallingMessageBuilder code(int code) {
+            this.code = code;
+            return this;
+        }
+
+        public MarshallingMessageBuilder type(Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public MarshallingMessageBuilder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public MarshallingMessage build() {
+            return new MarshallingMessage(elementUUID, code, type, message);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MarshallingMessage)) {
+            return false;
+        }
+        MarshallingMessage that = (MarshallingMessage) o;
+        return getCode() == that.getCode() &&
+                Objects.equals(getElementUUID(), that.getElementUUID()) &&
+                type == that.type &&
+                Objects.equals(getMessage(), that.getMessage());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getElementUUID(), getCode(), type, getMessage());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("MarshallingMessage{");
+        sb.append("elementUUID='").append(elementUUID).append('\'');
+        sb.append(", code=").append(code);
+        sb.append(", type=").append(type);
+        sb.append(", message='").append(message).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingMessage.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingMessage.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.marshaller;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
@@ -30,6 +32,8 @@ public class MarshallingMessage implements DomainViolation {
     private final int code;
     private final Type type;
     private final String message;
+    private final String messageKey;
+    private final List<?> messageArguments;
 
     public String getElementUUID() {
         return elementUUID;
@@ -49,12 +53,24 @@ public class MarshallingMessage implements DomainViolation {
         return code;
     }
 
+    public String getMessageKey() {
+        return messageKey;
+    }
+
+    public List<?> getMessageArguments() {
+        return messageArguments;
+    }
+
     public MarshallingMessage(@MapsTo("elementUUID") String elementUUID, @MapsTo("code") int code,
-                              @MapsTo("type") Type type, @MapsTo("message") String message) {
+                              @MapsTo("type") Type type, @MapsTo("message") String message,
+                              @MapsTo("messageKey") String messageKey,
+                              @MapsTo("messageArguments") List<?> messageArguments) {
         this.elementUUID = elementUUID;
         this.code = code;
         this.type = type;
         this.message = message;
+        this.messageKey = messageKey;
+        this.messageArguments = messageArguments;
     }
 
     public static MarshallingMessageBuilder builder(){
@@ -67,6 +83,8 @@ public class MarshallingMessage implements DomainViolation {
         private int code;
         private Type type = Type.ERROR;
         private String message;
+        private String messageKey;
+        private List<?> messageArguments = Collections.emptyList();
 
         public MarshallingMessageBuilder elementUUID(String elementUUID) {
             this.elementUUID = elementUUID;
@@ -88,8 +106,18 @@ public class MarshallingMessage implements DomainViolation {
             return this;
         }
 
+        public MarshallingMessageBuilder messageKey(String messageKey) {
+            this.messageKey = messageKey;
+            return this;
+        }
+
+        public MarshallingMessageBuilder messageArguments(List<?> messageArguments) {
+            this.messageArguments = messageArguments;
+            return this;
+        }
+
         public MarshallingMessage build() {
-            return new MarshallingMessage(elementUUID, code, type, message);
+            return new MarshallingMessage(elementUUID, code, type, message, messageKey, messageArguments);
         }
     }
 
@@ -98,30 +126,34 @@ public class MarshallingMessage implements DomainViolation {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof MarshallingMessage)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
         MarshallingMessage that = (MarshallingMessage) o;
-        return getCode() == that.getCode() &&
-                Objects.equals(getElementUUID(), that.getElementUUID()) &&
+        return code == that.code &&
+                Objects.equals(elementUUID, that.elementUUID) &&
                 type == that.type &&
-                Objects.equals(getMessage(), that.getMessage());
+                Objects.equals(message, that.message) &&
+                Objects.equals(messageKey, that.messageKey) &&
+                Objects.equals(messageArguments, that.messageArguments);
     }
 
     @Override
     public int hashCode() {
         return HashUtil.combineHashCodes(Objects.hashCode(getElementUUID()), Objects.hashCode(getCode()),
-                                         Objects.hashCode(type), Objects.hashCode(getMessage()));
+                                         Objects.hashCode(type), Objects.hashCode(getMessage()),
+                                         Objects.hashCode(getMessageKey()), Objects.hashCode(getMessageArguments()));
     }
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("MarshallingMessage{");
-        sb.append("elementUUID='").append(elementUUID).append('\'');
-        sb.append(", code=").append(code);
-        sb.append(", type=").append(type);
-        sb.append(", message='").append(message).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "MarshallingMessage{" +
+                "elementUUID='" + elementUUID + '\'' +
+                ", code=" + code +
+                ", type=" + type +
+                ", message='" + message + '\'' +
+                ", messageKey='" + messageKey + '\'' +
+                ", messageArguments=" + messageArguments +
+                '}';
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingMessage.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingMessage.java
@@ -18,14 +18,18 @@ package org.kie.workbench.common.stunner.core.marshaller;
 
 import java.util.Objects;
 
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 import org.kie.workbench.common.stunner.core.validation.DomainViolation;
 
+@Portable
 public class MarshallingMessage implements DomainViolation {
 
-    private String elementUUID;
-    private int code;
-    private Type type;
-    private String message;
+    private final String elementUUID;
+    private final int code;
+    private final Type type;
+    private final String message;
 
     public String getElementUUID() {
         return elementUUID;
@@ -45,7 +49,8 @@ public class MarshallingMessage implements DomainViolation {
         return code;
     }
 
-    public MarshallingMessage(String elementUUID, int code, Type type, String message) {
+    public MarshallingMessage(@MapsTo("elementUUID") String elementUUID, @MapsTo("code") int code,
+                              @MapsTo("type") Type type, @MapsTo("message") String message) {
         this.elementUUID = elementUUID;
         this.code = code;
         this.type = type;
@@ -105,7 +110,8 @@ public class MarshallingMessage implements DomainViolation {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getElementUUID(), getCode(), type, getMessage());
+        return HashUtil.combineHashCodes(Objects.hashCode(getElementUUID()), Objects.hashCode(getCode()),
+                                         Objects.hashCode(type), Objects.hashCode(getMessage()));
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.marshaller;
+
+import java.util.Objects;
+
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+
+public class MarshallingRequest<I, M extends Metadata> {
+
+    /**
+     * Mode
+     * <p>
+     * ERROR:
+     * - return errors when it has unsupported nodes
+     * - error messages
+     * AUTO:
+     * - try to adapt unsupported nodes do generic ones
+     * - warn messages
+     * IGNORE:
+     * - remove unsupported nodes and relationships to them
+     * - warn messages
+     */
+    public enum Mode {
+        ERROR,
+        AUTO,
+        IGNORE
+    }
+
+    private I input;
+    private M metadata;
+    private Mode mode;
+
+    public MarshallingRequest(I input, M metadata, Mode mode) {
+        this.input = input;
+        this.metadata = metadata;
+        this.mode = mode;
+    }
+
+    public I getInput() {
+        return input;
+    }
+
+    public M getMetadata() {
+        return metadata;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public static <I, M extends Metadata> MarshallingRequestBuilder<I, M> builder() {
+        return new MarshallingRequestBuilder<>();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("MarshallingRequest{");
+        sb.append("input=").append(input);
+        sb.append(", metadata=").append(metadata);
+        sb.append(", mode=").append(mode);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MarshallingRequest)) {
+            return false;
+        }
+        MarshallingRequest<?, ?> that = (MarshallingRequest<?, ?>) o;
+        return Objects.equals(getInput(), that.getInput()) &&
+                Objects.equals(getMetadata(), that.getMetadata()) &&
+                getMode() == that.getMode();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getInput(), getMetadata(), getMode());
+    }
+
+    public static class MarshallingRequestBuilder<I, M extends Metadata> {
+
+        private I input;
+        private M metadata;
+        private Mode mode;
+
+        public MarshallingRequestBuilder input(I input) {
+            this.input = input;
+            return this;
+        }
+
+        public MarshallingRequestBuilder metadata(M metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public MarshallingRequestBuilder mode(Mode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public MarshallingRequest build() {
+            return new MarshallingRequest(input, metadata, mode);
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 /**
- * Encapsulates the attriutes required on a marshalling process.
+ * Encapsulates the attributes required on a marshalling process.
  * Includes the {@link Mode} that represents how the marshaller should handle errors and exceptions.
  *
  * @param <I> represents the input type

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
@@ -41,7 +41,7 @@ public class MarshallingRequest<I, M extends Metadata> {
      * - return ERROR messages
      * AUTO:
      * - try to adapt and convert unsupported nodes to generic ones
-     * - retun warn messages
+     * - return warn messages
      * - ignore unsupported nodes that doesn't have options to be converted
      * IGNORE:
      * - remove all unsupported nodes and relationships to them

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
@@ -18,8 +18,12 @@ package org.kie.workbench.common.stunner.core.marshaller;
 
 import java.util.Objects;
 
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+@Portable
 public class MarshallingRequest<I, M extends Metadata> {
 
     /**
@@ -41,11 +45,11 @@ public class MarshallingRequest<I, M extends Metadata> {
         IGNORE
     }
 
-    private I input;
-    private M metadata;
-    private Mode mode;
+    private final I input;
+    private final M metadata;
+    private final Mode mode;
 
-    public MarshallingRequest(I input, M metadata, Mode mode) {
+    public MarshallingRequest(@MapsTo("input") I input, @MapsTo("metadata") M metadata, @MapsTo("mode") Mode mode) {
         this.input = input;
         this.metadata = metadata;
         this.mode = mode;
@@ -93,7 +97,8 @@ public class MarshallingRequest<I, M extends Metadata> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getInput(), getMetadata(), getMode());
+        return HashUtil.combineHashCodes(Objects.hashCode(getInput()), Objects.hashCode(getMetadata()),
+                                         Objects.hashCode(getMode()));
     }
 
     public static class MarshallingRequestBuilder<I, M extends Metadata> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingRequest.java
@@ -23,20 +23,28 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+/**
+ * Encapsulates the attriutes required on a marshalling process.
+ * Includes the {@link Mode} that represents how the marshaller should handle errors and exceptions.
+ *
+ * @param <I> represents the input type
+ * @param <M> represents the metadata type
+ */
 @Portable
 public class MarshallingRequest<I, M extends Metadata> {
 
     /**
-     * Mode
+     * Mode of the marshalling process
      * <p>
      * ERROR:
      * - return errors when it has unsupported nodes
-     * - error messages
+     * - return ERROR messages
      * AUTO:
-     * - try to adapt unsupported nodes do generic ones
-     * - warn messages
+     * - try to adapt and convert unsupported nodes to generic ones
+     * - retun warn messages
+     * - ignore unsupported nodes that doesn't have options to be converted
      * IGNORE:
-     * - remove unsupported nodes and relationships to them
+     * - remove all unsupported nodes and relationships to them
      * - warn messages
      */
     public enum Mode {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.marshaller;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class MarshallingResponse<T> {
+
+    public enum State {
+        ERROR,
+        SUCCESS
+    }
+
+    private List<MarshallingMessage> messages;
+    private State state;
+    private Optional<T> result;
+
+    private MarshallingResponse(List<MarshallingMessage> messages, State state, Optional<T> result) {
+        this.messages = messages;
+        this.state = state;
+        this.result = result;
+    }
+
+    public List<MarshallingMessage> getMessages() {
+        return messages;
+    }
+
+    public State getState() {
+        return state;
+    }
+
+    public Optional<T> getResult() {
+        return result;
+    }
+
+    public static <T> MarshallingResponseBuilder<T> builder() {
+        return new MarshallingResponseBuilder<>();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("MarshallingResponse{");
+        sb.append("messages=").append(messages);
+        sb.append(", state=").append(state);
+        sb.append(", result=").append(result);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MarshallingResponse)) {
+            return false;
+        }
+        MarshallingResponse<?> that = (MarshallingResponse<?>) o;
+        return Objects.equals(getMessages(), that.getMessages()) &&
+                getState() == that.getState() &&
+                Objects.equals(getResult(), that.getResult());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getMessages(), getState(), getResult());
+    }
+
+    public static class MarshallingResponseBuilder<T> {
+
+        private final List<MarshallingMessage> messages = new ArrayList<>();
+        private State state;
+        private Optional<T> result = Optional.empty();
+
+        public MarshallingResponseBuilder messages(List<MarshallingMessage> messages) {
+            messages.addAll(messages);
+            return this;
+        }
+
+        public MarshallingResponseBuilder addMessage(MarshallingMessage message) {
+            messages.add(message);
+            return this;
+        }
+
+        public MarshallingResponseBuilder state(State state) {
+            this.state = state;
+            return this;
+        }
+
+        public MarshallingResponseBuilder result(T result) {
+            this.result = Optional.ofNullable(result);
+            return this;
+        }
+
+        public MarshallingResponse build() {
+            return new MarshallingResponse(messages, state, result);
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
@@ -21,6 +21,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
+
+@Portable
 public class MarshallingResponse<T> {
 
     public enum State {
@@ -28,11 +33,12 @@ public class MarshallingResponse<T> {
         SUCCESS
     }
 
-    private List<MarshallingMessage> messages;
-    private State state;
-    private Optional<T> result;
+    private final List<MarshallingMessage> messages;
+    private final State state;
+    private final Optional<T> result;
 
-    private MarshallingResponse(List<MarshallingMessage> messages, State state, Optional<T> result) {
+    private MarshallingResponse(@MapsTo("messages") List<MarshallingMessage> messages,
+                                @MapsTo("state") State state, @MapsTo("result") Optional<T> result) {
         this.messages = messages;
         this.state = state;
         this.result = result;
@@ -80,7 +86,8 @@ public class MarshallingResponse<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getMessages(), getState(), getResult());
+        return HashUtil.combineHashCodes(Objects.hashCode(getMessages()), Objects.hashCode(getState()),
+                                         Objects.hashCode(getResult()));
     }
 
     public static class MarshallingResponseBuilder<T> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
@@ -25,6 +25,10 @@ import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+/**
+ * Encapcsulates the response of a marshalling process, containing messages details and the respective {@link State}.
+ * @param <T> result type in case of marshalling success.
+ */
 @Portable
 public class MarshallingResponse<T> {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/java/org/kie/workbench/common/stunner/core/marshaller/MarshallingResponse.java
@@ -26,7 +26,7 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 /**
- * Encapcsulates the response of a marshalling process, containing messages details and the respective {@link State}.
+ * Encapsulates the response of a marshalling process, containing messages details and the respective {@link State}.
  * @param <T> result type in case of marshalling success.
  */
 @Portable

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/resources/org/kie/workbench/common/stunner/core/StunnerBackendApi.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/main/resources/org/kie/workbench/common/stunner/core/StunnerBackendApi.gwt.xml
@@ -23,5 +23,6 @@
   <source path="api"/>
   <source path="definition"/>
   <source path="service"/>
+  <source path="marshaller"/>
 
 </module>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/test/java/org/kie/workbench/common/stunner/core/definition/service/DiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/test/java/org/kie/workbench/common/stunner/core/definition/service/DiagramMarshallerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.definition.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.marshaller.MarshallingMessage;
+import org.kie.workbench.common.stunner.core.marshaller.MarshallingRequest;
+import org.kie.workbench.common.stunner.core.marshaller.MarshallingResponse;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiagramMarshallerTest {
+
+    public static final String MESSAGE = "error unmarshalling";
+    private DiagramMarshaller tested;
+
+    @Mock
+    private Graph graph;
+
+    @Mock
+    private InputStream input;
+
+    @Mock
+    private Metadata metadata;
+
+    private MarshallingRequest request;
+
+    @Before
+    public void setUp() {
+
+        tested = spy(new DiagramMarshaller() {
+            @Override
+            public Graph unmarshall(Metadata metadata, InputStream input) throws IOException {
+                return graph;
+            }
+
+            @Override
+            public String marshall(Diagram diagram) throws IOException {
+                return null;
+            }
+
+            @Override
+            public DiagramMetadataMarshaller getMetadataMarshaller() {
+                return null;
+            }
+        });
+
+        request =
+                MarshallingRequest.builder()
+                        .metadata(metadata)
+                        .input(input)
+                        .mode(MarshallingRequest.Mode.ERROR)
+                        .build();
+    }
+
+    @Test
+    public void unmarshallWithValidation() throws Exception {
+        final MarshallingResponse response = tested.unmarshallWithValidation(request);
+        verify(tested).unmarshall(metadata, input);
+        assertEquals(response.getResult().orElse(null), graph);
+        assertEquals(response.getState(), MarshallingResponse.State.SUCCESS);
+    }
+
+    @Test
+    public void unmarshallWithValidationError() throws Exception {
+        tested = spy(new DiagramMarshaller() {
+            @Override
+            public Graph unmarshall(Metadata metadata, InputStream input) throws IOException {
+                throw new RuntimeException(MESSAGE);
+            }
+
+            @Override
+            public String marshall(Diagram diagram) throws IOException {
+                return null;
+            }
+
+            @Override
+            public DiagramMetadataMarshaller getMetadataMarshaller() {
+                return null;
+            }
+        });
+
+        final MarshallingResponse response = tested.unmarshallWithValidation(request);
+        verify(tested).unmarshall(metadata, input);
+        assertFalse(response.getResult().isPresent());
+        assertEquals(response.getState(), MarshallingResponse.State.ERROR);
+        assertEquals(response.getMessages().size(), 1);
+        final MarshallingMessage marshallingMessage =
+                (MarshallingMessage) response.getMessages().stream().findFirst().get();
+        assertEquals(marshallingMessage.getMessage(), MESSAGE);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/test/java/org/kie/workbench/common/stunner/core/definition/service/DiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/test/java/org/kie/workbench/common/stunner/core/definition/service/DiagramMarshallerTest.java
@@ -16,10 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.definition.service;
 
-import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -53,17 +51,16 @@ public class DiagramMarshallerTest {
 
     private MarshallingRequest request;
 
-    @Before
-    public void setUp() {
-
+    @Test
+    public void unmarshallWithValidation() throws Exception {
         tested = spy(new DiagramMarshaller() {
             @Override
-            public Graph unmarshall(Metadata metadata, InputStream input) throws IOException {
+            public Graph unmarshall(Metadata metadata, InputStream input) {
                 return graph;
             }
 
             @Override
-            public String marshall(Diagram diagram) throws IOException {
+            public String marshall(Diagram diagram) {
                 return null;
             }
 
@@ -73,16 +70,12 @@ public class DiagramMarshallerTest {
             }
         });
 
-        request =
-                MarshallingRequest.builder()
-                        .metadata(metadata)
-                        .input(input)
-                        .mode(MarshallingRequest.Mode.ERROR)
-                        .build();
-    }
+        request = MarshallingRequest.builder()
+                .metadata(metadata)
+                .input(input)
+                .mode(MarshallingRequest.Mode.ERROR)
+                .build();
 
-    @Test
-    public void unmarshallWithValidation() throws Exception {
         final MarshallingResponse response = tested.unmarshallWithValidation(request);
         verify(tested).unmarshall(metadata, input);
         assertEquals(response.getResult().orElse(null), graph);
@@ -93,12 +86,12 @@ public class DiagramMarshallerTest {
     public void unmarshallWithValidationError() throws Exception {
         tested = spy(new DiagramMarshaller() {
             @Override
-            public Graph unmarshall(Metadata metadata, InputStream input) throws IOException {
+            public Graph unmarshall(Metadata metadata, InputStream input) {
                 throw new RuntimeException(MESSAGE);
             }
 
             @Override
-            public String marshall(Diagram diagram) throws IOException {
+            public String marshall(Diagram diagram) {
                 return null;
             }
 
@@ -107,6 +100,12 @@ public class DiagramMarshallerTest {
                 return null;
             }
         });
+
+        request = MarshallingRequest.builder()
+                .metadata(metadata)
+                .input(input)
+                .mode(MarshallingRequest.Mode.ERROR)
+                .build();
 
         final MarshallingResponse response = tested.unmarshallWithValidation(request);
         verify(tested).unmarshall(metadata, input);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/test/java/org/kie/workbench/common/stunner/core/definition/service/DiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/src/test/java/org/kie/workbench/common/stunner/core/definition/service/DiagramMarshallerTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.core.definition.service;
 
 import java.io.InputStream;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -51,6 +52,15 @@ public class DiagramMarshallerTest {
 
     private MarshallingRequest request;
 
+    @Before
+    public void setUp(){
+        request = MarshallingRequest.builder()
+                .metadata(metadata)
+                .input(input)
+                .mode(MarshallingRequest.Mode.ERROR)
+                .build();
+    }
+
     @Test
     public void unmarshallWithValidation() throws Exception {
         tested = spy(new DiagramMarshaller() {
@@ -69,12 +79,6 @@ public class DiagramMarshallerTest {
                 return null;
             }
         });
-
-        request = MarshallingRequest.builder()
-                .metadata(metadata)
-                .input(input)
-                .mode(MarshallingRequest.Mode.ERROR)
-                .build();
 
         final MarshallingResponse response = tested.unmarshallWithValidation(request);
         verify(tested).unmarshall(metadata, input);
@@ -100,12 +104,6 @@ public class DiagramMarshallerTest {
                 return null;
             }
         });
-
-        request = MarshallingRequest.builder()
-                .metadata(metadata)
-                .input(input)
-                .mode(MarshallingRequest.Mode.ERROR)
-                .build();
 
         final MarshallingResponse response = tested.unmarshallWithValidation(request);
         verify(tested).unmarshall(metadata, input);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/service/AbstractVFSDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/src/test/java/org/kie/workbench/common/stunner/core/backend/service/AbstractVFSDiagramServiceTest.java
@@ -43,6 +43,8 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
+import org.kie.workbench.common.stunner.core.marshaller.MarshallingMessage;
+import org.kie.workbench.common.stunner.core.marshaller.MarshallingResponse;
 import org.kie.workbench.common.stunner.core.registry.BackendRegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.factory.FactoryRegistry;
 import org.kie.workbench.common.stunner.core.util.UUID;
@@ -186,7 +188,9 @@ public abstract class AbstractVFSDiagramServiceTest<M extends Metadata, D extend
         when(metadata.getDefinitionSetId()).thenReturn(DEFINITION_SET_ID);
         when(diagramMarshaller.marshall(diagram)).thenReturn(DIAGRAM_MARSHALLED);
         when(metadataMarshaller.marshall(metadata)).thenReturn(METADATA_MARSHALLED);
-
+        when(diagramMarshaller.unmarshallWithValidation(anyObject())).thenReturn(MarshallingResponse.builder()
+                                                                                         .result(graph)
+                                                                                         .build());
         when(diagramMarshaller.unmarshall(anyObject(),
                                           anyObject())).thenReturn(graph);
         when(graph.getContent()).thenReturn(graphContent);
@@ -264,8 +268,11 @@ public abstract class AbstractVFSDiagramServiceTest<M extends Metadata, D extend
 
         //Mock failure to unmarshall XML to Graph
         try {
-            Mockito.when(diagramMarshaller.unmarshall(anyObject(),
-                                                      anyObject())).thenThrow(IOException.class);
+            Mockito.when(diagramMarshaller.unmarshallWithValidation(anyObject()))
+                    .thenReturn(MarshallingResponse.builder()
+                                        .state(MarshallingResponse.State.ERROR)
+                                        .addMessage(MarshallingMessage.builder().message("error").build())
+                                        .build());
 
             diagramService.getDiagramByPath(path);
         } catch (DiagramParsingException dpe) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDiagramMarshallerTest.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.enterprise.inject.spi.BeanManager;
-
 import org.eclipse.bpmn2.Activity;
 import org.eclipse.bpmn2.DataInput;
 import org.eclipse.bpmn2.DataInputAssociation;
@@ -261,9 +259,6 @@ public class BPMNDiagramMarshallerTest {
 
     @Mock
     AdapterRegistry adapterRegistry;
-
-    @Mock
-    BeanManager beanManager;
 
     @Mock
     RuleManager rulesManager;


### PR DESCRIPTION
- API for Marshalling that contains a response with messages regarding the marshaling process. 
- A simple implementation that for now just return an error message (in case current marshallers throws an exception due to any unsupported element or whatever) or success with the expected result (Graph). 

@romartin 
@wmedvede 
@LuboTerifaj  @hasys 