### PR TITLE
DROOLS-4155: [DMN Designer] Placeholder doesn't fit a column.

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/context/ExpressionEditorColumn.java
@@ -41,6 +41,8 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.GridWidgetRegistry;
 public class ExpressionEditorColumn extends DMNGridColumn<BaseGrid<? extends Expression>, Optional<BaseExpressionGrid<? extends Expression, ? extends GridData, ? extends BaseUIModelMapper>>>
         implements HasDOMElementResources {
 
+    public static final double DEFAULT_WIDTH = 200.0;
+
     public ExpressionEditorColumn(final GridWidgetRegistry registry,
                                   final HeaderMetaData headerMetaData,
                                   final double width,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -336,8 +336,10 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                                              kind,
                                                              expression,
                                                              (editor) -> {
-                                                                 resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);
-                                                                 editor.ifPresent(BaseExpressionGrid::selectFirstCell);
+                                                                 editor.ifPresent(e -> {
+                                                                     e.resize(BaseExpressionGrid.RESIZE_EXISTING);
+                                                                     e.selectFirstCell();
+                                                                 });
                                                              },
                                                              () -> {
                                                                  resize(BaseExpressionGrid.RESIZE_EXISTING_MINIMUM);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/FunctionSupplementaryGrid.java
@@ -38,7 +38,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.context.Con
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ContextUIModelMapperHelper;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionEditorColumn;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGridRenderer;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
@@ -137,7 +136,7 @@ public class FunctionSupplementaryGrid extends BaseExpressionGrid<Context, Funct
                                                      this);
         final ExpressionEditorColumn expressionColumn = new ExpressionEditorColumn(gridLayer,
                                                                                    Collections.emptyList(),
-                                                                                   getAndSetInitialWidth(2, UndefinedExpressionColumn.DEFAULT_WIDTH),
+                                                                                   getAndSetInitialWidth(2, ExpressionEditorColumn.DEFAULT_WIDTH),
                                                                                    this);
 
         model.appendColumn(rowNumberColumn);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -338,6 +338,10 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
         return false;
     }
 
+    public DMNGridPanel getGridPanel() {
+        return gridPanel;
+    }
+
     @Override
     public Viewport getViewport() {
         // A GridWidget's Viewport may not have been set IF the grid has not been attached to a Layer.
@@ -420,23 +424,24 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
         doResize(new GridLayerRedrawManager.PrioritizedCommand(0) {
                      @Override
                      public void execute() {
-                         gridLayer.draw();
+                         getLayer().draw();
                      }
                  },
                  requiredWidthSupplier);
     }
 
-    protected void doResize(final GridLayerRedrawManager.PrioritizedCommand command,
-                            final Function<BaseExpressionGrid, Double> requiredWidthSupplier) {
+    public void doResize(final GridLayerRedrawManager.PrioritizedCommand command,
+                         final Function<BaseExpressionGrid, Double> requiredWidthSupplier) {
         final double proposedWidth = getWidth() + getPadding() * 2;
-        parent.proposeContainingColumnWidth(proposedWidth, requiredWidthSupplier);
+        getParentInformation().proposeContainingColumnWidth(proposedWidth, requiredWidthSupplier);
 
-        gridPanel.refreshScrollPosition();
-        gridPanel.updatePanelSize();
-        gridPanel.setFocus(true);
-        parent.onResize();
+        getGridPanel().refreshScrollPosition();
+        getGridPanel().updatePanelSize();
+        getGridPanel().setFocus(true);
+        getParentInformation().onResize();
 
-        gridLayer.batch(command);
+        //This cast is safe as the constructor expects a DMNGridLayer.
+        ((DMNGridLayer) getLayer()).batch(command);
     }
 
     public void selectFirstCell() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/BaseFunctionSupplementaryGridTest.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommand
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ContextGridRowNumberColumn;
-import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionColumn;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionEditorColumn;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
@@ -163,7 +163,7 @@ public abstract class BaseFunctionSupplementaryGridTest<D extends ExpressionEdit
 
         assertComponentWidths(ContextGridRowNumberColumn.DEFAULT_WIDTH,
                               DMNGridColumn.DEFAULT_WIDTH,
-                              UndefinedExpressionColumn.DEFAULT_WIDTH);
+                              ExpressionEditorColumn.DEFAULT_WIDTH);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4155

This PR makes the width of the _expression_ columns for Java and PMML kinds wider. This PR does not depend on #2683 however if merged on top of it you'll see the placeholders are no longer truncated.