### PR TITLE
DROOLS-4317: [DMN Designer] Documentation - Add the "Download .doc file" button to the documentation tab

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.html
@@ -15,13 +15,17 @@
   -->
 
 <div>
-    <div data-field="documentation-panel" class="documentation-panel">
+    <div id="documentation-panel" data-field="documentation-panel" class="documentation-panel">
         <div class="documentation-header">
-            <button data-field="print-button" class="btn btn-default">
+            <button data-field="print-button" class="btn btn-default print-button">
                 <i class="fa pficon-print"></i>
                 <span data-i18n-key="Print"></span>
             </button>
+            <button data-field="download-html-file" class="btn btn-default download-html-button">
+                <i class="fa fa-file"></i>
+                <span data-i18n-key="DownloadHtmlFile"></span>
+            </button>
         </div>
-        <div data-field="documentation-content"></div>
+        <div id="documentation-content" data-field="documentation-content"></div>
     </div>
 </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.java
@@ -27,6 +27,7 @@ import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.editors.documentation.common.DMNDocumentationService;
+import org.kie.workbench.common.dmn.client.editors.documentation.common.HTMLDownloadHelper;
 import org.kie.workbench.common.stunner.core.client.util.PrintHelper;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.documentation.DefaultDiagramDocumentationView;
