### PR TITLE
[7.26.x] RHDM-1076 / DROOLS-4496: Empty Structure causes DMN editor to crash

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.dmn.api.graph.DMNDiagramUtils;
 import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hitpolicy.HitPolicyPopoverView;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
@@ -118,6 +119,9 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
     private NameAndDataTypePopoverView.Presenter headerEditor;
 
     @Mock
+    protected ItemDefinitionUtils itemDefinitionUtils;
+
+    @Mock
     protected GridCellTuple parent;
 
     protected Decision decision = new Decision();
@@ -149,7 +153,8 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
                                                             hitPolicyEditor,
                                                             headerEditor,
                                                             new DecisionTableEditorDefinitionEnricher(sessionManager,
-                                                                                                      new DMNGraphUtils(sessionManager, new DMNDiagramUtils())));
+                                                                                                      new DMNGraphUtils(sessionManager,new DMNDiagramUtils()),
+                                                                                                      itemDefinitionUtils));
 
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(canvasHandler.getDiagram()).thenReturn(diagram);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridTest.java
@@ -64,6 +64,7 @@ import org.kie.workbench.common.dmn.client.commands.general.SetTypeRefCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.GridFactoryCommandUtils;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hitpolicy.HitPolicyPopoverView;
 import org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverView;
+import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
@@ -197,6 +198,9 @@ public class DecisionTableGridTest {
 
     @Mock
     private SessionManager sessionManager;
+
+    @Mock
+    private ItemDefinitionUtils itemDefinitionUtils;
 
     @Mock
     private DMNDiagramUtils dmnDiagramUtils;
@@ -333,7 +337,8 @@ public class DecisionTableGridTest {
                                                             hitPolicyEditor,
                                                             headerEditor,
                                                             new DecisionTableEditorDefinitionEnricher(sessionManager,
-                                                                                                      new DMNGraphUtils(sessionManager, dmnDiagramUtils)));
+                                                                                                      new DMNGraphUtils(sessionManager, dmnDiagramUtils),
+                                                                                                      itemDefinitionUtils));
 
         expression = definition.getModelClass();
         definition.enrich(Optional.empty(), hasExpression, expression);


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/kiegroup/kie-wb-common/pull/2860 to `7.26.x`.

---

See https://issues.jboss.org/browse/DROOLS-4496

Before:
![2019-09-03 15 35 08](https://user-images.githubusercontent.com/1079279/64199990-f50e1080-ce61-11e9-9bef-6a88b188ef7d.gif)

After:
![2019-09-03 15 28 08](https://user-images.githubusercontent.com/1079279/64200004-f9d2c480-ce61-11e9-8daf-528d08556cf6.gif)
