### PR TITLE
DROOLS-4082: Cant use whitespaces in expression duration("P1Y")

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/common/DurationHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/common/DurationHelper.java
@@ -18,15 +18,23 @@ package org.kie.workbench.common.dmn.client.editors.types.listview.constraint.co
 
 public class DurationHelper {
 
-    private static final String PREFIX = "duration(\"";
+    private static final String PREFIX = "duration";
 
-    private static final String SUFFIX = "\")";
+    private static final String OPEN_BRACKET = "(";
 
-    public static String addPrefixAndSuffix(final String value) {
-        return PREFIX + value + SUFFIX;
+    private static final String CLOSE_BRACKET = ")";
+
+    private static final String QUOTE = "\"";
+
+    public static String addFunctionCall(final String value) {
+        return PREFIX + OPEN_BRACKET + QUOTE + value + QUOTE + CLOSE_BRACKET;
     }
 
-    public static String removePrefixAndSuffix(final String rawValue) {
-        return rawValue.replace(PREFIX, "").replace(SUFFIX, "");
+    public static String getFunctionParameter(final String rawValue) {
+        return rawValue.replace(PREFIX, "")
+                   .replace(CLOSE_BRACKET, "")
+                   .replace(OPEN_BRACKET, "")
+                   .replace(" ", "")
+                   .replace(QUOTE, "");
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/day/time/DayTimeValueConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/day/time/DayTimeValueConverter.java
@@ -30,8 +30,8 @@ import com.google.gwt.json.client.JSONValue;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.client.views.pfly.widgets.MomentDurationObject;
 
-import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.addPrefixAndSuffix;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.removePrefixAndSuffix;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.addFunctionCall;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.getFunctionParameter;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DayTimeValueConverter_Day;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DayTimeValueConverter_Days;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DayTimeValueConverter_Hour;
@@ -58,11 +58,11 @@ public class DayTimeValueConverter {
                                                            value.getMinutes(),
                                                            value.getSeconds());
 
-        return addPrefixAndSuffix(moment.duration(properties).toISOString());
+        return addFunctionCall(moment.duration(properties).toISOString());
     }
 
     DayTimeValue fromDMNString(final String dmnString) {
-        final MomentDurationObject duration = moment.duration(removePrefixAndSuffix(dmnString));
+        final MomentDurationObject duration = moment.duration(getFunctionParameter(dmnString));
         return new DayTimeValue(duration.days(),
                                 duration.hours(),
                                 duration.minutes(),
@@ -78,9 +78,9 @@ public class DayTimeValueConverter {
         final String secondsLabel = pluralize(value.getSeconds(), DayTimeValueConverter_Second, DayTimeValueConverter_Seconds);
 
         return Stream
-                .of(daysLabel, hoursLabel, minutesLabel, secondsLabel)
-                .filter(e -> !isEmpty(e))
-                .collect(Collectors.joining(", "));
+                   .of(daysLabel, hoursLabel, minutesLabel, secondsLabel)
+                   .filter(e -> !isEmpty(e))
+                   .collect(Collectors.joining(", "));
     }
 
     private JavaScriptObject makeProperties(final Integer days,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/years/months/YearsMonthsValueConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/years/months/YearsMonthsValueConverter.java
@@ -151,10 +151,10 @@ public class YearsMonthsValueConverter {
     }
 
     static String addPrefixAndSuffix(final String value) {
-        return DurationHelper.addPrefixAndSuffix("P" + value);
+        return DurationHelper.addFunctionCall("P" + value);
     }
 
     String removePrefixAndSuffix(final String dmnString) {
-        return DurationHelper.removePrefixAndSuffix(dmnString).substring(1);
+        return DurationHelper.getFunctionParameter(dmnString).substring(1);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/common/DurationHelperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/common/DurationHelperTest.java
@@ -19,24 +19,42 @@ package org.kie.workbench.common.dmn.client.editors.types.listview.constraint.co
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.addPrefixAndSuffix;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.removePrefixAndSuffix;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.addFunctionCall;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.typed.common.DurationHelper.getFunctionParameter;
 
 public class DurationHelperTest {
 
     @Test
-    public void testAddPrefixAndSuffix() {
+    public void testAddFunctionCall() {
 
-        final String actual = addPrefixAndSuffix("<VALUE>");
+        final String actual = addFunctionCall("<VALUE>");
         final String expected = "duration(\"<VALUE>\")";
 
         assertEquals(expected, actual);
     }
 
     @Test
-    public void testRemovePrefixAndSuffix() {
+    public void testGetFunctionParameter() {
 
-        final String actual = removePrefixAndSuffix("duration(\"<VALUE>\")");
+        final String actual = getFunctionParameter("duration(\"<VALUE>\")");
+        final String expected = "<VALUE>";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetFunctionParameterWithSpacesBeforeOpenBracket() {
+
+        final String actual = getFunctionParameter("duration        (\"<VALUE>\")");
+        final String expected = "<VALUE>";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetFunctionParameterWithSpacesInsideBrackets() {
+
+        final String actual = getFunctionParameter("duration(     \"<VALUE>\"     )");
         final String expected = "<VALUE>";
 
         assertEquals(expected, actual);


### PR DESCRIPTION
@manstis @jomarko I decided to use a simpler approach since using the FEELParser would demand too many changes.