### PR TITLE
JBPM-8449: [Stunner] Can't click node edit button when line is over top of it

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ToolboxImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/main/java/org/kie/workbench/common/stunner/lienzo/toolbox/items/impl/ToolboxImpl.java
@@ -189,9 +189,11 @@ public class ToolboxImpl
         // Obtain the toolbox's location relative to the cardinal direction.
         final Point2D location = Positions.anchorFor(shapeBoundingBoxSupplier.get(),
                                                      this.at);
-        // Set the toolbox primitive's location.
-        asPrimitive().setLocation(location
-                                          .offset(this.offset));
+        // Set the toolbox primitive's location
+        // and ensure it's on top of any node or connector present in the layer below.
+        asPrimitive()
+                .setLocation(location.offset(this.offset))
+                .moveToTop();
         fireRefresh();
     }
 


### PR DESCRIPTION
Hey @hasys 

Here is the fix for [JBPM-8449](https://issues.jboss.org/browse/JBPM-8449).

See also a video that shows the fixed version [here](https://issues.jboss.org/browse/JBPM-8449?focusedCommentId=13736908&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13736908)

Thanks!