### PR TITLE
AF-2116: Verify Async load of Projects and Spaces Cards

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
@@ -174,8 +174,12 @@ public class ProjectImportServiceImpl extends BaseProjectImportService implement
                             .map(exampleProject -> {
                                 WorkspaceProject project = this.importProject(activeOU,
                                                                               exampleProject);
-                                return this.renameIfNecessary(activeOU,
+                                project = this.renameIfNecessary(activeOU,
                                                               project);
+
+                                newProjectEvent.fire(new NewProjectEvent(project));
+
+                                return project;
                             })
                             .collect(Collectors.toList());
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/LibraryInfo.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/LibraryInfo.java
@@ -15,7 +15,7 @@
  */
 package org.kie.workbench.common.screens.library.api;
 
-import java.util.Collection;
+import java.util.List;
 
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.jboss.errai.common.client.api.annotations.MapsTo;
@@ -26,14 +26,13 @@ import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull
 @Portable
 public class LibraryInfo {
 
-    private Collection<WorkspaceProject> projects;
+    private List<WorkspaceProject> projects;
 
-    public LibraryInfo(@MapsTo("projects") final Collection<WorkspaceProject> projects) {
-        this.projects = checkNotNull("projects",
-                                     projects);
+    public LibraryInfo(@MapsTo("projects") final List<WorkspaceProject> projects) {
+        this.projects = checkNotNull("projects", projects);
     }
 
-    public Collection<WorkspaceProject> getProjects() {
+    public List<WorkspaceProject> getProjects() {
         return projects;
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetUpdateNotifier.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryAssetUpdateNotifier.java
@@ -28,6 +28,7 @@ import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.kie.workbench.common.screens.library.api.ProjectAssetListUpdated;
 import org.kie.workbench.common.screens.library.api.Remote;
 import org.kie.workbench.common.screens.library.api.index.Constants;
+import org.kie.workbench.common.services.refactoring.model.index.events.IndexingFinishedEvent;
 import org.slf4j.Logger;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.ext.metadata.event.BatchIndexEvent;
@@ -93,4 +94,13 @@ public class LibraryAssetUpdateNotifier {
               });
     }
 
+    private void onProjectIndexingFinishedEvent(@Observes IndexingFinishedEvent event) {
+        WorkspaceProject project = projectService.resolveProject(event.getPath());
+
+        if (project == null) {
+            throw new IllegalStateException("Cannot resolve Project for KClusterId: '" + event.getkClusterId() + "' and path: '" + event.getPath().toString() + "'.");
+        }
+
+        assetListUpdateEvent.fire(new ProjectAssetListUpdated(project));
+    }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/main/java/org/kie/workbench/common/screens/impl/LibraryServiceImpl.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -76,6 +77,7 @@ import org.kie.workbench.common.services.refactoring.backend.server.query.standa
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.LibraryValueFileExtensionIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.LibraryValueFileNameIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.LibraryValueRepositoryRootIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.events.IndexingFinishedEvent;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRequest;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
@@ -196,15 +198,9 @@ public class LibraryServiceImpl implements LibraryService {
 
     @Override
     public LibraryInfo getLibraryInfo(final OrganizationalUnit organizationalUnit) {
-        final Collection<WorkspaceProject> projects = projectService.getAllWorkspaceProjects(organizationalUnit).stream()
+        final List<WorkspaceProject> projects = projectService.getAllWorkspaceProjects(organizationalUnit).stream()
                 .filter(p -> userCanReadProject(p))
                 .collect(Collectors.toList());
-
-        projects.stream().forEach(p -> {
-            if (p.getMainModule() != null) {
-                p.getMainModule().setNumberOfAssets(getNumberOfAssets(p));
-            }
-        });
 
         return new LibraryInfo(projects);
     }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/PopulatedLibraryView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/PopulatedLibraryView.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.screens.library.client.screens;
 import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.KeyUpEvent;
+import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.Input;
@@ -27,6 +28,7 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.screens.library.client.resources.i18n.LibraryConstants;
+import org.kie.workbench.common.screens.library.client.widgets.common.TileWidget;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 
 @Templated
@@ -63,8 +65,18 @@ public class PopulatedLibraryView implements PopulatedLibraryScreen.View,
     }
 
     @Override
-    public void addProject(final HTMLElement project) {
-        projectList.appendChild(project);
+    public void addProject(final TileWidget<WorkspaceProject> project) {
+        projectList.appendChild(project.getView().getElement());
+    }
+
+    @Override
+    public void addProject(TileWidget<WorkspaceProject> tileToAdd, TileWidget<WorkspaceProject> tileAfter) {
+        projectList.insertBefore(tileToAdd.getView().getElement(), tileAfter.getView().getElement());
+    }
+
+    @Override
+    public void removeProject(TileWidget<WorkspaceProject> tile) {
+        projectList.removeChild(tile.getView().getElement());
     }
 
     @Override
@@ -75,12 +87,6 @@ public class PopulatedLibraryView implements PopulatedLibraryScreen.View,
     @Override
     public void clearFilterText() {
         this.filterText.setValue("");
-    }
-
-    @Override
-    public String getNumberOfAssetsMessage(int numberOfAssets) {
-        return ts.format(LibraryConstants.NumberOfAssets,
-                         numberOfAssets);
     }
 
     @EventHandler("filter-text")

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/util/LibraryPlaces.java
@@ -463,9 +463,7 @@ public class LibraryPlaces implements WorkspaceProjectContextChangeHandler {
         final PartDefinitionImpl part = new PartDefinitionImpl(placeRequest);
         part.setSelectable(false);
 
-        if (!projectContext.getActiveWorkspaceProject().isPresent()) {
-            projectContextChangeEvent.fire(new WorkspaceProjectContextChangeEvent(activeOu));
-        }
+        projectContextChangeEvent.fire(new WorkspaceProjectContextChangeEvent(activeOu));
 
         closeLibraryPlaces();
         placeManager.goTo(part,

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/common/TileView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/common/TileView.java
@@ -26,6 +26,7 @@ import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.screens.library.client.resources.i18n.LibraryConstants;
 import org.uberfire.mvp.Command;
 
 @Templated
@@ -61,22 +62,19 @@ public class TileView implements TileWidget.View,
     }
 
     @Override
-    public void setup(final String label,
-                      final String description,
-                      final String circleLabel,
-                      final String circleDescription,
-                      final Command selectCommand) {
+    public void setup(String label, String description, Command selectCommand) {
         this.label.setTextContent(label);
         this.description.setTextContent(description);
         this.description.setTitle(description);
         this.card.setOnclick(event -> selectCommand.execute());
+        circle.setHidden(true);
+    }
 
-        if (circleLabel != null) {
-            this.circle.setTextContent(circleLabel);
-            this.circle.setTitle(circleDescription);
-        } else {
-            this.circle.setHidden(true);
-        }
+    @Override
+    public void setNumberOfAssets(Integer numberOfAssets) {
+        circle.setHidden(false);
+        this.circle.setTextContent(String.valueOf(numberOfAssets));
+        this.circle.setTitle(ts.format(LibraryConstants.NumberOfAssets, numberOfAssets));
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/common/TileWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/common/TileWidget.java
@@ -18,23 +18,26 @@ package org.kie.workbench.common.screens.library.client.widgets.common;
 
 import javax.inject.Inject;
 
+import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.mvp.Command;
 
-public class TileWidget {
+public class TileWidget<CONTENT> {
 
     public interface View extends UberElement<TileWidget> {
 
         void setup(String label,
                    String description,
-                   String circleLabel,
-                   String circleDescription,
                    Command selectCommand);
 
         boolean isSelected();
 
         void setSelected(boolean selected);
+
+        void setNumberOfAssets(Integer numberOfAssets);
     }
+
+    private CONTENT content;
 
     private View view;
 
@@ -47,17 +50,25 @@ public class TileWidget {
 
     public void init(final String label,
                      final String description,
-                     final String circleLabel,
-                     final String circleDescription,
                      final Command selectCommand) {
+
         this.label = label;
 
         view.init(this);
+
         view.setup(label,
                    description,
-                   circleLabel,
-                   circleDescription,
                    selectCommand);
+
+        view.setNumberOfAssets(0);
+    }
+
+    public CONTENT getContent() {
+        return content;
+    }
+
+    public void setContent(CONTENT content) {
+        this.content = content;
     }
 
     public boolean isSelected() {
@@ -70,6 +81,10 @@ public class TileWidget {
 
     public String getLabel() {
         return label;
+    }
+
+    public void setNumberOfAssets(Integer numberOfAssets) {
+        view.setNumberOfAssets(numberOfAssets);
     }
 
     public View getView() {

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/library/AddProjectButtonPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/widgets/library/AddProjectButtonPresenter.java
@@ -110,11 +110,8 @@ public class AddProjectButtonPresenter {
 
     public void addProject() {
         if (userCanCreateProjects()) {
-            libraryPlaces.closeAllPlacesOrNothing(() -> {
-                libraryPlaces.goToLibrary();
-                final AddProjectPopUpPresenter addProjectPopUpPresenter = addProjectPopUpPresenters.get();
-                addProjectPopUpPresenter.show();
-            });
+            final AddProjectPopUpPresenter addProjectPopUpPresenter = addProjectPopUpPresenters.get();
+            addProjectPopUpPresenter.show();
         }
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/LibraryScreenTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/LibraryScreenTest.java
@@ -135,6 +135,7 @@ public class LibraryScreenTest {
 
     @Test
     public void setupTest() {
+        when(view.isProjectsTabActive()).thenReturn(true);
         final OrganizationalUnit organizationalUnit = mock(OrganizationalUnit.class);
         doReturn("name").when(organizationalUnit).getName();
         doReturn(Optional.of(organizationalUnit)).when(projectContext).getActiveOrganizationalUnit();
@@ -143,8 +144,11 @@ public class LibraryScreenTest {
 
         verify(view).init(libraryScreen);
         verify(view).setTitle("name");
-        verify(contributorsListPresenter).setup(eq(spaceContributorsListService),
-                                                any());
+        verify(contributorsListPresenter).setup(eq(spaceContributorsListService), any());
+
+        verify(view).setProjectsCount(0);
+        verify(view).isProjectsTabActive();
+        verify(view).updateContent(any());
     }
 
     @Test
@@ -272,8 +276,7 @@ public class LibraryScreenTest {
         libraryScreen.showProjects();
 
         verify(view).updateContent(emptyLibraryScreenElement);
-        verify(view,
-               times(2)).setProjectsCount(0);
+        verify(view, times(1)).setProjectsCount(0);
     }
 
     @Test

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/util/LibraryPlacesTest.java
@@ -609,11 +609,9 @@ public class LibraryPlacesTest {
         libraryPlaces.goToLibrary();
 
         verify(libraryPlaces).closeLibraryPlaces();
-        verify(placeManager).goTo(eq(part),
-                                  any(PanelDefinition.class));
+        verify(placeManager).goTo(eq(part), any(PanelDefinition.class));
         verify(libraryBreadcrumbs).setupForSpace(activeOrganizationalUnit);
-        verify(projectContextChangeEvent,
-               never()).fire(any(WorkspaceProjectContextChangeEvent.class));
+        verify(projectContextChangeEvent).fire(any(WorkspaceProjectContextChangeEvent.class));
     }
 
     @Test

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/widgets/common/TileWidgetTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/widgets/common/TileWidgetTest.java
@@ -44,14 +44,12 @@ public class TileWidgetTest {
 
         presenter.init("label",
                        "description",
-                       "circleLabel",
-                       "circleDescription",
                        selectCommand);
+
+        verify(view).init(presenter);
 
         verify(view).setup("label",
                            "description",
-                           "circleLabel",
-                           "circleDescription",
                            selectCommand);
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultApplicationScopedProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultApplicationScopedProducer.java
@@ -39,6 +39,7 @@ import org.uberfire.commons.concurrent.Unmanaged;
 import org.uberfire.commons.services.cdi.Startup;
 import org.uberfire.commons.services.cdi.StartupType;
 import org.uberfire.ext.metadata.MetadataConfig;
+import org.uberfire.ext.metadata.engine.BatchIndexListener;
 import org.uberfire.ext.metadata.engine.IndexerScheduler.Factory;
 import org.uberfire.ext.metadata.event.BatchIndexEvent;
 import org.uberfire.ext.metadata.io.ConstrainedIndexerScheduler.ConstraintBuilder;
@@ -70,6 +71,7 @@ public class DefaultApplicationScopedProducer implements ApplicationScopedProduc
     private IndexersFactory indexersFactory;
     private IndexerDispatcherFactory dispatcherFactory;
     private Event<BatchIndexEvent> batchIndexEvent;
+    private BatchIndexListener batchIndexListener;
 
     public DefaultApplicationScopedProducer() {
         if (System.getProperty("org.uberfire.watcher.autostart") == null) {
@@ -90,7 +92,8 @@ public class DefaultApplicationScopedProducer implements ApplicationScopedProduc
                                             DefaultIndexEngineObserver defaultIndexEngineObserver,
                                             IndexersFactory indexersFactory,
                                             Event<BatchIndexEvent> batchIndexEvent,
-                                            @Unmanaged ExecutorService executorService) {
+                                            @Unmanaged ExecutorService executorService,
+                                            BatchIndexListener batchIndexListener) {
         this();
         this.config = config;
         this.watchService = watchService;
@@ -99,6 +102,7 @@ public class DefaultApplicationScopedProducer implements ApplicationScopedProduc
         this.indexersFactory = indexersFactory;
         this.batchIndexEvent = batchIndexEvent;
         this.executorService = executorService;
+        this.batchIndexListener = batchIndexListener;
     }
 
     @PostConstruct
@@ -114,6 +118,7 @@ public class DefaultApplicationScopedProducer implements ApplicationScopedProduc
                                                   executorService,
                                                   indexersFactory,
                                                   dispatcherFactory,
+                                                  batchIndexListener,
                                                   DublinCoreView.class,
                                                   VersionAttributeView.class,
                                                   OtherMetaView.class);

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultBatchIndexListener.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/main/java/org/kie/workbench/screens/workbench/backend/impl/DefaultBatchIndexListener.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.screens.workbench.backend.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.services.refactoring.model.index.events.IndexingFinishedEvent;
+import org.kie.workbench.common.services.refactoring.model.index.events.IndexingStartedEvent;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.ext.metadata.engine.BatchIndexListener;
+import org.uberfire.ext.metadata.model.KCluster;
+import org.uberfire.java.nio.file.Path;
+
+@ApplicationScoped
+public class DefaultBatchIndexListener implements BatchIndexListener {
+
+    private final Event<IndexingStartedEvent> indexingStartedEventEvent;
+    private final Event<IndexingFinishedEvent> indexingFinishedEventEvent;
+
+    @Inject
+    public DefaultBatchIndexListener(final Event<IndexingStartedEvent> indexingStartedEventEvent,
+                                     final Event<IndexingFinishedEvent> indexingFinishedEventEvent) {
+        this.indexingStartedEventEvent = indexingStartedEventEvent;
+        this.indexingFinishedEventEvent = indexingFinishedEventEvent;
+    }
+
+    @Override
+    public void notifyIndexIngStarted(KCluster kCluster, Path path) {
+        indexingStartedEventEvent.fire(new IndexingStartedEvent(kCluster.getClusterId(), Paths.convert(path)));
+    }
+
+    @Override
+    public void notifyIndexIngFinished(KCluster kCluster, Path path) {
+        indexingFinishedEventEvent.fire(new IndexingFinishedEvent(kCluster.getClusterId(), Paths.convert(path)));
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/test/java/org/kie/workbench/screens/workbench/backend/impl/DefaultBatchIndexListenerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/src/test/java/org/kie/workbench/screens/workbench/backend/impl/DefaultBatchIndexListenerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.screens.workbench.backend.impl;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import javax.enterprise.event.Event;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.refactoring.model.index.events.IndexingFinishedEvent;
+import org.kie.workbench.common.services.refactoring.model.index.events.IndexingStartedEvent;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.metadata.model.KCluster;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.mocks.FileSystemTestingUtils;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultBatchIndexListenerTest {
+
+    private static final String KCLUSTER_ID = "id";
+
+    private FileSystemTestingUtils fileSystemTestingUtils = new FileSystemTestingUtils();
+
+    @Mock
+    private Event<IndexingStartedEvent> indexingStartedEventEvent;
+
+    @Mock
+    private Event<IndexingFinishedEvent> indexingFinishedEventEvent;
+
+    private DefaultBatchIndexListener indexListener;
+
+    @Mock
+    private KCluster kCluster;
+
+    private Path path;
+
+    @Before
+    public void init() throws IOException {
+
+        fileSystemTestingUtils.setup();
+
+        path = fileSystemTestingUtils.getIoService().get("");
+
+        when(kCluster.getClusterId()).thenReturn(KCLUSTER_ID);
+
+        indexListener = new DefaultBatchIndexListener(indexingStartedEventEvent, indexingFinishedEventEvent);
+    }
+
+    @Test
+    public void testFireEvents() {
+        indexListener.notifyIndexIngStarted(kCluster, path);
+
+        verify(kCluster).getClusterId();
+        verify(indexingStartedEventEvent).fire(any());
+
+        indexListener.notifyIndexIngFinished(kCluster, path);
+
+        verify(kCluster, times(2)).getClusterId();
+        verify(indexingFinishedEventEvent).fire(any());
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/events/BaseIndexingEvent.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/events/BaseIndexingEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.services.refactoring.model.index.events;
+
+import org.uberfire.backend.vfs.Path;
+
+public abstract class BaseIndexingEvent {
+
+    private String kClusterId;
+    private Path path;
+
+    public BaseIndexingEvent(String kClusterId, Path path) {
+        this.kClusterId = kClusterId;
+        this.path = path;
+    }
+
+    public String getkClusterId() {
+        return kClusterId;
+    }
+
+    public Path getPath() {
+        return path;
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/events/IndexingFinishedEvent.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/events/IndexingFinishedEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.services.refactoring.model.index.events;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.clusterapi.Clustered;
+
+@Portable
+@Clustered
+public class IndexingFinishedEvent extends BaseIndexingEvent {
+
+    public IndexingFinishedEvent(@MapsTo("kClusterId") String kClusterId, @MapsTo("path") Path path) {
+        super(kClusterId, path);
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/events/IndexingStartedEvent.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/events/IndexingStartedEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.kie.workbench.common.services.refactoring.model.index.events;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.clusterapi.Clustered;
+
+@Portable
+@Clustered
+public class IndexingStartedEvent extends BaseIndexingEvent {
+
+    public IndexingStartedEvent(@MapsTo("kClusterId") String kClusterId, @MapsTo("path") Path path) {
+        super(kClusterId, path);
+    }
+}


### PR DESCRIPTION
- Added DefaultBatchIndexListener to get notifications when a project indexing has started or finished
- Improved PopulatedLibraryScreen by minimizing its backend calls and keeping its state on client. The state changes are handled by system events.
- Made the TileWidgets asset count load / refresh asynchronous.
- Removed unnecessary screen refresh on Library when importing/adding new project
- Solved context inconsistency when moving from a project to library

This is part of an ensemble, please merge with:
https://github.com/kiegroup/appformer/pull/755
https://github.com/kiegroup/kie-wb-common/pull/2794