### PR TITLE
DROOLS-4450: [DMN Designer] DMN Graph - Tooltips are not showing the text properly

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
@@ -49,7 +49,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.InputClause"),
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.InputClause"),
         startElement = "id")
 public class InputClause extends DMNElement implements HasTypeRefs,
                                                        DomainObject {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
@@ -62,7 +62,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseLiteralExpression"),
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.InputClauseLiteralExpression"),
         startElement = "text")
 public class InputClauseLiteralExpression extends DMNModelInstrumentedBase implements IsLiteralExpression,
                                                                                       HasTypeRef,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTests.java
@@ -48,7 +48,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @PropertySet
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests"),
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.InputClauseUnaryTests"),
         startElement = "text")
 public class InputClauseUnaryTests extends DMNModelInstrumentedBase implements IsUnaryTests,
                                                                                DMNPropertySet {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
@@ -50,7 +50,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause"),
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.OutputClause"),
         startElement = "id")
 public class OutputClause extends DMNElement implements HasTypeRef,
                                                         DomainObject {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpression.java
@@ -58,7 +58,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Definition(graphFactory = NodeFactory.class)
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseLiteralExpression"),
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.OutputClauseLiteralExpression"),
         startElement = "id")
 public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase implements IsLiteralExpression,
                                                                                        HasTypeRef,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
