### PR TITLE
RHPAM-958 Error is visible in Alerts view even after it is fixed

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/ValidationExecutedNotification.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/ValidationExecutedNotification.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.notification;
+
+import java.util.Optional;
+
+public class ValidationExecutedNotification extends AbstractNotification {
+
+    public ValidationExecutedNotification(NotificationContext context) {
+        super(context, Type.INFO, "Validation Executed");
+    }
+
+    @Override
+    public Optional getSource() {
+        return Optional.empty();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/notification/NotificationsObserverTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/notification/NotificationsObserverTest.java
@@ -35,12 +35,14 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -72,6 +74,8 @@ public class NotificationsObserverTest {
     ParameterizedCommand<ValidationSuccessNotification> validationSuccess;
     @Mock
     ParameterizedCommand<ValidationFailedNotification> validationFailed;
+    @Mock
+    ParameterizedCommand<ValidationExecutedNotification> validationExecuted;
 
     private NotificationsObserver tested;
     private NotificationContext notificationContext;
@@ -95,6 +99,7 @@ public class NotificationsObserverTest {
         this.tested.onCommandExecutionFailed(commandFailed);
         this.tested.onValidationSuccess(validationSuccess);
         this.tested.onValidationFailed(validationFailed);
+        this.tested.onValidationExecuted(validationExecuted);
         this.tested.notificationBuilder = new NotificationsObserver.NotificationBuilder() {
             @Override
             public Notification createCommandNotification(NotificationContext context,
@@ -234,16 +239,14 @@ public class NotificationsObserverTest {
                                                  NAME,
                                                  TITLE);
         tested.onCanvasValidationSuccessEvent(validationSuccessEvent);
-        verify(onNotification,
-               times(1)).execute(any(Notification.class));
-        verify(validationSuccess,
-               times(1)).execute(eq(validationSuccessNotification));
-        verify(commandFailed,
-               never()).execute(any(CommandNotification.class));
-        verify(commandSuccess,
-               never()).execute(any(CommandNotification.class));
-        verify(validationFailed,
-               never()).execute(any(ValidationFailedNotification.class));
+        final InOrder inOrder = inOrder(validationExecuted, onNotification, validationFailed,
+                                  commandFailed, validationSuccess, commandSuccess);
+        inOrder.verify(validationExecuted).execute(any(ValidationExecutedNotification.class));
+        inOrder.verify(onNotification,times(1)).execute(any(Notification.class));
+        inOrder.verify(validationSuccess,times(1)).execute(eq(validationSuccessNotification));
+        inOrder.verify(commandFailed,never()).execute(any(CommandNotification.class));
+        inOrder.verify(commandSuccess,never()).execute(any(CommandNotification.class));
+        inOrder.verify(validationFailed,never()).execute(any(ValidationFailedNotification.class));
     }
 
     @Test
@@ -261,15 +264,13 @@ public class NotificationsObserverTest {
                                               TITLE,
                                               violations);
         tested.onCanvasValidationFailEvent(validationFailEvent);
-        verify(onNotification,
-               times(1)).execute(any(Notification.class));
-        verify(validationFailed,
-               times(1)).execute(eq(validationFailedNotification));
-        verify(commandFailed,
-               never()).execute(any(CommandNotification.class));
-        verify(validationSuccess,
-               never()).execute(any(ValidationSuccessNotification.class));
-        verify(commandSuccess,
-               never()).execute(any(CommandNotification.class));
+        final InOrder inOrder = inOrder(validationExecuted, onNotification, validationFailed,
+                                  commandFailed, validationSuccess, commandSuccess);
+        inOrder.verify(validationExecuted).execute(any(ValidationExecutedNotification.class));
+        inOrder.verify(onNotification, times(1)).execute(any(Notification.class));
+        inOrder.verify(validationFailed, times(1)).execute(eq(validationFailedNotification));
+        inOrder.verify(commandFailed, never()).execute(any(CommandNotification.class));
+        inOrder.verify(validationSuccess, never()).execute(any(ValidationSuccessNotification.class));
+        inOrder.verify(commandSuccess, never()).execute(any(CommandNotification.class));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListener.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.messageconsole.events.PublishMessagesEvent;
 import org.guvnor.messageconsole.events.SystemMessage;
+import org.guvnor.messageconsole.events.UnpublishMessagesEvent;
 import org.kie.workbench.common.stunner.client.widgets.notification.AbstractNotification;
 import org.kie.workbench.common.stunner.client.widgets.notification.NotificationsObserver;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -34,12 +35,15 @@ import org.uberfire.backend.vfs.Path;
 @Dependent
 public class ProjectMessagesListener {
 
+    public static final String MESSAGE_TYPE = "Stunner.";
     private final Event<PublishMessagesEvent> publishMessagesEvent;
+    private final Event<UnpublishMessagesEvent> unpublishMessagesEventEvent;
     private final NotificationsObserver notificationsObserver;
     private final SessionManager clientSessionManager;
 
     protected ProjectMessagesListener() {
         this(null,
+             null,
              null,
              null);
     }
@@ -47,20 +51,27 @@ public class ProjectMessagesListener {
     @Inject
     public ProjectMessagesListener(final NotificationsObserver notificationsObserver,
                                    final Event<PublishMessagesEvent> publishMessagesEvent,
+                                   final Event<UnpublishMessagesEvent> unpublishMessagesEventEvent,
                                    final SessionManager clientSessionManager) {
-        this.publishMessagesEvent = publishMessagesEvent;
         this.notificationsObserver = notificationsObserver;
+        this.publishMessagesEvent = publishMessagesEvent;
+        this.unpublishMessagesEventEvent = unpublishMessagesEventEvent;
         this.clientSessionManager = clientSessionManager;
     }
 
     public void enable() {
         notificationsObserver.onCommandExecutionFailed(parameter -> fireNotification(parameter));
         notificationsObserver.onValidationFailed(parameter -> fireNotification(parameter));
+        notificationsObserver.onValidationExecuted(parameter -> clearMessages(parameter));
+    }
+
+    private Path getDiagramPath() {
+        final ClientSession session = clientSessionManager.getCurrentSession();
+        return session.getCanvasHandler().getDiagram().getMetadata().getPath();
     }
 
     void fireNotification(final AbstractNotification notification) {
-        final ClientSession session = clientSessionManager.getCurrentSession();
-        final Path path = session.getCanvasHandler().getDiagram().getMetadata().getPath();
+
         final SystemMessage systemMessage = new SystemMessage();
         final ArrayList<SystemMessage> messagesList = new ArrayList<>();
 
@@ -75,12 +86,26 @@ public class ProjectMessagesListener {
                 systemMessage.setLevel(Level.INFO);
                 break;
         }
+
+        final Path path = getDiagramPath();
         systemMessage.setText(notification.getMessage());
         systemMessage.setPath(path);
+        systemMessage.setMessageType(getMessageType(path));
+
         messagesList.add(systemMessage);
         PublishMessagesEvent messages = new PublishMessagesEvent();
         messages.setShowSystemConsole(false);
         messages.setMessagesToPublish(messagesList);
         publishMessagesEvent.fire(messages);
+    }
+
+    private String getMessageType(Path path) {
+        return MESSAGE_TYPE + path.toURI();
+    }
+
+    protected void clearMessages(AbstractNotification notification) {
+        final UnpublishMessagesEvent unpublishMessagesEvent = new UnpublishMessagesEvent();
+        unpublishMessagesEvent.setMessageType(getMessageType(getDiagramPath()));
+        unpublishMessagesEventEvent.fire(unpublishMessagesEvent);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListener.java
@@ -37,7 +37,7 @@ public class ProjectMessagesListener {
 
     public static final String MESSAGE_TYPE = "Stunner.";
     private final Event<PublishMessagesEvent> publishMessagesEvent;
-    private final Event<UnpublishMessagesEvent> unpublishMessagesEventEvent;
+    private final Event<UnpublishMessagesEvent> unpublishMessagesEvent;
     private final NotificationsObserver notificationsObserver;
     private final SessionManager clientSessionManager;
 
@@ -51,11 +51,11 @@ public class ProjectMessagesListener {
     @Inject
     public ProjectMessagesListener(final NotificationsObserver notificationsObserver,
                                    final Event<PublishMessagesEvent> publishMessagesEvent,
-                                   final Event<UnpublishMessagesEvent> unpublishMessagesEventEvent,
+                                   final Event<UnpublishMessagesEvent> unpublishMessagesEvent,
                                    final SessionManager clientSessionManager) {
         this.notificationsObserver = notificationsObserver;
         this.publishMessagesEvent = publishMessagesEvent;
-        this.unpublishMessagesEventEvent = unpublishMessagesEventEvent;
+        this.unpublishMessagesEvent = unpublishMessagesEvent;
         this.clientSessionManager = clientSessionManager;
     }
 
@@ -106,6 +106,6 @@ public class ProjectMessagesListener {
     protected void clearMessages(AbstractNotification notification) {
         final UnpublishMessagesEvent unpublishMessagesEvent = new UnpublishMessagesEvent();
         unpublishMessagesEvent.setMessageType(getMessageType(getDiagramPath()));
-        unpublishMessagesEventEvent.fire(unpublishMessagesEvent);
+        this.unpublishMessagesEvent.fire(unpublishMessagesEvent);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListenerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListenerTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.project.client.screens;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.enterprise.event.Event;
@@ -32,9 +33,11 @@ import org.kie.workbench.common.stunner.client.widgets.notification.CommandNotif
 import org.kie.workbench.common.stunner.client.widgets.notification.Notification;
 import org.kie.workbench.common.stunner.client.widgets.notification.NotificationContext;
 import org.kie.workbench.common.stunner.client.widgets.notification.NotificationsObserver;
+import org.kie.workbench.common.stunner.client.widgets.notification.ValidationFailedNotification;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -47,7 +50,9 @@ import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -81,11 +86,10 @@ public class ProjectMessagesListenerTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
-        this.projectMessagesListener = new ProjectMessagesListener(notificationsObserver,
-                                                                   publishMessagesEvent,
-                                                                   unpublishMessagesEvent,
-                                                                   clientSessionManager
-        );
+        this.projectMessagesListener = spy(new ProjectMessagesListener(notificationsObserver,
+                                                                       publishMessagesEvent,
+                                                                       unpublishMessagesEvent,
+                                                                       clientSessionManager));
         when(clientSessionManager.getCurrentSession()).thenReturn(session);
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
@@ -96,9 +100,7 @@ public class ProjectMessagesListenerTest {
 
     @Test
     public void testFireNotificationError() {
-        NotificationContext context = new NotificationContext.Builder().build("test",
-                                                                              "test",
-                                                                              "test");
+        NotificationContext context = buildNotificationContext();
         Command<?, CanvasViolation> source = mock(Command.class);
         CommandNotification commandNotification = CommandNotification.Builder.build(
                 context,
@@ -130,9 +132,7 @@ public class ProjectMessagesListenerTest {
 
     @Test
     public void testFireNotificationInfo() {
-        NotificationContext context = new NotificationContext.Builder().build("test",
-                                                                              "test",
-                                                                              "test");
+        NotificationContext context = buildNotificationContext();
         Command<?, CanvasViolation> source = mock(Command.class);
         CommandNotification commandNotification = CommandNotification.Builder.build(
                 context,
@@ -143,15 +143,11 @@ public class ProjectMessagesListenerTest {
         ArgumentCaptor<PublishMessagesEvent> eventCaptor = ArgumentCaptor.forClass(PublishMessagesEvent.class);
         verify(publishMessagesEvent, times(1)).fire(eventCaptor.capture());
         testMessageToPublish(eventCaptor.getValue(), Level.INFO);
-
-
     }
 
     @Test
     public void testFireNotificationWarning() {
-        NotificationContext context = new NotificationContext.Builder().build("test",
-                                                                              "test",
-                                                                              "test");
+        NotificationContext context = buildNotificationContext();
         Command<?, CanvasViolation> source = mock(Command.class);
         CommandNotification commandNotification = CommandNotification.Builder.build(
                 context,
@@ -164,11 +160,42 @@ public class ProjectMessagesListenerTest {
         testMessageToPublish(eventCaptor.getValue(), Level.WARNING);
     }
 
+    private NotificationContext buildNotificationContext() {
+        return new NotificationContext.Builder().build("test",
+                                                       "test",
+                                                       "test");
+    }
+
     @Test
     public void testClearMessages() {
         final ArgumentCaptor<UnpublishMessagesEvent> eventCaptor = ArgumentCaptor.forClass(UnpublishMessagesEvent.class);
         projectMessagesListener.clearMessages(mock(AbstractNotification.class));
         verify(unpublishMessagesEvent).fire(eventCaptor.capture());
         assertEquals(eventCaptor.getValue().getMessageType(), ProjectMessagesListener.MESSAGE_TYPE + PATH);
+    }
+
+    @Test
+    public void testEnable() {
+        projectMessagesListener.enable();
+        final ArgumentCaptor<ParameterizedCommand> callbackCaptor =
+                ArgumentCaptor.forClass(ParameterizedCommand.class);
+
+        //onCommandExecutionFailed
+        verify(notificationsObserver).onCommandExecutionFailed(callbackCaptor.capture());
+        callbackCaptor.getAllValues().get(0).execute(CommandNotification.Builder.build(buildNotificationContext(),
+                                                                                       mock(Command.class),
+                                                                                       Notification.Type.INFO,
+                                                                                       "message"));
+        verify(projectMessagesListener, times(1)).fireNotification(any());
+
+        //onValidationFailed
+        verify(notificationsObserver).onValidationFailed(callbackCaptor.capture());
+        callbackCaptor.getAllValues().get(1).execute(ValidationFailedNotification.Builder.build(mock(ClientTranslationService.class), buildNotificationContext(), Collections.emptyList()));
+        verify(projectMessagesListener, times(2)).fireNotification(any());
+
+        //onValidationExecuted
+        verify(notificationsObserver).onValidationExecuted(callbackCaptor.capture());
+        callbackCaptor.getAllValues().get(2).execute(null);
+        verify(projectMessagesListener, times(1)).clearMessages(any());
     }
 }


### PR DESCRIPTION
Now validation alerts that have been solved on Stunner don't appear anymore on the panel.
[RHPAM-958](https://issues.jboss.org/browse/RHPAM-958)

@romartin 
@LuboTerifaj 