### PR TITLE
JBPM-7502 : Stunner - Sequence flow disappear after some cut/paste actions

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/ClipboardControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/ClipboardControl.java
@@ -18,11 +18,13 @@ package org.kie.workbench.common.stunner.core.client.canvas.controls;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
 
 public interface ClipboardControl<E extends Element, C extends Canvas, S extends ClientSession> extends CanvasControl<C> {
 
@@ -41,4 +43,8 @@ public interface ClipboardControl<E extends Element, C extends Canvas, S extends
     List<Command> getRollbackCommands();
 
     ClipboardControl<E, C, S> setRollbackCommand(Command... command);
+
+    Map<String, EdgeClipboard> getEdgeMap();
+
+    EdgeClipboard buildNewEdgeClipboard(final String source, final Connection sourceConnection, final String target, final Connection targetConnection);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/EdgeClipboard.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/EdgeClipboard.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls;
+
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+
+public class EdgeClipboard {
+
+    private String source;
+    private String target;
+    private Connection sourceConnection;
+    private Connection targetConnection;
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public Connection getSourceConnection() {
+        return sourceConnection;
+    }
+
+    public void setSourceConnection(Connection sourceConnection) {
+        this.sourceConnection = sourceConnection;
+    }
+
+    public Connection getTargetConnection() {
+        return targetConnection;
+    }
+
+    public void setTargetConnection(Connection targetConnection) {
+        this.targetConnection = targetConnection;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/EdgeClipboardTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/EdgeClipboardTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EdgeClipboardTest {
+
+    @Test
+    public void testEdgeClipboard() {
+        EdgeClipboard clipboard = new EdgeClipboard();
+        clipboard.setSource(null);
+        clipboard.setSourceConnection(null);
+        clipboard.setTarget(null);
+        clipboard.setTargetConnection(null);
+        assertEquals(null, clipboard.getSource());
+        assertEquals(null, clipboard.getSourceConnection());
+        assertEquals(null, clipboard.getTarget());
+        assertEquals(null, clipboard.getTargetConnection());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/clipboard/LocalClipboardControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/clipboard/LocalClipboardControl.java
@@ -33,10 +33,12 @@ import javax.enterprise.inject.Default;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.ClipboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.EdgeClipboard;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 
 @ApplicationScoped
@@ -48,6 +50,11 @@ public class LocalClipboardControl
     private final Set<Element> elements;
     private final Map<String, String> elementsParent;
     private final List<Command> commands;
+
+    /**
+     * Extra Clipboard for Edges. JBPM-7502
+     */
+    private Map<String, EdgeClipboard> edgeMap = new HashMap<>();
 
     public LocalClipboardControl() {
         this.elements = new HashSet<>();
@@ -111,5 +118,20 @@ public class LocalClipboardControl
     @Override
     protected void doDestroy() {
         clear();
+    }
+
+    @Override
+    public Map<String, EdgeClipboard> getEdgeMap() {
+        return edgeMap;
+    }
+
+    @Override
+    public EdgeClipboard buildNewEdgeClipboard(final String source, final Connection sourceConnection, final String target, final Connection targetConnection) {
+        final EdgeClipboard clipboard = new EdgeClipboard();
+        clipboard.setSource(source);
+        clipboard.setSourceConnection(sourceConnection);
+        clipboard.setTarget(target);
+        clipboard.setTargetConnection(targetConnection);
+        return clipboard;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
@@ -105,9 +105,9 @@ public class CopySelectionSessionCommand extends AbstractSelectionAwareSessionCo
                                              .toArray(Element[]::new));
                 final Set<String> clipboardNodes =
                         clipboardControl.getElements().stream()
-                        .filter(element -> element instanceof Node)
-                        .map(Element::getUUID)
-                        .collect(Collectors.toSet());
+                                .filter(element -> element instanceof Node)
+                                .map(Element::getUUID)
+                                .collect(Collectors.toSet());
 
                 clipboardControl.getEdgeMap().clear();
                 clipboardControl.getEdgeMap().putAll(clipboardControl.getElements().stream()

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
@@ -16,13 +16,16 @@
 
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
+import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.ClipboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.SelectionControl;
@@ -32,7 +35,11 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Canva
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent.Key;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 
 import static org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher.doKeysMatch;
 
@@ -47,7 +54,7 @@ public class CopySelectionSessionCommand extends AbstractSelectionAwareSessionCo
 
     private final Event<CopySelectionSessionCommandExecutedEvent> commandExecutedEvent;
 
-    private ClipboardControl clipboardControl;
+    private ClipboardControl<Element, AbstractCanvas, ClientSession> clipboardControl;
 
     public CopySelectionSessionCommand() {
         this(null);
@@ -96,6 +103,25 @@ public class CopySelectionSessionCommand extends AbstractSelectionAwareSessionCo
                 clipboardControl.set(selectionControl.getSelectedItems().stream()
                                              .map(this::getElement)
                                              .toArray(Element[]::new));
+                final Set<String> clipboardNodes =
+                        clipboardControl.getElements().stream()
+                        .filter(element -> element instanceof Node)
+                        .map(Element::getUUID)
+                        .collect(Collectors.toSet());
+
+                clipboardControl.getEdgeMap().clear();
+                clipboardControl.getEdgeMap().putAll(clipboardControl.getElements().stream()
+                                                             .filter(element -> element instanceof Edge)
+                                                             .map(edge -> (Edge) edge)
+                                                             .collect(Collectors.toList()).stream()
+                                                             .filter(edge -> clipboardNodes.contains(edge.getSourceNode().getUUID()) && clipboardNodes.contains(edge.getTargetNode().getUUID()))
+                                                             .collect(Collectors.toMap(Edge::getUUID, edge ->
+                                                                     clipboardControl.buildNewEdgeClipboard(edge.getSourceNode().getUUID(),
+                                                                                                            (Connection) ((ViewConnector) edge.getContent()).getSourceConnection().orElse(null),
+                                                                                                            edge.getTargetNode().getUUID(),
+                                                                                                            (Connection) ((ViewConnector) edge.getContent()).getTargetConnection().orElse(null))
+                                                             )));
+
                 commandExecutedEvent.fire(new CopySelectionSessionCommandExecutedEvent(this,
                                                                                        getSession()));
                 callback.onSuccess();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/clipboard/LocalClipboardControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/clipboard/LocalClipboardControlTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.EdgeClipboard;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
@@ -72,5 +73,16 @@ public class LocalClipboardControlTest {
         localClipboardControl.set(graphInstance.startNode);
         String parentUUID = localClipboardControl.getParent(graphInstance.startNode.getUUID());
         assertEquals(parentUUID, graphInstance.parentNode.getUUID());
+    }
+
+    @Test
+    public void testEdgeMap() {
+        final EdgeClipboard clipboard = localClipboardControl.buildNewEdgeClipboard("1D", null, "2D", null);
+        localClipboardControl.getEdgeMap().put("Node1", clipboard);
+        assertEquals(localClipboardControl.getEdgeMap().get("Node1").getSource(), clipboard.getSource());
+        assertEquals(localClipboardControl.getEdgeMap().get("Node1").getSourceConnection(), clipboard.getSourceConnection());
+
+        assertEquals(localClipboardControl.getEdgeMap().get("Node1").getTarget(), clipboard.getTarget());
+        assertEquals(localClipboardControl.getEdgeMap().get("Node1").getTargetConnection(), clipboard.getTargetConnection());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
@@ -112,12 +112,48 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
     public void testExecuteMultiSelection() {
         copySelectionSessionCommand.bind(session);
 
-        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(graphInstance.startNode.getUUID(),
-                                                                           graphInstance.edge1.getUUID(),
-                                                                           graphInstance.intermNode.getUUID()));
+        // test copying node - edge - node
+        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
+                graphInstance.startNode.getUUID(),
+                graphInstance.edge1.getUUID(),
+                graphInstance.intermNode.getUUID())
+        );
         copySelectionSessionCommand.execute(callback);
         verify(clipboardControl, times(1))
                 .set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
+        assertEquals(1, clipboardControl.getEdgeMap().size());
+        assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getSource(), graphInstance.startNode.getUUID());
+        assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getTarget(), graphInstance.intermNode.getUUID());
+
+        // test copying edge - node - edge - node
+        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
+                graphInstance.edge2.getUUID(),
+                graphInstance.startNode.getUUID(),
+                graphInstance.edge1.getUUID(),
+                graphInstance.intermNode.getUUID())
+        );
+        copySelectionSessionCommand.execute(callback);
+        verify(clipboardControl, times(1))
+                .set(graphInstance.edge2, graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
+        // edge map should contain only node - edge - node and discard edge that has no source being copied
+        assertEquals(1, clipboardControl.getEdgeMap().size());
+        assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getSource(), graphInstance.startNode.getUUID());
+        assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getTarget(), graphInstance.intermNode.getUUID());
+
+        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
+                graphInstance.startNode.getUUID(),
+                graphInstance.edge1.getUUID(),
+                graphInstance.intermNode.getUUID(),
+                graphInstance.edge2.getUUID())
+        );
+
+        copySelectionSessionCommand.execute(callback);
+        verify(clipboardControl, times(1))
+                .set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode, graphInstance.edge2);
+        // edge map should contain only node - edge - node and discard edge that has no target being copied
+        assertEquals(1, clipboardControl.getEdgeMap().size());
+        assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getSource(), graphInstance.startNode.getUUID());
+        assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getTarget(), graphInstance.intermNode.getUUID());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
@@ -154,7 +154,18 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
         assertEquals(1, clipboardControl.getEdgeMap().size());
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getSource(), graphInstance.startNode.getUUID());
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getTarget(), graphInstance.intermNode.getUUID());
-    }
+
+        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
+                graphInstance.startNode.getUUID(),
+                graphInstance.intermNode.getUUID())
+        );
+
+        copySelectionSessionCommand.execute(callback);
+        verify(clipboardControl, times(1))
+                .set(graphInstance.startNode, graphInstance.intermNode);
+        // edge map should not contain only node - node 
+        assertEquals(0, clipboardControl.getEdgeMap().size());
+      }
 
     @Override
     protected CopySelectionSessionCommand getCommand() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
