### PR TITLE
DROOLS-3515: [DMN Designer] Validation: Validate button should compile the DMN file and report issues

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
@@ -132,12 +132,22 @@
 
     <dependency>
       <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
       <artifactId>kie-dmn-feel</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-validation</artifactId>
     </dependency>
 
     <dependency>
@@ -277,7 +287,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.kie</groupId>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelper.java
@@ -52,6 +52,15 @@ public interface DMNMarshallerImportsHelper {
                                                        final List<Import> imports);
 
     /**
+     * This method loads {@link String} of all imported XML files from a list of imports.
+     * @param metadata represents the metadata from the main DMN model.
+     * @param imports represent the list of imported files.
+     * @return a map {@link String} indexed by {@link Import}s.
+     */
+    Map<Import, String> getImportXML(final Metadata metadata,
+                                     final List<Import> imports);
+
+    /**
      * This method extract a list of {@link DRGElement}s from the <code>importDefinitions</code> map.
      * @param importDefinitions is a map of {@link Definitions} indexed by {@link Import}.
      * @return a list of imported {@link DRGElement}s.

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperImpl.java
@@ -16,9 +16,12 @@
 
 package org.kie.workbench.common.dmn.backend.common;
 
-import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -121,6 +124,28 @@ public class DMNMarshallerImportsHelperImpl implements DMNMarshallerImportsHelpe
     }
 
     @Override
+    public Map<Import, String> getImportXML(final Metadata metadata,
+                                            final List<Import> imports) {
+
+        final Map<Import, String> importXML = new HashMap<>();
+
+        if (imports.size() > 0) {
+            for (final String xml : getOtherDMNDiagramsXML(metadata)) {
+                final Definitions definitions = marshaller.unmarshal(toStringReader(xml));
+                findImportByDefinitions(definitions, imports).ifPresent(anImport -> {
+                    importXML.put(anImport, xml);
+                });
+            }
+        }
+
+        return importXML;
+    }
+
+    StringReader toStringReader(final String xml) {
+        return new StringReader(xml);
+    }
+
+    @Override
     public List<DRGElement> getImportedDRGElements(final Map<Import, Definitions> importDefinitions) {
 
         final List<DRGElement> importedNodes = new ArrayList<>();
@@ -159,7 +184,7 @@ public class DMNMarshallerImportsHelperImpl implements DMNMarshallerImportsHelpe
         return pathsHelper
                 .getDMNModelsPaths(workspaceProject)
                 .stream()
-                .map(path -> loadPath(path).map(marshaller::unmarshal).orElse(null))
+                .map(path -> loadPath(path).map(this::toInputStreamReader).map(marshaller::unmarshal).orElse(null))
                 .filter(Objects::nonNull)
                 .filter(definitions -> Objects.equals(definitions.getNamespace(), namespace))
                 .findAny();
@@ -272,7 +297,7 @@ public class DMNMarshallerImportsHelperImpl implements DMNMarshallerImportsHelpe
         return diagramPaths
                 .stream()
                 .filter(path -> !Objects.equals(metadata.getPath(), path))
-                .map(path -> loadPath(path).map(marshaller::unmarshal).orElse(null))
+                .map(path -> loadPath(path).map(this::toInputStreamReader).map(marshaller::unmarshal).orElse(null))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
@@ -281,31 +306,47 @@ public class DMNMarshallerImportsHelperImpl implements DMNMarshallerImportsHelpe
         return pathsHelper.getPMMLModelsPaths(getProject(metadata));
     }
 
-    Optional<InputStreamReader> loadPath(final Path path) {
+    InputStreamReader toInputStreamReader(final InputStream inputStream) {
+        return new InputStreamReader(inputStream);
+    }
 
-        InputStreamReader mutableInputStream = null;
+    List<String> getOtherDMNDiagramsXML(final Metadata metadata) {
+
+        final List<Path> diagramPaths = pathsHelper.getDMNModelsPaths(getProject(metadata));
+
+        return diagramPaths
+                .stream()
+                .filter(path -> !Objects.equals(metadata.getPath(), path))
+                .map(path -> loadPath(path).orElse(null))
+                .filter(Objects::nonNull)
+                .map(this::toString)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    Optional<InputStream> loadPath(final Path path) {
 
         try {
-
-            final byte[] bytes = ioService.readAllBytes(convertPath(path));
-            final ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
-            mutableInputStream = new InputStreamReader(inputStream);
-
-            return Optional.of(mutableInputStream);
+            return Optional.ofNullable(ioService.newInputStream(convertPath(path)));
         } catch (final Exception e) {
-            closeInputStreamReader(mutableInputStream);
             return Optional.empty();
         }
     }
 
-    void closeInputStreamReader(final InputStreamReader mutableInputStream) {
-        if (mutableInputStream != null) {
-            try {
-                mutableInputStream.close();
-            } catch (final IOException e) {
-                // Ignore.
+    String toString(final InputStream inputStream) {
+        try {
+            final ByteArrayOutputStream result = new ByteArrayOutputStream();
+            final byte[] buffer = new byte[1024];
+            int length;
+            while ((length = inputStream.read(buffer)) != -1) {
+                result.write(buffer, 0, length);
             }
+
+            return result.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException ioe) {
+            //Swallow. null is returned by default.
         }
+        return null;
     }
 
     private WorkspaceProject getProject(final Metadata metadata) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperImpl.java
@@ -305,16 +305,11 @@ public class DMNMarshallerImportsHelperImpl implements DMNMarshallerImportsHelpe
     }
 
     Definitions toDefinitions(final InputStream inputStream) {
-        try (InputStreamReader reader = toInputStreamReader(inputStream)) {
+        try (InputStream inputStreamAutoClosable = inputStream;
+             InputStreamReader reader = toInputStreamReader(inputStreamAutoClosable)) {
             return marshaller.unmarshal(reader);
         } catch (IOException ioe) {
             //Swallow. null is returned by default.
-        } finally {
-            try {
-                inputStream.close();
-            } catch (IOException ioe) {
-                //Swallow. The Reader is already closed.
-            }
         }
         return null;
     }
@@ -348,22 +343,17 @@ public class DMNMarshallerImportsHelperImpl implements DMNMarshallerImportsHelpe
     }
 
     String toString(final InputStream inputStream) {
-        try (ByteArrayOutputStream result = new ByteArrayOutputStream()) {
+        try (InputStream inputStreamAutoClosable = inputStream;
+             ByteArrayOutputStream result = new ByteArrayOutputStream()) {
             final byte[] buffer = new byte[1024];
             int length;
-            while ((length = inputStream.read(buffer)) != -1) {
+            while ((length = inputStreamAutoClosable.read(buffer)) != -1) {
                 result.write(buffer, 0, length);
             }
 
             return result.toString(StandardCharsets.UTF_8.name());
         } catch (IOException ioe) {
             //Swallow. null is returned by default.
-        } finally {
-            try {
-                inputStream.close();
-            } catch (IOException ioe) {
-                //Swallow. The Reader is already closed.
-            }
         }
         return null;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidator.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidator.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.validation;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.api.builder.Message;
+import org.kie.dmn.api.core.DMNMessage;
+import org.kie.dmn.model.api.DMNElement;
+import org.kie.dmn.validation.DMNValidator;
+import org.kie.dmn.validation.DMNValidatorFactory;
+import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Definitions;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Import;
+import org.kie.workbench.common.dmn.api.graph.DMNDiagramUtils;
+import org.kie.workbench.common.dmn.backend.DMNMarshaller;
+import org.kie.workbench.common.dmn.backend.common.DMNMarshallerImportsHelper;
+import org.kie.workbench.common.dmn.backend.definition.v1_1.ImportConverter;
+import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.marshaller.MarshallingMessage;
+import org.kie.workbench.common.stunner.core.validation.DomainValidator;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class DMNDomainValidator implements DomainValidator {
+
+    static final String DEFAULT_UUID = "uuid";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DMNDomainValidator.class);
+
+    private DMNValidator dmnValidator;
+
+    private DMNMarshaller dmnMarshaller;
+    private DMNDiagramUtils dmnDiagramUtils;
+    private DMNMarshallerImportsHelper importsHelper;
+
+    @Inject
+    public DMNDomainValidator(final DMNMarshaller dmnMarshaller,
+                              final DMNDiagramUtils dmnDiagramUtils,
+                              final DMNMarshallerImportsHelper importsHelper) {
+        this.dmnMarshaller = dmnMarshaller;
+        this.dmnDiagramUtils = dmnDiagramUtils;
+        this.importsHelper = importsHelper;
+    }
+
+    @PostConstruct
+    public void setupValidator() {
+        this.dmnValidator = getDMNValidator();
+    }
+
+    DMNValidator getDMNValidator() {
+        return DMNValidatorFactory.newValidator();
+    }
+
+    @Override
+    public String getDefinitionSetId() {
+        return BindableAdapterUtils.getDefinitionSetId(DMNDefinitionSet.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void validate(final Diagram diagram,
+                         final Consumer<Collection<DomainViolation>> resultConsumer) {
+        try {
+            final List<Reader> dmnXMLReaders = new ArrayList<>();
+
+            // The Definitions contained within the diagram do not contain DRGElements therefore marshall
+            // the diagram to XML that then builds a fully enriched representation of the DMN model.
+            final String uiDiagramXML = dmnMarshaller.marshall(diagram);
+            dmnXMLReaders.add(getStringReader(uiDiagramXML));
+
+            // Load Readers for all other imported DMN models.
+            final Definitions uiDefinitions = dmnDiagramUtils.getDefinitions(diagram);
+            final List<Import> uiImports = uiDefinitions.getImport();
+            final List<org.kie.dmn.model.api.Import> dmnImports = uiImports.stream().map(ImportConverter::dmnFromWb).collect(Collectors.toList());
+            final Map<org.kie.dmn.model.api.Import, String> importedDiagramsXML = importsHelper.getImportXML(diagram.getMetadata(), dmnImports);
+            importedDiagramsXML.values().forEach(importedDiagramXML -> dmnXMLReaders.add(getStringReader(importedDiagramXML)));
+
+            final Reader[] aDMNXMLReaders = new Reader[]{};
+            final List<DMNMessage> messages = dmnValidator
+                    .validateUsing(DMNValidator.Validation.VALIDATE_MODEL,
+                                   DMNValidator.Validation.VALIDATE_COMPILATION,
+                                   DMNValidator.Validation.ANALYZE_DECISION_TABLE)
+                    .theseModels(dmnXMLReaders.toArray(aDMNXMLReaders));
+
+            resultConsumer.accept(convert(messages));
+        } catch (IOException ioe) {
+            LOGGER.error("Error while converting diagram with UUID [" + diagram.getName() + "] to XML.",
+                         ioe);
+        }
+    }
+
+    StringReader getStringReader(final String xml) {
+        return new StringReader(xml);
+    }
+
+    private Collection<DomainViolation> convert(final List<DMNMessage> messages) {
+        return messages.stream().map(this::convert).collect(Collectors.toList());
+    }
+
+    private DomainViolation convert(final DMNMessage message) {
+        return new MarshallingMessage.MarshallingMessageBuilder()
+                .elementUUID(getDMNElementUUID(message.getSourceReference()))
+                .type(convert(message.getLevel()))
+                .message(message.getText())
+                .build();
+    }
+
+    private String getDMNElementUUID(final Object source) {
+        if (source instanceof DMNElement) {
+            final DMNElement element = ((DMNElement) source);
+            if (Objects.isNull(element.getId())) {
+                return getDMNElementUUID(element.getParent());
+            } else {
+                return element.getId();
+            }
+        }
+        return DEFAULT_UUID;
+    }
+
+    private Violation.Type convert(final Message.Level level) {
+        switch (level) {
+            case ERROR:
+                return Violation.Type.ERROR;
+            case WARNING:
+                return Violation.Type.WARNING;
+            default:
+                return Violation.Type.INFO;
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidator.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidator.java
@@ -92,8 +92,8 @@ public class DMNDomainValidator implements DomainValidator {
     @SuppressWarnings("unchecked")
     public void validate(final Diagram diagram,
                          final Consumer<Collection<DomainViolation>> resultConsumer) {
+        final List<Reader> dmnXMLReaders = new ArrayList<>();
         try {
-            final List<Reader> dmnXMLReaders = new ArrayList<>();
 
             // The Definitions contained within the diagram do not contain DRGElements therefore marshall
             // the diagram to XML that then builds a fully enriched representation of the DMN model.
@@ -118,6 +118,14 @@ public class DMNDomainValidator implements DomainValidator {
         } catch (IOException ioe) {
             LOGGER.error("Error while converting diagram with UUID [" + diagram.getName() + "] to XML.",
                          ioe);
+        } finally {
+            dmnXMLReaders.forEach(reader -> {
+                try {
+                    reader.close();
+                } catch (IOException ioe) {
+                    //Swallow. The Reader is already closed.
+                }
+            });
         }
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.backend.validation;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.api.core.DMNMessage;
+import org.kie.dmn.api.core.DMNMessageType;
+import org.kie.dmn.core.impl.DMNMessageImpl;
+import org.kie.dmn.model.api.DMNElement;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.validation.DMNValidator;
+import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Definitions;
+import org.kie.workbench.common.dmn.api.definition.v1_1.Import;
+import org.kie.workbench.common.dmn.api.graph.DMNDiagramUtils;
+import org.kie.workbench.common.dmn.backend.DMNMarshaller;
+import org.kie.workbench.common.dmn.backend.common.DMNMarshallerImportsHelper;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNDomainValidatorTest {
+
+    private static final String DMN_XML = "<Some XML/>";
+
+    private static final String IMPORTED_DMN_XML = "<Some other XML/>";
+
+    @Mock
+    private DMNMarshaller dmnMarshaller;
+
+    @Mock
+    private DMNDiagramUtils dmnDiagramUtils;
+
+    @Mock
+    private DMNMarshallerImportsHelper importsHelper;
+
+    @Mock
+    private DMNValidator dmnValidator;
+
+    @Mock
+    private DMNValidator.ValidatorBuilder dmnValidatorBuilder;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Metadata metadata;
+
+    @Mock
+    private Consumer<Collection<DomainViolation>> resultConsumer;
+
+    @Captor
+    private ArgumentCaptor<Collection<DomainViolation>> domainViolationsArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<StringReader> readerArgumentCaptor;
+
+    private Definitions definitions;
+
+    private List<DMNMessage> validationMessages;
+
+    private DMNDomainValidator domainValidator;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() throws IOException {
+        this.definitions = new Definitions();
+        this.validationMessages = new ArrayList<>();
+        this.domainValidator = spy(new DMNDomainValidator(dmnMarshaller,
+                                                          dmnDiagramUtils,
+                                                          importsHelper));
+
+        doReturn(dmnValidator).when(domainValidator).getDMNValidator();
+        domainValidator.setupValidator();
+
+        when(dmnMarshaller.marshall(diagram)).thenReturn(DMN_XML);
+        when(dmnDiagramUtils.getDefinitions(diagram)).thenReturn(definitions);
+        when(dmnValidator.validateUsing(anyVararg())).thenReturn(dmnValidatorBuilder);
+        when(dmnValidatorBuilder.theseModels(any(Reader.class))).thenReturn(validationMessages);
+        when(diagram.getMetadata()).thenReturn(metadata);
+    }
+
+    @Test
+    public void testGetDefinitionSetId() {
+        assertThat(domainValidator.getDefinitionSetId()).isEqualTo(DMNDefinitionSet.class.getName());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBasicValidation() throws IOException {
+        final StringReader stringReader = mock(StringReader.class);
+        when(domainValidator.getStringReader(anyString())).thenReturn(stringReader);
+
+        domainValidator.validate(diagram,
+                                 resultConsumer);
+
+        verify(dmnMarshaller).marshall(diagram);
+        verify(dmnDiagramUtils).getDefinitions(diagram);
+        verify(dmnValidator).validateUsing(DMNValidator.Validation.VALIDATE_MODEL,
+                                           DMNValidator.Validation.VALIDATE_COMPILATION,
+                                           DMNValidator.Validation.ANALYZE_DECISION_TABLE);
+        verify(domainValidator).getStringReader(DMN_XML);
+        verify(dmnValidatorBuilder).theseModels(readerArgumentCaptor.capture());
+        assertThat(readerArgumentCaptor.getAllValues()).containsExactly(stringReader);
+
+        verify(resultConsumer).accept(Collections.emptyList());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testImportedModelValidation() throws IOException {
+        final StringReader stringReader1 = mock(StringReader.class);
+        final StringReader stringReader2 = mock(StringReader.class);
+        when(domainValidator.getStringReader(anyString())).thenReturn(stringReader1, stringReader2);
+
+        definitions.getImport().add(new Import());
+
+        when(importsHelper.getImportXML(eq(metadata), anyList())).thenAnswer(i -> {
+            final Map<org.kie.dmn.model.api.Import, String> importedModels = new HashMap<>();
+            final List<org.kie.dmn.model.api.Import> imports = (List) i.getArguments()[1];
+            importedModels.put(imports.get(0), IMPORTED_DMN_XML);
+            return importedModels;
+        });
+
+        domainValidator.validate(diagram,
+                                 resultConsumer);
+
+        verify(dmnMarshaller).marshall(diagram);
+        verify(dmnDiagramUtils).getDefinitions(diagram);
+        verify(dmnValidator).validateUsing(DMNValidator.Validation.VALIDATE_MODEL,
+                                           DMNValidator.Validation.VALIDATE_COMPILATION,
+                                           DMNValidator.Validation.ANALYZE_DECISION_TABLE);
+        verify(domainValidator).getStringReader(DMN_XML);
+        verify(domainValidator).getStringReader(IMPORTED_DMN_XML);
+        verify(dmnValidatorBuilder).theseModels(readerArgumentCaptor.capture());
+        assertThat(readerArgumentCaptor.getAllValues()).containsExactly(stringReader1, stringReader2);
+
+        verify(resultConsumer).accept(Collections.emptyList());
+    }
+
+    @Test
+    public void testValidationMessageConversion() {
+        final String dmnElementUUID = "element-uuid";
+        final DMNElement dmnElement1 = mock(DMNElement.class);
+        final DMNElement dmnElement2 = mock(DMNElement.class);
+
+        //Default UUID
+        validationMessages.add(makeDMNMessage(DMNMessage.Severity.ERROR, "error", null));
+        //Explicit UUID
+        when(dmnElement1.getId()).thenReturn(dmnElementUUID);
+        validationMessages.add(makeDMNMessage(DMNMessage.Severity.WARN, "warn", dmnElement1));
+        //Parent UUID
+        when(dmnElement2.getParent()).thenReturn(dmnElement1);
+        validationMessages.add(makeDMNMessage(DMNMessage.Severity.INFO, "info", dmnElement2));
+
+        domainValidator.validate(diagram,
+                                 resultConsumer);
+
+        verify(resultConsumer).accept(domainViolationsArgumentCaptor.capture());
+
+        final Collection<DomainViolation> domainViolations = domainViolationsArgumentCaptor.getValue();
+        assertThat(domainViolations).hasSize(3);
+        final Iterator<DomainViolation> domainViolationIterator = domainViolations.iterator();
+
+        final DomainViolation domainViolation0 = domainViolationIterator.next();
+        assertThat(domainViolation0.getViolationType()).isEqualTo(Violation.Type.ERROR);
+        assertThat(domainViolation0.getMessage()).contains("error");
+        assertThat(domainViolation0.getUUID()).isEqualTo(DMNDomainValidator.DEFAULT_UUID);
+
+        final DomainViolation domainViolation1 = domainViolationIterator.next();
+        assertThat(domainViolation1.getViolationType()).isEqualTo(Violation.Type.WARNING);
+        assertThat(domainViolation1.getMessage()).contains("warn");
+        assertThat(domainViolation1.getUUID()).isEqualTo(dmnElementUUID);
+
+        final DomainViolation domainViolation2 = domainViolationIterator.next();
+        assertThat(domainViolation2.getViolationType()).isEqualTo(Violation.Type.INFO);
+        assertThat(domainViolation2.getMessage()).contains("info");
+        assertThat(domainViolation2.getUUID()).isEqualTo(dmnElementUUID);
+    }
+
+    private DMNMessage makeDMNMessage(final DMNMessage.Severity severity,
+                                      final String text,
+                                      final DMNModelInstrumentedBase source) {
+        return new DMNMessageImpl(severity, text, DMNMessageType.KIE_API, source);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Annotation;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -163,6 +164,13 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         this.openDiagramLayoutExecutor = openDiagramLayoutExecutor;
         this.includedModelsPage = includedModelsPage;
         this.importsPageProvider = importsPageProvider;
+    }
+
+    @Override
+    @PostConstruct
+    public void init() {
+        super.init();
+        getMenuSessionItems().setErrorConsumer(e -> hideLoadingViews());
     }
 
     @OnStartup

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.project.client.editor;
 
 import java.lang.annotation.Annotation;
+import java.util.function.Consumer;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
@@ -48,6 +49,7 @@ import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectEdi
 import org.kie.workbench.common.widgets.client.docks.DefaultEditorDock;
 import org.kie.workbench.common.workbench.client.PerspectiveIds;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditor;
@@ -61,6 +63,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.inOrder;
@@ -126,6 +129,9 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
 
     @Mock
     private DefaultEditorDock docks;
+
+    @Captor
+    private ArgumentCaptor<Consumer<String>> errorConsumerCaptor;
 
     @Before
     public void before() {
@@ -197,6 +203,19 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     @Override
     protected AbstractProjectEditorMenuSessionItems getMenuSessionItems() {
         return dmnProjectMenuSessionItems;
+    }
+
+    @Test
+    public void testInit() {
+        diagramEditor.init();
+
+        //DMNProjectEditorMenuSessionItems.setErrorConsumer(..) is called several times so just check the last invocation
+        verify(dmnProjectMenuSessionItems, atLeast(1)).setErrorConsumer(errorConsumerCaptor.capture());
+
+        errorConsumerCaptor.getValue().accept("ERROR");
+
+        verify(view).hideBusyIndicator();
+        verify(errorPopupPresenter, never()).showMessage(anyString());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/StandaloneToolbarStateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/StandaloneToolbarStateHandler.java
@@ -31,7 +31,6 @@ public class StandaloneToolbarStateHandler implements ToolbarStateHandler {
     private boolean switchGridToolbarCommandEnabled = false;
     private boolean undoToolbarCommandEnabled = false;
     private boolean redoToolbarCommandEnabled = false;
-    private boolean validateToolbarCommandEnabled = false;
     private boolean exportToPngToolbarCommandEnabled = false;
     private boolean exportToJpgToolbarCommandEnabled = false;
     private boolean exportToPdfToolbarCommandEnabled = false;
@@ -53,7 +52,6 @@ public class StandaloneToolbarStateHandler implements ToolbarStateHandler {
         this.switchGridToolbarCommandEnabled = toolbar.isEnabled(toolbar.getSwitchGridToolbarCommand());
         this.undoToolbarCommandEnabled = toolbar.isEnabled(toolbar.getUndoToolbarCommand());
         this.redoToolbarCommandEnabled = toolbar.isEnabled(toolbar.getRedoToolbarCommand());
-        this.validateToolbarCommandEnabled = toolbar.isEnabled(toolbar.getValidateCommand());
         this.exportToPngToolbarCommandEnabled = toolbar.isEnabled((ToolbarCommand) toolbar.getExportToPngToolbarCommand());
         this.exportToJpgToolbarCommandEnabled = toolbar.isEnabled((ToolbarCommand) toolbar.getExportToJpgToolbarCommand());
         this.exportToPdfToolbarCommandEnabled = toolbar.isEnabled((ToolbarCommand) toolbar.getExportToPdfToolbarCommand());
@@ -73,8 +71,6 @@ public class StandaloneToolbarStateHandler implements ToolbarStateHandler {
         enableToolbarCommand(toolbar.getUndoToolbarCommand(),
                              false);
         enableToolbarCommand(toolbar.getRedoToolbarCommand(),
-                             false);
-        enableToolbarCommand(toolbar.getValidateCommand(),
                              false);
         enableToolbarCommand(toolbar.getExportToPngToolbarCommand(),
                              false);
@@ -106,8 +102,6 @@ public class StandaloneToolbarStateHandler implements ToolbarStateHandler {
                              undoToolbarCommandEnabled);
         enableToolbarCommand(toolbar.getRedoToolbarCommand(),
                              redoToolbarCommandEnabled);
-        enableToolbarCommand(toolbar.getValidateCommand(),
-                             validateToolbarCommandEnabled);
         enableToolbarCommand(toolbar.getExportToPngToolbarCommand(),
                              exportToPngToolbarCommandEnabled);
         enableToolbarCommand(toolbar.getExportToJpgToolbarCommand(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/notifications/Notifications.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/main/java/org/kie/workbench/common/dmn/showcase/client/screens/notifications/Notifications.java
@@ -68,6 +68,7 @@ public class Notifications implements IsWidget {
     public void init() {
         view.init(this);
         notificationsObserver.onNotification(this::add);
+        notificationsObserver.onValidationFailed(this::add);
         buildViewColumns();
     }
 
@@ -154,7 +155,7 @@ public class Notifications implements IsWidget {
         final Column<Notification, String> messageColumn = new Column<Notification, String>(messageCell) {
             @Override
             public String getValue(final Notification object) {
-                return getNotificationSourceMessage(object);
+                return getNotificationMessage(object);
             }
         };
         messageColumn.setSortable(false);
@@ -162,10 +163,8 @@ public class Notifications implements IsWidget {
     }
 
     @SuppressWarnings("unchecked")
-    private String getNotificationSourceMessage(final Notification notification) {
-        return notification.getSource().isPresent() ?
-                notification.getSource().toString() :
-                "-- No source --";
+    private String getNotificationMessage(final Notification notification) {
+        return notification.getMessage();
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ClearToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ClearToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class ClearToolbarCommand extends AbstractToolbarCommand<EditorSession, C
 
     @Inject
     public ClearToolbarCommand(final DefinitionUtils definitionUtils,
-                               final ManagedInstance<ClearSessionCommand> clearSessionCommand,
+                               final @Any ManagedInstance<ClearSessionCommand> clearSessionCommand,
                                final ClientTranslationService translationService) {
         super(definitionUtils,
               clearSessionCommand,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CopyToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CopyToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class CopyToolbarCommand extends AbstractToolbarCommand<EditorSession, Co
 
     @Inject
     public CopyToolbarCommand(final DefinitionUtils definitionUtils,
-                              final ManagedInstance<CopySelectionSessionCommand> command,
+                              final @Any ManagedInstance<CopySelectionSessionCommand> command,
                               final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CutToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/CutToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class CutToolbarCommand extends AbstractToolbarCommand<EditorSession, Cut
 
     @Inject
     public CutToolbarCommand(final DefinitionUtils definitionUtils,
-                             final ManagedInstance<CutSelectionSessionCommand> command,
+                             final @Any ManagedInstance<CutSelectionSessionCommand> command,
                              final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/DeleteSelectionToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/DeleteSelectionToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class DeleteSelectionToolbarCommand extends AbstractToolbarCommand<Editor
 
     @Inject
     public DeleteSelectionToolbarCommand(final DefinitionUtils definitionUtils,
-                                         final ManagedInstance<DeleteSelectionSessionCommand> command,
+                                         final @Any ManagedInstance<DeleteSelectionSessionCommand> command,
                                          final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToBpmnToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToBpmnToolbarCommand.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class ExportToBpmnToolbarCommand extends AbstractToolbarCommand<AbstractS
 
     @Inject
     public ExportToBpmnToolbarCommand(final DefinitionUtils definitionUtils,
-                                      final ManagedInstance<ExportToBpmnSessionCommand> command,
+                                      final @Any ManagedInstance<ExportToBpmnSessionCommand> command,
                                       final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToJpgToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToJpgToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -34,7 +35,7 @@ public class ExportToJpgToolbarCommand extends AbstractToolbarCommand<AbstractSe
 
     @Inject
     public ExportToJpgToolbarCommand(final DefinitionUtils definitionUtils,
-                                     final ManagedInstance<ExportToJpgSessionCommand> command,
+                                     final @Any ManagedInstance<ExportToJpgSessionCommand> command,
                                      final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPdfToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPdfToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -34,7 +35,7 @@ public class ExportToPdfToolbarCommand extends AbstractToolbarCommand<AbstractSe
 
     @Inject
     public ExportToPdfToolbarCommand(final DefinitionUtils definitionUtils,
-                                     final ManagedInstance<ExportToPdfSessionCommand> command,
+                                     final @Any ManagedInstance<ExportToPdfSessionCommand> command,
                                      final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPngToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToPngToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -34,7 +35,7 @@ public class ExportToPngToolbarCommand extends AbstractToolbarCommand<AbstractSe
 
     @Inject
     public ExportToPngToolbarCommand(final DefinitionUtils definitionUtils,
-                                     final ManagedInstance<ExportToPngSessionCommand> command,
+                                     final @Any ManagedInstance<ExportToPngSessionCommand> command,
                                      final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToSvgToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ExportToSvgToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -34,7 +35,7 @@ public class ExportToSvgToolbarCommand extends AbstractToolbarCommand<AbstractSe
 
     @Inject
     public ExportToSvgToolbarCommand(final DefinitionUtils definitionUtils,
-                                     final ManagedInstance<ExportToSvgSessionCommand> command,
+                                     final @Any ManagedInstance<ExportToSvgSessionCommand> command,
                                      final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/PasteToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/PasteToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class PasteToolbarCommand extends AbstractToolbarCommand<EditorSession, P
 
     @Inject
     public PasteToolbarCommand(final DefinitionUtils definitionUtils,
-                               final ManagedInstance<PasteSelectionSessionCommand> command,
+                               final @Any ManagedInstance<PasteSelectionSessionCommand> command,
                                final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/PerformAutomaticLayoutToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/PerformAutomaticLayoutToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class PerformAutomaticLayoutToolbarCommand extends AbstractToolbarCommand
 
     @Inject
     public PerformAutomaticLayoutToolbarCommand(final DefinitionUtils definitionUtils,
-                                                final ManagedInstance<PerformAutomaticLayoutCommand> commands,
+                                                final @Any ManagedInstance<PerformAutomaticLayoutCommand> commands,
                                                 final ClientTranslationService translationService) {
         super(definitionUtils, commands, translationService);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/RedoToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/RedoToolbarCommand.java
@@ -16,6 +16,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconRotate;
@@ -32,7 +33,7 @@ public class RedoToolbarCommand extends AbstractToolbarCommand<EditorSession, Re
 
     @Inject
     public RedoToolbarCommand(final DefinitionUtils definitionUtils,
-                              final ManagedInstance<RedoSessionCommand> command,
+                              final @Any ManagedInstance<RedoSessionCommand> command,
                               final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SaveToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SaveToolbarCommand.java
@@ -16,6 +16,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -31,7 +32,7 @@ public class SaveToolbarCommand extends AbstractToolbarCommand<EditorSession, Sa
 
     @Inject
     public SaveToolbarCommand(final DefinitionUtils definitionUtils,
-                              final ManagedInstance<SaveDiagramSessionCommand> command,
+                              final @Any ManagedInstance<SaveDiagramSessionCommand> command,
                               final ClientTranslationService translationService) {
         super(definitionUtils, command, translationService);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SwitchGridToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/SwitchGridToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class SwitchGridToolbarCommand extends AbstractToolbarCommand<EditorSessi
 
     @Inject
     public SwitchGridToolbarCommand(final DefinitionUtils definitionUtils,
-                                    final ManagedInstance<SwitchGridSessionCommand> command,
+                                    final @Any ManagedInstance<SwitchGridSessionCommand> command,
                                     final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/UndoToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/UndoToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class UndoToolbarCommand extends AbstractToolbarCommand<EditorSession, Un
 
     @Inject
     public UndoToolbarCommand(final DefinitionUtils definitionUtils,
-                              final ManagedInstance<UndoSessionCommand> command,
+                              final @Any ManagedInstance<UndoSessionCommand> command,
                               final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ValidateToolbarCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/toolbar/command/ValidateToolbarCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.client.widgets.toolbar.command;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -32,7 +33,7 @@ public class ValidateToolbarCommand extends AbstractToolbarCommand<EditorSession
 
     @Inject
     public ValidateToolbarCommand(final DefinitionUtils definitionUtils,
-                                  final ManagedInstance<ValidateSessionCommand> command,
+                                  final @Any ManagedInstance<ValidateSessionCommand> command,
                                   final ClientTranslationService translationService) {
         super(definitionUtils,
               command,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/AbstractDiagramValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/validation/impl/AbstractDiagramValidator.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.validation.impl;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -78,18 +79,24 @@ public abstract class AbstractDiagramValidator
                 // If the underlying bean is a Definition, it accomplishes JSR303 validations.
                 modelValidator.validate(element,
                                         modelViolations -> {
-                                            violations.get().add(new ElementViolationImpl.Builder()
-                                                                         .setUuid(element.getUUID())
-                                                                         .setGraphViolations(ruleViolations)
-                                                                         .setModelViolations(modelViolations)
-                                                                         .build());
+                                            if ((Objects.nonNull(ruleViolations) && !ruleViolations.isEmpty()) || (Objects.nonNull(modelViolations) && !modelViolations.isEmpty())) {
+                                                //Don't add a ElementViolation if there are no rule or model violations
+                                                violations.get().add(new ElementViolationImpl.Builder()
+                                                                             .setUuid(element.getUUID())
+                                                                             .setGraphViolations(ruleViolations)
+                                                                             .setModelViolations(modelViolations)
+                                                                             .build());
+                                            }
                                         });
             } else {
                 // Otherwise, no need not perform bean validation.
-                violations.get().add(new ElementViolationImpl.Builder()
-                                             .setUuid(element.getUUID())
-                                             .setGraphViolations(ruleViolations)
-                                             .build());
+                if (Objects.nonNull(ruleViolations) && !ruleViolations.isEmpty()) {
+                    //Don't add a ElementViolation if there are no rule or model violations
+                    violations.get().add(new ElementViolationImpl.Builder()
+                                                 .setUuid(element.getUUID())
+                                                 .setGraphViolations(ruleViolations)
+                                                 .build());
+                }
             }
         };
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3515

This change leverages the existing Stunner support for validation execution and reporting.

The changes to Stunner's commands are not as such part of the change, but whilst looking into how to re-use Stunner's support I found that the commands needed to have `@Any` injected otherwise subsequent lookup of specific commands for different domains (BPMN, DMN, CM) was failing... if/when different domains need to provide different implementations. 