@@ -44,7 +44,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @PropertySet
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseUnaryTests"),
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.OutputClauseUnaryTests"),
         startElement = "text")
 public class OutputClauseUnaryTests extends DMNModelInstrumentedBase implements IsUnaryTests,
                                                                                 DMNPropertySet {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/TextAnnotation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/TextAnnotation.java
@@ -52,7 +52,7 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
 @Definition(graphFactory = NodeFactory.class, nameField = "text")
 @FormDefinition(policy = FieldPolicy.ONLY_MARKED,
         defaultFieldSettings = {@FieldParam(name = FIELD_CONTAINER_PARAM, value = COLLAPSIBLE_CONTAINER)},
-        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation"),
+        i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.TextAnnotation"),
         startElement = "id")
 public class TextAnnotation extends Artifact implements DMNViewDefinition<GeneralRectangleDimensionsSet>,
                                                         DynamicReadOnly {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/dataproviders/ConstraintTypeDataProvider.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/dataproviders/ConstraintTypeDataProvider.java
@@ -37,7 +37,7 @@ public class ConstraintTypeDataProvider implements SelectorDataProvider {
 
     private static Map<Object, Integer> valuePosition;
 
-    private static final String KEY_PREFIX = "org.kie.workbench.common.dmn.api.definition.v1_1.ConstraintType.";
+    private static final String KEY_PREFIX = "org.kie.workbench.common.dmn.api.definition.model.ConstraintType.";
 
     @Inject
     public ConstraintTypeDataProvider(final TranslationService translationService) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/resources/org/kie/workbench/common/dmn/api/resources/i18n/DMNAPIConstants.properties
@@ -6,65 +6,65 @@ org.kie.workbench.common.dmn.api.DMNDefinitionSet.description=DMN
 #######################
 # Categories
 #######################
-org.kie.workbench.common.dmn.api.definition.v1_1.Categories.DMNDiagram=DMN Diagram
-org.kie.workbench.common.dmn.api.definition.v1_1.Categories.DMNNodes=DMN Nodes
-org.kie.workbench.common.dmn.api.definition.v1_1.Categories.DMNConnectors=DMN Connectors
-org.kie.workbench.common.dmn.api.definition.v1_1.Categories.DMNMiscellaneousObjects=DMN Others
+org.kie.workbench.common.dmn.api.definition.model.Categories.DMNDiagram=DMN Diagram
+org.kie.workbench.common.dmn.api.definition.model.Categories.DMNNodes=DMN Nodes
+org.kie.workbench.common.dmn.api.definition.model.Categories.DMNConnectors=DMN Connectors
+org.kie.workbench.common.dmn.api.definition.model.Categories.DMNMiscellaneousObjects=DMN Others
 
 #######################
 # Definitions
 #######################
-org.kie.workbench.common.dmn.api.definition.v1_1.DMNDiagram.title=DMN Diagram
-org.kie.workbench.common.dmn.api.definition.v1_1.DMNDiagram.description=DMN Diagram
-org.kie.workbench.common.dmn.api.definition.v1_1.InputData.title=DMN Input Data
-org.kie.workbench.common.dmn.api.definition.v1_1.InputData.description=DMN Input Data
-org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource.title=DMN Knowledge Source
-org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeSource.description=DMN Knowledge Source
-org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel.title=DMN Business Knowledge Model
-org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel.description=DMN Business Knowledge Model
-org.kie.workbench.common.dmn.api.definition.v1_1.Decision.title=DMN Decision
-org.kie.workbench.common.dmn.api.definition.v1_1.Decision.description=DMN Decision
-org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation.title=DMN Text Annotation
-org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation.description=DMN Text Annotation
-org.kie.workbench.common.dmn.api.definition.v1_1.TextAnnotation.text=Text
-org.kie.workbench.common.dmn.api.definition.v1_1.Association.title=DMN Association
-org.kie.workbench.common.dmn.api.definition.v1_1.Association.description=DMN Association
-org.kie.workbench.common.dmn.api.definition.v1_1.InformationRequirement.title=DMN Information Requirement
-org.kie.workbench.common.dmn.api.definition.v1_1.InformationRequirement.description=DMN Information Requirement
-org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeRequirement.title=DMN Knowledge Requirement
-org.kie.workbench.common.dmn.api.definition.v1_1.KnowledgeRequirement.description=DMN Knowledge Requirement
-org.kie.workbench.common.dmn.api.definition.v1_1.AuthorityRequirement.title=DMN Authority Requirement
-org.kie.workbench.common.dmn.api.definition.v1_1.AuthorityRequirement.description=DMN Authority Requirement
-org.kie.workbench.common.dmn.api.definition.v1_1.InputClause.title=DMN Input Clause
-org.kie.workbench.common.dmn.api.definition.v1_1.InputClause.description=DMN Input Clause
-org.kie.workbench.common.dmn.api.definition.v1_1.InputClause.inputExpression=Input expression
-org.kie.workbench.common.dmn.api.definition.v1_1.InputClause.inputValues=Constraint
-org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseLiteralExpression.text=Input expression
-org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests.text=Constraint value
-org.kie.workbench.common.dmn.api.definition.v1_1.InputClauseUnaryTests.constraintType=Type
-org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause.title=DMN Output Clause
-org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause.description=DMN Output Clause
-org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause.outputValues=Output values
-org.kie.workbench.common.dmn.api.definition.v1_1.OutputClause.defaultOutputEntry=Default output
-org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseUnaryTests.text=Output value
-org.kie.workbench.common.dmn.api.definition.v1_1.OutputClauseLiteralExpression.text=Default output value
-org.kie.workbench.common.dmn.api.definition.v1_1.DecisionService.title=DMN Decision Service
-org.kie.workbench.common.dmn.api.definition.v1_1.DecisionService.description=DMN Decision Service
+org.kie.workbench.common.dmn.api.definition.model.DMNDiagram.title=DMN Diagram
+org.kie.workbench.common.dmn.api.definition.model.DMNDiagram.description=DMN Diagram
+org.kie.workbench.common.dmn.api.definition.model.InputData.title=DMN Input Data
+org.kie.workbench.common.dmn.api.definition.model.InputData.description=DMN Input Data
+org.kie.workbench.common.dmn.api.definition.model.KnowledgeSource.title=DMN Knowledge Source
+org.kie.workbench.common.dmn.api.definition.model.KnowledgeSource.description=DMN Knowledge Source
+org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel.title=DMN Business Knowledge Model
+org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel.description=DMN Business Knowledge Model
+org.kie.workbench.common.dmn.api.definition.model.Decision.title=DMN Decision
+org.kie.workbench.common.dmn.api.definition.model.Decision.description=DMN Decision
+org.kie.workbench.common.dmn.api.definition.model.TextAnnotation.title=DMN Text Annotation
+org.kie.workbench.common.dmn.api.definition.model.TextAnnotation.description=DMN Text Annotation
+org.kie.workbench.common.dmn.api.definition.model.TextAnnotation.text=Text
+org.kie.workbench.common.dmn.api.definition.model.Association.title=DMN Association
+org.kie.workbench.common.dmn.api.definition.model.Association.description=DMN Association
+org.kie.workbench.common.dmn.api.definition.model.InformationRequirement.title=DMN Information Requirement
+org.kie.workbench.common.dmn.api.definition.model.InformationRequirement.description=DMN Information Requirement
+org.kie.workbench.common.dmn.api.definition.model.KnowledgeRequirement.title=DMN Knowledge Requirement
+org.kie.workbench.common.dmn.api.definition.model.KnowledgeRequirement.description=DMN Knowledge Requirement
+org.kie.workbench.common.dmn.api.definition.model.AuthorityRequirement.title=DMN Authority Requirement
+org.kie.workbench.common.dmn.api.definition.model.AuthorityRequirement.description=DMN Authority Requirement
+org.kie.workbench.common.dmn.api.definition.model.InputClause.title=DMN Input Clause
+org.kie.workbench.common.dmn.api.definition.model.InputClause.description=DMN Input Clause
+org.kie.workbench.common.dmn.api.definition.model.InputClause.inputExpression=Input expression
+org.kie.workbench.common.dmn.api.definition.model.InputClause.inputValues=Constraint
+org.kie.workbench.common.dmn.api.definition.model.InputClauseLiteralExpression.text=Input expression
+org.kie.workbench.common.dmn.api.definition.model.InputClauseUnaryTests.text=Constraint value
+org.kie.workbench.common.dmn.api.definition.model.InputClauseUnaryTests.constraintType=Type
+org.kie.workbench.common.dmn.api.definition.model.OutputClause.title=DMN Output Clause
+org.kie.workbench.common.dmn.api.definition.model.OutputClause.description=DMN Output Clause
+org.kie.workbench.common.dmn.api.definition.model.OutputClause.outputValues=Output values
+org.kie.workbench.common.dmn.api.definition.model.OutputClause.defaultOutputEntry=Default output
+org.kie.workbench.common.dmn.api.definition.model.OutputClauseUnaryTests.text=Output value
+org.kie.workbench.common.dmn.api.definition.model.OutputClauseLiteralExpression.text=Default output value
+org.kie.workbench.common.dmn.api.definition.model.DecisionService.title=DMN Decision Service
+org.kie.workbench.common.dmn.api.definition.model.DecisionService.description=DMN Decision Service
 
 ###############
 # Property Sets
 ###############
-org.kie.workbench.common.dmn.api.definition.v1_1.FunctionDefinition.label=Function definition
-org.kie.workbench.common.dmn.api.definition.v1_1.LiteralExpression.label=Literal expression
-org.kie.workbench.common.dmn.api.definition.v1_1.ImportedValues.label=Imported values
-org.kie.workbench.common.dmn.api.definition.v1_1.Import.label=Import
-org.kie.workbench.common.dmn.api.definition.v1_1.InformationItem.label=Information item
-org.kie.workbench.common.dmn.api.definition.v1_1.InformationItemPrimary.label=Information item
-org.kie.workbench.common.dmn.api.definition.v1_1.ConstraintType.expression=Expression
-org.kie.workbench.common.dmn.api.definition.v1_1.ConstraintType.enumeration=Enumeration
-org.kie.workbench.common.dmn.api.definition.v1_1.ConstraintType.range=Range
-org.kie.workbench.common.dmn.api.definition.v1_1.ConstraintType.none=None
-org.kie.workbench.common.dmn.api.definition.v1_1.ConstraintType.selectType=Select a type
+org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition.label=Function definition
+org.kie.workbench.common.dmn.api.definition.model.LiteralExpression.label=Literal expression
+org.kie.workbench.common.dmn.api.definition.model.ImportedValues.label=Imported values
+org.kie.workbench.common.dmn.api.definition.model.Import.label=Import
+org.kie.workbench.common.dmn.api.definition.model.InformationItem.label=Information item
+org.kie.workbench.common.dmn.api.definition.model.InformationItemPrimary.label=Information item
+org.kie.workbench.common.dmn.api.definition.model.ConstraintType.expression=Expression
+org.kie.workbench.common.dmn.api.definition.model.ConstraintType.enumeration=Enumeration
+org.kie.workbench.common.dmn.api.definition.model.ConstraintType.range=Range
+org.kie.workbench.common.dmn.api.definition.model.ConstraintType.none=None
+org.kie.workbench.common.dmn.api.definition.model.ConstraintType.selectType=Select a type
 
 #######################
 # Background property


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4450

Before:
![before](https://user-images.githubusercontent.com/1079279/63393927-b2ddcd00-c393-11e9-8d9a-698008803616.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/63393931-b7a28100-c393-11e9-8933-482d0e942187.gif)

The rename of the `org.kie.workbench.common.dmn.api.1_1` package (https://github.com/kiegroup/kie-wb-common/pull/2787) caused this issue. Now the labels are updated, and the issue is fixed.