@@ -112,12 +112,15 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
     public void testExecuteMultiSelection() {
         copySelectionSessionCommand.bind(session);
 
-        // test copying node - edge - node
+        // 1) test copying node - edge - node
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
                 graphInstance.startNode.getUUID(),
                 graphInstance.edge1.getUUID(),
                 graphInstance.intermNode.getUUID())
         );
+        graphInstance.edge1.setSourceNode(graphInstance.startNode);
+        graphInstance.edge1.setTargetNode(graphInstance.intermNode);
+
         copySelectionSessionCommand.execute(callback);
         verify(clipboardControl, times(1))
                 .set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
@@ -125,13 +128,20 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getSource(), graphInstance.startNode.getUUID());
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getTarget(), graphInstance.intermNode.getUUID());
 
-        // test copying edge - node - edge - node
+        // 2) test copying edge - node - edge - node
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
                 graphInstance.edge2.getUUID(),
                 graphInstance.startNode.getUUID(),
                 graphInstance.edge1.getUUID(),
                 graphInstance.intermNode.getUUID())
         );
+
+        graphInstance.edge2.setSourceNode(graphInstance.endNode);
+        graphInstance.edge2.setTargetNode(graphInstance.startNode);
+
+        graphInstance.edge1.setSourceNode(graphInstance.startNode);
+        graphInstance.edge1.setTargetNode(graphInstance.intermNode);
+
         copySelectionSessionCommand.execute(callback);
         verify(clipboardControl, times(1))
                 .set(graphInstance.edge2, graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
@@ -140,12 +150,20 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getSource(), graphInstance.startNode.getUUID());
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getTarget(), graphInstance.intermNode.getUUID());
 
