### PR TITLE
AF-1965 :Replace name logo images in masthead etc.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-client/src/main/java/org/kie/workbench/common/screens/home/client/widgets/home/HomeView.less
+++ b/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-client/src/main/java/org/kie/workbench/common/screens/home/client/widgets/home/HomeView.less
@@ -29,7 +29,7 @@
   }
   .kie-content--bg-image {
     background-color: @color-pf-black-700;
-
+    background-position: top center;
     background-size: cover;
     .blank-slate-pf {
       background-color: transparent;


### PR DESCRIPTION
- Added a css property that will allow the home screen background to "crop both left and right as the screen gets narrower" (As per the discussion with @ederign @bdellasc ).
- Related to PR https://github.com/kiegroup/kie-wb-distributions/pull/933