### PR TITLE
JBPM-8246: Stunner - non empty sub-process lose it's content after morph

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerView.java
@@ -127,7 +127,8 @@ public class TreeExplorerView extends Composite implements TreeExplorer.View {
     public boolean isItemChanged(final String uuid,
                                  final String parentUuid,
                                  final String name,
-                                 final OptionalInt index) {
+                                 final int childCount,
+                                 final OptionalInt indexIntoParent) {
 
         final TreeItem oldItem = tree.getItemByUuid(uuid);
         if (oldItem != null) {
@@ -137,9 +138,13 @@ public class TreeExplorerView extends Composite implements TreeExplorer.View {
             }
             final TreeItem oldItemParent = oldItem.getParentItem();
             final String oldParentUuid = null != oldItemParent ? oldItemParent.getUuid() : null;
+            final boolean isChildrenCountChanged = oldItem.getChildCount() != childCount;
+            if (isChildrenCountChanged) {
+                return true;
+            }
             return (((oldParentUuid == null && parentUuid == null) ||
                     (null != parentUuid && !parentUuid.equals(oldParentUuid)))) ||
-                    isIndexChanged().test(oldItem, index);
+                    isIndexChanged().test(oldItem, indexIntoParent);
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerTest.java
@@ -67,6 +67,7 @@ import org.uberfire.mvp.Command;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
@@ -298,7 +299,7 @@ public class TreeExplorerTest {
         when(parent.getOutEdges()).thenReturn(edges);
         when(child.getInEdges()).thenReturn(edges);
 
-        when(view.isItemChanged(anyString(), anyString(), anyString(), any(OptionalInt.class))).thenReturn(true);
+        when(view.isItemChanged(anyString(), anyString(), anyString(), anyInt(), any(OptionalInt.class))).thenReturn(true);
 
         testedTree.show(canvasHandler);
         final CanvasElementUpdatedEvent event = new CanvasElementUpdatedEvent(canvasHandler, child);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/explorer/tree/TreeExplorerViewTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.when;
 public class TreeExplorerViewTest {
 
     static final String ITEM_UUID = "item";
+    static final int ITEM_CHILDREN_COUNT = 0;
     static final String PARENT_UUID = "parent";
     static final String NAME = "name";
 
@@ -209,6 +210,7 @@ public class TreeExplorerViewTest {
     private TreeItem mockOldItem() {
         TreeItem oldItem = mock(TreeItem.class);
         when(tree.getItemByUuid(ITEM_UUID)).thenReturn(oldItem);
+        when(oldItem.getChildCount()).thenReturn(ITEM_CHILDREN_COUNT);
         when(oldItem.getLabel()).thenReturn(NAME);
         when(oldItem.getParentItem()).thenReturn(parentItem);
         when(oldItem.getUuid()).thenReturn(ITEM_UUID);
@@ -223,6 +225,20 @@ public class TreeExplorerViewTest {
         boolean isItemChanged = testedTreeExplorerView.isItemChanged(ITEM_UUID,
                                                                      PARENT_UUID,
                                                                      NAME,
+                                                                     ITEM_CHILDREN_COUNT,
+                                                                     OptionalInt.empty());
+        assertTrue(isItemChanged);
+    }
+
+    @Test
+    public void isChildrenCountChanged() {
+        TreeItem oldItem = mockOldItem();
+        when(oldItem.getChildCount()).thenReturn(1);
+
+        boolean isItemChanged = testedTreeExplorerView.isItemChanged(ITEM_UUID,
+                                                                     PARENT_UUID,
+                                                                     NAME,
+                                                                     ITEM_CHILDREN_COUNT,
                                                                      OptionalInt.empty());
         assertTrue(isItemChanged);
     }
@@ -235,6 +251,7 @@ public class TreeExplorerViewTest {
         assertTrue(testedTreeExplorerView.isItemChanged(ITEM_UUID,
                                                         PARENT_UUID,
                                                         NAME,
+                                                        ITEM_CHILDREN_COUNT,
                                                         OptionalInt.empty()));
     }
 
@@ -249,14 +266,17 @@ public class TreeExplorerViewTest {
         assertTrue(testedTreeExplorerView.isItemChanged(ITEM_UUID,
                                                         PARENT_UUID,
                                                         NAME,
+                                                        ITEM_CHILDREN_COUNT,
                                                         OptionalInt.of(0)));
         assertFalse(testedTreeExplorerView.isItemChanged(ITEM_UUID,
                                                          PARENT_UUID,
                                                          NAME,
+                                                         ITEM_CHILDREN_COUNT,
                                                          OptionalInt.of(1)));
         assertTrue(testedTreeExplorerView.isItemChanged(ITEM_UUID,
                                                         PARENT_UUID,
                                                         NAME,
+                                                        ITEM_CHILDREN_COUNT,
                                                         OptionalInt.of(2)));
     }
 
@@ -270,6 +290,7 @@ public class TreeExplorerViewTest {
         assertFalse(testedTreeExplorerView.isItemChanged(ITEM_UUID,
                                                          PARENT_UUID,
                                                          NAME,
+                                                         ITEM_CHILDREN_COUNT,
                                                          OptionalInt.of(0)));
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
@@ -23,35 +23,37 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.client.shape.EdgeShape;
 import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.util.ShapeUtils;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
-import org.kie.workbench.common.stunner.core.definition.morph.MorphDefinition;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Dock;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
-import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+
+import static org.kie.workbench.common.stunner.core.graph.util.GraphUtils.getChildNodes;
+import static org.kie.workbench.common.stunner.core.graph.util.GraphUtils.getDockParent;
+import static org.kie.workbench.common.stunner.core.graph.util.GraphUtils.getDockedNodes;
 
 public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
 
     private Node<? extends Definition<?>, Edge> candidate;
-    private MorphDefinition morphDefinition;
     private String shapeSetId;
 
     public MorphCanvasNodeCommand(final Node<? extends Definition<?>, Edge> candidate,
-                                  final MorphDefinition morphDefinition,
                                   final String shapeSetId) {
         this.candidate = candidate;
-        this.morphDefinition = morphDefinition;
         this.shapeSetId = shapeSetId;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
-        final Optional<Node> dockParentOptional = GraphUtils.getDockParent(candidate);
         final Optional<Node> parentOptional = getParent();
+        final Optional<Node> dockParentOptional = getDockParent(candidate);
+        final List<Node> dockedNodes = getDockedNodes(candidate);
+        final List<Node> childNodes = getChildNodes(candidate);
 
         // Removing parent from morphed node
         if (dockParentOptional.isPresent()) {
@@ -61,10 +63,10 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
         }
 
         //Remove docked nodes
-        GraphUtils.getDockedNodes(candidate).stream().forEach(node -> context.undock(candidate, node));
+        dockedNodes.stream().forEach(node -> context.undock(candidate, node));
 
         //Remove child
-        GraphUtils.getChildNodes(candidate).stream().forEach(node -> context.removeChild(candidate, node));
+        childNodes.stream().forEach(node -> context.removeChild(candidate, node));
 
         // Deregister the existing shape.
         context.deregister(candidate);
@@ -72,16 +74,11 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
         // Register the shape for the new morphed element.
         context.register(shapeSetId, candidate);
 
-        context.applyElementMutation(candidate, MutationContext.STATIC);
-
-        //Update connections
-        updateConnectionEdges(context, candidate);
-
         //Adding the Docked nodes
-        GraphUtils.getDockedNodes(candidate).stream().forEach(node -> context.dock(candidate, node));
+        dockedNodes.stream().forEach(node -> context.dock(candidate, node));
 
         //Adding the child
-        GraphUtils.getChildNodes(candidate).stream().forEach(node -> context.removeChild(candidate, node));
+        childNodes.stream().forEach(node -> context.removeChild(candidate, node));
 
         // Adding parent to the new morphed node
         if (dockParentOptional.isPresent()) {
@@ -89,6 +86,12 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
         } else {
             parentOptional.ifPresent(parent -> context.addChild(parent, candidate));
         }
+
+        //Update connections.
+        updateConnectionEdges(context, candidate);
+
+        // Update the new shape.
+        context.applyElementMutation(candidate, MutationContext.STATIC);
 
         return buildResult();
     }
@@ -105,6 +108,7 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
                 .ifPresent(edges -> edges.stream()
                         .filter(this::isViewEdge)
                         .forEach(edge -> updateConnections(context, edge, candidate, edge.getTargetNode())));
+        ShapeUtils.moveViewConnectorsToTop(context, candidate);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
@@ -78,7 +78,7 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
         dockedNodes.stream().forEach(node -> context.dock(candidate, node));
 
         //Adding the child
-        childNodes.stream().forEach(node -> context.removeChild(candidate, node));
+        childNodes.stream().forEach(node -> context.addChild(candidate, node));
 
         // Adding parent to the new morphed node
         if (dockParentOptional.isPresent()) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphNodeCommand.java
@@ -53,7 +53,6 @@ public class MorphNodeCommand extends AbstractCanvasGraphCommand {
     @Override
     protected AbstractCanvasCommand newCanvasCommand(final AbstractCanvasHandler context) {
         return new MorphCanvasNodeCommand(candidate,
-                                          morphDefinition,
                                           shapeSetId);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommandTest.java
@@ -36,7 +36,10 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,11 +47,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MorphCanvasNodeCommandTest extends AbstractCanvasCommandTest {
 
-    protected static final String NEW_SHAPE_SET_ID = "ssid2";
-
-    private MorphCanvasNodeCommand tested;
-
-    private TestingGraphInstanceBuilder.TestGraph4 graphInstance;
+    static final String NEW_SHAPE_SET_ID = "ssid2";
 
     @Mock
     private ViewConnector viewConnector;
@@ -65,51 +64,95 @@ public class MorphCanvasNodeCommandTest extends AbstractCanvasCommandTest {
     @Mock
     private ShapeView edge2ShapeView;
 
+    private MorphCanvasNodeCommand tested;
+
     @Before
-    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         super.setUp();
-
-        final TestingGraphMockHandler graphTestHandler = new TestingGraphMockHandler();
-        graphInstance = TestingGraphInstanceBuilder.newGraph4(graphTestHandler);
-        when(diagram.getGraph()).thenReturn(graphInstance.graph);
-        when(graphIndex.getGraph()).thenReturn(graphInstance.graph);
-
-        //mocking shapes
-        StreamSupport.<Node>stream(graphInstance.graph.nodes().spliterator(), true)
-                .map(node -> ((Node) node).getUUID())
-                .forEach(uuid -> when(canvas.getShape((String) uuid)).thenReturn(mock(Shape.class)));
-        when(canvas.getShape(graphInstance.edge1.getUUID())).thenReturn(edge1Shape);
-        when(canvas.getShape(graphInstance.edge2.getUUID())).thenReturn(edge2Shape);
         when(edge1Shape.getShapeView()).thenReturn(edge1ShapeView);
         when(edge2Shape.getShapeView()).thenReturn(edge2ShapeView);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void executeDockedNode() {
+    public void testMorphDockedNode() {
+        TestingGraphInstanceBuilder.TestGraph4 graphInstance = mockGraph4();
         this.tested = new MorphCanvasNodeCommand(graphInstance.dockedNode, NEW_SHAPE_SET_ID);
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         assertFalse(CommandUtils.isError(result));
-        verify(canvasHandler).deregister(graphInstance.dockedNode);
-        verify(canvasHandler).register(NEW_SHAPE_SET_ID, graphInstance.dockedNode);
-        verify(canvasHandler).applyElementMutation(graphInstance.dockedNode, MutationContext.STATIC);
-        verify(canvasHandler).undock(graphInstance.intermNode, graphInstance.dockedNode);
-        verify(canvasHandler).dock(graphInstance.intermNode, graphInstance.dockedNode);
+        verify(canvasHandler, times(1)).deregister(graphInstance.dockedNode);
+        verify(canvasHandler, times(1)).register(NEW_SHAPE_SET_ID, graphInstance.dockedNode);
+        verify(canvasHandler, times(1)).undock(graphInstance.intermNode, graphInstance.dockedNode);
+        verify(canvasHandler, times(1)).dock(graphInstance.intermNode, graphInstance.dockedNode);
+        verify(canvasHandler, times(1)).applyElementMutation(graphInstance.dockedNode, MutationContext.STATIC);
+        verify(canvasHandler, never()).removeChild(anyObject(), anyObject());
+        verify(canvasHandler, never()).addChild(anyObject(), anyObject());
+        verify(edge1ShapeView, never()).moveToTop();
+        verify(edge2ShapeView, never()).moveToTop();
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void executeIntermediateNode() {
+    public void testMorphSomeIntermediateNode() {
+        TestingGraphInstanceBuilder.TestGraph4 graphInstance = mockGraph4();
         this.tested = new MorphCanvasNodeCommand(graphInstance.intermNode, NEW_SHAPE_SET_ID);
         CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
         assertFalse(CommandUtils.isError(result));
-        verify(canvasHandler).deregister(graphInstance.intermNode);
-        verify(canvasHandler).register(NEW_SHAPE_SET_ID, graphInstance.intermNode);
-        verify(canvasHandler).applyElementMutation(graphInstance.intermNode, MutationContext.STATIC);
-        verify(canvasHandler).removeChild(graphInstance.parentNode, graphInstance.intermNode);
-        verify(canvasHandler).addChild(graphInstance.parentNode, graphInstance.intermNode);
+        verify(canvasHandler, times(1)).undock(eq(graphInstance.intermNode), eq(graphInstance.dockedNode));
+        verify(canvasHandler, times(1)).removeChild(graphInstance.parentNode, graphInstance.intermNode);
+        verify(canvasHandler, times(1)).deregister(graphInstance.intermNode);
+        verify(canvasHandler, times(1)).register(NEW_SHAPE_SET_ID, graphInstance.intermNode);
+        verify(canvasHandler, times(1)).addChild(graphInstance.parentNode, graphInstance.intermNode);
+        verify(canvasHandler, times(1)).dock(eq(graphInstance.intermNode), eq(graphInstance.dockedNode));
+        verify(canvasHandler, times(1)).applyElementMutation(graphInstance.intermNode, MutationContext.STATIC);
         verify(edge1ShapeView, times(1)).moveToTop();
         verify(edge2ShapeView, times(1)).moveToTop();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMorphSomeContainerNode() {
+        TestingGraphInstanceBuilder.TestGraph3 graphInstance = mockGraph3();
+        this.tested = new MorphCanvasNodeCommand(graphInstance.containerNode, NEW_SHAPE_SET_ID);
+        CommandResult<CanvasViolation> result = tested.execute(canvasHandler);
+        assertFalse(CommandUtils.isError(result));
+        verify(canvasHandler, times(1)).deregister(graphInstance.containerNode);
+        verify(canvasHandler, times(1)).removeChild(graphInstance.parentNode, graphInstance.containerNode);
+        verify(canvasHandler, times(1)).removeChild(graphInstance.containerNode, graphInstance.startNode);
+        verify(canvasHandler, times(1)).removeChild(graphInstance.containerNode, graphInstance.intermNode);
+        verify(canvasHandler, times(1)).removeChild(graphInstance.containerNode, graphInstance.endNode);
+        verify(canvasHandler, times(1)).register(NEW_SHAPE_SET_ID, graphInstance.containerNode);
+        verify(canvasHandler, times(1)).addChild(graphInstance.parentNode, graphInstance.containerNode);
+        verify(canvasHandler, times(1)).addChild(graphInstance.containerNode, graphInstance.startNode);
+        verify(canvasHandler, times(1)).addChild(graphInstance.containerNode, graphInstance.intermNode);
+        verify(canvasHandler, times(1)).addChild(graphInstance.containerNode, graphInstance.endNode);
+        verify(canvasHandler, times(1)).applyElementMutation(graphInstance.containerNode, MutationContext.STATIC);
+        verify(edge1ShapeView, times(1)).moveToTop();
+        verify(edge2ShapeView, times(1)).moveToTop();
+    }
+
+    private TestingGraphInstanceBuilder.TestGraph3 mockGraph3() {
+        TestingGraphInstanceBuilder.TestGraph3 graph3 = TestingGraphInstanceBuilder.newGraph3(new TestingGraphMockHandler());
+        when(canvas.getShape(eq(graph3.edge1.getUUID()))).thenReturn(edge1Shape);
+        when(canvas.getShape(eq(graph3.edge2.getUUID()))).thenReturn(edge2Shape);
+        return mockGraph(graph3);
+    }
+
+    private TestingGraphInstanceBuilder.TestGraph4 mockGraph4() {
+        TestingGraphInstanceBuilder.TestGraph4 graph4 = TestingGraphInstanceBuilder.newGraph4(new TestingGraphMockHandler());
+        when(canvas.getShape(eq(graph4.edge1.getUUID()))).thenReturn(edge1Shape);
+        when(canvas.getShape(eq(graph4.edge2.getUUID()))).thenReturn(edge2Shape);
+        return mockGraph(graph4);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends TestingGraphInstanceBuilder.TestGraph> T mockGraph(T graph) {
+        when(diagram.getGraph()).thenReturn(graph.graph);
+        when(graphIndex.getGraph()).thenReturn(graph.graph);
+        //mocking shapes
+        StreamSupport.<Node>stream(graph.graph.nodes().spliterator(), true)
+                .map(node -> ((Node) node).getUUID())
+                .forEach(uuid -> when(canvas.getShape(eq((String) uuid))).thenReturn(mock(Shape.class)));
+        return graph;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/AbstractElementFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/factory/impl/AbstractElementFactory.java
@@ -16,9 +16,11 @@
 
 package org.kie.workbench.common.stunner.core.factory.impl;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionAdapter;
 import org.kie.workbench.common.stunner.core.definition.adapter.DefinitionId;
 import org.kie.workbench.common.stunner.core.factory.graph.ElementFactory;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -34,11 +36,22 @@ public abstract class AbstractElementFactory<C, D extends Definition<C>, T exten
 
     protected void appendLabels(final Set<String> target,
                                 final Object definition) {
-        final DefinitionId id = getDefinitionManager().adapters().forDefinition().getId(definition);
+        target.addAll(computeLabels(getDefinitionManager()
+                                            .adapters()
+                                            .registry()
+                                            .getDefinitionAdapter(definition.getClass()),
+                                    definition));
+    }
+
+    public static <T> Set<String> computeLabels(final DefinitionAdapter<T> adapter,
+                                                final T definition) {
+        final Set<String> target = new HashSet<>();
+        final DefinitionId id = adapter.getId(definition);
         target.add(id.value());
         if (id.isDynamic()) {
             target.add(id.type());
         }
-        target.addAll(getDefinitionManager().adapters().forDefinition().getLabels(definition));
+        target.addAll(adapter.getLabels(definition));
+        return target;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphInstanceBuilder.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/TestingGraphInstanceBuilder.java
@@ -64,6 +64,11 @@ public class TestingGraphInstanceBuilder {
     public static final String EDGE3_UUID = "edge3";
     public static final String CONTAINER_NODE_UUID = "container1";
 
+    public static class TestGraph {
+
+        public Graph graph;
+    }
+
     /**
      * **********
      * * Graph1 *
@@ -72,9 +77,8 @@ public class TestingGraphInstanceBuilder {
      * Structure:
      * startNode --(edge1)--> intermNode --(edge2)--> endNode
      */
-    public static class TestGraph1 {
+    public static class TestGraph1 extends TestGraph {
 
-        public Graph graph;
         public Object startNodeBean;
         public Node startNode;
         public Object intermNodeBean;
@@ -103,9 +107,8 @@ public class TestingGraphInstanceBuilder {
      * |                     |                     |
      * startNode --(edge1)--> intermNode --(edge2)--> endNode
      */
-    public static class TestGraph2 {
+    public static class TestGraph2 extends TestGraph {
 
-        public Graph graph;
         public Node parentNode;
         public Node startNode;
         public Node intermNode;
@@ -135,9 +138,8 @@ public class TestingGraphInstanceBuilder {
      * ----------------------------------------------------------------------
      */
 
-    public static class TestGraph3 {
+    public static class TestGraph3 extends TestGraph {
 
-        public Graph graph;
         public Node parentNode;
         public Node containerNode;
         public Node startNode;
@@ -200,9 +202,8 @@ public class TestingGraphInstanceBuilder {
      * |                     |                                        |
      * startNode --(edge1)--> intermNode --(edge2)--> intermNode   endNode
      */
-    public static class TestGraph5 {
+    public static class TestGraph5 extends TestGraph {
 
-        public Graph graph;
         public Node parentNode;
         public Node startNode;
         public Node intermNode;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/MorphNodeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/MorphNodeCommandTest.java
@@ -46,6 +46,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MorphNodeCommandTest extends AbstractGraphCommandTest {
 
+    private static final String UUID = "uuid";
+
     private static final String CURRENT_DEFINITION = "current-definition";
 
     private static final String CURRENT_DEFINITION_ID = "current-definition-id";
@@ -68,34 +70,32 @@ public class MorphNodeCommandTest extends AbstractGraphCommandTest {
     @Mock
     private MorphAdapter morphAdaptor;
 
-    private Set<String> labels = new HashSet<>();
-
     private MorphNodeCommand tested;
+    private Set<String> labels = new HashSet<>();
 
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         super.init();
-
-        this.tested = new MorphNodeCommand(candidate, morphDefinition, CURRENT_DEFINITION_ID);
-
+        when(candidate.getUUID()).thenReturn(UUID);
         when(candidate.getLabels()).thenReturn(labels);
         when(candidate.getContent()).thenReturn(content);
         when(content.getDefinition()).thenReturn(CURRENT_DEFINITION);
         when(adapterRegistry.getMorphAdapter(any(Class.class))).thenReturn(morphAdaptor);
-
+        when(graphIndex.get(eq(UUID))).thenReturn(candidate);
+        when(graphIndex.getNode(eq(UUID))).thenReturn(candidate);
         when(definitionAdapter.getId(CURRENT_DEFINITION)).thenReturn(DefinitionId.build(CURRENT_DEFINITION_ID));
         when(definitionAdapter.getLabels(CURRENT_DEFINITION)).thenReturn(Collections.emptySet());
         when(morphAdaptor.morph(CURRENT_DEFINITION, morphDefinition, CURRENT_DEFINITION_ID)).thenReturn(NEW_DEFINITION);
-
         when(definitionAdapter.getId(NEW_DEFINITION)).thenReturn(DefinitionId.build(NEW_DEFINITION_ID));
         when(definitionAdapter.getLabels(NEW_DEFINITION)).thenReturn(Collections.singleton(NEW_DEFINITION_LABEL));
         when(morphAdaptor.morph(NEW_DEFINITION, morphDefinition, CURRENT_DEFINITION_ID)).thenReturn(CURRENT_DEFINITION);
+        tested = new MorphNodeCommand(candidate, morphDefinition, CURRENT_DEFINITION_ID);
     }
 
     @Test
     public void testAllow() {
-        final CommandResult<RuleViolation> result = tested.allow(graphCommandExecutionContext);
+        CommandResult<RuleViolation> result = tested.allow(graphCommandExecutionContext);
         assertEquals(CommandResult.Type.INFO,
                      result.getType());
         verify(ruleManager,
@@ -106,7 +106,7 @@ public class MorphNodeCommandTest extends AbstractGraphCommandTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testExecute() {
-        final CommandResult<RuleViolation> result = tested.execute(graphCommandExecutionContext);
+        CommandResult<RuleViolation> result = tested.execute(graphCommandExecutionContext);
         assertEquals(CommandResult.Type.INFO,
                      result.getType());
 
@@ -123,8 +123,7 @@ public class MorphNodeCommandTest extends AbstractGraphCommandTest {
         tested.execute(graphCommandExecutionContext);
         reset(content);
         when(content.getDefinition()).thenReturn(NEW_DEFINITION);
-
-        final CommandResult<RuleViolation> result = tested.undo(graphCommandExecutionContext);
+        CommandResult<RuleViolation> result = tested.undo(graphCommandExecutionContext);
         assertEquals(CommandResult.Type.INFO,
                      result.getType());
 


### PR DESCRIPTION
Hey @hasys 

Here is the fix for [JBPM-8246](https://issues.jboss.org/browse/JBPM-8246).

PS: Notice there is still some old TODO in the code that should nice to have, altghough IMO it's not urgent, so just created a new ticket for it too, see [JBPM-8524](https://issues.jboss.org/browse/JBPM-8524)

Thanks!