### PR TITLE
[AF-2213] Trimming the URL when importing a project

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenter.java
@@ -99,7 +99,7 @@ public class ImportRepositoryPopUpPresenter {
                                view.hideBusyIndicator();
                                view.showError(view.getNoProjectsToImportMessage());
                                return false;
-                           }).getProjects(new ExampleRepository(repositoryUrl,
+                           }).getProjects(new ExampleRepository(repositoryUrl.trim(),
                                                                 new Credentials(
                                                                         view.getUserName(),
                                                                         view.getPassword())));

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/importrepository/ImportRepositoryPopUpPresenterTest.java
@@ -20,6 +20,8 @@ import org.jboss.errai.common.client.api.Caller;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.examples.model.Credentials;
+import org.kie.workbench.common.screens.examples.model.ExampleRepository;
 import org.kie.workbench.common.screens.examples.model.ImportProject;
 import org.kie.workbench.common.screens.examples.service.ProjectImportService;
 import org.kie.workbench.common.screens.library.client.util.LibraryPlaces;
@@ -31,7 +33,6 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -87,6 +88,21 @@ public class ImportRepositoryPopUpPresenterTest {
         verify(view).hideBusyIndicator();
         verify(view).hide();
         verify(libraryPlaces).goToExternalImportPresenter(any());
+    }
+
+    @Test
+    public void importRepositoryWhenUrlNeedsTrimTest() {
+        ExampleRepository repository = new ExampleRepository("repoUrl",
+                                                             new Credentials("username",
+                                                                             "password"));
+
+        doReturn("     repoUrl     ").when(view).getRepositoryURL();
+        doReturn("username").when(view).getUserName();
+        doReturn("password").when(view).getPassword();
+
+        presenter.importRepository();
+
+        verify(libraryService).getProjects(repository);
     }
 
     @Test


### PR DESCRIPTION
JIRA task: [AF-2213](https://issues.jboss.org/browse/AF-2213)
If the URL has a leading or trailing space for importing a git project, the import fails.

Thus, trimming the URL in order to automatically handle this case for the user.

@paulovmr 