### PR TITLE
Fix for failing tests in Windows

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -282,7 +282,7 @@ public class BPMNDirectDiagramMarshallerTest {
         final Node<? extends Definition, ?> element = diagram.getGraph().getNode(uuid);
         assertDiagram(diagram, 4);
         assertTrue(element.getContent().getDefinition() instanceof NoneTask);
-        assertTrue(result.contains("<bpmn2:task id=\"$uuid\" name=\"manual\">\n".replace("$uuid", uuid)));
+        assertTrue(result.contains("<bpmn2:task id=\"$uuid\" name=\"manual\">".replace("$uuid", uuid)));
     }
 
     @Test
@@ -293,7 +293,7 @@ public class BPMNDirectDiagramMarshallerTest {
         final Node<? extends Definition, ?> element = diagram.getGraph().getNode(uuid);
         assertDiagram(diagram, 4);
         assertTrue(element.getContent().getDefinition() instanceof NoneTask);
-        assertTrue(result.contains("<bpmn2:task id=\"$uuid\" name=\"send\">\n".replace("$uuid", uuid)));
+        assertTrue(result.contains("<bpmn2:task id=\"$uuid\" name=\"send\">".replace("$uuid", uuid)));
     }
 
     @Test
@@ -304,7 +304,7 @@ public class BPMNDirectDiagramMarshallerTest {
         final Node<? extends Definition, ?> element = diagram.getGraph().getNode(uuid);
         assertDiagram(diagram, 4);
         assertTrue(element.getContent().getDefinition() instanceof NoneTask);
-        assertTrue(result.contains("<bpmn2:task id=\"$uuid\" name=\"received\">\n".replace("$uuid", uuid)));
+        assertTrue(result.contains("<bpmn2:task id=\"$uuid\" name=\"received\">".replace("$uuid", uuid)));
     }
 
     @Test


### PR DESCRIPTION
Due to different line endings across platforms, some tests were failing when executed in Windows. 
Since the line ending was inside a string, probably due to copy pasting it, GIT was not able to pick this up, causing the failed tests. This fixes this issue.