### PR TITLE
[AF-2065]: Added repository removed event to SpacesScreen observer

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/src/spaces-screen/index.tsx
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/src/spaces-screen/index.tsx
@@ -29,7 +29,8 @@ export class SpacesScreenAppFormerComponent extends AppFormer.Screen {
       ["org.guvnor.structure.organizationalunit.NewOrganizationalUnitEvent", (e: any) => this.self.refreshSpaces()],
       ["org.guvnor.structure.organizationalunit.RemoveOrganizationalUnitEvent", (e: any) => this.self.refreshSpaces()],
       ["org.kie.workbench.common.screens.library.api.sync.ClusterLibraryEvent", (e: any) => this.self.refreshSpaces()],
-      ["org.guvnor.common.services.project.events.NewProjectEvent", (e: any) => this.self.refreshSpaces()]
+      ["org.guvnor.common.services.project.events.NewProjectEvent", (e: any) => this.self.refreshSpaces()],
+      ["org.guvnor.structure.repositories.RepositoryRemovedEvent", (e: any) => this.self.refreshSpaces()]
     ]);
   }
 


### PR DESCRIPTION
The event that refreshes SpacesView when a Repository is removed was missing.

IMPORTANT: Refresh Browser cache when testing this because it needs a fresh spaces-bundle.js, if not you will not be able to see changes.  A Jira to force refresh will be created.

@paulovmr @ederign @tomasdavidorg 