### PR TITLE
[DROOLS-3993] Modified KieAssetsDropdown for better/easier reusability

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/included/modal/dropdown/DMNAssetsDropdown.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/included/modal/dropdown/DMNAssetsDropdown.java
@@ -19,11 +19,11 @@ package org.kie.workbench.common.dmn.client.editors.included.modal.dropdown;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.kie.workbench.common.widgets.client.assets.dropdown.KieAssetsDropdown;
+import org.kie.workbench.common.widgets.client.assets.dropdown.SubmarineKieAssetsDropdown;
 import org.kie.workbench.common.widgets.client.submarine.IsSubmarine;
 
 @Dependent
-public class DMNAssetsDropdown extends KieAssetsDropdown {
+public class DMNAssetsDropdown extends SubmarineKieAssetsDropdown {
 
     @Inject
     public DMNAssetsDropdown(final View view,

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdown.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdown.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.assets.dropdown;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import javax.annotation.PostConstruct;
+
+import elemental2.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.uberfire.client.mvp.UberElemental;
+import org.uberfire.mvp.Command;
+
+public abstract class AbstractKieAssetsDropdown implements KieAssetsDropdown {
+
+    protected final View view;
+
+    protected final KieAssetsDropdownItemsProvider dataProvider;
+
+    protected final List<KieAssetsDropdownItem> kieAssets = new ArrayList<>();
+
+    protected Command onValueChangeHandler = () -> {/* Nothing. */};
+
+    public AbstractKieAssetsDropdown(final View view,
+                                     final KieAssetsDropdownItemsProvider dataProvider) {
+        this.view = view;
+        this.dataProvider = dataProvider;
+    }
+
+    @Override
+    @PostConstruct
+    public void init() {
+        view.init(this);
+    }
+
+    @Override
+    public void registerOnChangeHandler(final Command onChangeHandler) {
+        this.onValueChangeHandler = onChangeHandler;
+    }
+
+    @Override
+    public void loadAssets() {
+        clear();
+        initializeDropdown();
+    }
+
+    @Override
+    public void initialize() {
+        view.refreshSelectPicker();
+    }
+
+    @Override
+    public void clear() {
+        kieAssets.clear();
+        view.clear();
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return view.getElement();
+    }
+
+    @Override
+    public Optional<KieAssetsDropdownItem> getValue() {
+        String currentValue = view.getValue();
+        return  kieAssets
+                .stream()
+                .filter(kieAsset -> Objects.equals(currentValue, kieAsset.getValue()))
+                .findAny();
+    }
+
+    @Override
+    public void onValueChanged() {
+        onValueChangeHandler.execute();
+    }
+
+    @Override
+    public void initializeDropdown() {
+        dataProvider.getItems(getAssetListConsumer());
+    }
+
+    @Override
+    public void addValue(final KieAssetsDropdownItem kieAsset) {
+        kieAssets.add(kieAsset);
+        view.addValue(kieAsset);
+    }
+
+    protected Consumer<List<KieAssetsDropdownItem>> getAssetListConsumer() {
+        return this::assetListConsumerMethod;
+    }
+
+    protected void assetListConsumerMethod(List<KieAssetsDropdownItem> assetList) {
+        assetList.forEach(this::addValue);
+        view.refreshSelectPicker();
+        view.initialize();
+    }
+
+    protected List<KieAssetsDropdownItem> getKieAssets() {
+        return kieAssets;
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdown.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdown.java
@@ -25,8 +25,6 @@ import java.util.function.Consumer;
 import javax.annotation.PostConstruct;
 
 import elemental2.dom.HTMLElement;
-import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
-import org.uberfire.client.mvp.UberElemental;
 import org.uberfire.mvp.Command;
 
 public abstract class AbstractKieAssetsDropdown implements KieAssetsDropdown {
@@ -81,7 +79,7 @@ public abstract class AbstractKieAssetsDropdown implements KieAssetsDropdown {
     @Override
     public Optional<KieAssetsDropdownItem> getValue() {
         String currentValue = view.getValue();
-        return  kieAssets
+        return kieAssets
                 .stream()
                 .filter(kieAsset -> Objects.equals(currentValue, kieAsset.getValue()))
                 .findAny();

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdown.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdown.java
@@ -105,13 +105,10 @@ public abstract class AbstractKieAssetsDropdown implements KieAssetsDropdown {
         return this::assetListConsumerMethod;
     }
 
-    protected void assetListConsumerMethod(List<KieAssetsDropdownItem> assetList) {
+    protected void assetListConsumerMethod(final List<KieAssetsDropdownItem> assetList) {
         assetList.forEach(this::addValue);
         view.refreshSelectPicker();
         view.initialize();
     }
 
-    protected List<KieAssetsDropdownItem> getKieAssets() {
-        return kieAssets;
-    }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdown.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdown.java
@@ -16,119 +16,37 @@
 
 package org.kie.workbench.common.widgets.client.assets.dropdown;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
-
-import javax.annotation.PostConstruct;
 
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
-import org.kie.workbench.common.widgets.client.submarine.IsSubmarine;
 import org.uberfire.client.mvp.UberElemental;
 import org.uberfire.mvp.Command;
 
-public abstract class KieAssetsDropdown {
+public interface KieAssetsDropdown {
 
-    private final View view;
+    void init();
 
-    private final KieAssetsDropdownItemsProvider dataProvider;
+    void registerOnChangeHandler(final Command onChangeHandler);
 
-    private final IsSubmarine isSubmarine;
+    void loadAssets();
 
-    private final List<KieAssetsDropdownItem> kieAssets = new ArrayList<>();
+    void initialize();
 
-    private Command onValueChangeHandler = () -> {/* Nothing. */};
+    void clear();
 
-    public KieAssetsDropdown(final View view,
-                             final IsSubmarine isSubmarine,
-                             final KieAssetsDropdownItemsProvider dataProvider) {
-        this.view = view;
-        this.isSubmarine = isSubmarine;
-        this.dataProvider = dataProvider;
-    }
+    HTMLElement getElement();
 
-    @PostConstruct
-    public void setup() {
-        view.init(this);
-    }
+    Optional<KieAssetsDropdownItem> getValue();
 
-    public void registerOnChangeHandler(final Command onChangeHandler) {
-        this.onValueChangeHandler = onChangeHandler;
-    }
+    void onValueChanged();
 
-    public void loadAssets() {
-        clear();
+    void initializeDropdown();
 
-        if (isSubmarine.get()) {
-            initializeInput();
-        } else {
-            initializeDropdown();
-        }
-    }
+    void addValue(final KieAssetsDropdownItem kieAsset);
 
-    public void initialize() {
-        if (!isSubmarine.get()) {
-            view.refreshSelectPicker();
-        }
-    }
-
-    public void clear() {
-        getKieAssets().clear();
-        view.clear();
-    }
-
-    private void initializeInput() {
-        view.enableInputMode();
-        view.initialize();
-    }
-
-    private void initializeDropdown() {
-        view.enableDropdownMode();
-        dataProvider.getItems(getAssetListConsumer());
-    }
-
-    Consumer<List<KieAssetsDropdownItem>> getAssetListConsumer() {
-        return assetList -> {
-            assetList.forEach(this::addValue);
-            view.refreshSelectPicker();
-            view.initialize();
-        };
-    }
-
-    private void addValue(final KieAssetsDropdownItem kieAsset) {
-        getKieAssets().add(kieAsset);
-        view.addValue(kieAsset);
-    }
-
-    public HTMLElement getElement() {
-        return view.getElement();
-    }
-
-    public Optional<KieAssetsDropdownItem> getValue() {
-        if (isSubmarine.get()) {
-            return Optional.of(new KieAssetsDropdownItem("", "", view.getValue(), new HashMap<>()));
-        } else {
-            return getKieAssets()
-                    .stream()
-                    .filter(kieAsset -> Objects.equals(view.getValue(), kieAsset.getValue()))
-                    .findAny();
-        }
-    }
-
-    List<KieAssetsDropdownItem> getKieAssets() {
-        return kieAssets;
-    }
-
-    void onValueChanged() {
-        onValueChangeHandler.execute();
-    }
-
-    public interface View extends UberElemental<KieAssetsDropdown>,
-                                  IsElement {
+    interface View extends UberElemental<KieAssetsDropdown>,
+                           IsElement {
 
         void clear();
 
@@ -139,9 +57,5 @@ public abstract class KieAssetsDropdown {
         void initialize();
 
         String getValue();
-
-        void enableInputMode();
-
-        void enableDropdownMode();
     }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownView.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownView.html
@@ -16,6 +16,6 @@
 
 <div>
     <label>
-        <select data-field="native-select" class="selectpicker"></select>
+        <select class="selectpicker" data-field="native-select"></select>
     </label>
 </div>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownView.java
@@ -38,16 +38,11 @@ public class KieAssetsDropdownView implements KieAssetsDropdown.View {
     public static final String HIDDEN_CSS_CLASS = "hidden";
 
     public static final String SELECT_PICKER_SUBTEXT_ATTRIBUTE = "data-subtext";
-
-    protected KieAssetsDropdown presenter;
-
     @DataField("native-select")
     protected final HTMLSelectElement nativeSelect;
-
     protected final HTMLOptionElement htmlOptionElement;
-
     protected final TranslationService translationService;
-
+    protected KieAssetsDropdown presenter;
 
     @Inject
     public KieAssetsDropdownView(final HTMLSelectElement nativeSelect,

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownView.java
@@ -20,17 +20,14 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.event.dom.client.KeyUpEvent;
 import elemental2.dom.Element;
-import elemental2.dom.HTMLInputElement;
 import elemental2.dom.HTMLOptionElement;
 import elemental2.dom.HTMLSelectElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
-import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker;
-import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker.CallbackFunction;
+import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerEvent;
 
 import static org.kie.workbench.common.widgets.client.resources.i18n.KieWorkbenchWidgetsConstants.KieAssetsDropdownView_Select;
 
@@ -38,29 +35,25 @@ import static org.kie.workbench.common.widgets.client.resources.i18n.KieWorkbenc
 @Templated
 public class KieAssetsDropdownView implements KieAssetsDropdown.View {
 
-    static final String HIDDEN_CSS_CLASS = "hidden";
+    public static final String HIDDEN_CSS_CLASS = "hidden";
 
-    static final String SELECT_PICKER_SUBTEXT_ATTRIBUTE = "data-subtext";
+    public static final String SELECT_PICKER_SUBTEXT_ATTRIBUTE = "data-subtext";
+
+    protected KieAssetsDropdown presenter;
 
     @DataField("native-select")
-    private final HTMLSelectElement nativeSelect;
+    protected final HTMLSelectElement nativeSelect;
 
-    @DataField("fallback-input")
-    private final HTMLInputElement fallbackInput;
+    protected final HTMLOptionElement htmlOptionElement;
 
-    private final HTMLOptionElement htmlOptionElement;
+    protected final TranslationService translationService;
 
-    private final TranslationService translationService;
-
-    private KieAssetsDropdown presenter;
 
     @Inject
     public KieAssetsDropdownView(final HTMLSelectElement nativeSelect,
-                                 final HTMLInputElement fallbackInput,
                                  final HTMLOptionElement htmlOptionElement,
                                  final TranslationService translationService) {
         this.nativeSelect = nativeSelect;
-        this.fallbackInput = fallbackInput;
         this.htmlOptionElement = htmlOptionElement;
         this.translationService = translationService;
     }
@@ -73,15 +66,7 @@ public class KieAssetsDropdownView implements KieAssetsDropdown.View {
     @PostConstruct
     public void init() {
         nativeSelect.hidden = false;
-        fallbackInput.hidden = true;
         dropdown().on("hidden.bs.select", getOnDropdownChangeHandler());
-    }
-
-    CallbackFunction getOnDropdownChangeHandler() {
-        return event -> {
-            fallbackInput.value = event.target.value;
-            presenter.onValueChanged();
-        };
     }
 
     @Override
@@ -98,8 +83,8 @@ public class KieAssetsDropdownView implements KieAssetsDropdown.View {
 
     @Override
     public void initialize() {
-        fallbackInput.value = "";
         dropdown().selectpicker("val", "");
+        dropdown().selectpicker("show");
     }
 
     @Override
@@ -109,56 +94,42 @@ public class KieAssetsDropdownView implements KieAssetsDropdown.View {
 
     @Override
     public String getValue() {
-        return fallbackInput.value;
+        return dropdown().val();
     }
 
-    @Override
-    public void enableInputMode() {
-        nativeSelect.classList.add(HIDDEN_CSS_CLASS);
-        fallbackInput.classList.remove(HIDDEN_CSS_CLASS);
-        dropdown().selectpicker("hide");
+    protected JQuerySelectPicker.CallbackFunction getOnDropdownChangeHandler() {
+        return this::onDropdownChangeHandlerMethod;
     }
 
-    @Override
-    public void enableDropdownMode() {
-        fallbackInput.classList.add(HIDDEN_CSS_CLASS);
-        nativeSelect.classList.remove(HIDDEN_CSS_CLASS);
-        dropdown().selectpicker("show");
-    }
-
-    @EventHandler("fallback-input")
-    public void onFallbackInputChange(final KeyUpEvent e) {
+    protected void onDropdownChangeHandlerMethod(JQuerySelectPickerEvent event) {
         presenter.onValueChanged();
     }
 
-    HTMLOptionElement selectOption() {
+    protected HTMLOptionElement selectOption() {
         final HTMLOptionElement option = makeHTMLOptionElement();
         option.text = translationService.format(KieAssetsDropdownView_Select);
         option.value = "";
         return option;
     }
 
-    private HTMLOptionElement entryOption(final KieAssetsDropdownItem entry) {
-
-        final HTMLOptionElement option = makeHTMLOptionElement();
-
-        option.text = entry.getText();
-        option.value = entry.getValue();
-        option.setAttribute(SELECT_PICKER_SUBTEXT_ATTRIBUTE, entry.getSubText());
-
-        return option;
-    }
-
-    HTMLOptionElement makeHTMLOptionElement() {
+    protected HTMLOptionElement makeHTMLOptionElement() {
         // This is a workaround for an issue on Errai (ERRAI-1114) related to 'ManagedInstance' + 'HTMLOptionElement'.
         return (HTMLOptionElement) htmlOptionElement.cloneNode(false);
     }
 
-    JQuerySelectPicker dropdown() {
+    protected JQuerySelectPicker dropdown() {
         return JQuerySelectPicker.$(nativeSelect);
     }
 
-    private void removeChildren(final Element element) {
+    protected HTMLOptionElement entryOption(final KieAssetsDropdownItem entry) {
+        final HTMLOptionElement option = makeHTMLOptionElement();
+        option.text = entry.getText();
+        option.value = entry.getValue();
+        option.setAttribute(SELECT_PICKER_SUBTEXT_ATTRIBUTE, entry.getSubText());
+        return option;
+    }
+
+    protected void removeChildren(final Element element) {
         while (element.firstChild != null) {
             element.removeChild(element.firstChild);
         }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdown.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdown.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.assets.dropdown;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.kie.workbench.common.widgets.client.submarine.IsSubmarine;
+
+public abstract class SubmarineKieAssetsDropdown extends AbstractKieAssetsDropdown {
+
+    protected final IsSubmarine isSubmarine;
+
+
+    public SubmarineKieAssetsDropdown(final SubmarineKieAssetsDropdown.View view,
+                                      final IsSubmarine isSubmarine,
+                                      final KieAssetsDropdownItemsProvider dataProvider) {
+        super(view, dataProvider);
+        this.isSubmarine = isSubmarine;
+    }
+
+    @Override
+    public void loadAssets() {
+        if (isSubmarine.get()) {
+            clear();
+            initializeInput();
+        } else {
+           super.loadAssets();
+        }
+    }
+
+    @Override
+    public void initialize() {
+        if (!isSubmarine.get()) {
+            super.initialize();
+        }
+    }
+
+    @Override
+    public void initializeDropdown() {
+        ((SubmarineKieAssetsDropdown.View)view).enableDropdownMode();
+        super.initializeDropdown();
+    }
+
+    protected void initializeInput() {
+        ((SubmarineKieAssetsDropdown.View)view).enableInputMode();
+        view.initialize();
+    }
+
+    @Override
+    public Optional<KieAssetsDropdownItem> getValue() {
+        if (isSubmarine.get()) {
+            return Optional.of(new KieAssetsDropdownItem("", "", view.getValue(), new HashMap<>()));
+        } else {
+            return super.getValue();
+        }
+    }
+
+    public interface View extends AbstractKieAssetsDropdown.View, IsElement {
+
+        void enableInputMode();
+
+        void enableDropdownMode();
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdown.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdown.java
@@ -26,7 +26,6 @@ public abstract class SubmarineKieAssetsDropdown extends AbstractKieAssetsDropdo
 
     protected final IsSubmarine isSubmarine;
 
-
     public SubmarineKieAssetsDropdown(final SubmarineKieAssetsDropdown.View view,
                                       final IsSubmarine isSubmarine,
                                       final KieAssetsDropdownItemsProvider dataProvider) {
@@ -40,7 +39,7 @@ public abstract class SubmarineKieAssetsDropdown extends AbstractKieAssetsDropdo
             clear();
             initializeInput();
         } else {
-           super.loadAssets();
+            super.loadAssets();
         }
     }
 
@@ -53,12 +52,12 @@ public abstract class SubmarineKieAssetsDropdown extends AbstractKieAssetsDropdo
 
     @Override
     public void initializeDropdown() {
-        ((SubmarineKieAssetsDropdown.View)view).enableDropdownMode();
+        ((SubmarineKieAssetsDropdown.View) view).enableDropdownMode();
         super.initializeDropdown();
     }
 
     protected void initializeInput() {
-        ((SubmarineKieAssetsDropdown.View)view).enableInputMode();
+        ((SubmarineKieAssetsDropdown.View) view).enableInputMode();
         view.initialize();
     }
 
@@ -71,7 +70,8 @@ public abstract class SubmarineKieAssetsDropdown extends AbstractKieAssetsDropdo
         }
     }
 
-    public interface View extends AbstractKieAssetsDropdown.View, IsElement {
+    public interface View extends AbstractKieAssetsDropdown.View,
+                                  IsElement {
 
         void enableInputMode();
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.html
@@ -17,5 +17,6 @@
 <div>
     <label>
         <select data-field="native-select" class="selectpicker"></select>
+        <input data-field="fallback-input" type="text" class="form-control"/>
     </label>
 </div>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.html
@@ -16,7 +16,7 @@
 
 <div>
     <label>
-        <select data-field="native-select" class="selectpicker"></select>
-        <input data-field="fallback-input" type="text" class="form-control"/>
+        <select class="selectpicker" data-field="native-select"></select>
+        <input class="form-control" data-field="fallback-input" type="text"/>
     </label>
 </div>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.assets.dropdown;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import elemental2.dom.HTMLInputElement;
+import elemental2.dom.HTMLOptionElement;
+import elemental2.dom.HTMLSelectElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerEvent;
+
+@Dependent
+@Templated
+public class SubmarineKieAssetsDropdownView extends KieAssetsDropdownView implements SubmarineKieAssetsDropdown.View {
+
+    @DataField("fallback-input")
+    protected final HTMLInputElement fallbackInput;
+
+    @Inject
+    public SubmarineKieAssetsDropdownView(final HTMLSelectElement nativeSelect,
+                                          final HTMLInputElement fallbackInput,
+                                          final HTMLOptionElement htmlOptionElement,
+                                          final TranslationService translationService) {
+        super(nativeSelect, htmlOptionElement, translationService);
+        this.fallbackInput = fallbackInput;
+    }
+
+    @PostConstruct
+    public void init() {
+        super.init();
+        fallbackInput.hidden = true;
+    }
+
+    @Override
+    public void initialize() {
+        fallbackInput.value = "";
+        dropdown().selectpicker("val", "");
+    }
+
+    @Override
+    public String getValue() {
+        return fallbackInput.value;
+    }
+
+    @Override
+    public void enableInputMode() {
+        nativeSelect.classList.add(HIDDEN_CSS_CLASS);
+        fallbackInput.classList.remove(HIDDEN_CSS_CLASS);
+        dropdown().selectpicker("hide");
+    }
+
+    @Override
+    public void enableDropdownMode() {
+        fallbackInput.classList.add(HIDDEN_CSS_CLASS);
+        nativeSelect.classList.remove(HIDDEN_CSS_CLASS);
+        dropdown().selectpicker("show");
+    }
+
+    @EventHandler("fallback-input")
+    public void onFallbackInputChange(final KeyUpEvent e) {
+        presenter.onValueChanged();
+    }
+
+    @Override
+    protected void onDropdownChangeHandlerMethod(JQuerySelectPickerEvent event) {
+        fallbackInput.value = event.target.value;
+        super.onDropdownChangeHandlerMethod(event);
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.java
@@ -87,5 +87,4 @@ public class SubmarineKieAssetsDropdownView extends KieAssetsDropdownView implem
         fallbackInput.value = event.target.value;
         super.onDropdownChangeHandlerMethod(event);
     }
-
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.less
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownView.less
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+[data-i18n-prefix="SubmarineKieAssetsDropdownView."] {
+
+  label,
+  .bootstrap-select,
+  .bootstrap-select:not([class*=col-]):not([class*=form-control]):not(.input-group-btn) {
+    width: 100%;
+    margin: 0;
+  }
+
+  .bootstrap-select {
+    .dropdown-menu {
+      .text {
+        font-weight: 600;
+      }
+
+      .text-muted,
+      .disabled .text {
+        font-weight: normal;
+      }
+    }
+  }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractDropdownTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.widgets.client.assets.dropdown;
+
+import elemental2.dom.HTMLElement;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractDropdownTest {
+
+
+    protected final static String KIEASSETSDROPDOWNVIEW_SELECT = "KIEASSETSDROPDOWNVIEW_SELECT";
+    protected final static String DEFAULT_VALUE = "DEFAULT_VALUE";
+
+
+    @Mock
+    protected HTMLElement htmlElementMock;
+
+    @Mock
+    protected KieAssetsDropdownItem kieAssetsDropdownItemMock;
+
+    protected KieAssetsDropdown dropdown;
+
+    protected KieAssetsDropdown.View viewMock;
+
+
+
+    protected void commonSetup() {
+        when(viewMock.getElement()).thenReturn(htmlElementMock);
+        when(viewMock.getValue()).thenReturn(DEFAULT_VALUE);
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractDropdownTest.java
@@ -22,10 +22,8 @@ import static org.mockito.Mockito.when;
 
 public abstract class AbstractDropdownTest {
 
-
     protected final static String KIEASSETSDROPDOWNVIEW_SELECT = "KIEASSETSDROPDOWNVIEW_SELECT";
     protected final static String DEFAULT_VALUE = "DEFAULT_VALUE";
-
 
     @Mock
     protected HTMLElement htmlElementMock;
@@ -33,15 +31,12 @@ public abstract class AbstractDropdownTest {
     @Mock
     protected KieAssetsDropdownItem kieAssetsDropdownItemMock;
 
-    protected KieAssetsDropdown dropdown;
-
-    protected KieAssetsDropdown.View viewMock;
-
-
-
     protected void commonSetup() {
-        when(viewMock.getElement()).thenReturn(htmlElementMock);
-        when(viewMock.getValue()).thenReturn(DEFAULT_VALUE);
+        when(getViewMock().getElement()).thenReturn(htmlElementMock);
+        when(getViewMock().getValue()).thenReturn(DEFAULT_VALUE);
     }
 
+    protected abstract KieAssetsDropdown.View getViewMock();
+
+    protected abstract KieAssetsDropdown getDropdown();
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdownTest.java
@@ -52,7 +52,6 @@ public class AbstractKieAssetsDropdownTest extends AbstractDropdownTest {
     @Mock
     protected Command onValueChangeHandlerMock;
 
-
     protected List<KieAssetsDropdownItem> assetList = IntStream.range(0, 3)
             .mapToObj(i -> new KieAssetsDropdownItem("File_" + i + ".txt", "", DEFAULT_VALUE, new HashMap<>()))
             .collect(Collectors.toList());
@@ -60,10 +59,12 @@ public class AbstractKieAssetsDropdownTest extends AbstractDropdownTest {
     @Mock
     private KieAssetsDropdownView viewlocalMock;
 
+    @Mock
+    private KieAssetsDropdown dropdownLocal;
+
     @Before
     public void setup() {
-        viewMock = viewlocalMock;
-        dropdown = spy(new AbstractKieAssetsDropdown(viewMock, dataProviderMock) {
+        dropdownLocal = spy(new AbstractKieAssetsDropdown(getViewMock(), dataProviderMock) {
             {
                 onValueChangeHandler = onValueChangeHandlerMock;
                 this.kieAssets.addAll(assetList);
@@ -74,74 +75,84 @@ public class AbstractKieAssetsDropdownTest extends AbstractDropdownTest {
 
     @Test
     public void init() {
-        dropdown.init();
-        verify(viewMock, times(1)).init(eq(dropdown));
+        getDropdown().init();
+        verify(getViewMock(), times(1)).init(eq(getDropdown()));
     }
 
     @Test
     public void loadAssets() {
-        dropdown.loadAssets();
-        verify(dropdown, times(1)).clear();
-        verify(dropdown, times(1)).initializeDropdown();
+        getDropdown().loadAssets();
+        verify(getDropdown(), times(1)).clear();
+        verify(getDropdown(), times(1)).initializeDropdown();
     }
 
     @Test
     public void initialize() {
-        dropdown.initialize();
-        verify(viewMock, times(1)).refreshSelectPicker();
+        getDropdown().initialize();
+        verify(getViewMock(), times(1)).refreshSelectPicker();
     }
 
     @Test
     public void clear() {
-        dropdown.clear();
-        verify(viewMock, times(1)).clear();
+        getDropdown().clear();
+        verify(getViewMock(), times(1)).clear();
     }
 
     @Test
     public void getElement() {
-        final HTMLElement retrieved = dropdown.getElement();
-        verify(viewMock, times(1)).getElement();
+        final HTMLElement retrieved = getDropdown().getElement();
+        verify(getViewMock(), times(1)).getElement();
         assertEquals(htmlElementMock, retrieved);
     }
 
     @Test
     public void getValue() {
-        when(viewMock.getValue()).thenReturn(DEFAULT_VALUE);
-        Optional<KieAssetsDropdownItem> retrieved = dropdown.getValue();
+        when(getViewMock().getValue()).thenReturn(DEFAULT_VALUE);
+        Optional<KieAssetsDropdownItem> retrieved = getDropdown().getValue();
         assertNotNull(retrieved);
         assertTrue(retrieved.isPresent());
-        verify(viewMock, times(1)).getValue();
-        reset(viewMock);
-        when(viewMock.getValue()).thenReturn("UNKNOWN");
-        retrieved = dropdown.getValue();
+        verify(getViewMock(), times(1)).getValue();
+        reset(getViewMock());
+        when(getViewMock().getValue()).thenReturn("UNKNOWN");
+        retrieved = getDropdown().getValue();
         assertNotNull(retrieved);
         assertFalse(retrieved.isPresent());
     }
 
     @Test
     public void assetListConsumerMethod() {
-        ((AbstractKieAssetsDropdown) dropdown).assetListConsumerMethod(assetList);
+        ((AbstractKieAssetsDropdown) getDropdown()).assetListConsumerMethod(assetList);
         assetList.forEach(asset ->
-                                  verify(dropdown, times(1)).addValue(eq(asset)));
-        verify(viewMock, times(1)).refreshSelectPicker();
-        verify(viewMock, times(1)).initialize();
+                                  verify(getDropdown(), times(1)).addValue(eq(asset)));
+        verify(getViewMock(), times(1)).refreshSelectPicker();
+        verify(getViewMock(), times(1)).initialize();
     }
 
     @Test
     public void onValueChanged() {
-        dropdown.onValueChanged();
+        getDropdown().onValueChanged();
         verify(onValueChangeHandlerMock, times(1)).execute();
     }
 
     @Test
     public void initializeDropdown() {
-        dropdown.initializeDropdown();
+        getDropdown().initializeDropdown();
         verify(dataProviderMock, times(1)).getItems(isA(Consumer.class));
     }
 
     @Test
     public void addValue() {
-        dropdown.addValue(kieAssetsDropdownItemMock);
-        verify(viewMock, times(1)).addValue(eq(kieAssetsDropdownItemMock));
+        getDropdown().addValue(kieAssetsDropdownItemMock);
+        verify(getViewMock(), times(1)).addValue(eq(kieAssetsDropdownItemMock));
+    }
+
+    @Override
+    protected KieAssetsDropdown getDropdown() {
+        return dropdownLocal;
+    }
+
+    @Override
+    protected KieAssetsDropdown.View getViewMock() {
+        return viewlocalMock;
     }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdownTest.java
@@ -59,7 +59,6 @@ public class AbstractKieAssetsDropdownTest extends AbstractDropdownTest {
     @Mock
     private KieAssetsDropdownView viewlocalMock;
 
-    @Mock
     private KieAssetsDropdown dropdownLocal;
 
     @Before

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/AbstractKieAssetsDropdownTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.assets.dropdown;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class AbstractKieAssetsDropdownTest extends AbstractDropdownTest {
+
+    @Mock
+    protected KieAssetsDropdownItemsProvider dataProviderMock;
+
+    @Mock
+    protected Command onValueChangeHandlerMock;
+
+
+    protected List<KieAssetsDropdownItem> assetList = IntStream.range(0, 3)
+            .mapToObj(i -> new KieAssetsDropdownItem("File_" + i + ".txt", "", DEFAULT_VALUE, new HashMap<>()))
+            .collect(Collectors.toList());
+
+    @Mock
+    private KieAssetsDropdownView viewlocalMock;
+
+    @Before
+    public void setup() {
+        viewMock = viewlocalMock;
+        dropdown = spy(new AbstractKieAssetsDropdown(viewMock, dataProviderMock) {
+            {
+                onValueChangeHandler = onValueChangeHandlerMock;
+                this.kieAssets.addAll(assetList);
+            }
+        });
+        commonSetup();
+    }
+
+    @Test
+    public void init() {
+        dropdown.init();
+        verify(viewMock, times(1)).init(eq(dropdown));
+    }
+
+    @Test
+    public void loadAssets() {
+        dropdown.loadAssets();
+        verify(dropdown, times(1)).clear();
+        verify(dropdown, times(1)).initializeDropdown();
+    }
+
+    @Test
+    public void initialize() {
+        dropdown.initialize();
+        verify(viewMock, times(1)).refreshSelectPicker();
+    }
+
+    @Test
+    public void clear() {
+        dropdown.clear();
+        verify(viewMock, times(1)).clear();
+    }
+
+    @Test
+    public void getElement() {
+        final HTMLElement retrieved = dropdown.getElement();
+        verify(viewMock, times(1)).getElement();
+        assertEquals(htmlElementMock, retrieved);
+    }
+
+    @Test
+    public void getValue() {
+        when(viewMock.getValue()).thenReturn(DEFAULT_VALUE);
+        Optional<KieAssetsDropdownItem> retrieved = dropdown.getValue();
+        assertNotNull(retrieved);
+        assertTrue(retrieved.isPresent());
+        verify(viewMock, times(1)).getValue();
+        reset(viewMock);
+        when(viewMock.getValue()).thenReturn("UNKNOWN");
+        retrieved = dropdown.getValue();
+        assertNotNull(retrieved);
+        assertFalse(retrieved.isPresent());
+    }
+
+    @Test
+    public void assetListConsumerMethod() {
+        ((AbstractKieAssetsDropdown) dropdown).assetListConsumerMethod(assetList);
+        assetList.forEach(asset ->
+                                  verify(dropdown, times(1)).addValue(eq(asset)));
+        verify(viewMock, times(1)).refreshSelectPicker();
+        verify(viewMock, times(1)).initialize();
+    }
+
+    @Test
+    public void onValueChanged() {
+        dropdown.onValueChanged();
+        verify(onValueChangeHandlerMock, times(1)).execute();
+    }
+
+    @Test
+    public void initializeDropdown() {
+        dropdown.initializeDropdown();
+        verify(dataProviderMock, times(1)).getItems(isA(Consumer.class));
+    }
+
+    @Test
+    public void addValue() {
+        dropdown.addValue(kieAssetsDropdownItemMock);
+        verify(viewMock, times(1)).addValue(eq(kieAssetsDropdownItemMock));
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownViewTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,212 +16,158 @@
 
 package org.kie.workbench.common.widgets.client.assets.dropdown;
 
-import java.util.Map;
-
-import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.DOMTokenList;
-import elemental2.dom.HTMLInputElement;
 import elemental2.dom.HTMLOptionElement;
 import elemental2.dom.HTMLSelectElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.soup.commons.util.Maps;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker;
-import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker.CallbackFunction;
 import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerEvent;
 import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerTarget;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.kie.workbench.common.widgets.client.assets.dropdown.KieAssetsDropdownView.HIDDEN_CSS_CLASS;
-import static org.kie.workbench.common.widgets.client.assets.dropdown.KieAssetsDropdownView.SELECT_PICKER_SUBTEXT_ATTRIBUTE;
 import static org.kie.workbench.common.widgets.client.resources.i18n.KieWorkbenchWidgetsConstants.KieAssetsDropdownView_Select;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class KieAssetsDropdownViewTest {
+public class KieAssetsDropdownViewTest extends AbstractDropdownTest {
 
     @Mock
-    private HTMLSelectElement nativeSelect;
+    private HTMLSelectElement nativeSelectMock;
 
     @Mock
-    private HTMLInputElement fallbackInput;
+    private DOMTokenList nativeSelectClassListMock;
 
     @Mock
-    private HTMLOptionElement htmlOptionElement;
+    private HTMLOptionElement htmlOptionElementMock;
 
     @Mock
-    private KieAssetsDropdown presenter;
+    private HTMLOptionElement htmlOptionElementClonedMock;
 
     @Mock
-    private JQuerySelectPicker dropdown;
+    private TranslationService translationServiceMock;
 
     @Mock
-    private TranslationService translationService;
+    private AbstractKieAssetsDropdown presenterMock;
 
-    private KieAssetsDropdownView view;
+    @Mock
+    private JQuerySelectPicker dropdownMock;
+
+    @Mock
+    private JQuerySelectPicker.CallbackFunction onDropdownChangeHandlerMock;
+
+    @Mock
+    private HTMLOptionElement entryOptionMock;
+
+    @Mock
+    private HTMLOptionElement selectOptionMock;
+
+    private KieAssetsDropdownView kieAssetsDropdownView;
 
     @Before
     public void setup() {
+        when(dropdownMock.val()).thenReturn(DEFAULT_VALUE);
+        nativeSelectMock.classList = nativeSelectClassListMock;
+        when(htmlOptionElementMock.cloneNode(eq(false))).thenReturn(htmlOptionElementClonedMock);
+        when(translationServiceMock.format(eq(KieAssetsDropdownView_Select))).thenReturn(KIEASSETSDROPDOWNVIEW_SELECT);
+        kieAssetsDropdownView = spy(new KieAssetsDropdownView(nativeSelectMock,
+                                                              htmlOptionElementMock,
+                                                              translationServiceMock) {
+            {
+                this.presenter = presenterMock;
+            }
 
-        view = Mockito.spy(new KieAssetsDropdownView(nativeSelect, fallbackInput, htmlOptionElement, translationService));
-        view.init(presenter);
+            @Override
+            protected JQuerySelectPicker dropdown() {
+                return dropdownMock;
+            }
 
-        doReturn(dropdown).when(view).dropdown();
-    }
+            @Override
+            protected JQuerySelectPicker.CallbackFunction getOnDropdownChangeHandler() {
+                return onDropdownChangeHandlerMock;
+            }
 
-    @Test
-    public void testInit() {
-
-        final CallbackFunction callbackFunction = mock(CallbackFunction.class);
-        doReturn(callbackFunction).when(view).getOnDropdownChangeHandler();
-
-        view.init();
-
-        assertFalse(nativeSelect.hidden);
-        assertTrue(fallbackInput.hidden);
-        verify(dropdown).on("hidden.bs.select", callbackFunction);
-    }
-
-    @Test
-    public void testGetOnDropdownChangeHandler() {
-
-        final JQuerySelectPickerEvent event = mock(JQuerySelectPickerEvent.class);
-        final JQuerySelectPickerTarget target = mock(JQuerySelectPickerTarget.class);
-        final String expectedValue = "newValue";
-
-        fallbackInput.value = "something";
-        event.target = target;
-        target.value = expectedValue;
-
-        view.getOnDropdownChangeHandler().call(event);
-
-        final String actualValue = event.target.value;
-
-        assertEquals(expectedValue, actualValue);
-        verify(presenter).onValueChanged();
-    }
-
-    @Test
-    public void testAddValue() {
-
-        final HTMLOptionElement optionElement = mock(HTMLOptionElement.class);
-        final KieAssetsDropdownItem entry = new KieAssetsDropdownItem("text", "subtext", "value", getMetaData());
-
-        doReturn(optionElement).when(view).makeHTMLOptionElement();
-
-        view.addValue(entry);
-
-        assertEquals("text", optionElement.text);
-        assertEquals("value", optionElement.value);
-        verify(optionElement).setAttribute(SELECT_PICKER_SUBTEXT_ATTRIBUTE, "subtext");
-        verify(nativeSelect).appendChild(optionElement);
-    }
-
-    @Test
-    public void testClear() {
-
-        final HTMLOptionElement oldOptionElement = mock(HTMLOptionElement.class);
-        final HTMLOptionElement newOptionElement = mock(HTMLOptionElement.class);
-        nativeSelect.firstChild = oldOptionElement;
-
-        doReturn(newOptionElement).when(view).selectOption();
-        when(nativeSelect.removeChild(oldOptionElement)).then(a -> {
-            nativeSelect.firstChild = null;
-            return oldOptionElement;
+            @Override
+            protected HTMLOptionElement entryOption(KieAssetsDropdownItem entry) {
+                return entryOptionMock;
+            }
         });
-
-        view.clear();
-
-        verify(nativeSelect).removeChild(oldOptionElement);
-        verify(nativeSelect).appendChild(newOptionElement);
-        verify(view).refreshSelectPicker();
     }
 
     @Test
-    public void testSelectOption() {
-
-        final String select = "Select";
-
-        doReturn(mock(HTMLOptionElement.class)).when(view).makeHTMLOptionElement();
-        when(translationService.format(KieAssetsDropdownView_Select)).thenReturn(select);
-
-        final HTMLOptionElement optionElement = view.selectOption();
-
-        assertEquals(select, optionElement.text);
-        assertEquals("", optionElement.value);
+    public void init() {
+        kieAssetsDropdownView.init();
+        assertFalse(nativeSelectMock.hidden);
+        verify(kieAssetsDropdownView, times(1)).dropdown();
+        verify(kieAssetsDropdownView, times(1)).getOnDropdownChangeHandler();
+        verify(dropdownMock, times(1)).on(eq("hidden.bs.select"), eq(onDropdownChangeHandlerMock));
     }
 
     @Test
-    public void testInitialize() {
-
-        fallbackInput.value = "something";
-
-        view.initialize();
-
-        assertEquals("", fallbackInput.value);
-        verify(dropdown).selectpicker("val", "");
+    public void addValue() {
+        kieAssetsDropdownView.addValue(kieAssetsDropdownItemMock);
+        verify(kieAssetsDropdownView, times(1)).entryOption(eq(kieAssetsDropdownItemMock));
+        verify(nativeSelectMock, times(1)).appendChild(eq(entryOptionMock));
     }
 
     @Test
-    public void testRefreshSelectPicker() {
-        view.refreshSelectPicker();
-        verify(dropdown).selectpicker("refresh");
+    public void clear() {
+        doReturn(selectOptionMock).when(kieAssetsDropdownView).selectOption();
+        kieAssetsDropdownView.clear();
+        verify(kieAssetsDropdownView, times(1)).removeChildren(eq(nativeSelectMock));
+        verify(kieAssetsDropdownView, times(1)).selectOption();
+        verify(nativeSelectMock, times(1)).appendChild(eq(selectOptionMock));
+        verify(kieAssetsDropdownView, times(1)).refreshSelectPicker();
     }
 
     @Test
-    public void testGetValue() {
-
-        final String expected = "value";
-        fallbackInput.value = expected;
-
-        final String actual = view.getValue();
-
-        assertEquals(expected, actual);
+    public void initialize() {
+        kieAssetsDropdownView.initialize();
+        verify(kieAssetsDropdownView, times(2)).dropdown();
+        verify(dropdownMock, times(1)).selectpicker(eq("val"), eq(""));
     }
 
     @Test
-    public void testEnableInputMode() {
-
-        nativeSelect.classList = mock(DOMTokenList.class);
-        fallbackInput.classList = mock(DOMTokenList.class);
-
-        view.enableInputMode();
-
-        verify(nativeSelect.classList).add(HIDDEN_CSS_CLASS);
-        verify(fallbackInput.classList).remove(HIDDEN_CSS_CLASS);
-        verify(dropdown).selectpicker("hide");
+    public void refreshSelectPicker() {
+        kieAssetsDropdownView.refreshSelectPicker();
+        verify(kieAssetsDropdownView, times(1)).dropdown();
+        verify(dropdownMock, times(1)).selectpicker(eq("refresh"));
     }
 
     @Test
-    public void testEnableDropdownMode() {
-
-        nativeSelect.classList = mock(DOMTokenList.class);
-        fallbackInput.classList = mock(DOMTokenList.class);
-
-        view.enableDropdownMode();
-
-        verify(fallbackInput.classList).add(HIDDEN_CSS_CLASS);
-        verify(nativeSelect.classList).remove(HIDDEN_CSS_CLASS);
-        verify(dropdown).selectpicker("show");
+    public void getValue() {
+        assertEquals(DEFAULT_VALUE, kieAssetsDropdownView.getValue());
+        verify(dropdownMock, times(1)).val();
     }
 
     @Test
-    public void testOnFallbackInputChange() {
-        view.onFallbackInputChange(mock(KeyUpEvent.class));
-        verify(presenter).onValueChanged();
+    public void selectOption() {
+        final HTMLOptionElement retrieved = kieAssetsDropdownView.selectOption();
+        assertNotNull(retrieved);
+        assertEquals(KIEASSETSDROPDOWNVIEW_SELECT, retrieved.text);
+        assertEquals("", retrieved.value);
     }
 
-    private Map<String, String> getMetaData() {
-        return new Maps.Builder<String, String>().put("foo", "bar").build();
+    @Test
+    public void onDropdownChangeHandlerMethod() {
+        JQuerySelectPickerTarget targetMock = mock(JQuerySelectPickerTarget.class);
+        targetMock.value = DEFAULT_VALUE;
+        JQuerySelectPickerEvent eventMock = mock(JQuerySelectPickerEvent.class);
+        eventMock.target = targetMock;
+        kieAssetsDropdownView.onDropdownChangeHandlerMethod(eventMock);
+        verify(presenterMock, times(1)).onValueChanged();
     }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownViewTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/KieAssetsDropdownViewTest.java
@@ -32,7 +32,6 @@ import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerTarget;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.widgets.client.resources.i18n.KieWorkbenchWidgetsConstants.KieAssetsDropdownView_Select;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -169,5 +168,15 @@ public class KieAssetsDropdownViewTest extends AbstractDropdownTest {
         eventMock.target = targetMock;
         kieAssetsDropdownView.onDropdownChangeHandlerMethod(eventMock);
         verify(presenterMock, times(1)).onValueChanged();
+    }
+
+    @Override
+    protected KieAssetsDropdown getDropdown() {
+        return null;
+    }
+
+    @Override
+    protected KieAssetsDropdown.View getViewMock() {
+        return kieAssetsDropdownView;
     }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownTest.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLElement;
@@ -30,45 +32,44 @@ import org.kie.workbench.common.widgets.client.submarine.IsSubmarine;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class KieAssetsDropdownTest {
+public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTest {
 
-    @Mock
-    private KieAssetsDropdown.View view;
 
     @Mock
     private IsSubmarine isSubmarine;
 
     @Mock
-    private KieAssetsDropdownItemsProvider dataProvider;
-
-    @Mock
     private Consumer<List<KieAssetsDropdownItem>> kieAssetsConsumer;
 
-    private KieAssetsDropdownFake dropdown;
+    @Mock
+    private SubmarineKieAssetsDropdownView viewlocalMock;
+
 
     @Before
     public void setup() {
-        dropdown = spy(new KieAssetsDropdownFake(view, isSubmarine, dataProvider));
+        viewMock = viewlocalMock;
         when(isSubmarine.get()).thenReturn(false);
-    }
-
-    @Test
-    public void testSetup() {
-        dropdown.setup();
-        verify(view).init(dropdown);
+        dropdown = spy(new SubmarineKieAssetsDropdown(viewlocalMock, isSubmarine, dataProviderMock) {
+            {
+                onValueChangeHandler = onValueChangeHandlerMock;
+                this.kieAssets.addAll(assetList);
+            }
+        });
+        commonSetup();
     }
 
     @Test
@@ -89,52 +90,40 @@ public class KieAssetsDropdownTest {
         dropdown.loadAssets();
 
         verify(dropdown).clear();
-        verify(view).enableInputMode();
-        verify(view).initialize();
+        verify(viewlocalMock).enableInputMode();
+        verify(viewMock).initialize();
     }
 
     @Test
     public void testLoadAssetsWhenEnvIsNotSubmarine() {
 
-        doReturn(kieAssetsConsumer).when(dropdown).getAssetListConsumer();
+        doReturn(kieAssetsConsumer).when((SubmarineKieAssetsDropdown)dropdown).getAssetListConsumer();
 
         dropdown.loadAssets();
 
         verify(dropdown).clear();
-        verify(view).enableDropdownMode();
-        verify(dataProvider).getItems(kieAssetsConsumer);
+        verify(viewlocalMock).enableDropdownMode();
+        verify(dataProviderMock).getItems(kieAssetsConsumer);
     }
 
     @Test
     public void testInitialize() {
         dropdown.initialize();
-        verify(view).refreshSelectPicker();
+        verify(viewMock).refreshSelectPicker();
     }
 
     @Test
     public void testInitializeWhenItIsNotSubmarine() {
         when(isSubmarine.get()).thenReturn(true);
         dropdown.initialize();
-        verify(view, never()).refreshSelectPicker();
-    }
-
-    @Test
-    public void testClear() {
-
-        final List<KieAssetsDropdownItem> kieAssets = spy(new ArrayList<>());
-        doReturn(kieAssets).when(dropdown).getKieAssets();
-
-        dropdown.clear();
-
-        verify(kieAssets).clear();
-        verify(view).clear();
+        verify(viewMock, never()).refreshSelectPicker();
     }
 
     @Test
     public void testGetElement() {
 
         final HTMLElement expectedElement = mock(HTMLElement.class);
-        when(view.getElement()).thenReturn(expectedElement);
+        when(viewMock.getElement()).thenReturn(expectedElement);
 
         final HTMLElement actualElement = dropdown.getElement();
 
@@ -143,30 +132,23 @@ public class KieAssetsDropdownTest {
 
     @Test
     public void testGetValue() {
+        final List<KieAssetsDropdownItem> kieAssets = IntStream.range(0, 4).mapToObj(i -> {
+            final KieAssetsDropdownItem toReturn =  mock(KieAssetsDropdownItem.class);
+            when(toReturn.getValue()).thenReturn("item" + i);
+            return toReturn;
+        }).collect(Collectors.toList());
 
-        final KieAssetsDropdownItem dropdownItem1 = mock(KieAssetsDropdownItem.class);
-        final KieAssetsDropdownItem dropdownItem2 = mock(KieAssetsDropdownItem.class);
-        final KieAssetsDropdownItem dropdownItem3 = mock(KieAssetsDropdownItem.class);
-        final List<KieAssetsDropdownItem> kieAssets = asList(dropdownItem1, dropdownItem2, dropdownItem3);
-
-        when(dropdownItem1.getValue()).thenReturn("item1");
-        when(dropdownItem2.getValue()).thenReturn("item2");
-        when(dropdownItem3.getValue()).thenReturn("item3");
-        when(view.getValue()).thenReturn("item2");
-
-        doReturn(kieAssets).when(dropdown).getKieAssets();
-
-        final Optional<KieAssetsDropdownItem> value = dropdown.getValue();
-
-        assertTrue(value.isPresent());
-        assertEquals(dropdownItem2, value.get());
+        when(viewMock.getValue()).thenReturn("item2");
+        ((SubmarineKieAssetsDropdown)dropdown).kieAssets.clear();
+        ((SubmarineKieAssetsDropdown)dropdown).kieAssets.addAll(kieAssets);
+        final Optional<KieAssetsDropdownItem> retrieved = dropdown.getValue();
+        assertTrue(retrieved.isPresent());
+        assertEquals("item2", retrieved.get().getValue());
     }
 
     @Test
     public void testGetValueWhenOptionDoesNotExist() {
-
-        doReturn(emptyList()).when(dropdown).getKieAssets();
-
+        ((SubmarineKieAssetsDropdown)dropdown).kieAssets.clear();
         assertFalse(dropdown.getValue().isPresent());
     }
 
@@ -176,7 +158,7 @@ public class KieAssetsDropdownTest {
         final String expectedValue = "value";
 
         when(isSubmarine.get()).thenReturn(true);
-        when(view.getValue()).thenReturn(expectedValue);
+        when(viewMock.getValue()).thenReturn(expectedValue);
 
         final Optional<KieAssetsDropdownItem> value = dropdown.getValue();
 
@@ -185,31 +167,18 @@ public class KieAssetsDropdownTest {
     }
 
     @Test
-    public void testGetAssetListConsumer() {
-
-        final KieAssetsDropdownItem dropdownItem1 = mock(KieAssetsDropdownItem.class);
-        final KieAssetsDropdownItem dropdownItem2 = mock(KieAssetsDropdownItem.class);
-        final KieAssetsDropdownItem dropdownItem3 = mock(KieAssetsDropdownItem.class);
-        final List<KieAssetsDropdownItem> expectedDropdownItems = asList(dropdownItem1, dropdownItem2, dropdownItem3);
-
-        dropdown.getAssetListConsumer().accept(expectedDropdownItems);
-
-        final List<KieAssetsDropdownItem> actualDropdownItems = dropdown.getKieAssets();
-
-        verify(view).addValue(dropdownItem1);
-        verify(view).addValue(dropdownItem2);
-        verify(view).addValue(dropdownItem3);
-        verify(view).refreshSelectPicker();
-        verify(view).initialize();
-        assertEquals(expectedDropdownItems, actualDropdownItems);
+    public void getAssetListConsumer() {
+        final List<KieAssetsDropdownItem> expectedDropdownItems = new ArrayList<>();
+        ((SubmarineKieAssetsDropdown)dropdown).getAssetListConsumer().accept(expectedDropdownItems);
+        verify(((SubmarineKieAssetsDropdown)dropdown), times(1)).assetListConsumerMethod(eq(expectedDropdownItems));
     }
 
-    class KieAssetsDropdownFake extends KieAssetsDropdown {
-
-        KieAssetsDropdownFake(final View view,
-                              final IsSubmarine isSubmarine,
-                              final KieAssetsDropdownItemsProvider dataProvider) {
-            super(view, isSubmarine, dataProvider);
-        }
+    @Test
+    public void assetListConsumerMethod() {
+        ((SubmarineKieAssetsDropdown)dropdown).assetListConsumerMethod(assetList);
+        assetList.forEach(item -> verify(viewMock).addValue(item));
+        verify(viewMock).refreshSelectPicker();
+        verify(viewMock).initialize();
     }
+    
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownTest.java
@@ -32,7 +32,6 @@ import org.kie.workbench.common.widgets.client.submarine.IsSubmarine;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
-import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTest {
 
-
     @Mock
     private IsSubmarine isSubmarine;
 
@@ -58,12 +56,13 @@ public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTes
     @Mock
     private SubmarineKieAssetsDropdownView viewlocalMock;
 
+    @Mock
+    private KieAssetsDropdown dropdownLocal;
 
     @Before
     public void setup() {
-        viewMock = viewlocalMock;
         when(isSubmarine.get()).thenReturn(false);
-        dropdown = spy(new SubmarineKieAssetsDropdown(viewlocalMock, isSubmarine, dataProviderMock) {
+        dropdownLocal = spy(new SubmarineKieAssetsDropdown(viewlocalMock, isSubmarine, dataProviderMock) {
             {
                 onValueChangeHandler = onValueChangeHandlerMock;
                 this.kieAssets.addAll(assetList);
@@ -76,8 +75,8 @@ public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTes
     public void testRegisterOnChangeHandler() {
         final Command command = mock(Command.class);
 
-        dropdown.registerOnChangeHandler(command);
-        dropdown.onValueChanged();
+        getDropdown().registerOnChangeHandler(command);
+        getDropdown().onValueChanged();
 
         verify(command).execute();
     }
@@ -87,45 +86,45 @@ public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTes
 
         when(isSubmarine.get()).thenReturn(true);
 
-        dropdown.loadAssets();
+        getDropdown().loadAssets();
 
-        verify(dropdown).clear();
+        verify(getDropdown()).clear();
         verify(viewlocalMock).enableInputMode();
-        verify(viewMock).initialize();
+        verify(getViewMock()).initialize();
     }
 
     @Test
     public void testLoadAssetsWhenEnvIsNotSubmarine() {
 
-        doReturn(kieAssetsConsumer).when((SubmarineKieAssetsDropdown)dropdown).getAssetListConsumer();
+        doReturn(kieAssetsConsumer).when((SubmarineKieAssetsDropdown) getDropdown()).getAssetListConsumer();
 
-        dropdown.loadAssets();
+        getDropdown().loadAssets();
 
-        verify(dropdown).clear();
+        verify(getDropdown()).clear();
         verify(viewlocalMock).enableDropdownMode();
         verify(dataProviderMock).getItems(kieAssetsConsumer);
     }
 
     @Test
     public void testInitialize() {
-        dropdown.initialize();
-        verify(viewMock).refreshSelectPicker();
+        getDropdown().initialize();
+        verify(getViewMock()).refreshSelectPicker();
     }
 
     @Test
     public void testInitializeWhenItIsNotSubmarine() {
         when(isSubmarine.get()).thenReturn(true);
-        dropdown.initialize();
-        verify(viewMock, never()).refreshSelectPicker();
+        getDropdown().initialize();
+        verify(getViewMock(), never()).refreshSelectPicker();
     }
 
     @Test
     public void testGetElement() {
 
         final HTMLElement expectedElement = mock(HTMLElement.class);
-        when(viewMock.getElement()).thenReturn(expectedElement);
+        when(getViewMock().getElement()).thenReturn(expectedElement);
 
-        final HTMLElement actualElement = dropdown.getElement();
+        final HTMLElement actualElement = getDropdown().getElement();
 
         assertEquals(expectedElement, actualElement);
     }
@@ -133,23 +132,23 @@ public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTes
     @Test
     public void testGetValue() {
         final List<KieAssetsDropdownItem> kieAssets = IntStream.range(0, 4).mapToObj(i -> {
-            final KieAssetsDropdownItem toReturn =  mock(KieAssetsDropdownItem.class);
+            final KieAssetsDropdownItem toReturn = mock(KieAssetsDropdownItem.class);
             when(toReturn.getValue()).thenReturn("item" + i);
             return toReturn;
         }).collect(Collectors.toList());
 
-        when(viewMock.getValue()).thenReturn("item2");
-        ((SubmarineKieAssetsDropdown)dropdown).kieAssets.clear();
-        ((SubmarineKieAssetsDropdown)dropdown).kieAssets.addAll(kieAssets);
-        final Optional<KieAssetsDropdownItem> retrieved = dropdown.getValue();
+        when(getViewMock().getValue()).thenReturn("item2");
+        ((SubmarineKieAssetsDropdown) getDropdown()).kieAssets.clear();
+        ((SubmarineKieAssetsDropdown) getDropdown()).kieAssets.addAll(kieAssets);
+        final Optional<KieAssetsDropdownItem> retrieved = getDropdown().getValue();
         assertTrue(retrieved.isPresent());
         assertEquals("item2", retrieved.get().getValue());
     }
 
     @Test
     public void testGetValueWhenOptionDoesNotExist() {
-        ((SubmarineKieAssetsDropdown)dropdown).kieAssets.clear();
-        assertFalse(dropdown.getValue().isPresent());
+        ((SubmarineKieAssetsDropdown) getDropdown()).kieAssets.clear();
+        assertFalse(getDropdown().getValue().isPresent());
     }
 
     @Test
@@ -158,9 +157,9 @@ public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTes
         final String expectedValue = "value";
 
         when(isSubmarine.get()).thenReturn(true);
-        when(viewMock.getValue()).thenReturn(expectedValue);
+        when(getViewMock().getValue()).thenReturn(expectedValue);
 
-        final Optional<KieAssetsDropdownItem> value = dropdown.getValue();
+        final Optional<KieAssetsDropdownItem> value = getDropdown().getValue();
 
         assertTrue(value.isPresent());
         assertEquals(expectedValue, value.get().getValue());
@@ -169,16 +168,25 @@ public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTes
     @Test
     public void getAssetListConsumer() {
         final List<KieAssetsDropdownItem> expectedDropdownItems = new ArrayList<>();
-        ((SubmarineKieAssetsDropdown)dropdown).getAssetListConsumer().accept(expectedDropdownItems);
-        verify(((SubmarineKieAssetsDropdown)dropdown), times(1)).assetListConsumerMethod(eq(expectedDropdownItems));
+        ((SubmarineKieAssetsDropdown) getDropdown()).getAssetListConsumer().accept(expectedDropdownItems);
+        verify(((SubmarineKieAssetsDropdown) getDropdown()), times(1)).assetListConsumerMethod(eq(expectedDropdownItems));
     }
 
     @Test
     public void assetListConsumerMethod() {
-        ((SubmarineKieAssetsDropdown)dropdown).assetListConsumerMethod(assetList);
-        assetList.forEach(item -> verify(viewMock).addValue(item));
-        verify(viewMock).refreshSelectPicker();
-        verify(viewMock).initialize();
+        ((SubmarineKieAssetsDropdown) getDropdown()).assetListConsumerMethod(assetList);
+        assetList.forEach(item -> verify(getViewMock()).addValue(item));
+        verify(getViewMock()).refreshSelectPicker();
+        verify(getViewMock()).initialize();
     }
-    
+
+    @Override
+    protected KieAssetsDropdown getDropdown() {
+        return dropdownLocal;
+    }
+
+    @Override
+    protected KieAssetsDropdown.View getViewMock() {
+        return viewlocalMock;
+    }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineKieAssetsDropdownTest.java
@@ -56,7 +56,6 @@ public class SubmarineKieAssetsDropdownTest extends AbstractKieAssetsDropdownTes
     @Mock
     private SubmarineKieAssetsDropdownView viewlocalMock;
 
-    @Mock
     private KieAssetsDropdown dropdownLocal;
 
     @Before

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineSubmarineKieAssetsDropdownViewTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/assets/dropdown/SubmarineSubmarineKieAssetsDropdownViewTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.assets.dropdown;
+
+import java.util.Map;
+
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.DOMTokenList;
+import elemental2.dom.HTMLInputElement;
+import elemental2.dom.HTMLOptionElement;
+import elemental2.dom.HTMLSelectElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Maps;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker;
+import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker.CallbackFunction;
+import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerEvent;
+import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerTarget;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.widgets.client.assets.dropdown.SubmarineKieAssetsDropdownView.HIDDEN_CSS_CLASS;
+import static org.kie.workbench.common.widgets.client.assets.dropdown.SubmarineKieAssetsDropdownView.SELECT_PICKER_SUBTEXT_ATTRIBUTE;
+import static org.kie.workbench.common.widgets.client.resources.i18n.KieWorkbenchWidgetsConstants.KieAssetsDropdownView_Select;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class SubmarineSubmarineKieAssetsDropdownViewTest {
+
+    @Mock
+    private HTMLSelectElement nativeSelect;
+
+    @Mock
+    private HTMLInputElement fallbackInput;
+
+    @Mock
+    private HTMLOptionElement htmlOptionElement;
+
+    @Mock
+    private SubmarineKieAssetsDropdown presenter;
+
+    @Mock
+    private JQuerySelectPicker dropdown;
+
+    @Mock
+    private TranslationService translationService;
+
+    private SubmarineKieAssetsDropdownView view;
+
+    @Before
+    public void setup() {
+
+        view = Mockito.spy(new SubmarineKieAssetsDropdownView(nativeSelect, fallbackInput, htmlOptionElement, translationService));
+        view.init(presenter);
+
+        doReturn(dropdown).when(view).dropdown();
+    }
+
+    @Test
+    public void testInit() {
+
+        final CallbackFunction callbackFunction = mock(CallbackFunction.class);
+        doReturn(callbackFunction).when(view).getOnDropdownChangeHandler();
+
+        view.init();
+
+        assertFalse(nativeSelect.hidden);
+        assertTrue(fallbackInput.hidden);
+        verify(dropdown).on("hidden.bs.select", callbackFunction);
+    }
+
+    @Test
+    public void testGetOnDropdownChangeHandler() {
+
+        final JQuerySelectPickerEvent event = mock(JQuerySelectPickerEvent.class);
+        final JQuerySelectPickerTarget target = mock(JQuerySelectPickerTarget.class);
+        final String expectedValue = "newValue";
+
+        fallbackInput.value = "something";
+        event.target = target;
+        target.value = expectedValue;
+
+        view.getOnDropdownChangeHandler().call(event);
+
+        final String actualValue = event.target.value;
+
+        assertEquals(expectedValue, actualValue);
+        verify(presenter).onValueChanged();
+    }
+
+    @Test
+    public void testAddValue() {
+
+        final HTMLOptionElement optionElement = mock(HTMLOptionElement.class);
+        final KieAssetsDropdownItem entry = new KieAssetsDropdownItem("text", "subtext", "value", getMetaData());
+
+        doReturn(optionElement).when(view).makeHTMLOptionElement();
+
+        view.addValue(entry);
+
+        assertEquals("text", optionElement.text);
+        assertEquals("value", optionElement.value);
+        verify(optionElement).setAttribute(SELECT_PICKER_SUBTEXT_ATTRIBUTE, "subtext");
+        verify(nativeSelect).appendChild(optionElement);
+    }
+
+    @Test
+    public void testClear() {
+
+        final HTMLOptionElement oldOptionElement = mock(HTMLOptionElement.class);
+        final HTMLOptionElement newOptionElement = mock(HTMLOptionElement.class);
+        nativeSelect.firstChild = oldOptionElement;
+
+        doReturn(newOptionElement).when(view).selectOption();
+        when(nativeSelect.removeChild(oldOptionElement)).then(a -> {
+            nativeSelect.firstChild = null;
+            return oldOptionElement;
+        });
+
+        view.clear();
+
+        verify(nativeSelect).removeChild(oldOptionElement);
+        verify(nativeSelect).appendChild(newOptionElement);
+        verify(view).refreshSelectPicker();
+    }
+
+    @Test
+    public void testSelectOption() {
+
+        final String select = "Select";
+
+        doReturn(mock(HTMLOptionElement.class)).when(view).makeHTMLOptionElement();
+        when(translationService.format(KieAssetsDropdownView_Select)).thenReturn(select);
+
+        final HTMLOptionElement optionElement = view.selectOption();
+
+        assertEquals(select, optionElement.text);
+        assertEquals("", optionElement.value);
+    }
+
+    @Test
+    public void testInitialize() {
+
+        fallbackInput.value = "something";
+
+        view.initialize();
+
+        assertEquals("", fallbackInput.value);
+        verify(dropdown).selectpicker("val", "");
+    }
+
+    @Test
+    public void testRefreshSelectPicker() {
+        view.refreshSelectPicker();
+        verify(dropdown).selectpicker("refresh");
+    }
+
+    @Test
+    public void testGetValue() {
+
+        final String expected = "value";
+        fallbackInput.value = expected;
+
+        final String actual = view.getValue();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testEnableInputMode() {
+
+        nativeSelect.classList = mock(DOMTokenList.class);
+        fallbackInput.classList = mock(DOMTokenList.class);
+
+        view.enableInputMode();
+
+        verify(nativeSelect.classList).add(HIDDEN_CSS_CLASS);
+        verify(fallbackInput.classList).remove(HIDDEN_CSS_CLASS);
+        verify(dropdown).selectpicker("hide");
+    }
+
+    @Test
+    public void testEnableDropdownMode() {
+
+        nativeSelect.classList = mock(DOMTokenList.class);
+        fallbackInput.classList = mock(DOMTokenList.class);
+
+        view.enableDropdownMode();
+
+        verify(fallbackInput.classList).add(HIDDEN_CSS_CLASS);
+        verify(nativeSelect.classList).remove(HIDDEN_CSS_CLASS);
+        verify(dropdown).selectpicker("show");
+    }
+
+    @Test
+    public void testOnFallbackInputChange() {
+        view.onFallbackInputChange(mock(KeyUpEvent.class));
+        verify(presenter).onValueChanged();
+    }
+
+    private Map<String, String> getMetaData() {
+        return new Maps.Builder<String, String>().put("foo", "bar").build();
+    }
+}


### PR DESCRIPTION
@manstis @jomarko @karreiro 

This PR requires https://github.com/kiegroup/appformer/pull/696

I've slightly refactored original KieDropdown implementation.
My general point of view about abstract classes is
1) they are meant to be extended, so it should be possible to change the behavior, otherwise they are normal classes "masked"
2) to allow that, properties/methods must be readable/writable by child classes
3) only for very specific cases there must be an hidden/unchangeable inner state/behavior (but I do not see such case here)

For this specific one, my idea is 
1) it is GREAT to have one single elemental dropdown, to be used *everywhere* (I have at least one other case where I will use it)
2) following the above, the top-most parent must be absolutely independent of any specific constraint (e.g. IsSubmarine object)
3) the AbstractSubmarineDropDown is a specialization of the above; nevertheless, it must be possible for any actual implementation to change the behavior depending on the IsSubmarine state (for ex, my original issue was that in my scesim even if inside submarine I would need a full dropdown, not a manual input text box).





