### PR TITLE
DROOLS-4144: [DMN Designer] Imported model is broken after saving changes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/factory/AbstractDMNDiagramFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/factory/AbstractDMNDiagramFactory.java
@@ -76,15 +76,19 @@ public abstract class AbstractDMNDiagramFactory<M extends Metadata, D extends Di
 
         Stream.of(DMNModelInstrumentedBase.Namespace.values())
                 .filter(namespace -> !dmnDefinitions.getNsContext().containsValue(namespace.getUri()))
-                .forEach(namespace -> dmnDefinitions.getNsContext().put(namespace.getPrefix(), namespace.getUri()));
+                .forEach(namespace -> {
+                    if (!namespace.getPrefix().equalsIgnoreCase(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix())) {
+                        dmnDefinitions.getNsContext().put(namespace.getPrefix(), namespace.getUri());
+                    }
+                });
 
         String defaultNamespace = !StringUtils.isEmpty(dmnDefinitions.getNamespace().getValue())
                 ? dmnDefinitions.getNamespace().getValue()
                 : DMNModelInstrumentedBase.Namespace.DEFAULT.getUri() + UUID.uuid();
 
         dmnDefinitions.setNamespace(new Text(defaultNamespace));
-        dmnDefinitions.getNsContext().put(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix(),
-                                          defaultNamespace);
+        dmnDefinitions.getNsContext().putIfAbsent(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix(),
+                                                  defaultNamespace);
     }
 
     private void updateName(final Node<Definition<DMNDiagram>, ?> diagramNode,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverter.java
@@ -45,8 +45,8 @@ public class DefinitionsConverter {
         result.setId(id);
         result.setName(name);
         result.setNamespace(new Text(namespace));
-        result.getNsContext().put(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix(),
-                                  namespace);
+        result.getNsContext().putIfAbsent(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix(),
+                                          namespace);
         result.setDescription(description);
         for (Entry<String, String> kv : dmn.getNsContext().entrySet()) {
             String mappedURI = kv.getValue();
@@ -61,7 +61,11 @@ public class DefinitionsConverter {
                     mappedURI = org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_KIE;
                     break;
             }
-            result.getNsContext().put(kv.getKey(), mappedURI);
+            if (kv.getKey().equalsIgnoreCase(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix())) {
+                result.getNsContext().putIfAbsent(kv.getKey(), mappedURI);
+            } else {
+                result.getNsContext().put(kv.getKey(), mappedURI);
+            }
         }
 
         for (org.kie.dmn.model.api.ItemDefinition itemDef : dmn.getItemDefinition()) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverter.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.v1_1.TDefinitions;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
@@ -37,6 +38,15 @@ public class QNamePropertyConverter {
         if (parent instanceof org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase && parent.getURIFEEL().equals(parent.getNamespaceURI(qName.getPrefix()))) {
             return new QName(QName.NULL_NS_URI, qName.getLocalPart());
         }
+
+        if (parent instanceof org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase) {
+            final String defaultNs = getDefaultNamespace(parent);
+            final String localNs = parent.getNamespaceURI(qName.getPrefix());
+            if (defaultNs.equalsIgnoreCase(localNs)) {
+                return new QName(QName.NULL_NS_URI, qName.getLocalPart());
+            }
+        }
+
         return new QName(qName.getNamespaceURI(),
                          qName.getLocalPart(),
                          qName.getPrefix());
@@ -63,5 +73,16 @@ public class QNamePropertyConverter {
         } else {
             return Optional.empty();
         }
+    }
+
+    public static String getDefaultNamespace(final DMNModelInstrumentedBase parent) {
+        if (parent instanceof TDefinitions) {
+            final TDefinitions def = (TDefinitions) parent;
+            return def.getNamespace();
+        } else if (!Objects.isNull(parent.getParent())) {
+            return getDefaultNamespace(parent.getParent());
+        }
+
+        return "";
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DefinitionsConverterTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -92,5 +93,31 @@ public class DefinitionsConverterTest {
         assertNotNull(defaultNs);
         assertEquals(defaultNs, namespace);
         assertEquals(NAMESPACE, defaultNs);
+    }
+
+    @Test
+    public void testDmnFromWBWithExistingDefaultNamespace() {
+
+        final Map<String, String> existingNsContext = new HashMap<>();
+        final String existing = "existing";
+        existingNsContext.put(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix(),
+                              existing);
+
+        when(wbDefinitions.getNamespace()).thenReturn(new Text());
+        when(wbDefinitions.getNsContext()).thenReturn(existingNsContext);
+
+        org.kie.dmn.model.api.Definitions dmn = DefinitionsConverter.dmnFromWB(wbDefinitions);
+        String defaultNs = dmn.getNsContext().get(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix());
+
+        assertNotNull(defaultNs);
+        assertEquals(existing, defaultNs);
+
+        when(wbDefinitions.getNamespace()).thenReturn(new Text(NAMESPACE));
+
+        dmn = DefinitionsConverter.dmnFromWB(wbDefinitions);
+        defaultNs = dmn.getNsContext().get(DMNModelInstrumentedBase.Namespace.DEFAULT.getPrefix());
+
+        assertNotNull(defaultNs);
+        assertEquals(existing, defaultNs);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/QNamePropertyConverterTest.java
@@ -21,12 +21,17 @@ import java.util.Optional;
 import javax.xml.XMLConstants;
 
 import org.junit.Test;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.kie.dmn.model.api.Decision;
+import org.kie.dmn.model.v1_1.TDefinitions;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DMNModelInstrumentedBase.Namespace;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class QNamePropertyConverterTest {
 
@@ -56,6 +61,52 @@ public class QNamePropertyConverterTest {
                                                                                              BuiltInType.UNDEFINED.getName(),
                                                                                              Namespace.FEEL.getPrefix()));
         assertThat(dmn).isEmpty();
+    }
+
+    @Test
+    public void testGetDefaultNamespace() {
+
+        final String defaultNamespace = "http://www.kiegroup.org/";
+        final TDefinitions definition = mock(TDefinitions.class);
+        when(definition.getNamespace()).thenReturn(defaultNamespace);
+
+        final String actual = QNamePropertyConverter.getDefaultNamespace(definition);
+
+        assertEquals(defaultNamespace, actual);
+    }
+
+    @Test
+    public void testGetDefaultNamespaceFromParent() {
+
+        final String defaultNamespace = "http://www.kiegroup.org/";
+        final TDefinitions definition = mock(TDefinitions.class);
+        final DMNModelInstrumentedBase model = mock(DMNModelInstrumentedBase.class);
+
+        when(model.getParent()).thenReturn(definition);
+        when(definition.getNamespace()).thenReturn(defaultNamespace);
+
+        final String actual = QNamePropertyConverter.getDefaultNamespace(model);
+
+        assertEquals(defaultNamespace, actual);
+    }
+
+    @Test
+    public void testWbFromDMNForBuiltInDataType11WithSameUriAsDefaultNamespace(){
+
+        final String defaultNamespace = "http://www.kiegroup.org/";
+        final TDefinitions definition = mock(TDefinitions.class);
+
+        when(definition.getURIFEEL()).thenReturn("");
+        when(definition.getNamespace()).thenReturn(defaultNamespace);
+        when(definition.getNamespaceURI(Namespace.KIE.getPrefix())).thenReturn(defaultNamespace);
+
+        final javax.xml.namespace.QName dmn = new javax.xml.namespace.QName(defaultNamespace,
+                                                                            BuiltInType.STRING.getName(),
+                                                                            Namespace.KIE.getPrefix());
+        final QName wb = QNamePropertyConverter.wbFromDMN(dmn, definition);
+
+        assertEquals(BuiltInType.STRING.getName(), wb.getLocalPart());
+        assertEquals(XMLConstants.NULL_NS_URI, wb.getPrefix());
     }
 
     @Test


### PR DESCRIPTION
There was 2 issues that was causing the error that this PR fixes:
1. The `xmlns` was duplicated, since `XStreamMarshaller` looks for the DMN URI in the namespaces. If he doesn't found, it adds it as default. Since the default `xmlns` in the file attached to the JIRA was not the default DMN URI, it causes duplicated `xmlns`.

2. After the step 1 applied, there was another issue with `typeref`.  In the provided file, the `namespace` was the same as `kie:xmlns`, but after the conversion of file from DMN 1.1 to 1.2, the `kie:xmlns` is updated. It leads to some references not being found, since the variables was declared in the default namespace that is not the same as `kie:xmlns` anymore. With this PR, if `kie:xmlns` is the same as the default `namespace`, the prefix `kie` is removed from `typerefs`.