+        // 3) test copying node - edge - node - edge
+
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
                 graphInstance.startNode.getUUID(),
                 graphInstance.edge1.getUUID(),
                 graphInstance.intermNode.getUUID(),
                 graphInstance.edge2.getUUID())
         );
+
+        graphInstance.edge1.setSourceNode(graphInstance.startNode);
+        graphInstance.edge1.setTargetNode(graphInstance.intermNode);
+
+        graphInstance.edge2.setSourceNode(graphInstance.intermNode);
+        graphInstance.edge2.setTargetNode(graphInstance.endNode);
 
         copySelectionSessionCommand.execute(callback);
         verify(clipboardControl, times(1))
@@ -155,17 +173,23 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getSource(), graphInstance.startNode.getUUID());
         assertEquals(clipboardControl.getEdgeMap().get(graphInstance.edge1.getUUID()).getTarget(), graphInstance.intermNode.getUUID());
 
+        // 4) test copying node - node
+
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(
                 graphInstance.startNode.getUUID(),
-                graphInstance.intermNode.getUUID())
+                graphInstance.intermNode.getUUID(),
+                graphInstance.edge1.getUUID())
         );
+
+        graphInstance.edge1.setSourceNode(graphInstance.endNode);
+        graphInstance.edge1.setTargetNode(graphInstance.parentNode);
 
         copySelectionSessionCommand.execute(callback);
         verify(clipboardControl, times(1))
