### PR TITLE
[Stunner] Fix a core dependency issue (which was causing the project showcase not running properly on IntelliJ)

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNEditorSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNEditorSession.java
@@ -54,11 +54,11 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.registry.impl.ClientCommandRegistry;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.DefaultEditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 import org.uberfire.mvp.Command;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNEditorSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/DMNEditorSessionTest.java
@@ -43,10 +43,10 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.Abs
 import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.registry.impl.ClientCommandRegistry;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
-import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.mockito.Mock;
 
 import static org.mockito.Matchers.eq;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/CommandNotification.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/CommandNotification.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.client.widgets.notification;
 import java.util.Optional;
 
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationMessages;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
@@ -79,8 +80,8 @@ public final class CommandNotification
 
         private static String getErrorMessage(final ClientTranslationService translationService,
                                               final CommandResult<CanvasViolation> result) {
-            return CoreTranslationMessages.getCanvasCommandValidationsErrorMessage(translationService,
-                                                                                   result.getViolations());
+            return ClientTranslationMessages.getCanvasCommandValidationsErrorMessage(translationService,
+                                                                                     result.getViolations());
         }
 
         private static Notification.Type getNotificationType(final CommandResult<CanvasViolation> result) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/ClientRedoCommandHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/ClientRedoCommandHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.command;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Specializes;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.registry.impl.ClientCommandRegistry;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.command.util.RedoCommandHandler;
