### PR TITLE
JBPM-8525: Stunner - less and greater signs in data-types breaks the process

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBoxView;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.CustomDataTypeTextBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.workbench.events.NotificationEvent;
@@ -50,7 +51,7 @@ import org.uberfire.workbench.events.NotificationEvent;
 /**
  * A templated widget that will be used to display a row in a table of
  * {@link VariableRow}s.
- * <p/>
+ * <p>
  * The Name field of VariableRow is Bound, but other fields are not bound because
  * they use a combination of ListBox and TextBox to implement a drop-down combo
  * to hold the values.
@@ -101,7 +102,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Inject
     @DataField
-    protected TextBox customDataType;
+    protected CustomDataTypeTextBox customDataType;
 
     @Inject
     protected ComboBox dataTypeComboBox;
@@ -145,24 +146,10 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @PostConstruct
     public void init() {
-        // Configure dataType and customDataType controls
-        dataTypeComboBox.init(this,
-                              true,
-                              dataType,
-                              customDataType,
-                              false,
-                              true,
-                              CUSTOM_PROMPT,
-                              ENTER_TYPE_PROMPT);
         name.setRegExp(StringUtils.ALPHA_NUM_REGEXP,
                        StunnerFormsClientFieldsConstants.INSTANCE.Removed_invalid_characters_from_name(),
                        StunnerFormsClientFieldsConstants.INSTANCE.Invalid_character_in_name());
-        customDataType.addKeyDownHandler(event -> {
-            int iChar = event.getNativeKeyCode();
-            if (iChar == ' ') {
-                event.preventDefault();
-            }
-        });
+
         name.addChangeHandler(event -> {
             String value = name.getText();
             if (isDuplicateName(value)) {
@@ -176,6 +163,23 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                 ValueChangeEvent.fire(name, currentName);
             }
             notifyModelChanged();
+        });
+        dataTypeComboBox.init(this,
+                              true,
+                              dataType,
+                              customDataType,
+                              false,
+                              true,
+                              CUSTOM_PROMPT,
+                              ENTER_TYPE_PROMPT);
+        customDataType.setRegExp(StringUtils.ALPHA_NUM_DOT_REGEXP,
+                                 StunnerFormsClientFieldsConstants.INSTANCE.Removed_invalid_characters_from_name(),
+                                 StunnerFormsClientFieldsConstants.INSTANCE.Invalid_character_in_name());
+        customDataType.addKeyDownHandler(event -> {
+            int iChar = event.getNativeKeyCode();
+            if (iChar == ' ') {
+                event.preventDefault();
+            }
         });
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -27,6 +27,7 @@ import com.google.gwt.http.client.URL;
 public class StringUtils {
 
     public static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\_]*$";
+    public static final String ALPHA_NUM_DOT_REGEXP = "^[a-zA-Z0-9\\-\\_\\.]*$";
     public static final String ALPHA_NUM_SPACE_REGEXP = "^[a-zA-Z0-9\\-\\_\\ ]*$";
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AbstractValidatingTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/AbstractValidatingTextBox.java
@@ -24,6 +24,7 @@ import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.event.dom.client.KeyPressHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.regexp.shared.RegExp;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.uberfire.workbench.events.NotificationEvent;
 
@@ -118,5 +119,30 @@ public abstract class AbstractValidatingTextBox extends TextBox {
 
     protected int getKeyCodeFromKeyPressEvent(final KeyPressEvent event) {
         return event.getNativeEvent().getKeyCode();
+    }
+
+    public static String getInvalidCharsInName(final RegExp regExp,
+                                               final String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        } else {
+            StringBuilder invalidChars = new StringBuilder(value.length());
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (!isValidChar(regExp, c)) {
+                    invalidChars.append(c);
+                }
+            }
+            return invalidChars.toString();
+        }
+    }
+
+    public static boolean isValidChar(final RegExp regExp,
+                                      final char c) {
+        if (regExp != null) {
+            return regExp.test("" + c);
+        } else {
+            return true;
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBox.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.widgets;
+
+import com.google.gwt.regexp.shared.RegExp;
+
+public class CustomDataTypeTextBox extends AbstractValidatingTextBox {
+
+    private RegExp regExp;
+    private String invalidCharacterTypedMessage;
+    private String invalidCharactersInNameErrorMessage;
+
+    public CustomDataTypeTextBox() {
+        this.regExp = null;
+    }
+
+    public void setRegExp(final String pattern,
+                          final String invalidCharactersInNameErrorMessage,
+                          final String invalidCharacterTypedMessage) {
+        regExp = RegExp.compile(pattern);
+        this.invalidCharactersInNameErrorMessage = invalidCharactersInNameErrorMessage;
+        this.invalidCharacterTypedMessage = invalidCharacterTypedMessage;
+    }
+
+    @Override
+    public String isValidValue(final String value,
+                               final boolean isOnFocusLost) {
+        if (regExp != null) {
+            boolean isValid = this.regExp.test(value);
+            if (!isValid) {
+                String invalidChars = getInvalidCharsInName(regExp, value);
+                return (isOnFocusLost ? invalidCharactersInNameErrorMessage : invalidCharacterTypedMessage)
+                        + ": " + invalidChars;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected String makeValidValue(final String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        StringBuilder validValue = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (isValidChar(regExp, c)) {
+                validValue.append(c);
+            }
+        }
+        return validValue.toString();
+    }
+
+    protected String getInvalidCharsInName(final String value) {
+        return getInvalidCharsInName(regExp, value);
+    }
+
+    protected boolean isValidChar(final char c) {
+        return isValidChar(regExp, c);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/VariableNameTextBox.java
@@ -137,25 +137,10 @@ public class VariableNameTextBox extends AbstractValidatingTextBox {
     }
 
     protected String getInvalidCharsInName(final String value) {
-        if (value == null || value.isEmpty()) {
-            return "";
-        } else {
-            StringBuilder invalidChars = new StringBuilder(value.length());
-            for (int i = 0; i < value.length(); i++) {
-                char c = value.charAt(i);
-                if (!isValidChar(c)) {
-                    invalidChars.append(c);
-                }
-            }
-            return invalidChars.toString();
-        }
+        return getInvalidCharsInName(regExp, value);
     }
 
     protected boolean isValidChar(final char c) {
-        if (regExp != null) {
-            return regExp.test("" + c);
-        } else {
-            return true;
-        }
+        return isValidChar(regExp, c);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
@@ -34,9 +34,9 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.VariableRow;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBox;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.CustomDataTypeTextBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -56,7 +56,7 @@ public class VariableListItemWidgetTest {
 
     ValueListBox<String> dataType;
 
-    TextBox customDataType;
+    CustomDataTypeTextBox customDataType;
 
     ComboBox dataTypeComboBox;
 
@@ -69,9 +69,6 @@ public class VariableListItemWidgetTest {
     @GwtMock
     DataBinder<VariableRow> variable;
 
-    @Captor
-    ArgumentCaptor<String> regExpCaptor;
-
     //@Spy  // - cannot make Spy because of GWT error
     //@InjectMocks // - cannot InjectMocks because of GWT error
     private VariableListItemWidgetViewImpl widget;
@@ -80,7 +77,7 @@ public class VariableListItemWidgetTest {
     public void initTestCase() {
         GwtMockito.initMocks(this);
         dataType = mock(ValueListBox.class);
-        customDataType = mock(TextBox.class);
+        customDataType = mock(CustomDataTypeTextBox.class);
         dataTypeComboBox = mock(ComboBox.class);
         widget = GWT.create(VariableListItemWidgetViewImpl.class);
         VariableRow variableRow = new VariableRow();
@@ -119,21 +116,32 @@ public class VariableListItemWidgetTest {
                               true,
                               VariableListItemWidgetView.CUSTOM_PROMPT,
                               VariableListItemWidgetView.ENTER_TYPE_PROMPT);
+        ArgumentCaptor<String> nameRegExpCaptor = ArgumentCaptor.forClass(String.class);
         verify(name,
-               times(1)).setRegExp(regExpCaptor.capture(),
+               times(1)).setRegExp(nameRegExpCaptor.capture(),
                                    anyString(),
                                    anyString());
-        RegExp regExp = RegExp.compile(regExpCaptor.getValue());
-        assertEquals(false,
-                     regExp.test("a 1"));
-        assertEquals(false,
-                     regExp.test("a@1"));
-        assertEquals(true,
-                     regExp.test("a1"));
+        RegExp nameRegExp = RegExp.compile(nameRegExpCaptor.getValue());
+        assertEquals(false, nameRegExp.test("a 1"));
+        assertEquals(false, nameRegExp.test("a@1"));
+        assertEquals(true, nameRegExp.test("a1"));
+        verify(name, times(1)).addChangeHandler(any(ChangeHandler.class));
+        ArgumentCaptor<String> customValueRegExpCaptor = ArgumentCaptor.forClass(String.class);
         verify(customDataType,
-               times(1)).addKeyDownHandler(any(KeyDownHandler.class));
-        verify(name,
-               times(1)).addChangeHandler(any(ChangeHandler.class));
+               times(1)).setRegExp(customValueRegExpCaptor.capture(),
+                                   anyString(),
+                                   anyString());
+        RegExp customValueRegExp = RegExp.compile(customValueRegExpCaptor.getValue());
+        assertEquals(false, customValueRegExp.test("a 1"));
+        assertEquals(false, customValueRegExp.test("<a1"));
+        assertEquals(false, customValueRegExp.test("a1>"));
+        assertEquals(false, customValueRegExp.test("<a1>"));
+        assertEquals(false, customValueRegExp.test("<a1/>"));
+        assertEquals(false, customValueRegExp.test("<a1\\>"));
+        assertEquals(false, customValueRegExp.test("a@1"));
+        assertEquals(true, customValueRegExp.test("a1"));
+        assertEquals(true, customValueRegExp.test("org.kie.Object"));
+        verify(customDataType, times(1)).addKeyDownHandler(any(KeyDownHandler.class));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerFor
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.VariableRow;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBox;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.CustomDataTypeTextBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -78,7 +79,7 @@ public class VariableListItemWidgetViewImplTest {
     @GwtMock
     private Button deleteButton;
 
-    private TextBox customDataType;
+    private CustomDataTypeTextBox customDataType;
 
     private ValueListBox<String> dataType;
 
@@ -108,7 +109,7 @@ public class VariableListItemWidgetViewImplTest {
     @Before
     public void setUp() throws Exception {
         GwtMockito.initMocks(this);
-        customDataType = mock(TextBox.class);
+        customDataType = mock(CustomDataTypeTextBox.class);
         dataType = mock(ValueListBox.class);
         dataTypeComboBox = mock(ComboBox.class);
         processVarComboBox = mock(ComboBox.class);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBoxTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.widgets;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.KeyPressEvent;
+import com.google.gwt.event.dom.client.KeyPressHandler;
+import com.google.gwtmockito.GwtMockito;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyChar;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CustomDataTypeTextBoxTest {
+
+    private static final String ERROR_REMOVED = "some error reg exp";
+    private static final String ERROR_TYPED = "some error reg exp2";
+
+    @Captor
+    private ArgumentCaptor<BlurHandler> blurCaptor;
+
+    @Captor
+    private ArgumentCaptor<KeyPressHandler> keyPressCaptor;
+
+    @Mock
+    private BlurEvent blurEvent;
+
+    @Mock
+    private KeyPressEvent keyPressEvent;
+
+    private CustomDataTypeTextBox textBox;
+
+    @Before
+    public void init() {
+        GwtMockito.initMocks(this);
+        textBox = GWT.create(CustomDataTypeTextBox.class);
+        doCallRealMethod().when(textBox).setRegExp(anyString(),
+                                                   anyString(),
+                                                   anyString());
+        doCallRealMethod().when(textBox).isValidValue(anyString(),
+                                                      anyBoolean());
+        doCallRealMethod().when(textBox).setText(anyString());
+        doCallRealMethod().when(textBox).makeValidValue(anyString());
+        doCallRealMethod().when(textBox).getInvalidCharsInName(anyString());
+        doCallRealMethod().when(textBox).isValidChar(anyChar());
+        doCallRealMethod().when(textBox).setup();
+        doCallRealMethod().when(textBox).addBlurHandler(any(BlurHandler.class));
+        doCallRealMethod().when(textBox).addKeyPressHandler(any(KeyPressHandler.class));
+        textBox.setRegExp(StringUtils.ALPHA_NUM_DOT_REGEXP,
+                          ERROR_REMOVED,
+                          ERROR_TYPED);
+    }
+
+    @Test
+    public void testSetup() {
+        when(textBox.getKeyCodeFromKeyPressEvent(any(KeyPressEvent.class))).thenReturn(64);
+        when(keyPressEvent.isControlKeyDown()).thenReturn(false);
+        when(keyPressEvent.isShiftKeyDown()).thenReturn(true);
+        when(keyPressEvent.getCharCode()).thenReturn('@');
+        when(textBox.getCursorPos()).thenReturn(4);
+        when(textBox.getSelectionLength()).thenReturn(0);
+        when(textBox.getValue()).thenReturn("ab12");
+        when(textBox.getText()).thenReturn("ab12@");
+        textBox.setup();
+        verify(textBox,
+               times(1)).addBlurHandler(blurCaptor.capture());
+        verify(textBox,
+               times(1)).addKeyPressHandler(keyPressCaptor.capture());
+        BlurHandler blurHandler = blurCaptor.getValue();
+        blurHandler.onBlur(blurEvent);
+        verify(textBox,
+               times(1)).isValidValue("ab12@",
+                                      true);
+        verify(textBox,
+               times(1)).makeValidValue("ab12@");
+        verify(textBox,
+               times(1)).setValue("ab12");
+        KeyPressHandler keyPressHandler = keyPressCaptor.getValue();
+        keyPressHandler.onKeyPress(keyPressEvent);
+        verify(keyPressEvent,
+               times(1)).preventDefault();
+        verify(textBox,
+               times(1)).isValidValue("ab12@",
+                                      false);
+        verify(textBox,
+               times(1)).fireValidationError(ERROR_REMOVED + ": @");
+        verify(textBox,
+               times(1)).fireValidationError(ERROR_TYPED + ": @");
+    }
+
+    @Test
+    public void testMakeValid() {
+        String makeValidResult;
+        makeValidResult = textBox.makeValidValue(null);
+        assertEquals("",
+                     makeValidResult);
+        makeValidResult = textBox.makeValidValue("");
+        assertEquals("",
+                     makeValidResult);
+        makeValidResult = textBox.makeValidValue("c");
+        assertEquals("c",
+                     makeValidResult);
+        makeValidResult = textBox.makeValidValue("a#b$2%1");
+        assertEquals("ab21",
+                     makeValidResult);
+        makeValidResult = textBox.makeValidValue("<a#b$2%1.3-4_5>");
+        assertEquals("ab21.3-4_5",
+                     makeValidResult);
+    }
+
+    @Test
+    public void testIsValidValue() {
+        String isValidResult;
+        isValidResult = textBox.isValidValue("a",
+                                             true);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("a",
+                                             false);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("-",
+                                             true);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("-",
+                                             false);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("_",
+                                             true);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("_",
+                                             false);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("aBc",
+                                             false);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("CdE",
+                                             false);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("a#$%1",
+                                             false);
+        assertEquals(ERROR_TYPED + ": #$%",
+                     isValidResult);
+        isValidResult = textBox.isValidValue("Cd.E",
+                                             false);
+        assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("<a#$%1>",
+                                             false);
+        assertEquals(ERROR_TYPED + ": <#$%>",
+                     isValidResult);
+    }
+}


### PR DESCRIPTION
Hey @hasys 

Here is the fix for this **BLOCKER** - [JBPM-8525](https://issues.jboss.org/browse/JBPM-8525)

PS: TBH I just applied same solution as in the `name` field in the process variables editor. I don't really like it, but at this point we don't have too much time for improving the code. So used same approach and also added concrete tests for it.

Thanks!