-                .set(graphInstance.startNode, graphInstance.intermNode);
+                .set(graphInstance.startNode, graphInstance.intermNode, graphInstance.edge1);
         // edge map should not contain only node - node 
         assertEquals(0, clipboardControl.getEdgeMap().size());
-      }
+    }
 
     @Override
     protected CopySelectionSessionCommand getCommand() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.command.CloneConnectorCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.CloneNodeCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.ClipboardControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.EdgeClipboard;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.clipboard.LocalClipboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
@@ -53,8 +54,10 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
@@ -272,6 +275,87 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
     public void executeWithMultiSelection() {
         pasteSelectionSessionCommand.bind(session);
 
+        pasteSelectionSessionCommand.setTestEdgeFoundInCanvas(true);
+        pasteSelectionSessionCommand.setTestEdgeFoundInClipboard(false);
+
+        //Mock the callback of CloneNodeCommand
+        ArgumentCaptor<Consumer> consumerNode = ArgumentCaptor.forClass(Consumer.class);
+        ArgumentCaptor<Consumer> consumerNode2 = ArgumentCaptor.forClass(Consumer.class);
+        when(cloneNodeCommand.getCandidate()).thenReturn(node);
+        when(cloneNodeCommand2.getCandidate()).thenReturn(node2);
+        when(canvasCommandFactory.cloneNode(eq(node), any(), any(), consumerNode.capture())).thenReturn(cloneNodeCommand);
+        when(canvasCommandFactory.cloneNode(eq(node2), any(), any(), consumerNode2.capture())).thenReturn(cloneNodeCommand2);
+        Map<Node, ArgumentCaptor<Consumer>> consumerMap = new HashMap() {{
+            put(node, consumerNode);
+            put(node2, consumerNode2);
+        }};
+
+        //Mock the callback of CloneConnectorCommand
+        ArgumentCaptor<Consumer> consumerEdge = ArgumentCaptor.forClass(Consumer.class);
+        when(canvasCommandFactory.cloneConnector(any(), anyString(), anyString(), anyString(), consumerEdge.capture())).thenReturn(cloneConnectorCommand);
+
+        //apply callbacks mocks
+        when(sessionCommandManager.execute(eq(canvasHandler), any())).thenAnswer(param -> {
+            CompositeCommand argument = param.getArgumentAt(1, CompositeCommand.class);
+            //callback to nodes
+            argument.getCommands().stream().filter(c -> c instanceof CloneNodeCommand).forEach(c -> {
+                CloneNodeCommand cloneNodeCommand = (CloneNodeCommand) c;
+                Node candidate = cloneNodeCommand.getCandidate();
+                consumerMap.get(candidate).getValue().accept(cloneMap.get(candidate));
+            });
+
+            //callback to connectors
+            argument.getCommands().stream().filter(c -> c instanceof CloneConnectorCommand).forEach(c ->
+                                                                                                            consumerEdge.getValue().accept(cloneEdge)
+            );
+            return commandResult;
+        });
+
+        //Executing the command
+        clipboardControl.set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
+        when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(graphInstance.startNode.getUUID(), graphInstance.edge1.getUUID(), graphInstance.intermNode.getUUID()));
+
+        pasteSelectionSessionCommand.execute(callback);
+
+        verify(canvasCommandFactory, times(1))
+                .cloneNode(eq(graphInstance.startNode), eq(graphInstance.parentNode.getUUID()), eq(new Point2D(X, DEFAULT_PADDING + Y + NODE_SIZE)), any());
+
+        verify(canvasCommandFactory, times(1))
+                .cloneConnector(eq(graphInstance.edge1), anyString(), anyString(), anyString(), any());
+
+        //check command registry update after execution to allow a single undo/redo
+        verify(commandRegistry, times(2)).pop();
+        ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass(Command.class);
+        verify(commandRegistry, times(1)).register(commandArgumentCaptor.capture());
+        assertTrue(commandArgumentCaptor.getValue() instanceof CompositeCommand);
+        assertEquals(2, ((CompositeCommand) commandArgumentCaptor.getValue()).size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void executeWithMultiSelectionWithEdgesClipboard() {
+
+        final Connection sourceConnection = (Connection) ((ViewConnector) graphInstance.edge1.getContent()).getSourceConnection().orElse(null);
+        final Connection targetConnection = (Connection) ((ViewConnector) graphInstance.edge1.getContent()).getTargetConnection().orElse(null);
+
+        final EdgeClipboard clipboard = clipboardControl.buildNewEdgeClipboard(graphInstance.startNode.getUUID(), sourceConnection, graphInstance.intermNode.getUUID(), targetConnection);
+        clipboardControl.set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
+
+        final Map<String, EdgeClipboard> map = new HashMap<>();
+        map.put(graphInstance.edge1.getUUID(), clipboard);
+
+        when(clipboardControl.getEdgeMap()).thenReturn(map);
+
+        assertEquals(1, clipboardControl.getEdgeMap().size());
+
+        pasteSelectionSessionCommand.bind(session);
+
+        pasteSelectionSessionCommand.setTestEdgeFoundInCanvas(false);
+        pasteSelectionSessionCommand.setTestEdgeFoundInClipboard(true);
+
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge1));
+        assertEquals(true, pasteSelectionSessionCommand.isEdgeFoundInClipboard(graphInstance.edge1));
+
         //Mock the callback of CloneNodeCommand
         ArgumentCaptor<Consumer> consumerNode = ArgumentCaptor.forClass(Consumer.class);
         ArgumentCaptor<Consumer> consumerNode2 = ArgumentCaptor.forClass(Consumer.class);