+
+@Dependent
+@Specializes
+public class ClientRedoCommandHandler<C extends Command> extends RedoCommandHandler<C> {
+
+    @Inject
+    public ClientRedoCommandHandler(final ClientCommandRegistry<C> commandRegistry) {
+        super(commandRegistry);
+    }
+
+    public void setSession(final ClientSession clientSession) {
+        getClientRegistry().setSession(clientSession);
+    }
+
+    private ClientCommandRegistry<C> getClientRegistry() {
+        return (ClientCommandRegistry<C>) getRegistry();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/i18n/ClientTranslationMessages.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/i18n/ClientTranslationMessages.java
@@ -58,6 +58,23 @@ public class ClientTranslationMessages extends CoreTranslationMessages {
                                                        result);
     }
 
+    public static String getCanvasValidationsErrorMessage(final StunnerTranslationService translationService,
+                                                          final String key,
+                                                          final Iterable<CanvasViolation> result) {
+        final String message = translationService.getValue(key) + DOT + NEW_LINE
+                + translationService.getValue(CoreTranslationMessages.REASON) + COLON + NEW_LINE
+                + getValidationMessages(translationService,
+                                        result);
+        return message;
+    }
+
+    public static String getCanvasCommandValidationsErrorMessage(final StunnerTranslationService translationService,
+                                                                 final Iterable<CanvasViolation> result) {
+        return getCanvasValidationsErrorMessage(translationService,
+                                                CoreTranslationMessages.COMMAND_FAILED,
+                                                result);
+    }
+
     public String getRuleValidationMessage(final RuleViolation violation) {
         return getRuleValidationMessage(translationService,
                                         violation);
@@ -71,5 +88,18 @@ public class ClientTranslationMessages extends CoreTranslationMessages {
     public String getDomainValidationMessage(final DomainViolation violation) {
         return getDomainValidationMessage(translationService,
                                           violation);
+    }
+
+    private static String getValidationMessages(final StunnerTranslationService translationService,
+                                                final Iterable<CanvasViolation> violations) {
+        final StringBuilder message = new StringBuilder();
+        final int[] i = {1};
+        violations
+                .forEach(v -> message
+                        .append(OPEN_BRA).append(i[0]++).append(CLOSE_BRA)
+                        .append(getRuleValidationMessage(translationService,
+                                                         v))
+                        .append(NEW_LINE));
+        return message.toString();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/registry/impl/ClientCommandRegistry.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/registry/impl/ClientCommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.registry.impl;
+package org.kie.workbench.common.stunner.core.client.registry.impl;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.registry.impl.CommandRegistryImpl;
 
 /**
  * The client implementation for the CommandRegistry type.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandUndoneEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.command.ClientRedoCommandHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
@@ -35,7 +36,6 @@ import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
-import org.kie.workbench.common.stunner.core.command.util.RedoCommandHandler;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher.doKeysMatch;
@@ -45,7 +45,7 @@ import static org.kie.workbench.common.stunner.core.client.canvas.controls.keybo
 public class RedoSessionCommand extends AbstractClientSessionCommand<EditorSession> {
 
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
-    private final RedoCommandHandler<Command<AbstractCanvasHandler, CanvasViolation>> redoCommandHandler;
+    private final ClientRedoCommandHandler<Command<AbstractCanvasHandler, CanvasViolation>> redoCommandHandler;
 
     protected RedoSessionCommand() {
         this(null,
@@ -54,7 +54,7 @@ public class RedoSessionCommand extends AbstractClientSessionCommand<EditorSessi
 
     @Inject
     public RedoSessionCommand(final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                              final RedoCommandHandler<Command<AbstractCanvasHandler, CanvasViolation>> redoCommandHandler) {
+                              final ClientRedoCommandHandler<Command<AbstractCanvasHandler, CanvasViolation>> redoCommandHandler) {
         super(false);
         this.redoCommandHandler = redoCommandHandler;
         this.sessionCommandManager = sessionCommandManager;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
@@ -49,12 +49,12 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.registry.impl.ClientCommandRegistry;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
-import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.uberfire.mvp.Command;
 
 @Dependent

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/ClientRedoCommandHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/ClientRedoCommandHandlerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.command;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.registry.impl.ClientCommandRegistry;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientRedoCommandHandlerTest {
+
+    @Mock
+    private ClientCommandRegistry<Command> clientCommandRegistry;
+
+    private ClientRedoCommandHandler<Command> tested;
+
+    @Before
+    public void setup() {
+        tested = new ClientRedoCommandHandler<>(clientCommandRegistry);
+    }
+
+    @Test
+    public void testSetSession() {
+        ClientSession session = mock(ClientSession.class);
+        tested.setSession(session);
+        verify(clientCommandRegistry, times(1)).setSession(eq(session));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/i18n/ClientTranslationMessagesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/i18n/ClientTranslationMessagesTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.i18n;
+
+import java.util.Collections;
+
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessagesTest;
+import org.kie.workbench.common.stunner.core.i18n.StunnerTranslationService;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages.CLOSE_BRA;
+import static org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages.COLON;
+import static org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages.OPEN_BRA;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientTranslationMessagesTest {
+
+    @Mock
+    StunnerTranslationService translationService;
+
+    @Before
+    public void setup() {
+        when(translationService.getValue(eq(CoreTranslationMessages.REASON))).thenReturn("R");
+        when(translationService.getValue(eq(CoreTranslationMessages.ELEMENT_UUID))).thenReturn("E");
+        when(translationService.getValue(eq(CoreTranslationMessages.REASON))).thenReturn("R");
+        when(translationService.getValue(eq(CoreTranslationMessages.REASON))).thenReturn("R");
+    }
+
+    @Test
+    public void testCanvasValidationMessage() {
+
+        final RuleViolation ruleViolation = mock(RuleViolation.class);
+        final CanvasViolation canvasViolation = mock(CanvasViolation.class);
+        when(canvasViolation.getViolationType()).thenReturn(Violation.Type.ERROR);
+        when(canvasViolation.getRuleViolation()).thenReturn(ruleViolation);
+        when(ruleViolation.getViolationType()).thenReturn(Violation.Type.ERROR);
+        when(ruleViolation.getViolationType()).thenReturn(Violation.Type.ERROR);
+        final Iterable<CanvasViolation> violations = Collections.singletonList(canvasViolation);
+        when(translationService.getValue(eq("aKey"))).thenReturn("aValue");
+        when(translationService.getViolationMessage(eq(canvasViolation))).thenReturn("cv1");
+        String message = ClientTranslationMessages.getCanvasValidationsErrorMessage(translationService,
+                                                                                    "aKey",
+                                                                                    violations);
+        message = new SafeHtmlBuilder().appendEscapedLines(message).toSafeHtml().asString();
+        assertEquals("aValue." + CoreTranslationMessagesTest.HTML_NEW_LINE + "R" + COLON +
+                             CoreTranslationMessagesTest.HTML_NEW_LINE + OPEN_BRA + "1" + CLOSE_BRA + "(ERROR) "
+                             + "cv1" + CoreTranslationMessagesTest.HTML_NEW_LINE,
+                     message);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.Key
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandExecutedEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.command.CanvasCommandUndoneEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.client.command.ClientRedoCommandHandler;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
@@ -32,7 +33,6 @@ import org.kie.workbench.common.stunner.core.client.session.command.AbstractClie
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
-import org.kie.workbench.common.stunner.core.command.util.RedoCommandHandler;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -47,7 +47,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class RedoSessionCommandTest extends BaseSessionCommandKeyboardTest {
 
     @Mock
-    private RedoCommandHandler<Command<AbstractCanvasHandler, CanvasViolation>> redoCommandHandler;
+    private ClientRedoCommandHandler<Command<AbstractCanvasHandler, CanvasViolation>> redoCommandHandler;
 
     @Mock
     private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
@@ -132,8 +132,6 @@ public class RedoSessionCommandTest extends BaseSessionCommandKeyboardTest {
         doCallRealMethod().when(command).onCommandExecuted(any(CanvasCommandExecutedEvent.class));
         doCallRealMethod().when(command).bind(any(EditorSession.class));
 
-
-
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(session.getKeyboardControl()).thenReturn(keyboardControl);
         when(keyboardControl.addKeyShortcutCallback(any(KeyboardControl.KeyShortcutCallback.class))).thenReturn(keyboardControl);
@@ -151,8 +149,6 @@ public class RedoSessionCommandTest extends BaseSessionCommandKeyboardTest {
 
         doCallRealMethod().when(command).onCommandExecuted(any(CanvasCommandExecutedEvent.class));
         doCallRealMethod().when(command).bind(any(EditorSession.class));
-
-
 
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(session.getKeyboardControl()).thenReturn(keyboardControl);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
@@ -43,8 +43,8 @@ import org.kie.workbench.common.stunner.core.client.canvas.controls.select.Multi
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.registry.impl.ClientCommandRegistry;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mvp.Command;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
@@ -41,15 +41,7 @@
       <artifactId>kie-wb-common-stunner-core-api</artifactId>
     </dependency>
 
-    <!-- TODO: Should not be present here. -->
-    <dependency>
-      <groupId>org.kie.workbench.stunner</groupId>
-      <artifactId>kie-wb-common-stunner-client-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- GWT. -->
-
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
@@ -18,12 +18,11 @@ package org.kie.workbench.common.stunner.core.command.util;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
+import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 
 /**
  * This handler is an util class that achieves command "re-do" features.
@@ -44,15 +43,15 @@ import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry
 @Dependent
 public class RedoCommandHandler<C extends Command> {
 
-    private final ClientCommandRegistry<C> registry;
+    private final CommandRegistry<C> registry;
 
     protected RedoCommandHandler() {
         this(null);
     }
 
     @Inject
-    public RedoCommandHandler(final ClientCommandRegistry<C> clientCommandRegistry) {
-        this.registry = clientCommandRegistry;
+    public RedoCommandHandler(final CommandRegistry<C> commandRegistry) {
+        this.registry = commandRegistry;
     }
 
     public boolean onUndoCommandExecuted(final C command) {
@@ -88,15 +87,15 @@ public class RedoCommandHandler<C extends Command> {
                                       last);
     }
 
-    public void setSession(ClientSession clientSession) {
-        registry.setSession(clientSession);
-    }
-
     public boolean isEnabled() {
         return !registry.isEmpty();
     }
 
     public void clear() {
         registry.clear();
+    }
+
+    protected CommandRegistry<C> getRegistry() {
+        return registry;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/diagram/MetadataImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/diagram/MetadataImpl.java
@@ -16,14 +16,10 @@
 
 package org.kie.workbench.common.stunner.core.diagram;
 
-import java.util.Collection;
-
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.NonPortable;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
-import org.kie.workbench.common.stunner.core.client.ShapeSet;
-import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.uberfire.backend.vfs.Path;
 
 @Portable
@@ -46,7 +42,6 @@ public final class MetadataImpl extends AbstractMetadata {
 
         private final String defSetId;
         private final DefinitionManager definitionManager;
-        private final ShapeManager shapeManager;
         private String title;
         private String ssid;
         private Path root;
@@ -59,17 +54,8 @@ public final class MetadataImpl extends AbstractMetadata {
 
         public MetadataImplBuilder(final String defSetId,
                                    final DefinitionManager definitionManager) {
-            this(defSetId,
-                 definitionManager,
-                 null);
-        }
-
-        public MetadataImplBuilder(final String defSetId,
-                                   final DefinitionManager definitionManager,
-                                   final ShapeManager shapeManager) {
             this.defSetId = defSetId;
             this.definitionManager = definitionManager;
-            this.shapeManager = shapeManager;
         }
 
         public MetadataImplBuilder setPath(final Path path) {
@@ -101,30 +87,12 @@ public final class MetadataImpl extends AbstractMetadata {
                 if (null != defSet) {
                     result.setTitle(null != title ? title :
                                             definitionManager.adapters().forDefinitionSet().getDescription(defSet));
-                    final String s = null != ssid ? ssid : (null != getShapeSet() ? getShapeSet().getId() : null);
-                    if (null != s) {
-                        result.setShapeSetId(s);
-                    }
                 }
             } else {
                 result.setTitle(title);
                 result.setShapeSetId(ssid);
             }
             return result;
-        }
-
-        private ShapeSet<?> getShapeSet() {
-            if (null != shapeManager) {
-                final Collection<ShapeSet<?>> sets = shapeManager.getShapeSets();
-                if (null != sets && !sets.isEmpty()) {
-                    for (final ShapeSet<?> set : sets) {
-                        if (set.getDefinitionSetId().equals(defSetId)) {
-                            return set;
-                        }
-                    }
-                }
-            }
-            return null;
         }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessages.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessages.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.stunner.core.i18n;
 
 import java.util.Collection;
 
-import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
 import org.kie.workbench.common.stunner.core.validation.DomainViolation;
@@ -90,23 +89,6 @@ public class CoreTranslationMessages {
         return message;
     }
 
-    public static String getCanvasValidationsErrorMessage(final StunnerTranslationService translationService,
-                                                          final String key,
-                                                          final Iterable<CanvasViolation> result) {
-        final String message = translationService.getValue(key) + DOT + NEW_LINE
-                + translationService.getValue(CoreTranslationMessages.REASON) + COLON + NEW_LINE
-                + getValidationMessages(translationService,
-                                        result);
-        return message;
-    }
-
-    public static String getCanvasCommandValidationsErrorMessage(final StunnerTranslationService translationService,
-                                                                 final Iterable<CanvasViolation> result) {
-        return getCanvasValidationsErrorMessage(translationService,
-                                                CoreTranslationMessages.COMMAND_FAILED,
-                                                result);
-    }
-
     public static String getRuleValidationMessage(final StunnerTranslationService translationService,
                                                   final RuleViolation violation) {
         return getViolationTypeMessage(violation) + translationService.getViolationMessage(violation);
@@ -164,18 +146,5 @@ public class CoreTranslationMessages {
             return message.toString();
         }
         return "";
-    }
-
-    private static String getValidationMessages(final StunnerTranslationService translationService,
-                                                final Iterable<CanvasViolation> violations) {
-        final StringBuilder message = new StringBuilder();
-        final int[] i = {1};
-        violations
-                .forEach(v -> message
-                        .append(OPEN_BRA).append(i[0]++).append(CLOSE_BRA)
-                        .append(getRuleValidationMessage(translationService,
-                                                         v))
-                        .append(NEW_LINE));
-        return message.toString();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandlerTest.java
@@ -15,19 +15,15 @@
  */
 package org.kie.workbench.common.stunner.core.command.util;
 
-import javax.enterprise.event.Event;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.RegisterChangedEvent;
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
+import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
+import org.kie.workbench.common.stunner.core.registry.impl.CommandRegistryImpl;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -52,37 +48,21 @@ public class RedoCommandHandlerTest {
     @Mock
     private Command command2;
 
-    @Mock
-    private ClientCommandRegistry clientCommandRegistry;
-
-    @Mock
-    private ClientSession session;
-
-    @Mock
-    private CanvasHandler canvasHandler;
-
-    @Mock
-    private Event<RegisterChangedEvent> registerChangedEvent;
-
     private RedoCommandHandler tested;
+    private CommandRegistry commandRegistry;
 
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
-        this.tested = new RedoCommandHandler(clientCommandRegistry);
-        when(session.getCanvasHandler()).thenReturn(canvasHandler);
+        this.commandRegistry = spy(new CommandRegistryImpl());
+        this.tested = new RedoCommandHandler(commandRegistry);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testUndoCommandExecuted() {
-        ClientCommandRegistry clientCommandRegistry = new ClientCommandRegistry(registerChangedEvent);
-        clientCommandRegistry.setSession(session);
-
-        ClientCommandRegistry realRegistry = spy(clientCommandRegistry);
-        RedoCommandHandler tested = new RedoCommandHandler(realRegistry);
         assertTrue(tested.onUndoCommandExecuted(command1));
-        verify(realRegistry).register(eq(command1));
+        verify(commandRegistry).register(eq(command1));
         assertTrue(tested.isEnabled());
     }
 
@@ -92,9 +72,10 @@ public class RedoCommandHandlerTest {
         Object obj = mock(Object.class);
         CommandManager manager = mock(CommandManager.class);
         CommandResult expectedResult = mock(CommandResult.class);
-        when(clientCommandRegistry.peek()).thenReturn(command1);
-        when(manager.execute(obj,
-                             command1)).thenReturn(expectedResult);
+        when(commandRegistry.isEmpty()).thenReturn(false);
+        when(commandRegistry.peek()).thenReturn(command1);
+        when(manager.execute(anyObject(),
+                             eq(command1))).thenReturn(expectedResult);
 
         CommandResult actualResult = tested.execute(obj,
                                                     manager);
@@ -109,9 +90,9 @@ public class RedoCommandHandlerTest {
     public void testExecuteOnNull() {
         Object obj = mock(Object.class);
         CommandManager manager = mock(CommandManager.class);
-        when(clientCommandRegistry.isEmpty()).thenReturn(true);
+        when(commandRegistry.isEmpty()).thenReturn(true);
 
-        RedoCommandHandler tested = new RedoCommandHandler(clientCommandRegistry);
+        RedoCommandHandler tested = new RedoCommandHandler(commandRegistry);
 
         assertEquals(GraphCommandResultBuilder.SUCCESS,
                      tested.execute(obj, manager));
@@ -121,10 +102,6 @@ public class RedoCommandHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testExecuteJustRecentRedoCommand() {
-        ClientCommandRegistry clientCommandRegistry = new ClientCommandRegistry(registerChangedEvent);
-        clientCommandRegistry.setSession(session);
-
-        RedoCommandHandler tested = new RedoCommandHandler(spy(clientCommandRegistry));
         assertTrue(tested.onUndoCommandExecuted(command1));
         assertFalse(tested.onCommandExecuted(command1));
         assertFalse(tested.isEnabled());
@@ -133,10 +110,6 @@ public class RedoCommandHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testExecuteRemoveRedoCommands() {
-        ClientCommandRegistry clientCommandRegistry = new ClientCommandRegistry(registerChangedEvent);
-        clientCommandRegistry.setSession(session);
-
-        RedoCommandHandler tested = new RedoCommandHandler(spy(clientCommandRegistry));
         Command command3 = mock(Command.class);
         assertTrue(tested.onUndoCommandExecuted(command1));
         assertTrue(tested.onUndoCommandExecuted(command2));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessagesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/i18n/CoreTranslationMessagesTest.java
@@ -25,7 +25,6 @@ import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
 import org.kie.workbench.common.stunner.core.validation.ModelBeanViolation;
@@ -84,28 +83,6 @@ public class CoreTranslationMessagesTest {
         final String message = CoreTranslationMessages.getRuleValidationMessage(translationService,
                                                                                 ruleViolation);
         assertEquals("(WARNING) " + "rv1",
-                     message);
-    }
-
-    @Test
-    public void testCanvasValidationMessage() {
-
-        final RuleViolation ruleViolation = mock(RuleViolation.class);
-        final CanvasViolation canvasViolation = mock(CanvasViolation.class);
-        when(canvasViolation.getViolationType()).thenReturn(Violation.Type.ERROR);
-        when(canvasViolation.getRuleViolation()).thenReturn(ruleViolation);
-        when(ruleViolation.getViolationType()).thenReturn(Violation.Type.ERROR);
-        when(ruleViolation.getViolationType()).thenReturn(Violation.Type.ERROR);
-        final Iterable<CanvasViolation> violations = Collections.singletonList(canvasViolation);
-        when(translationService.getValue(eq("aKey"))).thenReturn("aValue");
-        when(translationService.getViolationMessage(eq(canvasViolation))).thenReturn("cv1");
-        String message = CoreTranslationMessages.getCanvasValidationsErrorMessage(translationService,
-                                                                                  "aKey",
-                                                                                  violations);
-        message = new SafeHtmlBuilder().appendEscapedLines(message).toSafeHtml().asString();
-        assertEquals("aValue." + HTML_NEW_LINE + "R" + COLON + HTML_NEW_LINE +
-                             OPEN_BRA + "1" + CLOSE_BRA + "(ERROR) "
-                             + "cv1" + HTML_NEW_LINE,
                      message);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-client/src/main/java/org/kie/workbench/common/stunner/cm/client/session/CaseManagementEditorSession.java
@@ -42,11 +42,11 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.command.Request;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.registry.impl.ClientCommandRegistry;
 import org.kie.workbench.common.stunner.core.client.session.Session;
 import org.kie.workbench.common.stunner.core.client.session.impl.DefaultEditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ManagedSession;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.core.registry.impl.ClientCommandRegistry;
 import org.uberfire.mvp.Command;
 
 @Dependent

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/README.md
@@ -40,15 +40,12 @@ To compile showcase project with source map execute following commands:
   - *GWT Modules to load*: org.kie.workbench.common.stunner.project.FastCompiledStunnerProjectShowcase             
   - *VM options*: 
         
-        -Xmx4g
+        -Xmx8g
         -Xms1g
         -Xss1M
         -XX:CompileThreshold=7000
         -Derrai.jboss.home=$PATH_OF_YOUR_CLONED_KIE_WB_COMMON_REPO/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/target/wildfly-14.0.1.Final
-        -Derrai.server.classOutput=$PATH_OF_YOUR_CLONED_KIE_WB_COMMON_REPO/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/target
-        -Djava.util.prefs.syncInterval=2000000
-        -Dorg.uberfire.async.executor.safemode=true
-        -Dorg.uberfire.nio.git.dir=/tmp/dir
+        -Derrai.marshalling.server.classOutput=$PATH_OF_YOUR_CLONED_KIE_WB_COMMON_REPO/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/target
         -Derrai.dynamic_validation.enabled=true
                       
   - *Dev mode parameters*: 


### PR DESCRIPTION
Hey @tiagodolphine @Josephblt @wmedvede @treblereel @hasys @LuboTerifaj 

Fixed the issue you're also facing with, about running the project showcase inside IntelliJ :+1

**Some feedback**
Will give you some feedback about how I did it, if you're instered on, so next times you can also consider this "approach" for debugging this.

I understand we're all getting stuck, inside IntelliJ, when running the project showcase at this point:

`[INFO] 2019-05-21 03:19:31,809 [pool-4-thread-6] INFO  Reachability strategy set to Annotated`

So I just run in debug mode, and once getting into that point paused the debugging, then on the same IntelliJ debug console just navigated to the frame "`pool-4-thread-6`" (it can change on each execution) and noticed it was in some kinda infitie loop when trying to resolve some injection point. Finally by looking on scope variables at this point, noticed some reference to a "`clientCommandRegistry`" type.

At that point, two fixes came into my mind:
1.- Quickly fix the project showcase by excluding from the server side Ioc (beans.xml) that concrete conflicting classes
2.- Fix the rigth dependencies on the code and injection points

Finally as solution 1) was faster, but dirty and not much reliable, just applid the solution 2) for the fix. See next section.

**Cause & fix**

The root cause was due to an invalid dependency from the (shared) core commons package to the client API, in fact there was an old TODO [here](https://github.com/kiegroup/kie-wb-common/blob/master/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml#L44), so that can easily lead to ambiguous or unsatisfied injection points, to non desired situations, and in this case, it ends up on some classpath issue as well on IntelliJ, ratherh than when running the showcase from command line.

So the fix has been just doing things well done - removing the invalid dependency and refactoring a few classes for it. It looks a safe change for me. Tested and everything seems to be working as before, on all shwocases.

PS: Notice also updated the README.md for the showcase project, changed a bit the gwt run configuration parameters, please check you've same ones in your IntelliJ configs. I also invalidated cache and restarted IntelliJ to be sure last changes were being applied...

Can you please review ASAP so we can all benefit from this running again?

Thanks!!