### PR TITLE
DROOLS-4211 / DROOLS-4212: Search feature - Implement search mechanism PoC on GDT / DMN graph

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/graph/DMNDiagramUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/graph/DMNDiagramUtils.java
@@ -40,7 +40,7 @@ public class DMNDiagramUtils {
         //CDI proxy
     }
 
-    public List<DRGElement> getNodes(final Diagram diagram) {
+    public List<DRGElement> getDRGElements(final Diagram diagram) {
         return getDefinitionStream(diagram)
                 .filter(d -> d instanceof DRGElement)
                 .map(d -> (DRGElement) d)
@@ -75,7 +75,7 @@ public class DMNDiagramUtils {
     }
 
     @SuppressWarnings("unchecked")
-    private Stream<Node> getNodeStream(final Diagram diagram) {
+    public Stream<Node> getNodeStream(final Diagram diagram) {
         final Graph<?, Node> graph = diagram.getGraph();
         return StreamSupport.stream(graph.nodes().spliterator(), false);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/graph/DMNDiagramUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/graph/DMNDiagramUtilsTest.java
@@ -100,7 +100,7 @@ public class DMNDiagramUtilsTest {
 
         when(definition.getDefinition()).thenReturn(drgElement);
 
-        final List<DRGElement> actualNodes = utils.getNodes(diagram);
+        final List<DRGElement> actualNodes = utils.getDRGElements(diagram);
         final List<DRGElement> expectedNodes = singletonList(drgElement);
 
         assertEquals(expectedNodes, actualNodes);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/common/DMNDiagramHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/common/DMNDiagramHelper.java
@@ -45,7 +45,7 @@ public class DMNDiagramHelper {
     }
 
     public List<DRGElement> getNodes(final Diagram diagram) {
-        return dmnDiagramUtils.getNodes(diagram);
+        return dmnDiagramUtils.getDRGElements(diagram);
     }
 
     public List<ItemDefinition> getItemDefinitions(final Diagram diagram) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/editors/common/DMNDiagramHelperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/editors/common/DMNDiagramHelperTest.java
@@ -67,7 +67,7 @@ public class DMNDiagramHelperTest {
         final DRGElement drgElement = mock(DRGElement.class);
         final List<DRGElement> expectedNodes = singletonList(drgElement);
 
-        when(dmnDiagramUtils.getNodes(diagram)).thenReturn(expectedNodes);
+        when(dmnDiagramUtils.getDRGElements(diagram)).thenReturn(expectedNodes);
 
         final List<DRGElement> actualNodes = helper.getNodes(diagram);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditor.java
@@ -153,4 +153,8 @@ public class ExpressionEditor implements ExpressionEditorView.Presenter {
     Optional<Command> getExitCommand() {
         return exitCommand;
     }
+
+    public boolean isActive() {
+        return exitCommand.isPresent();
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNEditorSearchIndex.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNEditorSearchIndex.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
+import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditor;
+import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
+import org.kie.workbench.common.widgets.client.search.common.BaseEditorSearchIndex;
+import org.uberfire.mvp.Command;
+
+@Dependent
+public class DMNEditorSearchIndex extends BaseEditorSearchIndex<DMNSearchableElement> {
+
+    private final DMNGraphSubIndex graphSubIndex;
+
+    private final DMNGridSubIndex gridSubIndex;
+
+    private final SessionManager sessionManager;
+
+    private final DMNGraphUtils graphUtils;
+
+    private final DMNGridHelper dmnGridHelper;
+
+    private final Event<CanvasClearSelectionEvent> canvasClearSelectionEventEvent;
+
+    private final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Inject
+    public DMNEditorSearchIndex(final DMNGraphSubIndex graphSubIndex,
+                                final DMNGridSubIndex gridSubIndex,
+                                final SessionManager sessionManager,
+                                final DMNGraphUtils graphUtils,
+                                final DMNGridHelper dmnGridHelper,
+                                final Event<CanvasClearSelectionEvent> canvasClearSelectionEventEvent,
+                                final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent) {
+        this.graphSubIndex = graphSubIndex;
+        this.gridSubIndex = gridSubIndex;
+        this.sessionManager = sessionManager;
+        this.graphUtils = graphUtils;
+        this.dmnGridHelper = dmnGridHelper;
+        this.canvasClearSelectionEventEvent = canvasClearSelectionEventEvent;
+        this.domainObjectSelectionEvent = domainObjectSelectionEvent;
+    }
+
+    @PostConstruct
+    public void init() {
+        registerSubIndex(graphSubIndex);
+        registerSubIndex(gridSubIndex);
+        setNoResultsFoundCallback(getNoResultsFoundCallback());
+    }
+
+    Command getNoResultsFoundCallback() {
+        return () -> {
+            if (getExpressionEditor().isActive()) {
+                clearGridSelection();
+            } else {
+                clearGraphSelection();
+            }
+        };
+    }
+
+    private void clearGraphSelection() {
+        canvasClearSelectionEventEvent.fire(new CanvasClearSelectionEvent(getCanvasHandler()));
+        domainObjectSelectionEvent.fire(new DomainObjectSelectionEvent(getCanvasHandler(), new NOPDomainObject()));
+    }
+
+    private CanvasHandler getCanvasHandler() {
+        return graphUtils.getCanvasHandler();
+    }
+
+    private void clearGridSelection() {
+        dmnGridHelper.clearSelections();
+    }
+
+    @Override
+    protected List<DMNSearchableElement> getSearchableElements() {
+        if (getExpressionEditor().isActive()) {
+            return gridSubIndex.getSearchableElements();
+        } else {
+            return graphSubIndex.getSearchableElements();
+        }
+    }
+
+    private ExpressionEditor getExpressionEditor() {
+        return (ExpressionEditor) getCurrentSession().getExpressionEditor();
+    }
+
+    private DMNSession getCurrentSession() {
+        return sessionManager.getCurrentSession();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNGraphSubIndex.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNGraphSubIndex.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
+import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
+import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasFocusedShapeEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.widgets.client.search.common.HasSearchableElements;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class DMNGraphSubIndex implements HasSearchableElements<DMNSearchableElement> {
+
+    private final DMNGraphUtils graphUtils;
+
+    private final Event<CanvasSelectionEvent> canvasSelectionEvent;
+
+    private final Event<CanvasFocusedShapeEvent> canvasFocusedSelectionEvent;
+
+    @Inject
+    public DMNGraphSubIndex(final DMNGraphUtils graphUtils,
+                            final Event<CanvasSelectionEvent> canvasSelectionEvent,
+                            final Event<CanvasFocusedShapeEvent> canvasFocusedSelectionEvent) {
+        this.graphUtils = graphUtils;
+        this.canvasSelectionEvent = canvasSelectionEvent;
+        this.canvasFocusedSelectionEvent = canvasFocusedSelectionEvent;
+    }
+
+    @Override
+    public List<DMNSearchableElement> getSearchableElements() {
+        return graphUtils
+                .getNodeStream()
+                .map(this::makeElement)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private DMNSearchableElement makeElement(final Node node) {
+
+        return getText(node).map(text -> {
+
+            final DMNSearchableElement element = new DMNSearchableElement();
+
+            element.setText(text);
+            element.setOnFound(makeOnFound(node.getUUID()));
+
+            return element;
+        }).orElse(null);
+    }
+
+    private Optional<String> getText(final Node node) {
+        final Object content = node.getContent();
+        if (content instanceof Definition) {
+            final Object definition = ((Definition) content).getDefinition();
+            if (definition instanceof DRGElement) {
+                final DRGElement drgElement = (DRGElement) definition;
+                return Optional.of(drgElement.getName().getValue());
+            }
+            if (definition instanceof TextAnnotation) {
+                final TextAnnotation textAnnotation = (TextAnnotation) definition;
+                return Optional.of(textAnnotation.getText().getValue());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Command makeOnFound(final String uuid) {
+        return () -> getCanvasHandler().ifPresent(canvasHandler -> {
+            canvasSelectionEvent.fire(new CanvasSelectionEvent(canvasHandler, uuid));
+            canvasFocusedSelectionEvent.fire(new CanvasFocusedShapeEvent(canvasHandler, uuid));
+        });
+    }
+
+    private Optional<CanvasHandler> getCanvasHandler() {
+        return Optional.ofNullable(graphUtils.getCanvasHandler());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridHelper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+import org.uberfire.ext.wires.core.grids.client.util.GridHighlightHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+public class DMNGridHelper {
+
+    private final SessionManager sessionManager;
+
+    @Inject
+    public DMNGridHelper(final SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    public void highlightCell(final int row,
+                              final int column,
+                              final GridWidget gridWidget) {
+        highlightHelper(gridWidget)
+                .withPaddingX(getIdColumnWidth(gridWidget, column))
+                .withPaddingY(getHeaderRowHeight(gridWidget, row))
+                .withPinnedGrid()
+                .highlight(row, column);
+    }
+
+    private double getIdColumnWidth(final GridWidget gridWidget,
+                                    final int column) {
+
+        final List<GridColumn<?>> columns = gridWidget.getModel().getColumns();
+        final double headerColumnWidth = getWidth(columns, 0);
+        final double currentColumnWidth = getWidth(columns, column);
+
+        return headerColumnWidth + currentColumnWidth;
+    }
+
+    private double getHeaderRowHeight(final GridWidget gridWidget,
+                                      final int row) {
+
+        final List<GridRow> rows = gridWidget.getModel().getRows();
+        final double headerRowHeight = getHeight(rows, 0);
+        final double currentRowHeight = getHeight(rows, row);
+
+        return headerRowHeight + currentRowHeight;
+    }
+
+    public void clearSelections() {
+        getGridWidgets().forEach(gridWidget -> highlightHelper(gridWidget).clearSelections());
+    }
+
+    public Set<GridWidget> getGridWidgets() {
+        return getDefaultGridLayer()
+                .getGridWidgets()
+                .stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    private DefaultGridLayer getDefaultGridLayer() {
+        return getGridPanel().getDefaultGridLayer();
+    }
+
+    private DMNGridPanel getGridPanel() {
+        return getCurrentSession().getGridPanel();
+    }
+
+    private DMNSession getCurrentSession() {
+        return sessionManager.getCurrentSession();
+    }
+
+    GridHighlightHelper highlightHelper(final GridWidget gridWidget) {
+        return new GridHighlightHelper(getGridPanel(), gridWidget);
+    }
+
+    private double getWidth(final List<GridColumn<?>> columns,
+                            final int index) {
+        if (index < columns.size()) {
+            return columns.get(index).getWidth();
+        }
+        return 0;
+    }
+
+    private double getHeight(final List<GridRow> rows,
+                             final int index) {
+        if (index < rows.size()) {
+            return rows.get(index).getHeight();
+        }
+        return 0;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridSubIndex.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridSubIndex.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.InformationItemCell.HasNameAndDataTypeCell;
+import org.kie.workbench.common.widgets.client.search.common.HasSearchableElements;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+
+@ApplicationScoped
+public class DMNGridSubIndex implements HasSearchableElements<DMNSearchableElement> {
+
+    private final DMNGridHelper dmnGridHelper;
+
+    @Inject
+    public DMNGridSubIndex(final DMNGridHelper dmnGridHelper) {
+        this.dmnGridHelper = dmnGridHelper;
+    }
+
+    @Override
+    public List<DMNSearchableElement> getSearchableElements() {
+        return dmnGridHelper
+                .getGridWidgets()
+                .stream()
+                .flatMap(gridWidget -> getSearchableElements(gridWidget).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<DMNSearchableElement> getSearchableElements(final GridWidget gridWidget) {
+
+        final List<DMNSearchableElement> elements = new ArrayList<>();
+        final GridData model = gridWidget.getModel();
+        final int rowCount = model.getRowCount();
+        final int columnCount = model.getColumnCount();
+
+        for (int row = 0; row < rowCount; row++) {
+            for (int column = 0; column < columnCount; column++) {
+                final Optional<? extends GridCell<?>> cell = getCell(model, row, column);
+                if (cell.isPresent()) {
+                    elements.add(makeElement(gridWidget, cell.get(), row, column));
+                }
+            }
+        }
+
+        return elements;
+    }
+
+    private Optional<? extends GridCell<?>> getCell(final GridData model,
+                                                    final int row,
+                                                    final int column) {
+        return Optional.ofNullable(model.getCell(row, column));
+    }
+
+    private DMNSearchableElement makeElement(final GridWidget gridWidget,
+                                             final GridCell<?> cell,
+                                             final int row,
+                                             final int column) {
+
+        final DMNSearchableElement searchableCell = new DMNSearchableElement();
+        final String value = getValue(cell);
+
+        searchableCell.setText(value);
+        searchableCell.setOnFound(() -> dmnGridHelper.highlightCell(row, column, gridWidget));
+
+        return searchableCell;
+    }
+
+    String getValue(final GridCell<?> cell) {
+
+        final GridCellValue<?> cellValue = cell.getValue();
+
+        if (cellValue != null) {
+
+            final Object value = cellValue.getValue();
+
+            if (value instanceof HasNameAndDataTypeCell) {
+                final HasNameAndDataTypeCell hasName = (HasNameAndDataTypeCell) value;
+                return hasName.hasData() ? hasName.getName().getValue() : "";
+            } else if (value instanceof String || value instanceof Integer) {
+                return String.valueOf(value);
+            }
+        }
+
+        return "";
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNSearchableElement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNSearchableElement.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import org.kie.workbench.common.widgets.client.search.common.Searchable;
+import org.uberfire.mvp.Command;
+
+public class DMNSearchableElement implements Searchable {
+
+    private Command onFound;
+
+    private String text;
+
+    @Override
+    public boolean matches(final String text) {
+        return this.text.toUpperCase().contains(text.toUpperCase());
+    }
+
+    @Override
+    public Command onFound() {
+        return onFound;
+    }
+
+    public void setOnFound(final Command onFound) {
+        this.onFound = onFound;
+    }
+
+    public void setText(final String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/graph/DMNGraphUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/graph/DMNGraphUtils.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.graph;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -30,6 +31,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.graph.Node;
 
 @Dependent
 public class DMNGraphUtils {
@@ -90,7 +92,15 @@ public class DMNGraphUtils {
     }
 
     public List<DRGElement> getDRGElements(final Diagram diagram) {
-        return dmnDiagramUtils.getNodes(diagram);
+        return dmnDiagramUtils.getDRGElements(diagram);
+    }
+
+    public Stream<Node> getNodeStream(final Diagram diagram) {
+        return dmnDiagramUtils.getNodeStream(diagram);
+    }
+
+    public Stream<Node> getNodeStream() {
+        return getNodeStream(getDiagram());
     }
 
     public Optional<ClientSession> getCurrentSession() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -285,5 +286,17 @@ public class ExpressionEditorTest {
         testedEditor.handleCanvasElementUpdated(event);
 
         verify(view, never()).setExpressionNameText(any(Optional.class));
+    }
+
+    @Test
+    public void testIsActiveWhenExpressionEditorIsNotActive() {
+        testedEditor.setExitCommand(null);
+        assertFalse(testedEditor.isActive());
+    }
+
+    @Test
+    public void testIsActiveWhenExpressionEditorIsActive() {
+        testedEditor.setExitCommand(mock(Command.class));
+        assertTrue(testedEditor.isActive());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNEditorSearchIndexTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNEditorSearchIndexTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.List;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditor;
+import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
+import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.Command;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DMNEditorSearchIndexTest {
+
+    @Mock
+    private DMNGraphSubIndex graphSubIndex;
+
+    @Mock
+    private DMNGridSubIndex gridSubIndex;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private DMNSession dmnSession;
+
+    @Mock
+    private DMNGraphUtils graphUtils;
+
+    @Mock
+    private DMNGridHelper dmnGridHelper;
+
+    @Mock
+    private EventSourceMock<CanvasClearSelectionEvent> canvasClearSelectionEventEvent;
+
+    @Mock
+    private EventSourceMock<DomainObjectSelectionEvent> domainObjectSelectionEvent;
+
+    @Mock
+    private ExpressionEditor expressionEditor;
+
+    private List<DMNSearchableElement> expectedElements = asList(mock(DMNSearchableElement.class), mock(DMNSearchableElement.class));
+
+    private DMNEditorSearchIndex searchIndex;
+
+    @Before
+    public void setup() {
+        searchIndex = spy(new DMNEditorSearchIndex(graphSubIndex, gridSubIndex, sessionManager, graphUtils, dmnGridHelper, canvasClearSelectionEventEvent, domainObjectSelectionEvent));
+
+        when(sessionManager.getCurrentSession()).thenReturn(dmnSession);
+        when(dmnSession.getExpressionEditor()).thenReturn(expressionEditor);
+    }
+
+    @Test
+    public void testInit() {
+
+        final Command noResultsFoundCallback = mock(Command.class);
+
+        doReturn(noResultsFoundCallback).when(searchIndex).getNoResultsFoundCallback();
+
+        searchIndex.init();
+
+        verify(searchIndex).registerSubIndex(graphSubIndex);
+        verify(searchIndex).registerSubIndex(gridSubIndex);
+        verify(searchIndex).setNoResultsFoundCallback(noResultsFoundCallback);
+    }
+
+    @Test
+    public void testGetSearchableElementsWhenExpressionEditorIsActive() {
+
+        when(expressionEditor.isActive()).thenReturn(true);
+        when(gridSubIndex.getSearchableElements()).thenReturn(expectedElements);
+        when(graphSubIndex.getSearchableElements()).thenReturn(emptyList());
+
+        final List<DMNSearchableElement> actualElements = searchIndex.getSearchableElements();
+
+        assertEquals(expectedElements, actualElements);
+    }
+
+    @Test
+    public void testGetSearchableElementsWhenExpressionEditorIsNotActive() {
+
+        when(expressionEditor.isActive()).thenReturn(false);
+        when(gridSubIndex.getSearchableElements()).thenReturn(emptyList());
+        when(graphSubIndex.getSearchableElements()).thenReturn(expectedElements);
+
+        final List<DMNSearchableElement> actualElements = searchIndex.getSearchableElements();
+
+        assertEquals(expectedElements, actualElements);
+    }
+
+    @Test
+    public void testGetNoResultsFoundCallbackWhenExpressionEditorIsActive() {
+
+        when(expressionEditor.isActive()).thenReturn(true);
+
+        searchIndex.getNoResultsFoundCallback().execute();
+
+        verify(dmnGridHelper).clearSelections();
+    }
+
+    @Test
+    public void testGetNoResultsFoundCallbackWhenExpressionEditorIsNotActive() {
+
+        when(expressionEditor.isActive()).thenReturn(false);
+
+        searchIndex.getNoResultsFoundCallback().execute();
+
+        verify(canvasClearSelectionEventEvent).fire(any(CanvasClearSelectionEvent.class));
+        verify(domainObjectSelectionEvent).fire(any(DomainObjectSelectionEvent.class));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNGraphSubIndexTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNGraphSubIndexTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
+import org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasFocusedShapeEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DMNGraphSubIndexTest {
+
+    @Mock
+    private DMNGraphUtils graphUtils;
+
+    @Mock
+    private EventSourceMock<CanvasSelectionEvent> canvasSelectionEvent;
+
+    @Mock
+    private EventSourceMock<CanvasFocusedShapeEvent> canvasFocusedSelectionEvent;
+
+    @Mock
+    private Node node1;
+
+    @Mock
+    private Node node2;
+
+    @Mock
+    private Node node3;
+
+    @Mock
+    private Node node4;
+
+    @Mock
+    private Node node5;
+
+    @Mock
+    private Node node6;
+
+    @Mock
+    private Definition definition1;
+
+    @Mock
+    private Definition definition2;
+
+    @Mock
+    private Definition definition3;
+
+    @Mock
+    private Definition definition4;
+
+    @Mock
+    private Definition definition5;
+
+    @Mock
+    private DRGElement drgElement1;
+
+    @Mock
+    private DRGElement drgElement2;
+
+    @Mock
+    private DRGElement drgElement3;
+
+    @Mock
+    private TextAnnotation textAnnotation1;
+
+    @Mock
+    private TextAnnotation textAnnotation2;
+
+    @Mock
+    private CanvasHandler canvasHandler;
+
+    private String drgElement1String = "DRG Element 1";
+
+    private String drgElement2String = "DRG Element 2";
+
+    private String drgElement3String = "DRG Element 3";
+
+    private String textAnnotation1String = "Text Annotation 1";
+
+    private String textAnnotation2String = "Text Annotation 2";
+
+    private String uuid1 = "1111-1111";
+
+    private String uuid2 = "2222-2222";
+
+    private String uuid3 = "3333-3333";
+
+    private String uuid4 = "4444-4444";
+
+    private String uuid5 = "5555-5555";
+
+    private String uuid6 = "6666-6666";
+
+    private DMNGraphSubIndex index;
+
+    @Before
+    public void setup() {
+
+        index = new DMNGraphSubIndex(graphUtils, canvasSelectionEvent, canvasFocusedSelectionEvent);
+
+        when(node1.getUUID()).thenReturn(uuid1);
+        when(node2.getUUID()).thenReturn(uuid2);
+        when(node3.getUUID()).thenReturn(uuid3);
+        when(node4.getUUID()).thenReturn(uuid4);
+        when(node5.getUUID()).thenReturn(uuid5);
+        when(node6.getUUID()).thenReturn(uuid6);
+
+        when(node1.getContent()).thenReturn(definition1);
+        when(node2.getContent()).thenReturn(definition2);
+        when(node3.getContent()).thenReturn(definition3);
+        when(node4.getContent()).thenReturn(definition4);
+        when(node5.getContent()).thenReturn(definition5);
+
+        when(definition1.getDefinition()).thenReturn(drgElement1);
+        when(definition2.getDefinition()).thenReturn(drgElement2);
+        when(definition3.getDefinition()).thenReturn(drgElement3);
+        when(definition4.getDefinition()).thenReturn(textAnnotation1);
+        when(definition5.getDefinition()).thenReturn(textAnnotation2);
+
+        when(drgElement1.getName()).thenReturn(new Name(drgElement1String));
+        when(drgElement2.getName()).thenReturn(new Name(drgElement2String));
+        when(drgElement3.getName()).thenReturn(new Name(drgElement3String));
+        when(textAnnotation1.getText()).thenReturn(new Text(textAnnotation1String));
+        when(textAnnotation2.getText()).thenReturn(new Text(textAnnotation2String));
+
+        when(graphUtils.getNodeStream()).thenReturn(Stream.of(node1, node2, node3, node4, node5, node6));
+
+        when(graphUtils.getCanvasHandler()).thenReturn(canvasHandler);
+    }
+
+    @Test
+    public void testGetSearchableElements() {
+
+        final List<DMNSearchableElement> elements = index
+                .getSearchableElements()
+                .stream()
+                .sorted(Comparator.comparing(DMNSearchableElement::getText))
+                .collect(Collectors.toList());
+
+        assertEquals(5, elements.size());
+
+        // Text values
+        assertEquals(drgElement1String, elements.get(0).getText());
+        assertEquals(drgElement2String, elements.get(1).getText());
+        assertEquals(drgElement3String, elements.get(2).getText());
+        assertEquals(textAnnotation1String, elements.get(3).getText());
+        assertEquals(textAnnotation2String, elements.get(4).getText());
+
+        // Text values
+        elements.get(0).onFound().execute();
+        elements.get(1).onFound().execute();
+        elements.get(2).onFound().execute();
+        elements.get(3).onFound().execute();
+        elements.get(4).onFound().execute();
+
+        verify(canvasSelectionEvent, times(5)).fire(any(CanvasSelectionEvent.class));
+        verify(canvasFocusedSelectionEvent, times(5)).fire(any(CanvasFocusedShapeEvent.class));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridHelperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridHelperTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+import org.uberfire.ext.wires.core.grids.client.util.GridHighlightHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DMNGridHelperTest {
+
+    @Mock
+    private DMNSession dmnSession;
+
+    @Mock
+    private DMNGridPanel gridPanel;
+
+    @Mock
+    private DefaultGridLayer defaultGridLayer;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private GridHighlightHelper highlightHelper;
+
+    @Mock
+    private GridWidget gridWidget1;
+
+    @Mock
+    private GridWidget gridWidget2;
+
+    @Mock
+    private GridWidget gridWidget3;
+
+    @Mock
+    private GridData model;
+
+    private DMNGridHelper helper;
+
+    @Before
+    public void setup() {
+
+        when(dmnSession.getGridPanel()).thenReturn(gridPanel);
+        when(gridPanel.getDefaultGridLayer()).thenReturn(defaultGridLayer);
+        when(sessionManager.getCurrentSession()).thenReturn(dmnSession);
+
+        helper = spy(new DMNGridHelper(sessionManager));
+    }
+
+    @Test
+    public void testHighlightHelper() {
+
+        final int row = 1;
+        final int column = 1;
+        final GridColumn<?> headerColumn = mock(GridColumn.class);
+        final GridColumn<?> currentColumn = mock(GridColumn.class);
+        final GridRow headerRow = mock(GridRow.class);
+        final GridRow currentRow = mock(GridRow.class);
+        final double headerColumnWidth = 2d;
+        final double currentColumnWidth = 4d;
+        final double headerRowWidth = 8d;
+        final double currentRowWidth = 16d;
+
+        doReturn(highlightHelper).when(helper).highlightHelper(gridWidget1);
+        when(gridWidget1.getModel()).thenReturn(model);
+        when(model.getColumns()).thenReturn(asList(headerColumn, currentColumn));
+        when(model.getRows()).thenReturn(asList(headerRow, currentRow));
+
+        when(headerColumn.getWidth()).thenReturn(headerColumnWidth);
+        when(currentColumn.getWidth()).thenReturn(currentColumnWidth);
+        when(headerRow.getHeight()).thenReturn(headerRowWidth);
+        when(currentRow.getHeight()).thenReturn(currentRowWidth);
+
+        when(highlightHelper.withPaddingX(headerColumnWidth + currentColumnWidth)).thenReturn(highlightHelper);
+        when(highlightHelper.withPaddingY(headerRowWidth + currentRowWidth)).thenReturn(highlightHelper);
+        when(highlightHelper.withPinnedGrid()).thenReturn(highlightHelper);
+
+        helper.highlightCell(row, column, gridWidget1);
+
+        verify(highlightHelper).highlight(row, column);
+    }
+
+    @Test
+    public void clearSelections() {
+
+        when(defaultGridLayer.getGridWidgets()).thenReturn(asSet(gridWidget1, null, gridWidget2, null, gridWidget3));
+
+        doReturn(highlightHelper).when(helper).highlightHelper(gridWidget1);
+        doReturn(highlightHelper).when(helper).highlightHelper(gridWidget2);
+        doReturn(highlightHelper).when(helper).highlightHelper(gridWidget3);
+
+        helper.clearSelections();
+
+        verify(highlightHelper, times(3)).clearSelections();
+    }
+
+    @Test
+    public void getGridWidgets() {
+
+        when(defaultGridLayer.getGridWidgets()).thenReturn(asSet(gridWidget1, null, gridWidget2, null, gridWidget3));
+
+        final Set<GridWidget> actualGridWidgets = helper.getGridWidgets();
+        final Set<GridWidget> expectedGridWidgets = asSet(gridWidget1, gridWidget2, gridWidget3);
+
+        assertEquals(expectedGridWidgets, actualGridWidgets);
+    }
+
+    private Set<GridWidget> asSet(final GridWidget... a) {
+        return new HashSet<>(asList(a));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridSubIndexTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNGridSubIndexTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.search;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.context.InformationItemCell.HasNameAndDataTypeCell;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DMNGridSubIndexTest {
+
+    @Mock
+    private DMNGridHelper dmnGridHelper;
+
+    @Mock
+    private GridWidget gridWidget1;
+
+    @Mock
+    private GridWidget gridWidget2;
+
+    @Mock
+    private GridWidget gridWidget3;
+
+    @Mock
+    private GridData gridData1;
+
+    @Mock
+    private GridData gridData2;
+
+    @Mock
+    private GridData gridData3;
+
+    @Mock
+    private GridCell<String> cell1;
+
+    @Mock
+    private GridCell<String> cell2;
+
+    @Mock
+    private GridCell<String> cell3;
+
+    @Mock
+    private GridCell<String> cell4;
+
+    @Mock
+    private GridCell<String> cell5;
+
+    @Mock
+    private GridCell<String> cell6;
+
+    @Mock
+    private GridCell<String> cell7;
+
+    @Mock
+    private GridCell<HasNameAndDataTypeCell> cell8;
+
+    @Mock
+    private GridCellValue<String> cellValue1;
+
+    @Mock
+    private GridCellValue<String> cellValue2;
+
+    @Mock
+    private GridCellValue<String> cellValue3;
+
+    @Mock
+    private GridCellValue<String> cellValue4;
+
+    @Mock
+    private GridCellValue<String> cellValue5;
+
+    @Mock
+    private GridCellValue<String> cellValue6;
+
+    @Mock
+    private GridCellValue<String> cellValue7;
+
+    @Mock
+    private GridCellValue<HasNameAndDataTypeCell> cellValue8;
+
+    @Mock
+    private HasNameAndDataTypeCell cellNameAndDataTypeValue8;
+
+    private String cellStringValue1 = "Cell value 1";
+
+    private String cellStringValue2 = "Cell value 2";
+
+    private String cellStringValue3 = "Cell value 3";
+
+    private String cellStringValue4 = "Cell value 4";
+
+    private String cellStringValue5 = "Cell value 5";
+
+    private String cellStringValue6 = "Cell value 6";
+
+    private String cellStringValue7 = "Cell value 7";
+
+    private String cellStringValue8 = "Cell value 8";
+
+    private DMNGridSubIndex index;
+
+    @Before
+    public void setup() {
+
+        index = spy(new DMNGridSubIndex(dmnGridHelper));
+
+        // GridWidget
+        when(dmnGridHelper.getGridWidgets()).thenReturn(asSet(gridWidget1, gridWidget2, gridWidget3));
+        when(gridWidget1.getModel()).thenReturn(gridData1);
+        when(gridWidget2.getModel()).thenReturn(gridData2);
+        when(gridWidget3.getModel()).thenReturn(gridData3);
+
+        // GridData
+        when(gridData1.getRowCount()).thenReturn(1);
+        when(gridData1.getColumnCount()).thenReturn(2);
+        when(gridData2.getRowCount()).thenReturn(2);
+        when(gridData2.getColumnCount()).thenReturn(1);
+        when(gridData3.getRowCount()).thenReturn(2);
+        when(gridData3.getColumnCount()).thenReturn(2);
+
+        // GridCell
+        doReturn(cell1).when(gridData1).getCell(0, 0);
+        doReturn(cell2).when(gridData1).getCell(0, 1);
+
+        doReturn(cell3).when(gridData2).getCell(0, 0);
+        doReturn(cell4).when(gridData2).getCell(1, 0);
+
+        doReturn(cell5).when(gridData3).getCell(0, 0);
+        doReturn(cell6).when(gridData3).getCell(0, 1);
+        doReturn(cell7).when(gridData3).getCell(1, 0);
+        doReturn(null).when(gridData3).getCell(1, 1);
+
+        // GridCellValue
+        when(cell1.getValue()).thenReturn(cellValue1);
+        when(cell2.getValue()).thenReturn(cellValue2);
+        when(cell3.getValue()).thenReturn(cellValue3);
+        when(cell4.getValue()).thenReturn(cellValue4);
+        when(cell5.getValue()).thenReturn(cellValue5);
+        when(cell6.getValue()).thenReturn(cellValue6);
+        when(cell7.getValue()).thenReturn(cellValue7);
+        when(cell8.getValue()).thenReturn(cellValue8);
+
+        when(cellValue1.getValue()).thenReturn(cellStringValue1);
+        when(cellValue2.getValue()).thenReturn(cellStringValue2);
+        when(cellValue3.getValue()).thenReturn(cellStringValue3);
+        when(cellValue4.getValue()).thenReturn(cellStringValue4);
+        when(cellValue5.getValue()).thenReturn(cellStringValue5);
+        when(cellValue6.getValue()).thenReturn(cellStringValue6);
+        when(cellValue7.getValue()).thenReturn(cellStringValue7);
+        when(cellValue8.getValue()).thenReturn(cellNameAndDataTypeValue8);
+
+        when(cellNameAndDataTypeValue8.getName()).thenReturn(new Name(cellStringValue8));
+        when(cellNameAndDataTypeValue8.hasData()).thenReturn(true);
+    }
+
+    @Test
+    public void testGetSearchableElements() {
+
+        final List<DMNSearchableElement> elements = index
+                .getSearchableElements()
+                .stream()
+                .sorted(Comparator.comparing(DMNSearchableElement::getText))
+                .collect(Collectors.toList());
+
+        assertEquals(7, elements.size());
+
+        // Text values
+        assertEquals(cellStringValue1, elements.get(0).getText());
+        assertEquals(cellStringValue2, elements.get(1).getText());
+        assertEquals(cellStringValue3, elements.get(2).getText());
+        assertEquals(cellStringValue4, elements.get(3).getText());
+        assertEquals(cellStringValue5, elements.get(4).getText());
+        assertEquals(cellStringValue6, elements.get(5).getText());
+        assertEquals(cellStringValue7, elements.get(6).getText());
+
+        // Text values
+        elements.get(0).onFound().execute();
+        elements.get(1).onFound().execute();
+        elements.get(2).onFound().execute();
+        elements.get(3).onFound().execute();
+        elements.get(4).onFound().execute();
+        elements.get(5).onFound().execute();
+        elements.get(6).onFound().execute();
+
+        verify(dmnGridHelper).highlightCell(0, 0, gridWidget1);
+        verify(dmnGridHelper).highlightCell(0, 1, gridWidget1);
+        verify(dmnGridHelper).highlightCell(0, 0, gridWidget2);
+        verify(dmnGridHelper).highlightCell(1, 0, gridWidget2);
+        verify(dmnGridHelper).highlightCell(0, 0, gridWidget3);
+        verify(dmnGridHelper).highlightCell(0, 1, gridWidget3);
+        verify(dmnGridHelper).highlightCell(1, 0, gridWidget3);
+    }
+
+    @Test
+    public void testGetValue() {
+
+        final String expected = cellStringValue1;
+        final String actual = index.getValue(cell1);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetValueWithCellThatHasNameAndDataType() {
+
+        final String expected = cellStringValue8;
+        final String actual = index.getValue(cell8);
+
+        assertEquals(expected, actual);
+    }
+
+    private Set<GridWidget> asSet(final GridWidget... a) {
+        return new HashSet<>(asList(a));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/graph/DMNGraphUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/graph/DMNGraphUtilsTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.graph;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +29,7 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.graph.Node;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -110,10 +112,22 @@ public class DMNGraphUtilsTest {
     public void testGetDRGElements() {
 
         final List<DRGElement> expectedDRGElements = asList(mock(DRGElement.class), mock(DRGElement.class));
-        when(dmnDiagramUtils.getNodes(diagram)).thenReturn(expectedDRGElements);
+        when(dmnDiagramUtils.getDRGElements(diagram)).thenReturn(expectedDRGElements);
 
         final List<DRGElement> actualDRGElements = utils.getDRGElements();
 
         assertEquals(expectedDRGElements, actualDRGElements);
+    }
+
+    @Test
+    public void testGetNodeStream() {
+
+        final Stream<Node> expectedStream = Stream.of(mock(Node.class));
+
+        when(dmnDiagramUtils.getNodeStream(diagram)).thenReturn(expectedStream);
+
+        final Stream<Node> actualStream = utils.getNodeStream();
+
+        assertEquals(expectedStream, actualStream);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp/src/test/java/org/kie/workbench/common/dmn/showcase/client/screens/editor/SessionDiagramEditorScreenTest.java
@@ -19,8 +19,11 @@ package org.kie.workbench.common.dmn.showcase.client.screens.editor;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +31,8 @@ import org.kie.workbench.common.dmn.client.decision.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
 import org.kie.workbench.common.dmn.client.editors.included.imports.IncludedModelsPageStateProviderImpl;
+import org.kie.workbench.common.dmn.client.editors.search.DMNEditorSearchIndex;
+import org.kie.workbench.common.dmn.client.editors.search.DMNSearchableElement;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
@@ -46,6 +51,7 @@ import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationPage;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
+import org.kie.workbench.common.widgets.client.search.component.SearchBarComponent;
 import org.kie.workbench.common.widgets.metadata.client.KieEditorWrapperView;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -121,6 +127,15 @@ public class SessionDiagramEditorScreenTest {
     @Mock
     private DocumentationView<Diagram> documentationView;
 
+    @Mock
+    private Elemental2DomUtil util;
+
+    @Mock
+    private DMNEditorSearchIndex editorSearchIndex;
+
+    @Mock
+    private SearchBarComponent<DMNSearchableElement> searchBarComponent;
+
     private SessionDiagramEditorScreen editor;
 
     @Before
@@ -165,7 +180,10 @@ public class SessionDiagramEditorScreenTest {
                                                     layoutExecutor,
                                                     includedModelsPage,
                                                     importsPageProvider,
-                                                    documentationView));
+                                                    documentationView,
+                                                    util,
+                                                    editorSearchIndex,
+                                                    searchBarComponent));
     }
 
     @Test
@@ -175,6 +193,7 @@ public class SessionDiagramEditorScreenTest {
         final MultiPageEditor multiPageEditor = mock(MultiPageEditor.class);
         final DocumentationPage documentationPage = mock(DocumentationPage.class);
 
+        doNothing().when(editor).setupSearchComponent();
         doReturn(documentationPage).when(editor).getDocumentationPage();
         when(kieView.getMultiPage()).thenReturn(multiPageEditor);
         when(screenPanelView.asWidget()).thenReturn(screenPanelWidget);
@@ -182,12 +201,36 @@ public class SessionDiagramEditorScreenTest {
         editor.init();
 
         verify(decisionNavigatorDock).init(AuthoringPerspective.PERSPECTIVE_ID);
+        verify(searchBarComponent).init(editorSearchIndex);
         verify(kieView).setPresenter(editor);
         verify(kieView).clear();
         verify(kieView).addMainEditorPage(screenPanelWidget);
         verify(multiPageEditor).addPage(dataTypesPage);
         verify(multiPageEditor).addPage(includedModelsPage);
         verify(multiPageEditor).addPage(documentationPage);
+        verify(editor).setupSearchComponent();
+    }
+
+    @Test
+    public void testSetupSearchComponent() {
+
+        final SessionPresenter.View view = mock(SessionPresenter.View.class);
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+        final Widget widget = mock(Widget.class);
+        final Element element = mock(Element.class);
+        final SearchBarComponent.View searchBarView = mock(SearchBarComponent.View.class);
+        final HTMLElement searchBarViewHTMLElement = mock(HTMLElement.class);
+
+        when(presenter.getView()).thenReturn(view);
+        when(view.asWidget()).thenReturn(widget);
+        when(widget.getElement()).thenReturn(element);
+        when(util.asHTMLElement(element)).thenReturn(htmlElement);
+        when(searchBarComponent.getView()).thenReturn(searchBarView);
+        when(searchBarView.getElement()).thenReturn(searchBarViewHTMLElement);
+
+        editor.setupSearchComponent();
+
+        verify(htmlElement).appendChild(searchBarViewHTMLElement);
     }
 
     @Test

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/BaseEditorSearchIndex.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/BaseEditorSearchIndex.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.uberfire.mvp.Command;
+
+import static org.kie.workbench.common.widgets.client.search.common.JavaStreamHelper.indexedStream;
+
+public abstract class BaseEditorSearchIndex<T extends Searchable> implements EditorSearchIndex<T> {
+
+    private final List<HasSearchableElements<T>> hasSearchableElementsList = new ArrayList<>();
+
+    private SearchResult<T> currentResult;
+
+    private String currentTerm;
+
+    private Supplier<Boolean> isDirtySupplier = () -> false;
+
+    private Command noResultsFoundCallback = () -> {/* Nothing */};
+
+    @Override
+    public List<HasSearchableElements<T>> getSubIndexes() {
+        return hasSearchableElementsList;
+    }
+
+    @Override
+    public void registerSubIndex(final HasSearchableElements<T> hasSearchableElements) {
+        hasSearchableElementsList.add(hasSearchableElements);
+    }
+
+    @Override
+    public void search(final String term) {
+
+        final boolean isNewSearch = !Objects.equals(term, currentTerm);
+        final Optional<SearchResult<T>> result;
+
+        if (isNewSearch) {
+            result = findFirstElement(term);
+        } else {
+            result = findNextElement(term);
+        }
+
+        currentResult = result.orElse(null);
+        currentTerm = term;
+
+        triggerOnFoundCommand();
+    }
+
+    private Optional<SearchResult<T>> findNextElement(final String term) {
+
+        final SearchResult<T>[] firstElement = new SearchResult[1];
+        final List<T> searchableElements = getSearchableElements();
+        final Optional<SearchResult<T>> next =
+                indexedStream(searchableElements)
+                        .filter((index, element) -> {
+                            final boolean matches = element.matches(term);
+                            if (matches && firstElement[0] == null) {
+                                firstElement[0] = new SearchResult<>(index, element);
+                            }
+                            return matches && index > currentResult.index;
+                        })
+                        .findFirst()
+                        .map(tuple -> new SearchResult<>(tuple.getIndex(), tuple.getElement()));
+
+        if (next.isPresent()) {
+            return next;
+        } else {
+            return Optional.ofNullable(firstElement[0]);
+        }
+    }
+
+    private Optional<SearchResult<T>> findFirstElement(final String term) {
+
+        final List<T> searchableElements = getSearchableElements();
+
+        return indexedStream(searchableElements)
+                .filter((index, element) -> element.matches(term))
+                .map(tuple -> new SearchResult<>(tuple.getIndex(), tuple.getElement()))
+                .findFirst();
+    }
+
+    private void triggerOnFoundCommand() {
+        if (getCurrentResult().isPresent()) {
+            getCurrentResult().get().element.onFound().execute();
+        } else {
+            triggerNoResultsFoundCommand();
+        }
+    }
+
+    private void triggerNoResultsFoundCommand() {
+        noResultsFoundCallback.execute();
+    }
+
+    private Optional<SearchResult> getCurrentResult() {
+        return Optional.ofNullable(currentResult);
+    }
+
+    protected abstract List<T> getSearchableElements();
+
+    @Override
+    public void setNoResultsFoundCallback(final Command callback) {
+        noResultsFoundCallback = callback;
+    }
+
+    @Override
+    public void setIsDirtySupplier(final Supplier<Boolean> isDirtySupplier) {
+        this.isDirtySupplier = isDirtySupplier;
+    }
+
+    @Override
+    public boolean isDirty() {
+        return isDirtySupplier.get();
+    }
+
+    class SearchResult<R extends Searchable> {
+
+        private final int index;
+        private final R element;
+
+        SearchResult(final int index,
+                     final R element) {
+            this.index = index;
+            this.element = element;
+        }
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/EditorSearchIndex.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/EditorSearchIndex.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.common;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.uberfire.mvp.Command;
+
+/**
+ * {@link EditorSearchIndex} holds the search logic.
+ * ---
+ * The {@link EditorSearchIndex} can have many sub-indexes that index different kinds of elements. Each sub-index, or
+ * {@link HasSearchableElements}, is naive and will load its searchable elements for every call.
+ * Thus, implementations of this interface control lazy approaches, cached approaches, or even the use of a third party
+ * library.
+ * ---
+ * @param <T> represents the type of {@link Searchable} element.
+ */
+public interface EditorSearchIndex<T extends Searchable> {
+
+    /**
+     * Returns the list of sub-indexes.
+     * @return the list of {@link HasSearchableElements}.
+     */
+    List<HasSearchableElements<T>> getSubIndexes();
+
+    /**
+     * Registers a new sub-index into {@link EditorSearchIndex}.
+     * @param hasSearchableElements represents a new index.
+     */
+    void registerSubIndex(final HasSearchableElements<T> hasSearchableElements);
+
+    /**
+     * Searches for any {@link Searchable} that satisfies the parameter, to finally trigger the <code>onFound</code>
+     * callback.
+     * @param term the string that will trigger the search
+     */
+    void search(final String term);
+
+    /**
+     * Sets the callback that will be triggered when no result is found.
+     * @param callback the callback that will be triggered
+     */
+    void setNoResultsFoundCallback(final Command callback);
+
+    /**
+     * Sets the <code>isDirty</code> logic.
+     * @param isDirtySupplier represents the <code>isDirty</code> logic.
+     */
+    void setIsDirtySupplier(final Supplier<Boolean> isDirtySupplier);
+
+    /**
+     * Check if the index is dirty.
+     * @return true if the index is dirty.
+     */
+    boolean isDirty();
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/HasSearchableElements.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/HasSearchableElements.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.common;
+
+import java.util.List;
+
+/**
+ * {@link HasSearchableElements} is a repository of searchable elements.
+ * ---
+ * @param <T> represents the type of {@link Searchable} element.
+ */
+public interface HasSearchableElements<T extends Searchable> {
+
+    /**
+     * Returns a non-lazy list of searchable elements.
+     * @return a list of {@link Searchable} elements.
+     */
+    List<T> getSearchableElements();
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/JavaStreamHelper.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/JavaStreamHelper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.common;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+public class JavaStreamHelper<T> {
+
+    private final List<T> list;
+
+    private JavaStreamHelper(final List<T> list) {
+        this.list = list;
+    }
+
+    public static <T> JavaStreamHelper<T> indexedStream(final List<T> list) {
+        return new JavaStreamHelper<>(list);
+    }
+
+    public Stream<Tuple<T>> filter(final BiFunction<Integer, T, Boolean> filter) {
+        final AtomicInteger index = new AtomicInteger(-1);
+        return list
+                .stream()
+                .filter(element -> {
+                    final int currentIndex = index.incrementAndGet();
+                    return filter.apply(currentIndex, element);
+                })
+                .map(e -> new Tuple<>(index.get(), e));
+    }
+
+    public static class Tuple<T> {
+
+        private final Integer index;
+        private final T element;
+
+        Tuple(final Integer index,
+              final T element) {
+            this.index = index;
+            this.element = element;
+        }
+
+        public Integer getIndex() {
+            return index;
+        }
+
+        public T getElement() {
+            return element;
+        }
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/Searchable.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/common/Searchable.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.common;
+
+import org.uberfire.mvp.Command;
+
+/**
+ * {@link Searchable} represents a searchable element.
+ */
+public interface Searchable {
+
+    /**
+     * Returns true when <code>text</code> satisfies the match logic.
+     * @param text represent the text used by the search mechanism.
+     * @return true if the text satisfies the match logic.
+     */
+    boolean matches(final String text);
+
+    /**
+     * Returns the command that is triggered when the element is found.
+     * @return the {@link Command} with the <code>onFound</code> logic.
+     */
+    Command onFound();
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponent.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.component;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.kie.workbench.common.widgets.client.search.common.EditorSearchIndex;
+import org.kie.workbench.common.widgets.client.search.common.Searchable;
+import org.uberfire.client.mvp.UberElemental;
+
+@Dependent
+public class SearchBarComponent<T extends Searchable> {
+
+    private final View view;
+
+    private EditorSearchIndex<T> editorSearchIndex;
+
+    @Inject
+    public SearchBarComponent(final View view) {
+        this.view = view;
+    }
+
+    @PostConstruct
+    void setup() {
+        view.init(this);
+    }
+
+    public void init(final EditorSearchIndex<T> editorSearchIndex) {
+        this.editorSearchIndex = editorSearchIndex;
+    }
+
+    public View getView() {
+        return view;
+    }
+
+    void search(final String term) {
+        if (!term.isEmpty()) {
+            editorSearchIndex.search(term);
+        }
+    }
+
+    public interface View extends UberElemental<SearchBarComponent>,
+                                  IsElement {
+
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentView.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentView.html
@@ -1,0 +1,53 @@
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="kie-search-bar" style="display: none">
+
+    <!-- TODO: https://issues.jboss.org/browse/DROOLS-4306 -->
+    <!-- Enabling the search bar: document.querySelector('.kie-search-bar').style.display = "" -->
+
+    <style type="text/css">
+
+        .kie-search-bar {
+            position: fixed;
+            width: 400px;
+            background: white;
+            border: 1px solid #CCC;
+            left: calc(100vw / 2 - 200px);
+            top: 200px;
+            padding: 20px;
+            box-shadow: 0 5px 5px rgba(0, 0, 0, .1);
+            z-index: 1;
+        }
+
+        .kie-search-bar input {
+            padding: 5px;
+        }
+
+        .kie-search-bar input,
+        .kie-search-bar label {
+            width: 100%;
+            font-weight: normal;
+        }
+
+    </style>
+
+    <form data-field="search-form">
+        <label>
+            <input data-field="search-input" placeholder="Search..." type="text"/>
+        </label>
+    </form>
+</div>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentView.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.component;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import elemental2.dom.HTMLFormElement;
+import elemental2.dom.HTMLInputElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+@Templated
+@Dependent
+public class SearchBarComponentView implements SearchBarComponent.View {
+
+    private SearchBarComponent<?> presenter;
+
+    @DataField("search-form")
+    private final HTMLFormElement searchForm;
+
+    @DataField("search-input")
+    private final HTMLInputElement inputElement;
+
+    @Inject
+    public SearchBarComponentView(final HTMLFormElement searchForm,
+                                  final HTMLInputElement inputElement) {
+        this.searchForm = searchForm;
+        this.inputElement = inputElement;
+    }
+
+    @PostConstruct
+    public void init() {
+        searchForm.onsubmit = (e) -> {
+            onSubmit();
+            return false;
+        };
+    }
+
+    private void onSubmit() {
+        presenter.search(inputElement.value);
+    }
+
+    @Override
+    public void init(final SearchBarComponent presenter) {
+        this.presenter = presenter;
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/common/BaseEditorSearchIndexTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/common/BaseEditorSearchIndexTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.common;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.uberfire.mvp.Command;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.IntStream.range;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class BaseEditorSearchIndexTest {
+
+    @Mock
+    private HasSearchableElements<FakeSearchable> hasSearchableElements1;
+
+    @Mock
+    private HasSearchableElements<FakeSearchable> hasSearchableElements2;
+
+    @Mock
+    private Command noResultsFoundCallback;
+
+    private FakeEditorSearchIndex index;
+
+    private List<FakeSearchable> searchableElements;
+
+    private FakeSearchable searchable1;
+
+    private FakeSearchable searchable2;
+
+    private FakeSearchable searchable3;
+
+    private FakeSearchable searchable4;
+
+    @Before
+    public void setup() {
+
+        searchable1 = spy(new FakeSearchable("Element 1"));
+        searchable2 = spy(new FakeSearchable("Element 2"));
+        searchable3 = spy(new FakeSearchable("Element 3"));
+        searchable4 = spy(new FakeSearchable("Element 4"));
+        searchableElements = asList(searchable1, searchable2, searchable3, searchable4);
+
+        index = new FakeEditorSearchIndex(searchableElements);
+        index.setNoResultsFoundCallback(noResultsFoundCallback);
+    }
+
+    @Test
+    public void testSearch() {
+
+        index.search("Element");
+
+        verify(searchable1).onFound();
+        verify(searchable2, never()).onFound();
+        verify(searchable3, never()).onFound();
+        verify(searchable4, never()).onFound();
+        verify(noResultsFoundCallback, never()).execute();
+    }
+
+    @Test
+    public void testSearchWhenAnyElementIsFound() {
+
+        index.search("Something");
+
+        verify(searchable1, never()).onFound();
+        verify(searchable2, never()).onFound();
+        verify(searchable3, never()).onFound();
+        verify(searchable4, never()).onFound();
+        verify(noResultsFoundCallback).execute();
+    }
+
+    @Test
+    public void testSearchWhenNextElementIsHighlighted() {
+
+        times(2, () -> index.search("Element"));
+
+        // The first element is highlighted by the first search
+        verify(searchable1).onFound();
+
+        // The next element is highlighted by the second search
+        verify(searchable2).onFound();
+        verify(searchable3, never()).onFound();
+        verify(searchable4, never()).onFound();
+        verify(noResultsFoundCallback, never()).execute();
+    }
+
+    @Test
+    public void testSearchWhenAllListWasHighlighted() {
+
+        times(5, () -> index.search("Element"));
+
+        // The next element to the last element of the list is the first one
+        verify(searchable1, Mockito.times(2)).onFound();
+        verify(searchable2).onFound();
+        verify(searchable3).onFound();
+        verify(searchable4).onFound();
+        verify(noResultsFoundCallback, never()).execute();
+    }
+
+    @Test
+    public void testIsDirtyWhenItReturnsFalse() {
+        index.setIsDirtySupplier(() -> false);
+        assertFalse(index.isDirty());
+    }
+
+    @Test
+    public void testIsDirtyWhenItReturnsTrue() {
+        index.setIsDirtySupplier(() -> true);
+        assertTrue(index.isDirty());
+    }
+
+    @Test
+    public void testGetSubIndexes() {
+
+        index.registerSubIndex(hasSearchableElements1);
+        index.registerSubIndex(hasSearchableElements2);
+
+        final List<HasSearchableElements<FakeSearchable>> actualSubIndexes = index.getSubIndexes();
+        final List<HasSearchableElements<FakeSearchable>> expectedSubIndexes = asList(hasSearchableElements1,
+                                                                                      hasSearchableElements2);
+
+        assertEquals(expectedSubIndexes, actualSubIndexes);
+    }
+
+    private void times(final int times,
+                       final Command command) {
+        range(0, times).forEach(i -> command.execute());
+    }
+
+    class FakeSearchable implements Searchable {
+
+        private final String text;
+
+        FakeSearchable(final String text) {
+            this.text = text;
+        }
+
+        @Override
+        public boolean matches(final String text) {
+            return this.text.contains(text);
+        }
+
+        @Override
+        public Command onFound() {
+            return () -> {/* Nothing. */};
+        }
+    }
+
+    class FakeEditorSearchIndex extends BaseEditorSearchIndex<FakeSearchable> {
+
+        private final List<FakeSearchable> searchableElements;
+
+        FakeEditorSearchIndex(final List<FakeSearchable> searchableElements) {
+            this.searchableElements = searchableElements;
+        }
+
+        @Override
+        protected List<FakeSearchable> getSearchableElements() {
+            return searchableElements;
+        }
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/common/JavaStreamHelperTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/common/JavaStreamHelperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.common;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.kie.workbench.common.widgets.client.search.common.JavaStreamHelper.Tuple;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.widgets.client.search.common.JavaStreamHelper.indexedStream;
+
+public class JavaStreamHelperTest {
+
+    @Test
+    public void testFilterElements() {
+
+        final List<String> companies = asList("Red Hat", "Github", "IBM", "Microsoft");
+        final List<String> expectedElements = asList("Red Hat", "IBM");
+
+        final List<String> actualElements =
+                indexedStream(companies)
+                        .filter((index, value) -> index % 2 == 0)
+                        .map(Tuple::getElement)
+                        .collect(Collectors.toList());
+
+        assertEquals(expectedElements, actualElements);
+    }
+
+    @Test
+    public void testFilterIndexes() {
+
+        final List<String> companies = asList("Red Hat", "Github", "IBM", "Microsoft");
+        final List<Integer> expectedIndexes = asList(0, 2);
+
+        final List<Integer> actualIndexes =
+                indexedStream(companies)
+                        .filter((index, value) -> index % 2 == 0)
+                        .map(Tuple::getIndex)
+                        .collect(Collectors.toList());
+
+        assertEquals(expectedIndexes, actualIndexes);
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.component;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.search.common.EditorSearchIndex;
+import org.kie.workbench.common.widgets.client.search.common.Searchable;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class SearchBarComponentTest {
+
+    @Mock
+    private SearchBarComponent.View view;
+
+    @Mock
+    private EditorSearchIndex<Searchable> index;
+
+    private SearchBarComponent<Searchable> component;
+
+    @Before
+    public void setup() {
+        component = new SearchBarComponent<>(view);
+        component.init(index);
+    }
+
+    @Test
+    public void testSetup() {
+        component.setup();
+        verify(view).init(component);
+    }
+
+    @Test
+    public void testGetView() {
+        assertEquals(view, component.getView());
+    }
+
+    @Test
+    public void testSearchWhenTermIsEmpty() {
+
+        final String term = "";
+
+        component.search(term);
+
+        verify(index, never()).search(term);
+    }
+
+    @Test
+    public void testSearchWhenTermIsNotEmpty() {
+
+        final String term = "something";
+
+        component.search(term);
+
+        verify(index).search(term);
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentViewTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/search/component/SearchBarComponentViewTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.search.component;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLFormElement;
+import elemental2.dom.HTMLInputElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class SearchBarComponentViewTest {
+
+    @Mock
+    private SearchBarComponent<?> presenter;
+
+    @Mock
+    private HTMLFormElement searchForm;
+
+    @Mock
+    private HTMLInputElement inputElement;
+
+    private SearchBarComponentView view;
+
+    @Before
+    public void setup() {
+        view = new SearchBarComponentView(searchForm, inputElement);
+        view.init(presenter);
+    }
+
+    @Test
+    public void testInit() {
+
+        final String term = "something...";
+
+        inputElement.value = term;
+
+        view.init();
+
+        final Boolean result = (Boolean) searchForm.onsubmit.onInvoke(mock(Event.class));
+
+        verify(presenter).search(term);
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
### JIRAs:

- https://issues.jboss.org/browse/DROOLS-4211
- https://issues.jboss.org/browse/DROOLS-4212

---

### Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/738
- https://github.com/kiegroup/kie-wb-common/pull/2749
- https://github.com/kiegroup/drools-wb/pull/1191

---

### Description
DROOLS-4211 and DROOLS-4212 JIRAs comprehend only the search mechanism. Thus, the PR implements that for Guided Decision Tables, DMN graphs, and DMN boxed expressions, without a rich user experience (which will be implemented on [DROOLS-4306](https://issues.jboss.org/browse/DROOLS-4306)).
 
To test this PR, just execute the following code into the _browser inspector_:
 
```javascript
document.querySelector('.kie-search-bar').style.display = ""
```

The search component will be enabled, and now you can type something and press <kbd>Enter</kbd> to trigger the search.

![2019-07-11 12 57 45](https://user-images.githubusercontent.com/1079279/61076885-a01ac480-a3f3-11e9-8eba-35faafb3a1e2.gif)