### PR TITLE
DROOLS-3974 : Guided Decision Table is not getting updated

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/DataEnumLoader.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/DataEnumLoader.java
@@ -112,6 +112,12 @@ public class DataEnumLoader {
                 }
                 return Collections.emptyMap();
             } else if (list instanceof String) {
+
+                if (mvelSource.contains("'" + entry.getValue() + "'") && !key.contains("[")) {
+                    final String field = key.substring(key.indexOf("#") + 1);
+                    key = key + "[" + field + "]";
+                }
+
                 newMap.put(key, new String[]{(String) list});
             } else {
                 List<?> items = (List<?>) list;

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/DataEnumLoaderTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/DataEnumLoaderTest.java
@@ -15,12 +15,15 @@
  */
 package org.kie.workbench.common.services.datamodel.backend.server.builder.util;
 
+import java.util.Map;
+
 import org.junit.Test;
 import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jgroups.util.Util.assertEquals;
 import static org.jgroups.util.Util.assertFalse;
 import static org.jgroups.util.Util.assertTrue;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * DataEnumLoader tests
@@ -146,6 +149,16 @@ public class DataEnumLoaderTest {
     public void testInvalidDependentEnum_AdvancedEnum2() {
         final String e = "'Fact.field[dependentField1]' : '(new org.company.DataHelper()).getList(\"@{dependentField1}\")'";
         final DataEnumLoader loader = new DataEnumLoader(e, new RawMVELEvaluator());
+        assertFalse(loader.hasErrors());
+    }
+
+    @Test
+    public void testValidDependentEnum_AdvancedEnumForDynamic() {
+        final String e = "'Fact.field' : '(new org.company.DataHelper()).getList()'";
+        final DataEnumLoader loader = new DataEnumLoader(e, new RawMVELEvaluator());
+        Map<String, String[]> data = loader.getData();
+
+        assertTrue(data.containsKey("Fact#field[field]"));
         assertFalse(loader.hasErrors());
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3974

Without this the dropdown just shows the code that should fetch the enumeration, while the documentation states that the use of ' quotes should let you use the code in the way this PR enables.

The fix changes 
'Fact.field' : '(new org.company.DataHelper()).getList()'
to
'Fact.field[field]' : '(new org.company.DataHelper()).getList()'

This is the most simple way of getting this to work. I don't really want to touch the areas on the client side code since the unit test coverage is weak.

@jomarko @manstis I think you two are again the best to review. Thank you. Or of course happy to ping anyone else who might be able to review this.