### PR TITLE
DROOLS-3918 : The error reporting should contain information about the corresponding test scenario asset

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/actions/ProjectMainActionsViewImpl.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/actions/ProjectMainActionsViewImpl.html
@@ -1,4 +1,7 @@
 <div class="btn-group">
+    
+    <button class="btn btn-default" type="button" id="runTests" data-i18n-key="Test"></button>
+
     <div class="kie-wb-common-library-project-actions-dropdown btn-group">
         <button type="button" class="btn btn-default kie-wb-common-library-project-actions-dropdown-button" id="build" data-i18n-key="Build"></button>
         <button type="button" class="btn btn-default dropdown-toggle" id="buildCaret" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -17,8 +20,6 @@
             <li id="redeployLI"><a href="#" id="redeploy" data-i18n-key="Redeploy"></a></li>
         </ul>
     </div>
-
-    <button class="btn btn-default" type="button" id="runTests" data-i18n-key="Test"></button>
 
     <div id="alerts"></div>
 </div>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingPanel.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingPanel.java
@@ -116,6 +116,7 @@ public class TestRunnerReportingPanel
         systemMessage.setMessageType("TestResults");
         systemMessage.setLevel(Level.ERROR);
         systemMessage.setText(makeMessage(failure));
+        systemMessage.setPath(failure.getPath());
         return systemMessage;
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3918
and
https://issues.jboss.org/browse/AF-1960

https://github.com/kiegroup/appformer/pull/695
https://github.com/kiegroup/kie-wb-common/pull/2630
https://github.com/kiegroup/drools-wb/pull/1135