### PR TITLE
DROOLS-4041: [DMN Designer] Submarine: Refactor service use to support pluggable implementation

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/DMNAPI.gwt.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/DMNAPI.gwt.xml
@@ -25,6 +25,7 @@
   <inherits name="org.kie.workbench.common.stunner.shapes.StunnerShapesApi"/>
   <inherits name="org.kie.workbench.common.forms.adf.AnnotationDrivenFormsBase"/>
   <inherits name="org.kie.workbench.common.forms.adf.engine.AnnotationDrivenFormsEngineAPI"/>
+  <inherits name="org.guvnor.common.services.project.GuvnorProjectAPI"/>
 
   <source path="api"/>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/DMNValidationServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/DMNValidationServiceImpl.java
@@ -16,9 +16,11 @@
 
 package org.kie.workbench.common.dmn.backend.editors.types;
 
+import org.jboss.errai.bus.server.annotations.Service;
 import org.kie.dmn.feel.parser.feel11.FEELParser;
 import org.kie.workbench.common.dmn.api.editors.types.DMNValidationService;
 
+@Service
 public class DMNValidationServiceImpl implements DMNValidationService {
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/TimeZoneServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/TimeZoneServiceImpl.java
@@ -20,9 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
+import org.jboss.errai.bus.server.annotations.Service;
 import org.kie.workbench.common.dmn.api.editors.types.DMNSimpleTimeZone;
 import org.kie.workbench.common.dmn.api.editors.types.TimeZoneService;
 
+@Service
 public class TimeZoneServiceImpl implements TimeZoneService {
 
     @Override
@@ -63,11 +65,11 @@ public class TimeZoneServiceImpl implements TimeZoneService {
         return milliseconds / 1000.0d / 60.0d / 60.0d;
     }
 
-    TimeZone getTimeZone(final String id){
+    TimeZone getTimeZone(final String id) {
         return TimeZone.getTimeZone(id);
     }
 
-    String[] getAvailableIds(){
+    String[] getAvailableIds() {
         return TimeZone.getAvailableIDs();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -170,6 +170,11 @@
     <!-- Uberfire & Errai -->
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
     </dependency>
 
@@ -211,37 +216,12 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-bus</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-security-server</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-security-management-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-security-management-client</artifactId>
     </dependency>
 
     <dependency>
@@ -255,13 +235,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-marshalling</artifactId>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>com.google.jsinterop</groupId>
-      <artifactId>jsinterop-annotations</artifactId>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
     </dependency>
 
     <!--Wires Grids dependencies-->
@@ -342,11 +322,6 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.elemental2</groupId>
-      <artifactId>elemental2-dom</artifactId>
     </dependency>
 
   </dependencies>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/service/DMNClientServicesProxy.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/service/DMNClientServicesProxy.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.service;
+
+import java.util.List;
+
+import elemental2.dom.DomGlobal;
+import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedModel;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedNode;
+import org.kie.workbench.common.dmn.api.editors.types.DMNSimpleTimeZone;
+import org.kie.workbench.common.dmn.api.editors.types.RangeValue;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+
+/**
+ * This is a proxy for the single provider of (external) services required by the Editor.
+ * An external service is one that may require an RPC in some environments (e.g. Business Central) however may be
+ * substituted for client-side implementations in other environments (e.g. Submarine).
+ */
+public interface DMNClientServicesProxy {
+
+    // ------------------------------------
+    // Default helper methods
+    // ------------------------------------
+
+    default void logWarning(final ClientRuntimeError error) {
+        warn("[WARNING] DMNClientService could not get the asset list.");
+        warn(error.getMessage());
+    }
+
+    default void warn(final String message) {
+        DomGlobal.console.warn(message);
+    }
+
+    // ------------------------------------
+    // Proxy for DMNIncludedModelsService
+    // ------------------------------------
+
+    /**
+     * This method loads all DMN models from a given project.
+     * @return all {@link DMNIncludedModel}s from a given project.
+     */
+    void loadModels(final ServiceCallback<List<DMNIncludedModel>> callback);
+
+    /**
+     * This method loads all nodes from an included model.
+     * @param includedModels represents all imports that provide the list of nodes.
+     * @return a list of {@link DMNIncludedNode}s.
+     */
+    void loadNodesFromImports(final List<DMNIncludedModel> includedModels,
+                              final ServiceCallback<List<DMNIncludedNode>> callback);
+
+    /**
+     * This method finds the list of {@link ItemDefinition}s for a given <code>namespace</code>.
+     * @param modelName is the value used as the prefix for imported {@link ItemDefinition}s.
+     * @param namespace is the namespace of the model that provides the list of {@link ItemDefinition}s.
+     * @return a list of {@link ItemDefinition}s.
+     */
+    void loadItemDefinitionsByNamespace(final String modelName,
+                                        final String namespace,
+                                        final ServiceCallback<List<ItemDefinition>> callback);
+
+    // ------------------------------------
+    // Proxy for DMNParseService
+    // ------------------------------------
+
+    void parseFEELList(final String source,
+                       final ServiceCallback<List<String>> callback);
+
+    void parseRangeValue(final String source,
+                         final ServiceCallback<RangeValue> callback);
+
+    // ------------------------------------
+    // Proxy for DMNValidationService
+    // ------------------------------------
+
+    void isValidVariableName(final String source,
+                             final ServiceCallback<Boolean> callback);
+
+    // ------------------------------------
+    // Proxy for TimeZoneService
+    // ------------------------------------
+
+    void getTimeZones(final ServiceCallback<List<DMNSimpleTimeZone>> callback);
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/service/DMNClientServicesProxy.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/service/DMNClientServicesProxy.java
@@ -38,7 +38,6 @@ public interface DMNClientServicesProxy {
     // ------------------------------------
 
     default void logWarning(final ClientRuntimeError error) {
-        warn("[WARNING] DMNClientService could not get the asset list.");
         warn(error.getMessage());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/DMNClient.gwt.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/DMNClient.gwt.xml
@@ -25,6 +25,7 @@
   <inherits name="org.kie.workbench.common.stunner.shapes.StunnerShapesClient"/>
   <inherits name="org.kie.workbench.common.stunner.client.StunnerWidgets"/>
   <inherits name="org.kie.workbench.common.stunner.forms.StunnerFormsClient"/>
+  <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>
 
   <inherits name="org.uberfire.ext.wires.core.grids.WiresCoreGrids"/>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/range/DataTypeConstraintRangeTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/range/DataTypeConstraintRangeTest.java
@@ -16,25 +16,22 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.listview.constraint.range;
 
-import java.util.List;
-
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
-import org.jboss.errai.common.client.api.RemoteCallback;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.api.editors.types.DMNParseService;
 import org.kie.workbench.common.dmn.api.editors.types.RangeValue;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.DataTypeConstraintModal;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.ConstraintPlaceholderHelper;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.DataTypeConstraintParserWarningEvent;
+import org.kie.workbench.common.dmn.client.service.DMNClientServicesProxy;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -50,10 +47,7 @@ public class DataTypeConstraintRangeTest {
     private ConstraintPlaceholderHelper placeholderHelper;
 
     @Mock
-    private Caller<DMNParseService> serviceCaller;
-
-    @Mock
-    private DMNParseService service;
+    private DMNClientServicesProxy clientServicesProxy;
 
     @Mock
     private EventSourceMock<DataTypeConstraintParserWarningEvent> parserWarningEvent;
@@ -65,7 +59,10 @@ public class DataTypeConstraintRangeTest {
 
     @Before
     public void setup() {
-        constraintRange = spy(new DataTypeConstraintRange(view, placeholderHelper, serviceCaller, parserWarningEvent));
+        constraintRange = spy(new DataTypeConstraintRange(view,
+                                                          placeholderHelper,
+                                                          clientServicesProxy,
+                                                          parserWarningEvent));
     }
 
     @Test
@@ -90,18 +87,14 @@ public class DataTypeConstraintRangeTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSetValue() {
-        final RemoteCallback<List<String>> successCallback = (c) -> { /* Nothing. */ };
-        final ErrorCallback<Object> errorCallback = (m, t) -> true;
         final String value = "value";
-
-        doReturn(successCallback).when(constraintRange).getSuccessCallback();
-        doReturn(errorCallback).when(constraintRange).getErrorCallback();
-        when(serviceCaller.call(successCallback, errorCallback)).thenReturn(service);
 
         constraintRange.setValue(value);
 
-        verify(service).parseRangeValue(value);
+        verify(clientServicesProxy).parseRangeValue(eq(value),
+                                                    any(ServiceCallback.class));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
@@ -151,6 +151,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-properties-editor-api</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/service/DMNClientServicesProxyImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/service/DMNClientServicesProxyImpl.java
@@ -73,7 +73,8 @@ public class DMNClientServicesProxyImpl implements DMNClientServicesProxy {
     }
 
     @Override
-    public void loadItemDefinitionsByNamespace(final String modelName, String namespace,
+    public void loadItemDefinitionsByNamespace(final String modelName,
+                                               final String namespace,
                                                final ServiceCallback<List<ItemDefinition>> callback) {
         includedModelsService.call(onSuccess(callback), onError(callback)).loadItemDefinitionsByNamespace(getWorkspaceProject(), modelName, namespace);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/service/DMNClientServicesProxyImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/service/DMNClientServicesProxyImpl.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.service;
+
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedModel;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedModelsService;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedNode;
+import org.kie.workbench.common.dmn.api.editors.types.DMNParseService;
+import org.kie.workbench.common.dmn.api.editors.types.DMNSimpleTimeZone;
+import org.kie.workbench.common.dmn.api.editors.types.DMNValidationService;
+import org.kie.workbench.common.dmn.api.editors.types.RangeValue;
+import org.kie.workbench.common.dmn.api.editors.types.TimeZoneService;
+import org.kie.workbench.common.dmn.client.service.DMNClientServicesProxy;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+
+@Dependent
+public class DMNClientServicesProxyImpl implements DMNClientServicesProxy {
+
+    private final WorkspaceProjectContext projectContext;
+    private final Caller<DMNIncludedModelsService> includedModelsService;
+    private final Caller<DMNParseService> parserService;
+    private final Caller<DMNValidationService> validationService;
+    private final Caller<TimeZoneService> timeZoneService;
+
+    @Inject
+    public DMNClientServicesProxyImpl(final WorkspaceProjectContext projectContext,
+                                      final Caller<DMNIncludedModelsService> includedModelsService,
+                                      final Caller<DMNParseService> parserService,
+                                      final Caller<DMNValidationService> validationService,
+                                      final Caller<TimeZoneService> timeZoneService) {
+        this.projectContext = projectContext;
+        this.includedModelsService = includedModelsService;
+        this.parserService = parserService;
+        this.validationService = validationService;
+        this.timeZoneService = timeZoneService;
+    }
+
+    @Override
+    public void loadModels(final ServiceCallback<List<DMNIncludedModel>> callback) {
+        includedModelsService.call(onSuccess(callback), onError(callback)).loadModels(getWorkspaceProject());
+    }
+
+    @Override
+    public void loadNodesFromImports(final List<DMNIncludedModel> includedModels,
+                                     final ServiceCallback<List<DMNIncludedNode>> callback) {
+        includedModelsService.call(onSuccess(callback), onError(callback)).loadNodesFromImports(getWorkspaceProject(), includedModels);
+    }
+
+    @Override
+    public void loadItemDefinitionsByNamespace(final String modelName, String namespace,
+                                               final ServiceCallback<List<ItemDefinition>> callback) {
+        includedModelsService.call(onSuccess(callback), onError(callback)).loadItemDefinitionsByNamespace(getWorkspaceProject(), modelName, namespace);
+    }
+
+    @Override
+    public void parseFEELList(final String source,
+                              final ServiceCallback<List<String>> callback) {
+        parserService.call(onSuccess(callback), onError(callback)).parseFEELList(source);
+    }
+
+    @Override
+    public void parseRangeValue(final String source,
+                                final ServiceCallback<RangeValue> callback) {
+        parserService.call(onSuccess(callback), onError(callback)).parseRangeValue(source);
+    }
+
+    @Override
+    public void isValidVariableName(final String source,
+                                    final ServiceCallback<Boolean> callback) {
+        validationService.call(onSuccess(callback), onError(callback)).isValidVariableName(source);
+    }
+
+    @Override
+    public void getTimeZones(final ServiceCallback<List<DMNSimpleTimeZone>> callback) {
+        timeZoneService.call(onSuccess(callback), onError(callback)).getTimeZones();
+    }
+
+    <T> RemoteCallback<T> onSuccess(final ServiceCallback<T> callback) {
+        return callback::onSuccess;
+    }
+
+    <T> ErrorCallback<Boolean> onError(final ServiceCallback<T> callback) {
+        return (message, throwable) -> {
+            callback.onError(new ClientRuntimeError(throwable));
+            return false;
+        };
+    }
+
+    private WorkspaceProject getWorkspaceProject() {
+        return projectContext.getActiveWorkspaceProject().orElse(null);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/service/DMNClientServicesProxyImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/service/DMNClientServicesProxyImplTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedModel;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedModelsService;
+import org.kie.workbench.common.dmn.api.editors.types.DMNParseService;
+import org.kie.workbench.common.dmn.api.editors.types.DMNValidationService;
+import org.kie.workbench.common.dmn.api.editors.types.TimeZoneService;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.mocks.CallerMock;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNClientServicesProxyImplTest {
+
+    @Mock
+    private CallerMock<DMNIncludedModelsService> includedModelsServiceCaller;
+
+    @Mock
+    private CallerMock<DMNParseService> parseServiceCaller;
+
+    @Mock
+    private CallerMock<DMNValidationService> validationServiceCaller;
+
+    @Mock
+    private CallerMock<TimeZoneService> timeZoneServiceCaller;
+
+    @Mock
+    private DMNIncludedModelsService includedModelsService;
+
+    @Mock
+    private DMNParseService parseService;
+
+    @Mock
+    private DMNValidationService validationService;
+
+    @Mock
+    private TimeZoneService timeZoneService;
+
+    @Mock
+    private WorkspaceProjectContext projectContext;
+
+    @Mock
+    private ServiceCallback serviceCallback;
+
+    @Mock
+    private WorkspaceProject workspaceProject;
+
+    @Captor
+    private ArgumentCaptor<ClientRuntimeError> clientRuntimeErrorArgumentCaptor;
+
+    private DMNClientServicesProxyImpl clientServicesProxy;
+
+    @Before
+    public void setup() {
+        clientServicesProxy = spy(new DMNClientServicesProxyImpl(projectContext,
+                                                                 includedModelsServiceCaller,
+                                                                 parseServiceCaller,
+                                                                 validationServiceCaller,
+                                                                 timeZoneServiceCaller));
+
+        when(includedModelsServiceCaller.call(any(RemoteCallback.class),
+                                              any(ErrorCallback.class))).thenReturn(includedModelsService);
+        when(parseServiceCaller.call(any(RemoteCallback.class),
+                                     any(ErrorCallback.class))).thenReturn(parseService);
+        when(validationServiceCaller.call(any(RemoteCallback.class),
+                                          any(ErrorCallback.class))).thenReturn(validationService);
+        when(timeZoneServiceCaller.call(any(RemoteCallback.class),
+                                        any(ErrorCallback.class))).thenReturn(timeZoneService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoadModels() {
+        final Optional<WorkspaceProject> optionalWorkspaceProject = Optional.of(workspaceProject);
+
+        when(projectContext.getActiveWorkspaceProject()).thenReturn(optionalWorkspaceProject);
+
+        clientServicesProxy.loadModels(serviceCallback);
+
+        verify(includedModelsService).loadModels(workspaceProject);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoadNodesFromImports() {
+        final Optional<WorkspaceProject> optionalWorkspaceProject = Optional.of(workspaceProject);
+        final DMNIncludedModel includedModel1 = mock(DMNIncludedModel.class);
+        final DMNIncludedModel includedModel2 = mock(DMNIncludedModel.class);
+        final List<DMNIncludedModel> imports = asList(includedModel1, includedModel2);
+
+        when(projectContext.getActiveWorkspaceProject()).thenReturn(optionalWorkspaceProject);
+
+        clientServicesProxy.loadNodesFromImports(imports, serviceCallback);
+
+        verify(includedModelsService).loadNodesFromImports(workspaceProject, imports);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoadItemDefinitionsByNamespace() {
+        final Optional<WorkspaceProject> optionalWorkspaceProject = Optional.of(workspaceProject);
+        final String modelName = "model1";
+        final String namespace = "://namespace1";
+
+        when(projectContext.getActiveWorkspaceProject()).thenReturn(optionalWorkspaceProject);
+
+        clientServicesProxy.loadItemDefinitionsByNamespace(modelName, namespace, serviceCallback);
+
+        verify(includedModelsService).loadItemDefinitionsByNamespace(workspaceProject, modelName, namespace);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testParseFEELList() {
+        final String source = "source";
+        clientServicesProxy.parseFEELList(source, serviceCallback);
+
+        verify(parseService).parseFEELList(eq(source));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testParseRangeValue() {
+        final String source = "source";
+        clientServicesProxy.parseRangeValue(source, serviceCallback);
+
+        verify(parseService).parseRangeValue(eq(source));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testIsValidVariableName() {
+        final String source = "source";
+        clientServicesProxy.isValidVariableName(source, serviceCallback);
+
+        verify(validationService).isValidVariableName(eq(source));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetTimeZones() {
+        clientServicesProxy.getTimeZones(serviceCallback);
+
+        verify(timeZoneService).getTimeZones();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnError() {
+        doCallRealMethod().when(clientServicesProxy).onError(any(ServiceCallback.class));
+
+        final boolean error = true;
+        final Throwable throwable = mock(Throwable.class);
+        doNothing().when(clientServicesProxy).warn(any());
+
+        assertFalse(clientServicesProxy.onError(serviceCallback).error(error, throwable));
+        verify(serviceCallback).onError(clientRuntimeErrorArgumentCaptor.capture());
+
+        assertEquals(throwable, clientRuntimeErrorArgumentCaptor.getValue().getRootCause());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnSuccess() {
+        doCallRealMethod().when(clientServicesProxy).onSuccess(any(ServiceCallback.class));
+
+        final Object result = new Object();
+
+        clientServicesProxy.onSuccess(serviceCallback).callback(result);
+
+        verify(serviceCallback).onSuccess(eq(result));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/service/DMNClientServicesProxyImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/service/DMNClientServicesProxyImpl.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.showcase.client.service;
+
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.kie.workbench.common.dmn.api.definition.v1_1.ItemDefinition;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedModel;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedModelsService;
+import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedNode;
+import org.kie.workbench.common.dmn.api.editors.types.DMNParseService;
+import org.kie.workbench.common.dmn.api.editors.types.DMNSimpleTimeZone;
+import org.kie.workbench.common.dmn.api.editors.types.DMNValidationService;
+import org.kie.workbench.common.dmn.api.editors.types.RangeValue;
+import org.kie.workbench.common.dmn.api.editors.types.TimeZoneService;
+import org.kie.workbench.common.dmn.client.service.DMNClientServicesProxy;
+import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+
+@Dependent
+public class DMNClientServicesProxyImpl implements DMNClientServicesProxy {
+
+    private final WorkspaceProjectContext projectContext;
+    private final Caller<DMNIncludedModelsService> includedModelsService;
+    private final Caller<DMNParseService> parserService;
+    private final Caller<DMNValidationService> validationService;
+    private final Caller<TimeZoneService> timeZoneService;
+
+    @Inject
+    public DMNClientServicesProxyImpl(final WorkspaceProjectContext projectContext,
+                                      final Caller<DMNIncludedModelsService> includedModelsService,
+                                      final Caller<DMNParseService> parserService,
+                                      final Caller<DMNValidationService> validationService,
+                                      final Caller<TimeZoneService> timeZoneService) {
+        this.projectContext = projectContext;
+        this.includedModelsService = includedModelsService;
+        this.parserService = parserService;
+        this.validationService = validationService;
+        this.timeZoneService = timeZoneService;
+    }
+
+    @Override
+    public void loadModels(final ServiceCallback<List<DMNIncludedModel>> callback) {
+        includedModelsService.call(onSuccess(callback), onError(callback)).loadModels(getWorkspaceProject());
+    }
+
+    @Override
+    public void loadNodesFromImports(final List<DMNIncludedModel> includedModels,
+                                     final ServiceCallback<List<DMNIncludedNode>> callback) {
+        includedModelsService.call(onSuccess(callback), onError(callback)).loadNodesFromImports(getWorkspaceProject(), includedModels);
+    }
+
+    @Override
+    public void loadItemDefinitionsByNamespace(final String modelName, String namespace,
+                                               final ServiceCallback<List<ItemDefinition>> callback) {
+        includedModelsService.call(onSuccess(callback), onError(callback)).loadItemDefinitionsByNamespace(getWorkspaceProject(), modelName, namespace);
+    }
+
+    @Override
+    public void parseFEELList(final String source,
+                              final ServiceCallback<List<String>> callback) {
+        parserService.call(onSuccess(callback), onError(callback)).parseFEELList(source);
+    }
+
+    @Override
+    public void parseRangeValue(final String source,
+                                final ServiceCallback<RangeValue> callback) {
+        parserService.call(onSuccess(callback), onError(callback)).parseRangeValue(source);
+    }
+
+    @Override
+    public void isValidVariableName(final String source,
+                                    final ServiceCallback<Boolean> callback) {
+        validationService.call(onSuccess(callback), onError(callback)).isValidVariableName(source);
+    }
+
+    @Override
+    public void getTimeZones(final ServiceCallback<List<DMNSimpleTimeZone>> callback) {
+        timeZoneService.call(onSuccess(callback), onError(callback)).getTimeZones();
+    }
+
+    <T> RemoteCallback<T> onSuccess(final ServiceCallback<T> callback) {
+        return callback::onSuccess;
+    }
+
+    <T> ErrorCallback<Boolean> onError(final ServiceCallback<T> callback) {
+        return (message, throwable) -> {
+            callback.onError(new ClientRuntimeError(throwable));
+            return false;
+        };
+    }
+
+    private WorkspaceProject getWorkspaceProject() {
+        return projectContext.getActiveWorkspaceProject().orElse(null);
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4041

This PR introduces a single `DMNClientServicesProxy` interface to be used in the _client_ to access **all** _external_ services. There is a single implementation of the interface in `-project-client` that uses Errai's `Caller` interface to make RPCs to the server (although the implementation is currently duplicated in the webapp module). The plan being that the Submarine editor has a different implementation to handle the requirements on the client-side (or return sensible defaults without a RPC).

When this is merged I'll rebase DROOLS-3727 with this and make the applicable changes for Submarine.