### PR TITLE
JBPM 8622: Stunner - missing freetext called element (e.g. unknown or # {...} for Reusable sub-process	

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ReusableSubprocessTaskExecutionSet.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ReusableSubprocessTaskExecutionSet.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.field.selector
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
 import org.kie.workbench.common.stunner.bpmn.definition.property.subProcess.IsCase;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldType;
 import org.kie.workbench.common.stunner.bpmn.forms.model.MultipleInstanceVariableFieldType;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.definition.annotation.PropertySet;
@@ -47,7 +48,7 @@ public class ReusableSubprocessTaskExecutionSet implements BaseReusableSubproces
     @SelectorDataProvider(
             type = SelectorDataProvider.ProviderType.REMOTE,
             className = "org.kie.workbench.common.stunner.bpmn.backend.dataproviders.CalledElementFormProvider")
-    @FormField(type = ListBoxFieldType.class
+    @FormField(type = ComboBoxFieldType.class
     )
     @Valid
     protected CalledElement calledElement;


### PR DESCRIPTION
@romartin can you review this PR? Changed type of control so that it allows for a New.. option, search for a previous value and ability to unset a value. Control handled those cases automatically, also please advise about unit tests as I did not find a way to test the control, I will keep looking