@@ -40,6 +41,8 @@ import static org.kie.workbench.common.stunner.core.documentation.model.Document
 @Templated
 public class DMNDocumentationView extends DefaultDiagramDocumentationView {
 
+    static final String DOCUMENTATION_FILENAME = "Documentation";
+
     @DataField("documentation-panel")
     private final HTMLDivElement documentationPanel;
 
@@ -49,21 +52,30 @@ public class DMNDocumentationView extends DefaultDiagramDocumentationView {
     @DataField("print-button")
     private final HTMLButtonElement printButton;
 
+    @DataField("download-html-file")
+    private final HTMLButtonElement downloadHtmlFile;
+
     private final PrintHelper printHelper;
 
     private final DMNDocumentationService documentationService;
+
+    private final HTMLDownloadHelper downloadHelper;
 
     @Inject
     public DMNDocumentationView(final HTMLDivElement documentationPanel,
                                 final HTMLDivElement documentationContent,
                                 final HTMLButtonElement printButton,
+                                final HTMLButtonElement downloadHtmlFile,
                                 final PrintHelper printHelper,
-                                final DMNDocumentationService documentationService) {
+                                final DMNDocumentationService documentationService,
+                                final HTMLDownloadHelper downloadHelper) {
         this.documentationPanel = documentationPanel;
         this.documentationContent = documentationContent;
         this.printButton = printButton;
+        this.downloadHtmlFile = downloadHtmlFile;
         this.printHelper = printHelper;
         this.documentationService = documentationService;
+        this.downloadHelper = downloadHelper;
     }
 
     @Override
@@ -80,6 +92,16 @@ public class DMNDocumentationView extends DefaultDiagramDocumentationView {
     @EventHandler("print-button")
     public void onPrintButtonClick(final ClickEvent e) {
         printHelper.print(documentationContent);
+    }
+
+    @EventHandler("download-html-file")
+    public void onDownloadHtmlFile(final ClickEvent e) {
+        final String html = getCurrentDocumentationHTML();
+        downloadHelper.download(DOCUMENTATION_FILENAME, html);
+    }
+
+    String getCurrentDocumentationHTML() {
+        return documentationContent.innerHTML;
     }
 
     private String getDocumentationHTML() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.java
@@ -97,7 +97,7 @@ public class DMNDocumentationView extends DefaultDiagramDocumentationView {
     @EventHandler("download-html-file")
     public void onDownloadHtmlFile(final ClickEvent e) {
         final String html = getCurrentDocumentationHTML();
-        downloadHelper.download(DOCUMENTATION_FILENAME, html);
+        downloadHelper.download(getCurrentDocumentationFilename(), html);
     }
 
     String getCurrentDocumentationHTML() {
@@ -109,5 +109,12 @@ public class DMNDocumentationView extends DefaultDiagramDocumentationView {
                 .map(documentationService::generate)
                 .map(DocumentationOutput::getValue)
                 .orElse(EMPTY.getValue());
+    }
+
+    String getCurrentDocumentationFilename() {
+        return getDiagram()
+                .map(diagram -> documentationService.processDocumentation(diagram))
+                .map(dmnDocumentation -> DOCUMENTATION_FILENAME + "-" + dmnDocumentation.getFileName())
+                .orElse(DOCUMENTATION_FILENAME);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.less
@@ -32,13 +32,12 @@
     button {
       position: absolute;
       top: 10px;
-      right: 10px;
-      left: unset;
       padding: 3px 13px;
       margin-left: 15px;
-
+      left: unset;
       @media (min-width: 2100px) {
         top: 0;
+
         left: 100%;
         right: unset;
       }
@@ -46,6 +45,14 @@
       i {
         margin-right: 2px;
       }
+    }
+
+    .download-html-button {
+      right: 10px;
+    }
+
+    .print-button {
+      right: 180px;
     }
   }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/HTMLDownloadHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/HTMLDownloadHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.documentation.common;
+
+import elemental2.core.Global;
+import elemental2.dom.HTMLAnchorElement;
+
+import static elemental2.dom.DomGlobal.document;
+
+public class HTMLDownloadHelper {
+
+    private final static String HEADER = "<html><body>";
+    private final static String FOOTER = "</body></html>";
+    private final static String FILE_EXTENSION = ".HTML";
+    private final static String ENCODING = "data:text/html;charset=utf-8,";
+
+    public void download(final String filename, final String html) {
+
+        final String sourceHTML = HEADER + html + FOOTER;
+        final String source = Global.encodeURIComponent(sourceHTML);
+
+        final HTMLAnchorElement fileDownload = (HTMLAnchorElement) document.createElement("a");
+        document.body.appendChild(fileDownload);
+        fileDownload.href = ENCODING + source;
+        fileDownload.download = filename + FILE_EXTENSION;
+        fileDownload.click();
+        document.body.removeChild(fileDownload);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
@@ -267,3 +267,4 @@ DMNDocumentationFactory.Constraints=Constraints:
 DMNDocumentationFactory.ListYes=List: Yes
 DMNDocumentationFactory.Structure=Structure
 DMNDocumentationView.Print=Print
+DMNDocumentationView.DownloadHtmlFile=Download .HTML file

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationViewTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.documentation.common.DMNDocumentationService;
+import org.kie.workbench.common.dmn.client.editors.documentation.common.HTMLDownloadHelper;
 import org.kie.workbench.common.stunner.core.client.util.PrintHelper;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.documentation.model.DocumentationOutput;
@@ -33,6 +34,7 @@ import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.documentation.DMNDocumentationView.DOCUMENTATION_FILENAME;
 import static org.kie.workbench.common.stunner.core.documentation.model.DocumentationOutput.EMPTY;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -61,11 +63,14 @@ public class DMNDocumentationViewTest {
     @Mock
     private Diagram diagram;
 
+    @Mock
+    private HTMLDownloadHelper downloadHelper;
+
     private DMNDocumentationView view;
 
     @Before
     public void setup() {
-        view = spy(new DMNDocumentationView(documentationPanel, documentationContent, printButton, printHelper, documentationService));
+        view = spy(new DMNDocumentationView(documentationPanel, documentationContent, printButton, null, printHelper, documentationService, downloadHelper));
     }
 
     @Test
@@ -111,5 +116,15 @@ public class DMNDocumentationViewTest {
     public void testOnPrintButtonClick() {
         view.onPrintButtonClick(mock(ClickEvent.class));
         verify(printHelper).print(documentationContent);
+    }
+
+    @Test
+    public void testOnDownloadHtmlFile() {
+        final String html = "<html><body>Hi</body></html>";
+        doReturn(html).when(view).getCurrentDocumentationHTML();
+
+        view.onDownloadHtmlFile(mock(ClickEvent.class));
+
+        verify(downloadHelper).download(DOCUMENTATION_FILENAME, html);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationViewTest.java
@@ -34,7 +34,6 @@ import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.kie.workbench.common.dmn.client.editors.documentation.DMNDocumentationView.DOCUMENTATION_FILENAME;
 import static org.kie.workbench.common.stunner.core.documentation.model.DocumentationOutput.EMPTY;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -121,10 +120,13 @@ public class DMNDocumentationViewTest {
     @Test
     public void testOnDownloadHtmlFile() {
         final String html = "<html><body>Hi</body></html>";
+        final String fileName = "file name";
+        doReturn(fileName).when(view).getCurrentDocumentationFilename();
         doReturn(html).when(view).getCurrentDocumentationHTML();
 
         view.onDownloadHtmlFile(mock(ClickEvent.class));
 
-        verify(downloadHelper).download(DOCUMENTATION_FILENAME, html);
+        verify(view).getCurrentDocumentationHTML();
+        verify(downloadHelper).download(fileName, html);
     }
 }


### PR DESCRIPTION
As discussed in e-mail, this option was changed for now to "Download HTML", since the approach that we are using to generate .doc have some issues with MS Word.