@@ -320,7 +404,43 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
         ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass(Command.class);
         verify(commandRegistry, times(1)).register(commandArgumentCaptor.capture());
         assertTrue(commandArgumentCaptor.getValue() instanceof CompositeCommand);
-        assertEquals(((CompositeCommand) commandArgumentCaptor.getValue()).size(), 2);
+        assertEquals(2, ((CompositeCommand) commandArgumentCaptor.getValue()).size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testFoundOnCanvasAndClipboard() {
+
+        pasteSelectionSessionCommand.bind(session);
+
+        pasteSelectionSessionCommand.setTestEdgeFoundInCanvas(false);
+        pasteSelectionSessionCommand.setTestEdgeFoundInClipboard(true);
+
+        final Connection sourceConnection = (Connection) ((ViewConnector) graphInstance.edge1.getContent()).getSourceConnection().orElse(null);
+        final Connection targetConnection = (Connection) ((ViewConnector) graphInstance.edge1.getContent()).getTargetConnection().orElse(null);
+
+        final EdgeClipboard clipboard = clipboardControl.buildNewEdgeClipboard(graphInstance.startNode.getUUID(), sourceConnection, graphInstance.intermNode.getUUID(), targetConnection);
+        clipboardControl.set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
+
+        final Map<String, EdgeClipboard> map = new HashMap<>();
+        map.put(graphInstance.edge1.getUUID(), clipboard);
+
+        when(clipboardControl.getEdgeMap()).thenReturn(map);
+
+        assertEquals(1, clipboardControl.getEdgeMap().size());
+
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge1));
+        assertEquals(true, pasteSelectionSessionCommand.isEdgeFoundInClipboard(graphInstance.edge1));
+
+        pasteSelectionSessionCommand.setTestEdgeFoundInClipboard(false);
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInClipboard(graphInstance.edge2));
+
+        pasteSelectionSessionCommand.setTestEdgeFoundInCanvas(true);
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge2));
+        graphInstance.edge2.setSourceNode(null);
+        graphInstance.edge2.setTargetNode(null);
+
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge2));
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
@@ -437,10 +437,23 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
 
         pasteSelectionSessionCommand.setTestEdgeFoundInCanvas(true);
         assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge2));
+        Node source = graphInstance.edge2.getSourceNode();
+        Node target = graphInstance.edge2.getTargetNode();
+
         graphInstance.edge2.setSourceNode(null);
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge2));
+
         graphInstance.edge2.setTargetNode(null);
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge2));
+
+        graphInstance.edge2.setSourceNode(source);
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge2));
+
+        pasteSelectionSessionCommand.setTestEdgeFoundInCanvas(false);
+        pasteSelectionSessionCommand.setTestEdgeFoundInClipboard(false);
 
         assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInCanvas(graphInstance.edge2));
+        assertEquals(false, pasteSelectionSessionCommand.isEdgeFoundInClipboard(graphInstance.edge2));
     }
 
     @Override


### PR DESCRIPTION
Hi @hasys can you check this PR? Basically it fixes the issue about Sequence flow dissapearing on cut/paste, also it now fixes the scenario when you copy something, then delete the original and then paste. before it did  not paste the sequence flows as well. 