### PR TITLE
[7.23.x] AF-2080 (RHDM-988): The method defined in a parent data object class is not visible when editing guided decision table (#2719)

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/ClassMethodInspector.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/ClassMethodInspector.java
@@ -16,9 +16,7 @@
 
 package org.kie.workbench.common.services.datamodel.backend.server.builder.projects;
 
-import java.io.IOException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -37,15 +35,17 @@ public class ClassMethodInspector {
     private final Set<MethodInfo> methods = new HashSet<MethodInfo>();
 
     public ClassMethodInspector(final Class<?> clazz,
-                                final ClassToGenericClassConverter converter) throws IOException {
-        final Method[] methods = clazz.getDeclaredMethods();
+                                final ClassToGenericClassConverter converter) {
+        // Get an array containing Method objects reflecting all the public methods of the class or interface
+        // represented by this Class object, including those declared by the class or interface and those
+        // inherited from superclasses and superinterfaces
+        final Method[] methods = clazz.getMethods();
         for (int i = 0; i < methods.length; i++) {
             Method aMethod = methods[i];
-            int modifiers = methods[i].getModifiers();
             String methodName = aMethod.getName();
 
             if (isNotGetterOrSetter(aMethod) && !BlackLists.isClassMethodBlackListed(clazz,
-                                                                                     methodName) && Modifier.isPublic(modifiers)) {
+                                                                                     methodName)) {
 
                 Class<?>[] listParam = aMethod.getParameterTypes();
 
@@ -62,7 +62,6 @@ public class ClassMethodInspector {
 
     /**
      * Translate Method Parameter types to the generic types used by DataModelOracle
-     *
      * @param converter
      * @param listParam
      * @return
@@ -89,7 +88,6 @@ public class ClassMethodInspector {
      * <p/>
      * If method starts with set or get and is longer than 3 characters.
      * For example java.util.List.set(int index, Object element) is considered to be a method, not a setter.
-     *
      * @param m
      */
     private boolean isNotGetterOrSetter(final Method m) {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/BlackLists.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/BlackLists.java
@@ -29,32 +29,32 @@ public class BlackLists {
      * @param methodName
      * @return
      */
-    public static boolean isClassMethodBlackListed( final Class<?> clazz,
-                                                    final String methodName ) {
-        if ( "class".equals( methodName ) || "hashCode".equals( methodName ) || "equals".equals( methodName ) || "toString".equals( methodName ) ) {
+    public static boolean isClassMethodBlackListed(final Class<?> clazz,
+                                                   final String methodName) {
+        if (isInObjectMethodsBlackList(methodName)) {
             return true;
         }
 
-        if ( Collection.class.isAssignableFrom( clazz ) ) {
-            if ( isInCollectionMethodsBlackList( methodName ) ) {
+        if (Collection.class.isAssignableFrom(clazz)) {
+            if (isInCollectionMethodsBlackList(methodName)) {
                 return true;
             }
         }
 
-        if ( Set.class.isAssignableFrom( clazz ) ) {
-            if ( isInSetMethodsBlackList( methodName ) ) {
+        if (Set.class.isAssignableFrom(clazz)) {
+            if (isInSetMethodsBlackList(methodName)) {
                 return true;
             }
         }
 
-        if ( List.class.isAssignableFrom( clazz ) ) {
-            if ( isInListMethodsBlackList( methodName ) ) {
+        if (List.class.isAssignableFrom(clazz)) {
+            if (isInListMethodsBlackList(methodName)) {
                 return true;
             }
         }
 
-        if ( Map.class.isAssignableFrom( clazz ) ) {
-            if ( isInMapMethodsBlackList( methodName ) ) {
+        if (Map.class.isAssignableFrom(clazz)) {
+            if (isInMapMethodsBlackList(methodName)) {
                 return true;
             }
         }
@@ -62,40 +62,39 @@ public class BlackLists {
         return false;
     }
 
-    private static boolean isInCollectionMethodsBlackList( final String methodName ) {
-        return ( "addAll".equals( methodName )
-                || "containsAll".equals( methodName )
-                || "iterator".equals( methodName )
-                || "removeAll".equals( methodName )
-                || "retainAll".equals( methodName )
-                || "toArray".equals( methodName ) );
+    private static boolean isInObjectMethodsBlackList(final String methodName) {
+        return "wait".equals(methodName)
+                || "notify".equals(methodName)
+                || "notifyAll".equals(methodName)
+                || "class".equals(methodName)
+                || "hashCode".equals(methodName)
+                || "equals".equals(methodName)
+                || "toString".equals(methodName);
     }
 
-    private static boolean isInSetMethodsBlackList( final String methodName ) {
-        return ( "addAll".equals( methodName )
-                || "containsAll".equals( methodName )
-                || "iterator".equals( methodName )
-                || "removeAll".equals( methodName )
-                || "retainAll".equals( methodName )
-                || "toArray".equals( methodName ) );
+    private static boolean isInCollectionMethodsBlackList(final String methodName) {
+        return "addAll".equals(methodName)
+                || "containsAll".equals(methodName)
+                || "iterator".equals(methodName)
+                || "removeAll".equals(methodName)
+                || "retainAll".equals(methodName)
+                || "toArray".equals(methodName);
     }
 
-    private static boolean isInListMethodsBlackList( final String methodName ) {
-        return ( "addAll".equals( methodName )
-                || "containsAll".equals( methodName )
-                || "iterator".equals( methodName )
-                || "listIterator".equals( methodName )
-                || "removeAll".equals( methodName )
-                || "retainAll".equals( methodName )
-                || "subList".equals( methodName )
-                || "toArray".equals( methodName )
-        );
+    private static boolean isInSetMethodsBlackList(final String methodName) {
+        return isInCollectionMethodsBlackList(methodName);
     }
 
-    private static boolean isInMapMethodsBlackList( final String methodName ) {
-        return ( "entrySet".equals( methodName )
-                || "keySet".equals( methodName )
-                || "putAll".equals( methodName ) );
+    private static boolean isInListMethodsBlackList(final String methodName) {
+        return isInCollectionMethodsBlackList(methodName)
+                || "listIterator".equals(methodName)
+                || "subList".equals(methodName);
+    }
+
+    private static boolean isInMapMethodsBlackList(final String methodName) {
+        return "entrySet".equals(methodName)
+                || "keySet".equals(methodName)
+                || "putAll".equals(methodName);
     }
 
     /**
@@ -103,7 +102,7 @@ public class BlackLists {
      * @param type
      * @return
      */
-    public static boolean isTypeBlackListed( final Class<?> type ) {
+    public static boolean isTypeBlackListed(final Class<?> type) {
         return type.isArray();
     }
 
@@ -112,8 +111,7 @@ public class BlackLists {
      * @param type
      * @return
      */
-    public static boolean isReturnTypeBlackListed( final Class<?> type ) {
+    public static boolean isReturnTypeBlackListed(final Class<?> type) {
         return type.isArray() || type.isPrimitive();
     }
-
 }

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/ClassMethodInspectorTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/ClassMethodInspectorTest.java
@@ -26,7 +26,9 @@ import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.MethodInfo;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 public class ClassMethodInspectorTest {
 
@@ -51,6 +53,23 @@ public class ClassMethodInspectorTest {
         assertEquals(DataType.TYPE_NUMERIC_INTEGER,
                      getMethodInfo("addOrSimilar",
                                    ext.getMethodInfos()).getParams().get(0));
+    }
+
+    @Test
+    public void testInheritedPublicMethods() {
+        final ClassMethodInspector ext = new ClassMethodInspector(ChildClass.class,
+                                                                  new JavaTypeSystemTranslator());
+
+        for (String s : ext.getMethodNames()) {
+            assertFalse("Method " + s + " is not allowed.",
+                        checkBlackList(s));
+        }
+        assertEquals(2,
+                     ext.getMethodInfos().size());
+        assertNotNull(getMethodInfo("aParentMethod",
+                                    ext.getMethodInfos()));
+        assertNotNull(getMethodInfo("aChildMethod",
+                                    ext.getMethodInfos()));
     }
 
     private MethodInfo getMethodInfo(final String methodName,
@@ -306,6 +325,19 @@ public class ClassMethodInspectorTest {
 
         public void isSomething(String a) {
 
+        }
+    }
+
+    public static class ParentClass {
+
+        public void aParentMethod() {
+
+        }
+    }
+
+    public static class ChildClass extends ParentClass {
+
+        public void aChildMethod() {
         }
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/AF-2080

(cherry picked from commit 85a22ef5fbb138694803aa1b101456c9e6999f26)