### PR TITLE
RHPAM-2360 - Signal name cannot be dynamic

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
@@ -35,28 +35,33 @@ import org.kie.workbench.common.stunner.core.definition.annotation.property.Valu
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class SignalRef implements BPMNProperty {
 
-    protected final static String STATIC_EXP = "[a-zA-Z0-9_]+";
-    protected final static String OR_EXP = "|";
-    protected final static String EXP_SEPARATOR = "[\\-]";
-    protected final static String MVEL_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[}]{1}";
-    protected final static String MVEL_PARAM_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[(]{1}[a-zA-Z0-9._\",\\s]+[)]{1}[}]{1}";
+    protected static final String STATIC_EXP = "[a-zA-Z0-9_]+";
+    protected static final String OR_EXP = "|";
+    protected static final String EXP_SEPARATOR = "[\\-]";
+    protected static final String MVEL_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[}]{1}";
+    protected static final String MVEL_COMPLEX_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[.]+[a-zA-Z0-9_]+[}]{1}";
+    protected static final String MVEL_COMPLEX_PARAM_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[(]{1}[a-zA-Z0-9._\",\\s]+[)]{1}[}]{1}";
 
     @Value
     @FieldValue
-    @Pattern(regexp = STATIC_EXP + EXP_SEPARATOR + MVEL_PARAM_EXP +
-                      OR_EXP +
-                      STATIC_EXP + EXP_SEPARATOR + MVEL_EXP +
-                      OR_EXP +
-                      STATIC_EXP + EXP_SEPARATOR + STATIC_EXP +
-                      OR_EXP +
-                      MVEL_PARAM_EXP +
-                      OR_EXP +
-                      MVEL_EXP +
-                      OR_EXP +
-                      STATIC_EXP +
-                      OR_EXP +
-                      "^$",
-             message = "Invalid characters. Click ? icon for more information")
+    @Pattern(regexp = STATIC_EXP + EXP_SEPARATOR + MVEL_COMPLEX_PARAM_EXP +
+            OR_EXP +
+            STATIC_EXP + EXP_SEPARATOR + MVEL_COMPLEX_EXP +
+            OR_EXP +
+            STATIC_EXP + EXP_SEPARATOR + MVEL_EXP +
+            OR_EXP +
+            STATIC_EXP + EXP_SEPARATOR + STATIC_EXP +
+            OR_EXP +
+            MVEL_COMPLEX_PARAM_EXP +
+            OR_EXP +
+            MVEL_COMPLEX_EXP +
+            OR_EXP +
+            MVEL_EXP +
+            OR_EXP +
+            STATIC_EXP +
+            OR_EXP +
+            "^$",
+            message = "Invalid characters. Hover over the \"i\" icon for more information")
     private String value;
 
     public SignalRef() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
@@ -35,9 +35,28 @@ import org.kie.workbench.common.stunner.core.definition.annotation.property.Valu
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class SignalRef implements BPMNProperty {
 
+    protected final static String STATIC_EXP = "[a-zA-Z0-9_]+";
+    protected final static String OR_EXP = "|";
+    protected final static String EXP_SEPARATOR = "[\\-]";
+    protected final static String MVEL_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[}]{1}";
+    protected final static String MVEL_PARAM_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[(]{1}[a-zA-Z0-9._\",\\s]+[)]{1}[}]{1}";
+
     @Value
     @FieldValue
-    @Pattern(regexp = "^$|[a-zA-Z0-9_]+|[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[}]{1}|[#]{1}[{]{1}[a-zA-Z0-9_]+[.]*[a-zA-Z0-9_]+[(]{1}[a-zA-Z0-9._\",\\s]+[)]{1}[}]{1}")
+    @Pattern(regexp = STATIC_EXP + EXP_SEPARATOR + MVEL_PARAM_EXP +
+                      OR_EXP +
+                      STATIC_EXP + EXP_SEPARATOR + MVEL_EXP +
+                      OR_EXP +
+                      STATIC_EXP + EXP_SEPARATOR + STATIC_EXP +
+                      OR_EXP +
+                      MVEL_PARAM_EXP +
+                      OR_EXP +
+                      MVEL_EXP +
+                      OR_EXP +
+                      STATIC_EXP +
+                      OR_EXP +
+                      "^$",
+             message = "Invalid characters. Click ? icon for more information")
     private String value;
 
     public SignalRef() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -284,7 +284,14 @@ org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.Interrupt
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.ScopedSignalEventExecutionSet.label=Implementation/Execution
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.label=Signal
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.description=The Signal Reference
-org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.helpMessage=The allowed characters for the SignalRef are alphanumeric characters (a-z, A-Z, 0-9) and underscore '_'
+org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.helpMessage=The allowed characters for the SignalRef are alphanumeric characters (a-z, A-Z, 0-9) and underscore "_".<br>\
+                                                                                             <br>\
+                                                                                             The following expressions are accepted:<br>\
+                                                                                             <ul><li>#{var}</li>\
+                                                                                             <li>#{obj.prop}</li>\
+                                                                                             <li>#{obj.met(var,o3.var)}</li></ul>\
+                                                                                             <br>\
+                                                                                             You can combine two expressions using hyphen "-" (e.g., exp-#{var}).
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalScope.label=Signal Scope
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalScope.description=Defines the Signal Propagation Scope
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
@@ -40,7 +40,13 @@ public class SignalRefTest {
 
     private static final String MVEL_INVALID_EXPRESSION = "#{.expression}";
 
-    private static final String MVEL_SYSTEM_PROPERTY = "#{System.getProperty(\"search.value\", \"default.value\")}";
+    private static final String MVEL_PARAM_EXPRESSION = "#{System.getProperty(\"search.value\", \"default.value\")}";
+
+    private static final String MIXED_MVEL_EXPRESSION = VALID_REF + "-" + MVEL_EXPRESSION ;
+
+    private static final String MIXED_MVEL_PARAM_EXPRESSION = VALID_REF + "-" + MVEL_PARAM_EXPRESSION ;
+
+    private static final String MIXED_EXPRESSION = VALID_REF + "-" + VALID_REF ;
 
     private Validator validator;
 
@@ -77,8 +83,8 @@ public class SignalRefTest {
     }
 
     @Test
-    public void testSignalRefWithMvelSystemProperty() {
-        SignalRef signalRef = new SignalRef(MVEL_SYSTEM_PROPERTY);
+    public void testSignalRefWithMvelParameterExpression() {
+        SignalRef signalRef = new SignalRef(MVEL_PARAM_EXPRESSION);
 
         Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
 
@@ -110,5 +116,32 @@ public class SignalRefTest {
         Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
 
         assertFalse(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithMixedMvelExpression() {
+        SignalRef signalRef = new SignalRef(MIXED_MVEL_EXPRESSION);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithMixedMvelParamExpression() {
+        SignalRef signalRef = new SignalRef(MIXED_MVEL_PARAM_EXPRESSION);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
+    }
+
+    @Test
+    public void testSignalRefWithMixedExpression() {
+        SignalRef signalRef = new SignalRef(MIXED_EXPRESSION);
+
+        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
+
+        assertTrue(validations.isEmpty());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
@@ -30,23 +30,52 @@ import static org.junit.Assert.assertTrue;
 
 public class SignalRefTest {
 
-    private static final String WRONG_REF = "~`!@#$%^&*()_+=-{}|][:\"';?><,./";
-
-    private static final String VALID_REF = "validSIGNALREF0123456789_";
-
-    private static final String MVEL_EXPRESSION = "#{validSIGNALREF0123456789_mvel}";
-
     private static final String MVEL_COMPLEX_OBJECT_EXPRESSION = "#{myObj.property}";
 
     private static final String MVEL_INVALID_EXPRESSION = "#{.expression}";
 
     private static final String MVEL_PARAM_EXPRESSION = "#{System.getProperty(\"search.value\", \"default.value\")}";
 
-    private static final String MIXED_MVEL_EXPRESSION = VALID_REF + "-" + MVEL_EXPRESSION ;
+    private static final String EMPTY_REF = "";
 
-    private static final String MIXED_MVEL_PARAM_EXPRESSION = VALID_REF + "-" + MVEL_PARAM_EXPRESSION ;
+    private static final String EXP_SEPARATOR = "-";
 
-    private static final String MIXED_EXPRESSION = VALID_REF + "-" + VALID_REF ;
+    private static final String VALID_STATIC_REF = "validSIGNALREF0123456789_";
+
+    private static final String VALID_MVEL_REF_1 = "#{myObj}";
+    private static final String VALID_MVEL_REF_2 = "#{m}";
+
+    private static final String VALID_MVEL_COMPLEX_REF_1 = "#{myObj.property}";
+    private static final String VALID_MVEL_COMPLEX_REF_2 = "#{m.p}";
+
+    private static final String VALID_MVEL_COMPLEX_PARAM_REF_1 = "#{myObj.property(parameter)}";
+    private static final String VALID_MVEL_COMPLEX_PARAM_REF_2 = "#{m.p(p)}";
+
+    private static final String VALID_COMBINATION_1 = VALID_STATIC_REF + EXP_SEPARATOR + VALID_STATIC_REF;
+    private static final String VALID_COMBINATION_2 = VALID_STATIC_REF + EXP_SEPARATOR + VALID_MVEL_REF_1;
+    private static final String VALID_COMBINATION_3 = VALID_STATIC_REF + EXP_SEPARATOR + VALID_MVEL_COMPLEX_REF_1;
+    private static final String VALID_COMBINATION_4 = VALID_STATIC_REF + EXP_SEPARATOR + VALID_MVEL_COMPLEX_PARAM_REF_1;
+
+    private static final String INVALID_STATIC_REF = "~`!@#$%^&*()_+=-{}|][:\"';?><,./";
+
+    private static final String INVALID_MVEL_REF = "#{~`!@#$%^&*()_+=-{}|][:\"';?><,./}";
+
+    private static final String INVALID_MVEL_COMPLEX_REF_1 = "#{m.}";
+    private static final String INVALID_MVEL_COMPLEX_REF_2 = "#{.p}";
+    private static final String INVALID_MVEL_COMPLEX_REF_3 = "#{m.~`!@#$%^&*()_+=-{}|][:\"';?><,./}";
+    private static final String INVALID_MVEL_COMPLEX_REF_4 = "#{m.~`!@#$%^&*()_+=-{}|][:\"';?><,./}";
+
+    private static final String INVALID_MVEL_PARAM_COMPLEX_REF_1 = "#{myObj.property()}";
+    private static final String INVALID_MVEL_PARAM_COMPLEX_REF_2 = "#{m.p()}";
+    private static final String INVALID_MVEL_PARAM_COMPLEX_REF_3 = "#{m.(parameter)}";
+    private static final String INVALID_MVEL_PARAM_COMPLEX_REF_4 = "#{.p(parameter)}";
+    private static final String INVALID_MVEL_PARAM_COMPLEX_REF_5 = "#{.(parameter)}";
+    private static final String INVALID_MVEL_PARAM_COMPLEX_REF_6 = "#{myObj~.property(parameter)}";
+
+    private static final String INVALID_COMBINATION_1 = INVALID_STATIC_REF + VALID_STATIC_REF;
+    private static final String INVALID_COMBINATION_2 = VALID_STATIC_REF + VALID_MVEL_REF_1;
+    private static final String INVALID_COMBINATION_3 = VALID_STATIC_REF + VALID_MVEL_COMPLEX_REF_1;
+    private static final String INVALID_COMBINATION_4 = VALID_STATIC_REF + VALID_MVEL_COMPLEX_PARAM_REF_1;
 
     private Validator validator;
 
@@ -56,92 +85,48 @@ public class SignalRefTest {
     }
 
     @Test
-    public void testSignalRefWithEmptySignal() {
-        SignalRef signalRef = new SignalRef();
+    public void testSignalRef() {
+        assertValidExpression(EMPTY_REF);
+        assertValidExpression(VALID_STATIC_REF);
+        assertValidExpression(VALID_MVEL_REF_1);
+        assertValidExpression(VALID_MVEL_REF_2);
+        assertValidExpression(VALID_MVEL_COMPLEX_REF_1);
+        assertValidExpression(VALID_MVEL_COMPLEX_REF_2);
+        assertValidExpression(VALID_MVEL_COMPLEX_PARAM_REF_1);
+        assertValidExpression(VALID_MVEL_COMPLEX_PARAM_REF_2);
+        assertValidExpression(VALID_COMBINATION_1);
+        assertValidExpression(VALID_COMBINATION_2);
+        assertValidExpression(VALID_COMBINATION_3);
+        assertValidExpression(VALID_COMBINATION_4);
 
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
+        assertInvalidExpression(INVALID_STATIC_REF);
+        assertInvalidExpression(INVALID_MVEL_REF);
+        assertInvalidExpression(INVALID_MVEL_COMPLEX_REF_1);
+        assertInvalidExpression(INVALID_MVEL_COMPLEX_REF_2);
+        assertInvalidExpression(INVALID_MVEL_COMPLEX_REF_3);
+        assertInvalidExpression(INVALID_MVEL_COMPLEX_REF_4);
+        assertInvalidExpression(INVALID_MVEL_PARAM_COMPLEX_REF_1);
+        assertInvalidExpression(INVALID_MVEL_PARAM_COMPLEX_REF_2);
+        assertInvalidExpression(INVALID_MVEL_PARAM_COMPLEX_REF_3);
+        assertInvalidExpression(INVALID_MVEL_PARAM_COMPLEX_REF_4);
+        assertInvalidExpression(INVALID_MVEL_PARAM_COMPLEX_REF_5);
+        assertInvalidExpression(INVALID_MVEL_PARAM_COMPLEX_REF_6);
+        assertInvalidExpression(INVALID_COMBINATION_1);
+        assertInvalidExpression(INVALID_COMBINATION_2);
+        assertInvalidExpression(INVALID_COMBINATION_3);
+        assertInvalidExpression(INVALID_COMBINATION_4);
     }
 
-    @Test
-    public void testSignalRefWithMvelExpression() {
-        SignalRef signalRef = new SignalRef(MVEL_EXPRESSION);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
+    private Set<ConstraintViolation<SignalRef>> validateExpression(String expression) {
+        final SignalRef signalRef = new SignalRef(expression);
+        return validator.validate(signalRef);
     }
 
-    @Test
-    public void testSignalRefWithMvelComplexObjectExpression() {
-        SignalRef signalRef = new SignalRef(MVEL_COMPLEX_OBJECT_EXPRESSION);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
+    private void assertValidExpression(String expression) {
+        assertTrue(validateExpression(expression).isEmpty());
     }
 
-    @Test
-    public void testSignalRefWithMvelParameterExpression() {
-        SignalRef signalRef = new SignalRef(MVEL_PARAM_EXPRESSION);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
-    }
-
-    @Test
-    public void testSignalRefWithMvelInvalidExpression() {
-        SignalRef signalRef = new SignalRef(MVEL_INVALID_EXPRESSION);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertFalse(validations.isEmpty());
-    }
-
-    @Test
-    public void testSignalRefWithValidSignal() {
-        SignalRef signalRef = new SignalRef(VALID_REF);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
-    }
-
-    @Test
-    public void testSignalRefWithWrongSignal() {
-        SignalRef signalRef = new SignalRef(WRONG_REF);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertFalse(validations.isEmpty());
-    }
-
-    @Test
-    public void testSignalRefWithMixedMvelExpression() {
-        SignalRef signalRef = new SignalRef(MIXED_MVEL_EXPRESSION);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
-    }
-
-    @Test
-    public void testSignalRefWithMixedMvelParamExpression() {
-        SignalRef signalRef = new SignalRef(MIXED_MVEL_PARAM_EXPRESSION);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
-    }
-
-    @Test
-    public void testSignalRefWithMixedExpression() {
-        SignalRef signalRef = new SignalRef(MIXED_EXPRESSION);
-
-        Set<ConstraintViolation<SignalRef>> validations = validator.validate(signalRef);
-
-        assertTrue(validations.isEmpty());
+    private void assertInvalidExpression(String expression) {
+        assertFalse(validateExpression(expression).isEmpty());
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/RHPAM-2360

Signal now supports mixed expressions (static and dynamic). 