### PR TITLE
JBPM-8525: Stunner - less and greater signs in datatypes breaks the process

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
@@ -42,15 +42,17 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerFor
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentRow;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable.VariableType;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBoxView;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.CustomDataTypeTextBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
 import org.uberfire.workbench.events.NotificationEvent;
 
 /**
  * A templated widget that will be used to display a row in a table of
  * {@link AssignmentRow}s.
- * <p/>
+ * <p>
  * The Name field of AssignmentRow is Bound, but other fields are not bound because
  * they use a combination of ListBox and TextBox to implement a drop-down combo
  * to hold the values.
@@ -98,7 +100,7 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
 
     @Inject
     @DataField
-    protected TextBox customDataType;
+    protected CustomDataTypeTextBox customDataType;
 
     @DataField
     protected ValueListBox<String> processVar = new ValueListBox<>(new Renderer<String>() {
@@ -181,33 +183,9 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
 
     @PostConstruct
     public void init() {
-        // Configure dataType and customDataType controls
-        dataTypeComboBox.init(this,
-                              false,
-                              dataType,
-                              customDataType,
-                              false,
-                              true,
-                              CUSTOM_PROMPT,
-                              ENTER_TYPE_PROMPT);
-        // Configure processVar and constant controls
-        processVarComboBox.init(this,
-                                false,
-                                processVar,
-                                constant,
-                                true,
-                                true,
-                                CONSTANT_PROMPT,
-                                ENTER_CONSTANT_PROMPT);
         name.setRegExp(ALLOWED_CHARS,
                        StunnerFormsClientFieldsConstants.INSTANCE.Removed_invalid_characters_from_name(),
                        StunnerFormsClientFieldsConstants.INSTANCE.Invalid_character_in_name());
-        customDataType.addKeyDownHandler(event -> {
-            int iChar = event.getNativeKeyCode();
-            if (iChar == ' ') {
-                event.preventDefault();
-            }
-        });
         name.addChangeHandler(event -> {
             String value = name.getText();
             String notifyMessage = null;
@@ -222,6 +200,31 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
                 ValueChangeEvent.fire(name, EMPTY_VALUE);
             }
         });
+        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+                                 StunnerFormsClientFieldsConstants.INSTANCE.Removed_invalid_characters_from_name(),
+                                 StunnerFormsClientFieldsConstants.INSTANCE.Invalid_character_in_name());
+        customDataType.addKeyDownHandler(event -> {
+            int iChar = event.getNativeKeyCode();
+            if (iChar == ' ') {
+                event.preventDefault();
+            }
+        });
+        dataTypeComboBox.init(this,
+                              false,
+                              dataType,
+                              customDataType,
+                              false,
+                              true,
+                              CUSTOM_PROMPT,
+                              ENTER_TYPE_PROMPT);
+        processVarComboBox.init(this,
+                                false,
+                                processVar,
+                                constant,
+                                true,
+                                true,
+                                CONSTANT_PROMPT,
+                                ENTER_CONSTANT_PROMPT);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -172,7 +172,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                               true,
                               CUSTOM_PROMPT,
                               ENTER_TYPE_PROMPT);
-        customDataType.setRegExp(StringUtils.ALPHA_NUM_DOT_REGEXP,
+        customDataType.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
                                  StunnerFormsClientFieldsConstants.INSTANCE.Removed_invalid_characters_from_name(),
                                  StunnerFormsClientFieldsConstants.INSTANCE.Invalid_character_in_name());
         customDataType.addKeyDownHandler(event -> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -27,7 +27,7 @@ import com.google.gwt.http.client.URL;
 public class StringUtils {
 
     public static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\_]*$";
-    public static final String ALPHA_NUM_DOT_REGEXP = "^[a-zA-Z0-9\\-\\_\\.]*$";
+    public static final String ALPHA_NUM_UNDERSCORE_DOT_REGEXP = "^[a-zA-Z0-9\\_\\.]*$";
     public static final String ALPHA_NUM_SPACE_REGEXP = "^[a-zA-Z0-9\\-\\_\\ ]*$";
 
     /**

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
@@ -34,7 +34,9 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerFor
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentRow;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBox;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.CustomDataTypeTextBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -42,6 +44,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
@@ -61,7 +64,7 @@ public class AssignmentListItemWidgetTest {
 
     ValueListBox<String> processVar;
 
-    TextBox customDataType;
+    CustomDataTypeTextBox customDataType;
 
     TextBox constant;
 
@@ -90,7 +93,7 @@ public class AssignmentListItemWidgetTest {
         GwtMockito.initMocks(this);
         dataType = mock(ValueListBox.class);
         processVar = mock(ValueListBox.class);
-        customDataType = mock(TextBox.class);
+        customDataType = mock(CustomDataTypeTextBox.class);
         constant = mock(TextBox.class);
         dataTypeComboBox = mock(ComboBox.class);
         processVarComboBox = mock(ComboBox.class);
@@ -134,6 +137,7 @@ public class AssignmentListItemWidgetTest {
         widget.init();
         verify(widget,
                times(1)).init();
+        verify(customDataType, times(1)).setRegExp(eq(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP), anyString(), anyString());
         verify(dataTypeComboBox,
                times(1)).init(widget,
                               false,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
@@ -38,7 +38,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentRow;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBox;
+import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.CustomDataTypeTextBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -48,6 +50,7 @@ import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anySet;
@@ -77,7 +80,7 @@ public class AssignmentListItemWidgetViewImplTest {
     @GwtMock
     private Button deleteButton;
 
-    private TextBox customDataType;
+    private CustomDataTypeTextBox customDataType;
 
     private TextBox constant;
 
@@ -105,7 +108,7 @@ public class AssignmentListItemWidgetViewImplTest {
     @Before
     public void setUp() throws Exception {
         GwtMockito.initMocks(this);
-        customDataType = mock(TextBox.class);
+        customDataType = mock(CustomDataTypeTextBox.class);
         constant = mock(TextBox.class);
         dataType = mock(ValueListBox.class);
         processVar = mock(ValueListBox.class);
@@ -258,6 +261,7 @@ public class AssignmentListItemWidgetViewImplTest {
     @Test
     public void testDataTypeHandlerSpace() {
         view.init();
+        verify(customDataType, times(1)).setRegExp(eq(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP), anyString(), anyString());
         verify(customDataType, times(1)).addKeyDownHandler(keyDownHandlerCaptor.capture());
         KeyDownHandler handler = keyDownHandlerCaptor.getValue();
         doReturn(Integer.valueOf(' ')).when(keyDownEvent).getNativeKeyCode();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBoxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/CustomDataTypeTextBoxTest.java
@@ -74,7 +74,7 @@ public class CustomDataTypeTextBoxTest {
         doCallRealMethod().when(textBox).setup();
         doCallRealMethod().when(textBox).addBlurHandler(any(BlurHandler.class));
         doCallRealMethod().when(textBox).addKeyPressHandler(any(KeyPressHandler.class));
-        textBox.setRegExp(StringUtils.ALPHA_NUM_DOT_REGEXP,
+        textBox.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
                           ERROR_REMOVED,
                           ERROR_TYPED);
     }
@@ -132,7 +132,7 @@ public class CustomDataTypeTextBoxTest {
         assertEquals("ab21",
                      makeValidResult);
         makeValidResult = textBox.makeValidValue("<a#b$2%1.3-4_5>");
-        assertEquals("ab21.3-4_5",
+        assertEquals("ab21.34_5",
                      makeValidResult);
     }
 
@@ -144,14 +144,6 @@ public class CustomDataTypeTextBoxTest {
         assertEquals(null,
                      isValidResult);
         isValidResult = textBox.isValidValue("a",
-                                             false);
-        assertEquals(null,
-                     isValidResult);
-        isValidResult = textBox.isValidValue("-",
-                                             true);
-        assertEquals(null,
-                     isValidResult);
-        isValidResult = textBox.isValidValue("-",
                                              false);
         assertEquals(null,
                      isValidResult);
@@ -170,6 +162,14 @@ public class CustomDataTypeTextBoxTest {
         isValidResult = textBox.isValidValue("CdE",
                                              false);
         assertEquals(null,
+                     isValidResult);
+        isValidResult = textBox.isValidValue("-",
+                                             true);
+        assertEquals(ERROR_REMOVED + ": -",
+                     isValidResult);
+        isValidResult = textBox.isValidValue("a-b",
+                                             true);
+        assertEquals(ERROR_REMOVED + ": -",
                      isValidResult);
         isValidResult = textBox.isValidValue("a#$%1",
                                              false);


### PR DESCRIPTION
Hey @hasys 

Here is the (2nd) fix for [JBPM-8525](https://issues.jboss.org/browse/JBPM-8525). Now it does not allow the "-" symbols in the `data type` field, and also the validation is being done not just for process variables, also for other fields (see [comment](https://issues.jboss.org/browse/JBPM-8525?focusedCommentId=13745589&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13745589)).

Thanks!