### PR TITLE
DROOLS-3976: edit cell by enter in Context, Function and Invocation

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
@@ -119,6 +120,9 @@ public class ExpressionEditorColumn extends DMNGridColumn<BaseGrid<? extends Exp
         cell.getValue().getValue()
                 .filter(nestedGrid -> !(nestedGrid instanceof UndefinedExpressionGrid))
                 .ifPresent(nestedGrid -> nestedGrid.selectFirstCell());
+        cell.getValue().getValue()
+                .filter(nestedGrid -> nestedGrid instanceof LiteralExpressionGrid)
+                .ifPresent(nestedGrid -> nestedGrid.startEditingCell(0, 0));
     }
 
     protected void updateWidthOfChildren() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumnTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
 import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.mocks.MockHasDOMElementResourcesHeaderMetaData;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseGrid;
@@ -385,6 +386,19 @@ public class ExpressionEditorColumnTest {
         column.edit(cell, null, null);
 
         verify(contextGrid).selectFirstCell();
+    }
+
+    @Test
+    public void testEditNestedLiteralExpressionGrid() {
+        final GridCell<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> cell = mock(GridCell.class);
+        final GridCellValue<Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>> cellValue = mock(GridCellValue.class);
+        final LiteralExpressionGrid leGrid = mock(LiteralExpressionGrid.class);
+        when(cell.getValue()).thenReturn(cellValue);
+        when(cellValue.getValue()).thenReturn(Optional.of(leGrid));
+
+        column.edit(cell, null, null);
+
+        verify(leGrid).startEditingCell(0, 0);
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3976

The fix enables to edit the cells in Context, Function and Invocation by keyboard. Edit by mouse was possible even without this fix.

@manstis @Bonuseto may I ask you for a review?