### PR TITLE
AF-2064: Unexpected error is displayed after project is created on OpenShift [Cat1]

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenter.java
@@ -252,8 +252,10 @@ public class AddProjectPopUpPresenter {
 
                            libraryService.call((WorkspaceProject project) -> {
                                                    newProjectPath = project.getRootPath();
+                                                   endProjectCreation();
+                                                   view.hide();
+                                                   notifySuccess();
                                                    if (projectsIndexed.contains(newProjectPath)) {
-                                                       endProjectCreation();
                                                        getSuccessCallback().execute(project);
                                                    }
                                                },
@@ -268,7 +270,6 @@ public class AddProjectPopUpPresenter {
         projectsIndexed.add(event.getPath());
         if (newProjectPath != null && newProjectPath.equals(event.getPath())) {
             projectService.call((WorkspaceProject project) -> {
-                                    endProjectCreation();
                                     getSuccessCallback().execute(project);
                                 },
                                 (o, throwable) -> {
@@ -393,8 +394,6 @@ public class AddProjectPopUpPresenter {
 
     public ParameterizedCommand<WorkspaceProject> getProjectCreationSuccessCallback() {
         return project -> {
-            view.hide();
-            notifySuccess();
             libraryPlaces.goToProject(project);
         };
     }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenterTest.java
@@ -193,7 +193,7 @@ public class AddProjectPopUpPresenterTest {
         verify(libraryService).createProject(eq(organizationalUnit),
                                              pomArgumentCaptor.capture(),
                                              eq(DeploymentMode.VALIDATED));
-        verify(view, never()).setAddButtonEnabled(true);
+        verify(view).setAddButtonEnabled(true);
     }
 
     @Test
@@ -216,7 +216,7 @@ public class AddProjectPopUpPresenterTest {
         verify(libraryService).createProject(eq(organizationalUnit),
                                              pomArgumentCaptor.capture(),
                                              eq(DeploymentMode.VALIDATED));
-        verify(view, never()).setAddButtonEnabled(true);
+        verify(view).setAddButtonEnabled(true);
 
         final POM pom = pomArgumentCaptor.getValue();
 
@@ -252,7 +252,7 @@ public class AddProjectPopUpPresenterTest {
         verify(libraryService).createProject(eq(organizationalUnit),
                                              pomArgumentCaptor.capture(),
                                              eq(DeploymentMode.VALIDATED));
-        verify(view, never()).setAddButtonEnabled(true);
+        verify(view).setAddButtonEnabled(true);
         
         final POM pom = pomArgumentCaptor.getValue();
 
@@ -277,9 +277,9 @@ public class AddProjectPopUpPresenterTest {
 
         verify(view).setAddButtonEnabled(false);
         verify(view).showBusyIndicator(anyString());
-        verify(view, never()).setAddButtonEnabled(true);
-        verify(view, never()).hide();
-        verify(notificationEvent, never()).fire(any(NotificationEvent.class));
+        verify(view).setAddButtonEnabled(true);
+        verify(view).hide();
+        verify(notificationEvent).fire(any(NotificationEvent.class));
         verify(libraryPlaces, never()).goToProject(any(WorkspaceProject.class));
     }
 
@@ -542,7 +542,7 @@ public class AddProjectPopUpPresenterTest {
 
         verify(view).setAddButtonEnabled(false);
         verify(view).showBusyIndicator(anyString());
-        verify(view, never()).setAddButtonEnabled(true);
+        verify(view).setAddButtonEnabled(true);
         verify(command, never()).execute(any());
     }
 


### PR DESCRIPTION
Now if any problem happens when trying to resolve project just after creation, the project will be created normally, the popup will be closed and the success message will appear, the only thing that might happen is the project not being automatically opened.