### PR TITLE
JBPM-8548 Stunner - Issue with ServiceTaks migrating from jBPM Designer to Stunner

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReader.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.prope
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.bpmn2.Assignment;
 import org.eclipse.bpmn2.DataInput;
@@ -70,11 +71,17 @@ public class InputAssignmentReader {
     }
 
     private String encode(String body) {
-        try {
-            return URLEncoder.encode(body, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(body, e);
-        }
+        return Optional
+                .ofNullable(body)
+                .filter(b -> !"null".equals(b))
+                .map(b -> {
+                    try {
+                        return URLEncoder.encode(b, "UTF-8");
+                    } catch (UnsupportedEncodingException e) {
+                        throw new IllegalArgumentException(body, e);
+                    }
+                })
+                .orElse("");
     }
 
     public AssociationDeclaration getAssociationDeclaration() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/AssociationDeclarationTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/AssociationDeclarationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Direction.Input;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Direction.Output;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Type.SourceTarget;
+
+public class AssociationDeclarationTest {
+
+    private static final String INPUT_ASSIGNMENTS_VALUE = "[din]var1->input1";
+    private static final String INPUT_ASSIGNMENTS_VALUE_MISSING = "[din]var1->";
+    private static final String OUTPUT_ASSIGNMENTS_VALUE = "[dout]output1->var1";
+    private static final String OUTPUT_ASSIGNMENTS_VALUE_MISSING = "[dout]output1->";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromStringNull() {
+        AssociationDeclaration.fromString(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromStringEmpty() {
+        AssociationDeclaration.fromString("");
+    }
+
+    @Test
+    public void testFromStringInput() {
+        AssociationDeclaration associationDeclaration = AssociationDeclaration.fromString(INPUT_ASSIGNMENTS_VALUE);
+        assertEquals(associationDeclaration.getSource(), "var1");
+        assertEquals(associationDeclaration.getTarget(), "input1");
+        assertEquals(associationDeclaration.getType(), SourceTarget);
+        assertEquals(associationDeclaration.getDirection(), Input);
+    }
+
+    @Test
+    public void testFromStringOutput() {
+        AssociationDeclaration associationDeclaration = AssociationDeclaration.fromString(OUTPUT_ASSIGNMENTS_VALUE);
+        assertEquals(associationDeclaration.getSource(), "output1");
+        assertEquals(associationDeclaration.getTarget(), "var1");
+        assertEquals(associationDeclaration.getType(), SourceTarget);
+        assertEquals(associationDeclaration.getDirection(), Output);
+    }
+
+    @Test
+    public void testFromStringInputMissing() {
+        AssociationDeclaration associationDeclaration = AssociationDeclaration.fromString(INPUT_ASSIGNMENTS_VALUE_MISSING);
+        assertEquals(associationDeclaration.getSource(), "var1");
+        assertEquals(associationDeclaration.getTarget(), "");
+        assertEquals(associationDeclaration.getType(), SourceTarget);
+        assertEquals(associationDeclaration.getDirection(), Input);
+    }
+
+    @Test
+    public void testFromStringOutputMissing() {
+        AssociationDeclaration associationDeclaration = AssociationDeclaration.fromString(OUTPUT_ASSIGNMENTS_VALUE_MISSING);
+        assertEquals(associationDeclaration.getSource(), "output1");
+        assertEquals(associationDeclaration.getTarget(), "");
+        assertEquals(associationDeclaration.getType(), SourceTarget);
+        assertEquals(associationDeclaration.getDirection(), Output);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/InputAssignmentReaderTest.java
@@ -29,26 +29,43 @@ import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunn
 
 public class InputAssignmentReaderTest {
 
+    public static final String ID = "ID";
+
     @Test
     public void urlEncodeConstants() throws UnsupportedEncodingException {
-        String decoded = "<<<#!!!#>>>";
-        String expected = URLEncoder.encode(decoded, "UTF-8");
+        final String decoded = "<<<#!!!#>>>";
+        final String expected = URLEncoder.encode(decoded, "UTF-8");
 
-        Assignment assignment = bpmn2.createAssignment();
-        FormalExpression from = bpmn2.createFormalExpression();
-        from.setBody(decoded);
+        final Assignment assignment = createAssignment(decoded);
 
-        FormalExpression to = bpmn2.createFormalExpression();
-        to.setBody("ID");
+        final InputAssignmentReader iar = new InputAssignmentReader(assignment, ID);
 
-        assignment.setFrom(from);
-        assignment.setTo(to);
-
-        InputAssignmentReader iar = new InputAssignmentReader(assignment, "ID");
-
-        AssociationDeclaration associationDeclaration = iar.getAssociationDeclaration();
+        final AssociationDeclaration associationDeclaration = iar.getAssociationDeclaration();
 
         assertEquals(AssociationDeclaration.Type.FromTo, associationDeclaration.getType());
         assertEquals(expected, associationDeclaration.getSource());
+    }
+
+    private Assignment createAssignment(String decodedBody) {
+        final Assignment assignment = bpmn2.createAssignment();
+        final FormalExpression from = bpmn2.createFormalExpression();
+        from.setBody(decodedBody);
+
+        final FormalExpression to = bpmn2.createFormalExpression();
+        to.setBody(ID);
+
+        assignment.setFrom(from);
+        assignment.setTo(to);
+        return assignment;
+    }
+
+    @Test
+    public void testNullBody() {
+        final Assignment assignment = createAssignment(null);
+        final InputAssignmentReader iar = new InputAssignmentReader(assignment, ID);
+        final AssociationDeclaration associationDeclaration = iar.getAssociationDeclaration();
+
+        assertEquals(AssociationDeclaration.Type.FromTo, associationDeclaration.getType());
+        assertEquals("", associationDeclaration.getSource());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -243,6 +243,8 @@ public class BPMNDirectDiagramMarshallerTest {
     private static final String ARIS_MULTIPLE_COLLAPSED_SUBPROCESSES = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/aris/ARIS_MULTIPLE_COLLAPSED_SUBPROCESSES.bpmn";
     private static final String ARIS_NESTED_COLLAPSED_SUBPROCESSES = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/aris/ARIS_NESTED_COLLAPSED_SUBPROCESES.bpmn";
     private static final String ARIS_COLLAPSED_SUBPROCESS_IN_LANE = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/aris/ARIS_COLLAPSED_SUBPROCESS_IN_LANE.bpmn";
+    private static final String BPMN_LOG_TASK_JBPM_DESIGNER = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/logtask.bpmn";
+    private static final String BPMN_SERVICETASKS_JBPM_DESIGNER = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/serviceTasksJBPMDeginer.bpmn";
 
     private static final String NEW_LINE = System.lineSeparator();
 
@@ -356,6 +358,33 @@ public class BPMNDirectDiagramMarshallerTest {
 
         Node<? extends Definition, ?> task1 = diagram.getGraph().getNode("810797AB-7D09-4E1F-8A5B-96C424E4B031");
         assertTrue(task1.getContent().getDefinition() instanceof NoneTask);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnmarshallLogTaskJBPMDesigner() throws Exception {
+        Diagram<Graph, Metadata> diagram = unmarshall(BPMN_LOG_TASK_JBPM_DESIGNER);
+        assertDiagram(diagram, 4);
+
+        Node<? extends Definition, ?> log = diagram.getGraph().getNode("_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF");
+        assertTrue(log.getContent().getDefinition() instanceof ServiceTask);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnmarshallServiceTaskJBPMDesigner() throws Exception {
+        Diagram<Graph, Metadata> diagram = unmarshall(BPMN_SERVICETASKS_JBPM_DESIGNER);
+        assertDiagram(diagram, 9);
+
+        Node<? extends Definition, ?> email = diagram.getGraph().getNode("_2255B80D-ADCF-47C8-A16F-82E7BB9AD929");
+        Node<? extends Definition, ?> rest = diagram.getGraph().getNode("_D8B91719-0540-4A98-9734-CAF4C703B051");
+        Node<? extends Definition, ?> ws = diagram.getGraph().getNode("_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA");
+        Node<? extends Definition, ?> log = diagram.getGraph().getNode("_324A9674-039E-4B80-80EF-A9B6A44ACA33");
+
+        assertTrue(email.getContent().getDefinition() instanceof ServiceTask);
+        assertTrue(rest.getContent().getDefinition() instanceof ServiceTask);
+        assertTrue(ws.getContent().getDefinition() instanceof ServiceTask);
+        assertTrue(log.getContent().getDefinition() instanceof ServiceTask);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/logtask.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/logtask.bpmn
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_Bgi3sIIrEemAcKfBWW5qNw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="1.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="__AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_MessageInputXItem" structureRef="String"/>
+  <bpmn2:process id="com.myspace.emptyproject.LogTask" drools:packageName="com.myspace.emptyproject" drools:version="1.0" name="LogTask" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_723FC466-F27A-43AF-8ED6-4A79CAF22487</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF" drools:selectable="true" drools:taskName="Log" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Log">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Log]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_723FC466-F27A-43AF-8ED6-4A79CAF22487</bpmn2:incoming>
+      <bpmn2:outgoing>_0613AB0B-824E-472C-BBA3-65B555B9EC5D</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_Bgi3sYIrEemAcKfBWW5qNw">
+        <bpmn2:dataInput id="_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_TaskNameInputX" drools:dtype="String" itemSubjectRef="__AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_MessageInputX" drools:dtype="String" itemSubjectRef="__AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_MessageInputXItem" name="Message"/>
+        <bpmn2:inputSet id="_Bgi3soIrEemAcKfBWW5qNw">
+          <bpmn2:dataInputRefs>_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_MessageInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_Bgi3s4IrEemAcKfBWW5qNw"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_Bgi3tIIrEemAcKfBWW5qNw">
+        <bpmn2:targetRef>_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_Bgi3tYIrEemAcKfBWW5qNw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_Bgi3toIrEemAcKfBWW5qNw"><![CDATA[Log]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_Bgi3t4IrEemAcKfBWW5qNw">_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_Bgi3uIIrEemAcKfBWW5qNw">
+        <bpmn2:targetRef>_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_MessageInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_Bgi3uYIrEemAcKfBWW5qNw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_Bgi3uoIrEemAcKfBWW5qNw"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_Bgi3u4IrEemAcKfBWW5qNw">_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF_MessageInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="_723FC466-F27A-43AF-8ED6-4A79CAF22487" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF"/>
+    <bpmn2:endEvent id="_FA85A4B1-A180-4348-ABDB-075A6CA2CA12" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0613AB0B-824E-472C-BBA3-65B555B9EC5D</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_0613AB0B-824E-472C-BBA3-65B555B9EC5D" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF" targetRef="_FA85A4B1-A180-4348-ABDB-075A6CA2CA12"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_Bgi3vIIrEemAcKfBWW5qNw">
+    <bpmndi:BPMNPlane id="_Bgi3vYIrEemAcKfBWW5qNw" bpmnElement="com.myspace.emptyproject.LogTask">
+      <bpmndi:BPMNShape id="_Bgi3voIrEemAcKfBWW5qNw" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="135.0" y="175.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_Bgi3v4IrEemAcKfBWW5qNw" bpmnElement="_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF">
+        <dc:Bounds height="80.0" width="100.0" x="255.0" y="150.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_Bgi3wIIrEemAcKfBWW5qNw" bpmnElement="_FA85A4B1-A180-4348-ABDB-075A6CA2CA12">
+        <dc:Bounds height="28.0" width="28.0" x="480.0" y="176.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_Bgi3wYIrEemAcKfBWW5qNw" bpmnElement="_723FC466-F27A-43AF-8ED6-4A79CAF22487" sourceElement="_Bgi3voIrEemAcKfBWW5qNw" targetElement="_Bgi3v4IrEemAcKfBWW5qNw">
+        <di:waypoint xsi:type="dc:Point" x="150.0" y="190.0"/>
+        <di:waypoint xsi:type="dc:Point" x="305.0" y="190.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_Bgi3woIrEemAcKfBWW5qNw" bpmnElement="_0613AB0B-824E-472C-BBA3-65B555B9EC5D" sourceElement="_Bgi3v4IrEemAcKfBWW5qNw" targetElement="_Bgi3wIIrEemAcKfBWW5qNw">
+        <di:waypoint xsi:type="dc:Point" x="305.0" y="190.0"/>
+        <di:waypoint xsi:type="dc:Point" x="494.0" y="190.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_Bgi3w4IrEemAcKfBWW5qNw" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FA85A4B1-A180-4348-ABDB-075A6CA2CA12" id="_Bgi3xIIrEemAcKfBWW5qNw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0613AB0B-824E-472C-BBA3-65B555B9EC5D" id="_Bgi3xYIrEemAcKfBWW5qNw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_723FC466-F27A-43AF-8ED6-4A79CAF22487" id="_Bgi3xoIrEemAcKfBWW5qNw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_Bgi3x4IrEemAcKfBWW5qNw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AE76ACC9-CCD0-425D-BD40-5E4F3533A1DF" id="_Bgi3yIIrEemAcKfBWW5qNw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_Bgi3sIIrEemAcKfBWW5qNw</bpmn2:source>
+    <bpmn2:target>_Bgi3sIIrEemAcKfBWW5qNw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/serviceTasksJBPMDeginer.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/serviceTasksJBPMDeginer.bpmn
@@ -1,0 +1,595 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_qQ-pgIIZEemTAPudtaeePg" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="1.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_ToInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_BodyInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_FromInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_SubjectInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_ContentDataInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_UsernameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_MethodInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_UrlInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_ConnectTimeoutInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_PasswordInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_ReadTimeoutInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D8B91719-0540-4A98-9734-CAF4C703B051_ResultOutputXItem" structureRef="java.lang.Object"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_EndpointInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_UrlInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_NamespaceInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_InterfaceInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ModeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ParameterInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_OperationInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ResultOutputXItem" structureRef="java.lang.Object"/>
+  <bpmn2:itemDefinition id="__324A9674-039E-4B80-80EF-A9B6A44ACA33_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__324A9674-039E-4B80-80EF-A9B6A44ACA33_MessageInputXItem" structureRef="String"/>
+  <bpmn2:process id="com.myspace.aaaaasdddc.servicetasks-old" drools:packageName="com.myspace.aaaaasdddc" drools:version="1.0" name="servicetasks-old" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_035B06B7-3090-470A-8C24-085981158CAC</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_8AC645E3-F041-4F99-9C04-FAC315EEBBD3" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="User">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[User]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_035B06B7-3090-470A-8C24-085981158CAC</bpmn2:incoming>
+      <bpmn2:outgoing>_29548BBE-6CFC-4BE2-A3F3-0549E354EE99</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_qQ-pgYIZEemTAPudtaeePg">
+        <bpmn2:dataInput id="_8AC645E3-F041-4F99-9C04-FAC315EEBBD3_SkippableInputX" name="Skippable"/>
+        <bpmn2:inputSet id="_qQ-pgoIZEemTAPudtaeePg">
+          <bpmn2:dataInputRefs>_8AC645E3-F041-4F99-9C04-FAC315EEBBD3_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_qQ-pg4IZEemTAPudtaeePg"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_qQ-phIIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_8AC645E3-F041-4F99-9C04-FAC315EEBBD3_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ-phYIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ-phoIZEemTAPudtaeePg">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ-ph4IZEemTAPudtaeePg">_8AC645E3-F041-4F99-9C04-FAC315EEBBD3_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_035B06B7-3090-470A-8C24-085981158CAC" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_8AC645E3-F041-4F99-9C04-FAC315EEBBD3"/>
+    <bpmn2:task id="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929" drools:selectable="true" drools:taskName="Email" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Email">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Email]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_91243854-977F-4B22-9671-DC6E48050890</bpmn2:incoming>
+      <bpmn2:outgoing>_4BFFC45F-E938-4E40-9ACE-ADEA5E11C3D8</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_qQ-piIIZEemTAPudtaeePg">
+        <bpmn2:dataInput id="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_TaskNameInputX" drools:dtype="String" itemSubjectRef="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_ToInputX" drools:dtype="String" itemSubjectRef="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_ToInputXItem" name="To"/>
+        <bpmn2:dataInput id="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_BodyInputX" drools:dtype="String" itemSubjectRef="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_BodyInputXItem" name="Body"/>
+        <bpmn2:dataInput id="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_FromInputX" drools:dtype="String" itemSubjectRef="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_FromInputXItem" name="From"/>
+        <bpmn2:dataInput id="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_SubjectInputX" drools:dtype="String" itemSubjectRef="__2255B80D-ADCF-47C8-A16F-82E7BB9AD929_SubjectInputXItem" name="Subject"/>
+        <bpmn2:inputSet id="_qQ-piYIZEemTAPudtaeePg">
+          <bpmn2:dataInputRefs>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_ToInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_BodyInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_FromInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_SubjectInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_qQ-pioIZEemTAPudtaeePg"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_qQ-pi4IZEemTAPudtaeePg">
+        <bpmn2:targetRef>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ-pjIIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ-pjYIZEemTAPudtaeePg"><![CDATA[Email]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ-pjoIZEemTAPudtaeePg">_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ-pj4IZEemTAPudtaeePg">
+        <bpmn2:targetRef>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_ToInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ-pkIIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ-pkYIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ-pkoIZEemTAPudtaeePg">_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_ToInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ-pk4IZEemTAPudtaeePg">
+        <bpmn2:targetRef>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_BodyInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ-plIIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ-plYIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_QkIIZEemTAPudtaeePg">_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_BodyInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_QkYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_FromInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QkoIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_Qk4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_QlIIZEemTAPudtaeePg">_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_FromInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_QlYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_SubjectInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QloIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_Ql4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_QmIIZEemTAPudtaeePg">_2255B80D-ADCF-47C8-A16F-82E7BB9AD929_SubjectInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:task id="_D8B91719-0540-4A98-9734-CAF4C703B051" drools:selectable="true" drools:taskName="Rest" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="REST">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[REST]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_D45DF987-6FA5-4E9A-803F-9744C2C90458</bpmn2:incoming>
+      <bpmn2:outgoing>_45168131-8012-49F3-BDEC-FCBA5662158C</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_qQ_QmYIZEemTAPudtaeePg">
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_TaskNameInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_ContentDataInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_ContentDataInputXItem" name="ContentData"/>
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_UsernameInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_UsernameInputXItem" name="Username"/>
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_MethodInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_MethodInputXItem" name="Method"/>
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_UrlInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_UrlInputXItem" name="Url"/>
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_ConnectTimeoutInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_ConnectTimeoutInputXItem" name="ConnectTimeout"/>
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_PasswordInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_PasswordInputXItem" name="Password"/>
+        <bpmn2:dataInput id="_D8B91719-0540-4A98-9734-CAF4C703B051_ReadTimeoutInputX" drools:dtype="String" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_ReadTimeoutInputXItem" name="ReadTimeout"/>
+        <bpmn2:dataOutput id="_D8B91719-0540-4A98-9734-CAF4C703B051_ResultOutputX" drools:dtype="java.lang.Object" itemSubjectRef="__D8B91719-0540-4A98-9734-CAF4C703B051_ResultOutputXItem" name="Result"/>
+        <bpmn2:inputSet id="_qQ_QmoIZEemTAPudtaeePg">
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_ContentDataInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_UsernameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_MethodInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_UrlInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_ConnectTimeoutInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_PasswordInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_ReadTimeoutInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_qQ_Qm4IZEemTAPudtaeePg">
+          <bpmn2:dataOutputRefs>_D8B91719-0540-4A98-9734-CAF4C703B051_ResultOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_qQ_QnIIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QnYIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_QnoIZEemTAPudtaeePg"><![CDATA[Rest]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_Qn4IZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_QoIIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_ContentDataInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QoYIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_QooIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_Qo4IZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_ContentDataInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_QpIIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_UsernameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QpYIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_QpoIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_Qp4IZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_UsernameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_QqIIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_MethodInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QqYIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_QqoIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_Qq4IZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_MethodInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_QrIIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_UrlInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QrYIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_QroIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_Qr4IZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_UrlInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_QsIIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_ConnectTimeoutInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_QsYIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3oIIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3oYIZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_ConnectTimeoutInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3ooIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_PasswordInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3o4IZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3pIIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3pYIZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_PasswordInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3poIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_D8B91719-0540-4A98-9734-CAF4C703B051_ReadTimeoutInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3p4IZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3qIIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3qYIZEemTAPudtaeePg">_D8B91719-0540-4A98-9734-CAF4C703B051_ReadTimeoutInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:task id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA" drools:selectable="true" drools:taskName="WebService" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="WS">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[WS]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_FAF3BDE6-D640-4F36-8F2B-32346FF62B23</bpmn2:incoming>
+      <bpmn2:outgoing>_03132C06-0F56-4538-9607-10F35594A542</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_qQ_3qoIZEemTAPudtaeePg">
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_TaskNameInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_EndpointInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_EndpointInputXItem" name="Endpoint"/>
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_UrlInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_UrlInputXItem" name="Url"/>
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_NamespaceInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_NamespaceInputXItem" name="Namespace"/>
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_InterfaceInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_InterfaceInputXItem" name="Interface"/>
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ModeInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ModeInputXItem" name="Mode"/>
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ParameterInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ParameterInputXItem" name="Parameter"/>
+        <bpmn2:dataInput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_OperationInputX" drools:dtype="String" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_OperationInputXItem" name="Operation"/>
+        <bpmn2:dataOutput id="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ResultOutputX" drools:dtype="java.lang.Object" itemSubjectRef="__FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ResultOutputXItem" name="Result"/>
+        <bpmn2:inputSet id="_qQ_3q4IZEemTAPudtaeePg">
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_EndpointInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_UrlInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_NamespaceInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_InterfaceInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ModeInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ParameterInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_OperationInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_qQ_3rIIZEemTAPudtaeePg">
+          <bpmn2:dataOutputRefs>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ResultOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_qQ_3rYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3roIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3r4IZEemTAPudtaeePg"><![CDATA[WebService]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3sIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3sYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_EndpointInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3soIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3s4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3tIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_EndpointInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3tYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_UrlInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3toIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3t4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3uIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_UrlInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3uYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_NamespaceInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3uoIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3u4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3vIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_NamespaceInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3vYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_InterfaceInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3voIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3v4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3wIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_InterfaceInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3wYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ModeInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3woIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3w4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3xIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ModeInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3xYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ParameterInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3xoIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3x4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3yIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_ParameterInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qQ_3yYIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_OperationInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qQ_3yoIZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qQ_3y4IZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qQ_3zIIZEemTAPudtaeePg">_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA_OperationInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:task id="_324A9674-039E-4B80-80EF-A9B6A44ACA33" drools:selectable="true" drools:taskName="Log" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Log">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Log]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_B8A63139-CF12-4DD3-A27F-79389B8D9CC3</bpmn2:incoming>
+      <bpmn2:outgoing>_4593F2E5-7D12-4891-B23B-4B3DD9B15DD6</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_qQ_3zYIZEemTAPudtaeePg">
+        <bpmn2:dataInput id="_324A9674-039E-4B80-80EF-A9B6A44ACA33_TaskNameInputX" drools:dtype="String" itemSubjectRef="__324A9674-039E-4B80-80EF-A9B6A44ACA33_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_324A9674-039E-4B80-80EF-A9B6A44ACA33_MessageInputX" drools:dtype="String" itemSubjectRef="__324A9674-039E-4B80-80EF-A9B6A44ACA33_MessageInputXItem" name="Message"/>
+        <bpmn2:inputSet id="_qRAesIIZEemTAPudtaeePg">
+          <bpmn2:dataInputRefs>_324A9674-039E-4B80-80EF-A9B6A44ACA33_MessageInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_324A9674-039E-4B80-80EF-A9B6A44ACA33_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_qRAesYIZEemTAPudtaeePg"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_qRAesoIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_324A9674-039E-4B80-80EF-A9B6A44ACA33_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qRAes4IZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qRAetIIZEemTAPudtaeePg"><![CDATA[Log]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qRAetYIZEemTAPudtaeePg">_324A9674-039E-4B80-80EF-A9B6A44ACA33_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_qRAetoIZEemTAPudtaeePg">
+        <bpmn2:targetRef>_324A9674-039E-4B80-80EF-A9B6A44ACA33_MessageInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_qRAet4IZEemTAPudtaeePg">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_qRAeuIIZEemTAPudtaeePg"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_qRAeuYIZEemTAPudtaeePg">_324A9674-039E-4B80-80EF-A9B6A44ACA33_MessageInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:exclusiveGateway id="_F4E1FC90-99F4-4BC7-A612-41939DE33636" drools:selectable="true" drools:dg="" color:background-color="#f0e68c" color:border-color="#a67f00" color:color="#000000" name="" gatewayDirection="Diverging">
+      <bpmn2:incoming>_29548BBE-6CFC-4BE2-A3F3-0549E354EE99</bpmn2:incoming>
+      <bpmn2:outgoing>_91243854-977F-4B22-9671-DC6E48050890</bpmn2:outgoing>
+      <bpmn2:outgoing>_D45DF987-6FA5-4E9A-803F-9744C2C90458</bpmn2:outgoing>
+      <bpmn2:outgoing>_FAF3BDE6-D640-4F36-8F2B-32346FF62B23</bpmn2:outgoing>
+      <bpmn2:outgoing>_B8A63139-CF12-4DD3-A27F-79389B8D9CC3</bpmn2:outgoing>
+    </bpmn2:exclusiveGateway>
+    <bpmn2:sequenceFlow id="_29548BBE-6CFC-4BE2-A3F3-0549E354EE99" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_8AC645E3-F041-4F99-9C04-FAC315EEBBD3" targetRef="_F4E1FC90-99F4-4BC7-A612-41939DE33636"/>
+    <bpmn2:sequenceFlow id="_91243854-977F-4B22-9671-DC6E48050890" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F4E1FC90-99F4-4BC7-A612-41939DE33636" targetRef="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929"/>
+    <bpmn2:sequenceFlow id="_D45DF987-6FA5-4E9A-803F-9744C2C90458" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F4E1FC90-99F4-4BC7-A612-41939DE33636" targetRef="_D8B91719-0540-4A98-9734-CAF4C703B051"/>
+    <bpmn2:sequenceFlow id="_FAF3BDE6-D640-4F36-8F2B-32346FF62B23" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F4E1FC90-99F4-4BC7-A612-41939DE33636" targetRef="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA"/>
+    <bpmn2:sequenceFlow id="_B8A63139-CF12-4DD3-A27F-79389B8D9CC3" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F4E1FC90-99F4-4BC7-A612-41939DE33636" targetRef="_324A9674-039E-4B80-80EF-A9B6A44ACA33"/>
+    <bpmn2:endEvent id="_319886B0-BF3D-4EBF-B76B-DA2A459C075E" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_4593F2E5-7D12-4891-B23B-4B3DD9B15DD6</bpmn2:incoming>
+      <bpmn2:incoming>_45168131-8012-49F3-BDEC-FCBA5662158C</bpmn2:incoming>
+      <bpmn2:incoming>_03132C06-0F56-4538-9607-10F35594A542</bpmn2:incoming>
+      <bpmn2:incoming>_4BFFC45F-E938-4E40-9ACE-ADEA5E11C3D8</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_4BFFC45F-E938-4E40-9ACE-ADEA5E11C3D8" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929" targetRef="_319886B0-BF3D-4EBF-B76B-DA2A459C075E"/>
+    <bpmn2:sequenceFlow id="_03132C06-0F56-4538-9607-10F35594A542" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA" targetRef="_319886B0-BF3D-4EBF-B76B-DA2A459C075E"/>
+    <bpmn2:sequenceFlow id="_4593F2E5-7D12-4891-B23B-4B3DD9B15DD6" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_324A9674-039E-4B80-80EF-A9B6A44ACA33" targetRef="_319886B0-BF3D-4EBF-B76B-DA2A459C075E"/>
+    <bpmn2:sequenceFlow id="_45168131-8012-49F3-BDEC-FCBA5662158C" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_D8B91719-0540-4A98-9734-CAF4C703B051" targetRef="_319886B0-BF3D-4EBF-B76B-DA2A459C075E"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_qRAeuoIZEemTAPudtaeePg">
+    <bpmndi:BPMNPlane id="_qRAeu4IZEemTAPudtaeePg" bpmnElement="com.myspace.aaaaasdddc.servicetasks-old">
+      <bpmndi:BPMNShape id="_qRAevIIZEemTAPudtaeePg" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_qRAevYIZEemTAPudtaeePg" bpmnElement="_8AC645E3-F041-4F99-9C04-FAC315EEBBD3">
+        <dc:Bounds height="80.0" width="100.0" x="85.0" y="285.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_qRAevoIZEemTAPudtaeePg" bpmnElement="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929">
+        <dc:Bounds height="80.0" width="100.0" x="393.0" y="128.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_qRAev4IZEemTAPudtaeePg" bpmnElement="_D8B91719-0540-4A98-9734-CAF4C703B051">
+        <dc:Bounds height="80.0" width="100.0" x="390.0" y="225.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_qRAewIIZEemTAPudtaeePg" bpmnElement="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA">
+        <dc:Bounds height="80.0" width="100.0" x="393.0" y="330.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_qRAewYIZEemTAPudtaeePg" bpmnElement="_324A9674-039E-4B80-80EF-A9B6A44ACA33">
+        <dc:Bounds height="80.0" width="100.0" x="390.0" y="435.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_qRAewoIZEemTAPudtaeePg" bpmnElement="_F4E1FC90-99F4-4BC7-A612-41939DE33636">
+        <dc:Bounds height="40.0" width="40.0" x="230.0" y="305.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_qRAew4IZEemTAPudtaeePg" bpmnElement="_319886B0-BF3D-4EBF-B76B-DA2A459C075E">
+        <dc:Bounds height="28.0" width="28.0" x="825.0" y="285.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_qRAexIIZEemTAPudtaeePg" bpmnElement="_035B06B7-3090-470A-8C24-085981158CAC" sourceElement="_qRAevIIZEemTAPudtaeePg" targetElement="_qRAevYIZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="325.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAexYIZEemTAPudtaeePg" bpmnElement="_29548BBE-6CFC-4BE2-A3F3-0549E354EE99" sourceElement="_qRAevYIZEemTAPudtaeePg" targetElement="_qRAewoIZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="325.0"/>
+        <di:waypoint xsi:type="dc:Point" x="250.0" y="325.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAexoIZEemTAPudtaeePg" bpmnElement="_91243854-977F-4B22-9671-DC6E48050890" sourceElement="_qRAewoIZEemTAPudtaeePg" targetElement="_qRAevoIZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="250.0" y="325.0"/>
+        <di:waypoint xsi:type="dc:Point" x="443.0" y="168.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAex4IZEemTAPudtaeePg" bpmnElement="_D45DF987-6FA5-4E9A-803F-9744C2C90458" sourceElement="_qRAewoIZEemTAPudtaeePg" targetElement="_qRAev4IZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="250.0" y="325.0"/>
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="265.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAeyIIZEemTAPudtaeePg" bpmnElement="_FAF3BDE6-D640-4F36-8F2B-32346FF62B23" sourceElement="_qRAewoIZEemTAPudtaeePg" targetElement="_qRAewIIZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="250.0" y="325.0"/>
+        <di:waypoint xsi:type="dc:Point" x="443.0" y="370.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAeyYIZEemTAPudtaeePg" bpmnElement="_B8A63139-CF12-4DD3-A27F-79389B8D9CC3" sourceElement="_qRAewoIZEemTAPudtaeePg" targetElement="_qRAewYIZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="250.0" y="325.0"/>
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="475.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAeyoIZEemTAPudtaeePg" bpmnElement="_4BFFC45F-E938-4E40-9ACE-ADEA5E11C3D8" sourceElement="_qRAevoIZEemTAPudtaeePg" targetElement="_qRAew4IZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="443.0" y="168.0"/>
+        <di:waypoint xsi:type="dc:Point" x="839.0" y="299.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAey4IZEemTAPudtaeePg" bpmnElement="_03132C06-0F56-4538-9607-10F35594A542" sourceElement="_qRAewIIZEemTAPudtaeePg" targetElement="_qRAew4IZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="443.0" y="370.0"/>
+        <di:waypoint xsi:type="dc:Point" x="839.0" y="299.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRAezIIZEemTAPudtaeePg" bpmnElement="_4593F2E5-7D12-4891-B23B-4B3DD9B15DD6" sourceElement="_qRAewYIZEemTAPudtaeePg" targetElement="_qRAew4IZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="475.0"/>
+        <di:waypoint xsi:type="dc:Point" x="839.0" y="299.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_qRBFwIIZEemTAPudtaeePg" bpmnElement="_45168131-8012-49F3-BDEC-FCBA5662158C" sourceElement="_qRAev4IZEemTAPudtaeePg" targetElement="_qRAew4IZEemTAPudtaeePg">
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="265.0"/>
+        <di:waypoint xsi:type="dc:Point" x="839.0" y="299.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_qRBFwYIZEemTAPudtaeePg" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_8AC645E3-F041-4F99-9C04-FAC315EEBBD3" id="_qRBFwoIZEemTAPudtaeePg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_324A9674-039E-4B80-80EF-A9B6A44ACA33" id="_qRBFw4IZEemTAPudtaeePg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_4BFFC45F-E938-4E40-9ACE-ADEA5E11C3D8" id="_qRBFxIIZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_4593F2E5-7D12-4891-B23B-4B3DD9B15DD6" id="_qRBFxYIZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_91243854-977F-4B22-9671-DC6E48050890" id="_qRBFxoIZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_45168131-8012-49F3-BDEC-FCBA5662158C" id="_qRBFx4IZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B8A63139-CF12-4DD3-A27F-79389B8D9CC3" id="_qRBFyIIZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_D8B91719-0540-4A98-9734-CAF4C703B051" id="_qRBFyYIZEemTAPudtaeePg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_319886B0-BF3D-4EBF-B76B-DA2A459C075E" id="_qRBFyoIZEemTAPudtaeePg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FAF3BDE6-D640-4F36-8F2B-32346FF62B23" id="_qRBFy4IZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_qRBFzIIZEemTAPudtaeePg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_29548BBE-6CFC-4BE2-A3F3-0549E354EE99" id="_qRBFzYIZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_D45DF987-6FA5-4E9A-803F-9744C2C90458" id="_qRBFzoIZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_035B06B7-3090-470A-8C24-085981158CAC" id="_qRBFz4IZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_03132C06-0F56-4538-9607-10F35594A542" id="_qRBF0IIZEemTAPudtaeePg">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FD3F17AB-199B-4A59-A8B4-CBDCCDBFF7DA" id="_qRBF0YIZEemTAPudtaeePg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_2255B80D-ADCF-47C8-A16F-82E7BB9AD929" id="_qRBF0oIZEemTAPudtaeePg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_qQ-pgIIZEemTAPudtaeePg</bpmn2:source>
+    <bpmn2:target>_qQ-pgIIZEemTAPudtaeePg</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>
+


### PR DESCRIPTION
Fix issue with service tasks marshaling containing a `null` body/value on the data assignments.
To test it can be generated any diagram **jBPM designer** with service tasks export the `bpmn` and import as a new asset on Stunner.

@wmedvede
@hasys 
@romartin 