### PR TITLE
DROOLS-4093: [DMN Designer] Sometimes shortcuts does not work when editing DataType items

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
@@ -122,6 +122,10 @@ public class DataTypeListShortcuts {
         view.focusIn();
     }
 
+    public void highlight(final Element dataTypeElement) {
+        view.highlight(dataTypeElement);
+    }
+
     public void reset() {
         view.reset();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
@@ -81,9 +81,8 @@ public class DataTypeListShortcuts {
             currentDataTypeListItem.get().disableEditMode();
         } else {
             getVisibleDataTypeListItems().forEach(DataTypeListItem::disableEditMode);
+            reset();
         }
-
-        reset();
     }
 
     void onCtrlBackspace() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
@@ -36,6 +36,8 @@ import static org.uberfire.client.views.pfly.selectpicker.JQuery.$;
 @ApplicationScoped
 public class DataTypeShortcuts {
 
+    static final String SELECT_DATATYPE_MENU = ".bs-container.btn-group.bootstrap-select.open";
+
     private final DataTypeListShortcuts listShortcuts;
 
     EventListener KEY_DOWN_LISTENER = this::keyDownListener;
@@ -83,7 +85,11 @@ public class DataTypeShortcuts {
             return;
         }
 
-        if (tabContentContainsTarget(event)) {
+        if (tabContentContainsTarget(event) || dropdownMenuContainsTarget(event)) {
+            final Element dataTypeElement = getDataTypeRowElement(event);
+            if (dataTypeElement != null) {
+                listShortcuts.highlight(dataTypeElement);
+            }
             listShortcuts.focusIn();
         } else {
             listShortcuts.reset();
@@ -195,10 +201,20 @@ public class DataTypeShortcuts {
         return element instanceof HTMLInputElement;
     }
 
-    private boolean tabContentContainsTarget(final Event event) {
+    boolean tabContentContainsTarget(final Event event) {
         final Element target = getTarget(event);
         final Element tabContent = getTabContent();
         return $.contains(tabContent, target);
+    }
+
+    private boolean dropdownMenuContainsTarget(final Event event) {
+        final Element target = getTarget(event);
+        return target.closest(SELECT_DATATYPE_MENU) != null;
+    }
+
+    private Element getDataTypeRowElement(final Event event) {
+        final Element target = getTarget(event);
+        return target.closest(".list-group-item");
     }
 
     private Element getTabContent() {
@@ -206,7 +222,7 @@ public class DataTypeShortcuts {
     }
 
     boolean isDropdownOpened() {
-        return querySelector(".bs-container.btn-group.bootstrap-select.open") != null;
+        return querySelector(SELECT_DATATYPE_MENU) != null;
     }
 
     boolean isLoaded() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
@@ -220,6 +220,14 @@ public class DataTypeListShortcutsTest {
     }
 
     @Test
+    public void testHighlight() {
+        final Element element = mock(Element.class);
+        shortcuts.highlight(element);
+
+        verify(view).highlight(element);
+    }
+
+    @Test
     public void testOnCtrlEWhenDataTypeIsReadOnly() {
         when(listItem.isReadOnly()).thenReturn(true);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
@@ -146,7 +146,7 @@ public class DataTypeListShortcutsTest {
         shortcuts.onEscape();
 
         verify(listItem).disableEditMode();
-        verify(shortcuts).reset();
+        verify(shortcuts, never()).reset();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcutsTest.java
@@ -32,6 +32,7 @@ import static com.google.gwt.dom.client.BrowserEvents.CLICK;
 import static com.google.gwt.dom.client.BrowserEvents.KEYDOWN;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.types.shortcuts.DataTypeShortcuts.SELECT_DATATYPE_MENU;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -123,6 +124,47 @@ public class DataTypeShortcutsTest {
         shortcuts.clickListener(target);
 
         verify(listShortcuts).focusIn();
+        verify(listShortcuts, never()).reset();
+    }
+
+    @Test
+    public void testClickListenerWhenDropdownMenuContainsTarget() {
+
+        final Event target = mock(Event.class);
+        final Element targetElement = mock(Element.class);
+        final Element targetMenu = mock(Element.class);
+        final JQuery jQuery = mock(JQuery.class);
+
+        JQuery.$ = jQuery;
+        target.target = targetElement;
+        doReturn(targetMenu).when(targetElement).closest(SELECT_DATATYPE_MENU);
+        doReturn(false).when(shortcuts).tabContentContainsTarget(target);
+
+        shortcuts.clickListener(target);
+
+        verify(listShortcuts).focusIn();
+        verify(listShortcuts, never()).reset();
+    }
+
+    @Test
+    public void testClickListenerWhenDatatypeElementIsClicked() {
+
+        final Event target = mock(Event.class);
+        final Element targetElement = mock(Element.class);
+        final Element targetMenu = mock(Element.class);
+        final Element dataTypeRowElement = mock(Element.class);
+        final JQuery jQuery = mock(JQuery.class);
+
+        JQuery.$ = jQuery;
+        target.target = targetElement;
+        doReturn(targetMenu).when(targetElement).closest(SELECT_DATATYPE_MENU);
+        doReturn(false).when(shortcuts).tabContentContainsTarget(target);
+        doReturn(dataTypeRowElement).when(targetElement).closest(".list-group-item");
+
+        shortcuts.clickListener(target);
+
+        verify(listShortcuts).focusIn();
+        verify(listShortcuts).highlight(dataTypeRowElement);
         verify(listShortcuts, never()).reset();
     }
 


### PR DESCRIPTION
This PR fix the following issues, that causes the shortcuts stop working when you are editing and/or creating a new Data Type:
1. When you click on a DataType row, the selection was not changed, staying on the previous Data Type. With this PR, clicking on a row also select it.

2. The focus and selection for the DataType was lost after you selected a type from the drop down menu. With this PR, now the focus gets back to the selected DataType.

Notice the two examples bellow, one showing the old behavior and other showing the new:

**OLD BEHAVIOR**:
Click doesn't select the row (notice the "light darker blue"), so when you are editing a row that is not selected, the CTRL + S doesn't work. Also, notice that the selection is lost when you select atype in the drop down menu:
![old](https://user-images.githubusercontent.com/7305741/58670627-1f59aa80-8316-11e9-88e3-5e36bdd1ac07.gif)

**NEW BEHAVIOR:**
Now when you click with the mouse, the selection also changes (notice a "light darker blue"). Also the CTRL + S (save) key and CTRL + E (edit) is working. The selection is not lost when you select a type from the drop down:
![new](https://user-images.githubusercontent.com/7305741/58670419-5ed3c700-8315-11e9-9d10-e4e223163462.gif)
