### PR TITLE
AF-2011: Redeploy does not abort running process instances when their process definition is deleted

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/build/exec/impl/executors/redeploy/SnapshotRedeployExecutor.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/build/exec/impl/executors/redeploy/SnapshotRedeployExecutor.java
@@ -44,6 +44,7 @@ public class SnapshotRedeployExecutor extends SnapshotBuildAndDeployExecutor {
 
     @Override
     protected void updateContainerSpec(final BuildExecutionContext context, final ContainerSpec containerSpec) {
+        containerSpec.setStatus(context.getServerTemplate().getContainerSpec(containerSpec.getId()).getStatus());
         specManagementService.call(ignore -> {
             notifyUpdateSuccess();
         }, (o, throwable) -> {

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/build/exec/impl/executors/redeploy/SnapshotRedeployExecutorTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/build/exec/impl/executors/redeploy/SnapshotRedeployExecutorTest.java
@@ -30,6 +30,8 @@ import org.guvnor.common.services.project.service.DeploymentMode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.KieServerMode;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
@@ -129,6 +131,7 @@ public class SnapshotRedeployExecutorTest extends AbstractBuildAndDeployExecutor
 
         ContainerSpec spec = mock(ContainerSpec.class);
         when(spec.getId()).thenReturn(context.getContainerId());
+        when(spec.getStatus()).thenReturn(KieContainerStatus.STARTED);
 
         serverTemplate.addContainerSpec(spec);
 
@@ -146,6 +149,7 @@ public class SnapshotRedeployExecutorTest extends AbstractBuildAndDeployExecutor
         ContainerSpec containerSpec = containerSpecArgumentCaptor.getValue();
 
         assertEquals(module.getPom().getGav().getArtifactId(), containerSpec.getContainerName());
+        assertEquals(KieContainerStatus.STARTED, containerSpec.getStatus());
 
         verifyNotification(ProjectEditorResources.CONSTANTS.BuildSuccessful(), NotificationEvent.NotificationType.SUCCESS);
         verifyNotification(ProjectEditorResources.CONSTANTS.DeploySuccessfulAndContainerUpdated(), NotificationEvent.NotificationType.SUCCESS);
@@ -169,6 +173,7 @@ public class SnapshotRedeployExecutorTest extends AbstractBuildAndDeployExecutor
 
         ContainerSpec spec = mock(ContainerSpec.class);
         when(spec.getId()).thenReturn(context.getContainerId());
+        when(spec.getStatus()).thenReturn(KieContainerStatus.STARTED);
 
         serverTemplate.addContainerSpec(spec);
 
@@ -186,6 +191,7 @@ public class SnapshotRedeployExecutorTest extends AbstractBuildAndDeployExecutor
         ContainerSpec containerSpec = containerSpecArgumentCaptor.getValue();
 
         assertEquals(module.getPom().getGav().getArtifactId(), containerSpec.getContainerName());
+        assertEquals(KieContainerStatus.STARTED, containerSpec.getStatus());
 
         verifyNotification(CONSTANTS.DeployFailed(), NotificationEvent.NotificationType.ERROR);
 


### PR DESCRIPTION
@paulovmr @domhanak would you mind take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/kie-wb-common/pull/2681
https://github.com/kiegroup/droolsjbpm-integration/pull/1839