### PR TITLE
AF-2053: Dialog remains open after asset is deleted at the same time

### DIFF
--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieEditor.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieEditor.java
@@ -55,7 +55,6 @@ import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.client.workbench.widgets.multipage.Page;
 import org.uberfire.ext.editor.commons.client.BaseEditor;
 import org.uberfire.ext.editor.commons.client.file.popups.CopyPopUpPresenter;
-import org.uberfire.ext.editor.commons.client.file.popups.DeletePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.menu.MenuItems;
@@ -103,8 +102,6 @@ public abstract class KieEditor<T>
     protected WorkspaceProjectContext workbenchContext;
     @Inject
     protected SavePopUpPresenter savePopUpPresenter;
-    @Inject
-    protected DeletePopUpPresenter deletePopUpPresenter;
     @Inject
     protected RenamePopUpPresenter renamePopUpPresenter;
     @Inject


### PR DESCRIPTION
The issue was caused when two users were trying to delete the same asset at same time (with the delete popup opened). When first user finally deletes the asset the second user gets the concurrent delete notification, whatever option he chooses (cancel or ignore) on that popup, the delete popup will still be opened, so he will be able click on the delete button, getting that error.

To prevent that situation, we'll be hiding the delete popup if there's a concurrent deletion.

@tomasdavidorg @adrielparedes @ederign Could you please take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/appformer/pull/731
https://github.com/kiegroup/kie-wb-common/pull/2740