### PR TITLE
DROOLS-3917 : The 'run all' panel should automatically close after leaving the project's library

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreen.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.workbench.client.test;
 
+import java.util.Objects;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -26,15 +28,22 @@ import org.uberfire.client.annotations.DefaultPosition;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.workbench.events.PlaceGainFocusEvent;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.Position;
 
 @ApplicationScoped
-@WorkbenchScreen(identifier = "org.kie.guvnor.TestResults", preferredWidth = 437)
+@WorkbenchScreen(identifier = TestRunnerReportingScreen.IDENTIFIER, preferredWidth = 437)
 public class TestRunnerReportingScreen {
+
+    public static final String IDENTIFIER = "org.kie.guvnor.TestResults";
 
     @Inject
     private TestRunnerReportingPanel panel;
+
+    @Inject
+    private PlaceManager placeManager;
 
     public TestRunnerReportingScreen() {
         //Zero argument constructor for CDI
@@ -53,6 +62,12 @@ public class TestRunnerReportingScreen {
     @WorkbenchPartView
     public Widget asWidget() {
         return panel.asWidget();
+    }
+
+    public void onPlaceGainFocusEvent(final @Observes PlaceGainFocusEvent placeGainFocusEvent) {
+        if (!Objects.equals(placeGainFocusEvent.getPlace().getIdentifier(), IDENTIFIER)) {
+            placeManager.closePlace(IDENTIFIER);
+        }
     }
 
     public void onTestRun(final @Observes TestResultMessage testResultMessage) {

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/test/TestRunnerReportingScreenTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.workbench.client.test;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.workbench.events.PlaceGainFocusEvent;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestRunnerReportingScreenTest {
+
+    @Mock
+    PlaceManager placeManager;
+
+    @InjectMocks
+    TestRunnerReportingScreen screen;
+
+    @Test
+    public void nullIdentifier() {
+        screen.onPlaceGainFocusEvent(new PlaceGainFocusEvent(new DefaultPlaceRequest()));
+        verify(placeManager).closePlace(TestRunnerReportingScreen.IDENTIFIER);
+    }
+
+    @Test
+    public void doNotCloseWhenThisScreenGainsFocus() {
+        screen.onPlaceGainFocusEvent(new PlaceGainFocusEvent(new DefaultPlaceRequest(TestRunnerReportingScreen.IDENTIFIER)));
+        verify(placeManager, never()).closePlace(TestRunnerReportingScreen.IDENTIFIER);
+    }
+
+    @Test
+    public void closeWhenAnyOtherScreenGainsFocus() {
+        screen.onPlaceGainFocusEvent(new PlaceGainFocusEvent(new DefaultPlaceRequest("ProjectScreen")));
+        verify(placeManager).closePlace(TestRunnerReportingScreen.IDENTIFIER);
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3917

@kkufova @danielezonca @gitgabrio Here you are.