### PR TITLE
[AF-2117] Get all users throw an exception when there is no implementation found

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
@@ -411,7 +411,7 @@ public class LibraryServiceImpl implements LibraryService {
                                                                                      Integer.MAX_VALUE)).getResults();
             return users.stream().map(User::getIdentifier).collect(Collectors.toList());
         } catch (Exception e) {
-            log.error("Error while searching all users: ", e);
+            log.error("Error while searching all users: " + e.getClass().getCanonicalName() );
             return Collections.emptyList();
         }
     }


### PR DESCRIPTION
@paulovmr just a more user-friendly message. The old one was showing the whole stack trace.

New error:
[INFO] 2019-07-22 18:14:45,105 [default task-1] ERROR Error while searching all users: org.uberfire.ext.security.management.api.exception.NoImplementationAvailableException