### PR TITLE
[AF-2216] Generic Error Pop Up when server is shutdown

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/entrypoint/GenericErrorPopup.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/entrypoint/GenericErrorPopup.java
@@ -33,6 +33,7 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.workbench.client.resources.i18n.DefaultWorkbenchConstants;
 import org.uberfire.client.util.Clipboard;
 import org.uberfire.ext.editor.commons.client.file.popups.elemental2.Elemental2Modal;
+import org.uberfire.mvp.Command;
 import org.uberfire.workbench.events.NotificationEvent;
 
 import static elemental2.dom.DomGlobal.console;
@@ -69,8 +70,9 @@ public class GenericErrorPopup extends Elemental2Modal<GenericErrorPopup> implem
 
     @Inject
     private Event<NotificationEvent> notificationEvent;
-    
+
     private final Clipboard clipboard;
+    private Command onClose = () -> {};
 
     @Inject
     public GenericErrorPopup(final GenericErrorPopup view,
@@ -90,18 +92,31 @@ public class GenericErrorPopup extends Elemental2Modal<GenericErrorPopup> implem
     }
 
     public void setup(final String details) {
+        setup(details,
+              () -> {});
+    }
+
+    public void setup(final String details,
+                      final Command onClose) {
         if (isShowing()) {
             //If multiple errors occur, we want to know the details of each one of them. In order.
             errorDetails.textContent += " | " + details;
         } else {
             errorDetails.textContent = details;
         }
+
+        this.onClose = onClose;
+    }
+    
+    public void close() {
+        hide();
+        this.onClose.execute();
     }
 
     @EventHandler("ignore-button")
     private void onIgnoreButtonClicked(final @ForEvent("click") elemental2.dom.Event e) {
         console.error(errorDetails.textContent);
-        hide();
+        close();
     }
 
     @EventHandler("copy-details-button")

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallback.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallback.java
@@ -16,16 +16,23 @@
 
 package org.kie.workbench.common.workbench.client.error;
 
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.List;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.Window;
+
 import org.dashbuilder.dataset.exception.DataSetLookupException;
 import org.jboss.errai.bus.client.api.InvalidBusContentException;
 import org.kie.server.api.exception.KieServicesException;
 import org.kie.server.api.exception.KieServicesHttpException;
 import org.kie.workbench.common.workbench.client.entrypoint.GenericErrorPopup;
 import org.kie.workbench.common.workbench.client.resources.i18n.DefaultWorkbenchConstants;
+import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 import org.uberfire.ext.widgets.common.client.common.popups.YesNoCancelPopup;
 import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.ext.widgets.common.client.resources.i18n.CommonConstants;
@@ -35,6 +42,8 @@ public class DefaultWorkbenchErrorCallback {
 
     @Inject
     private GenericErrorPopup genericErrorPopup;
+
+    private Queue<Throwable> queue = new ArrayDeque<>();
 
     public static boolean isKieServerForbiddenException(final Throwable throwable) {
         if (throwable instanceof KieServicesHttpException && ((KieServicesHttpException) throwable).getHttpCode() == 403) {
@@ -64,7 +73,55 @@ public class DefaultWorkbenchErrorCallback {
         return throwable instanceof InvalidBusContentException;
     }
 
+    public static boolean isServerOfflineException(final Throwable throwable) {
+        Throwable cause = throwable.getCause();
+        String message = throwable.getMessage();
+        List<String> messages = Arrays.asList(
+                "Script error. (:0)",
+                "Error parsing JSON: SyntaxError: Unexpected token � in JSON at position 1");
+
+        return cause == null
+            && message != null
+            && messages.stream().anyMatch(m -> message.equals(m));
+    }
+
     public void error(final Throwable throwable) {
+        BusyPopup.close();
+        queue(throwable);
+
+        if (queue.size() == 1) {
+            processQueue();
+        }
+    }
+    
+    public void queue(final Throwable throwable) {
+        queue.add(throwable);
+    }
+
+    public void dequeue() {
+        queue.poll();
+        processQueue();
+    }
+
+    public void processQueue() {
+        Throwable throwable = queue.peek();
+
+        if (throwable == null) {
+            return;
+        }
+
+        if (isServerOfflineException(throwable)) {
+            final YesNoCancelPopup result = YesNoCancelPopup.newYesNoCancelPopup(
+                    DefaultWorkbenchConstants.INSTANCE.DisconnectedFromServer(),
+                    DefaultWorkbenchConstants.INSTANCE.CouldNotConnectToServer(),
+                    Window.Location::reload,
+                    null,
+                    this::dequeue);
+
+            result.clearScrollHeight();
+            result.show();
+            return;
+        }
 
         if (isInvalidBusContentException(throwable)) {
             final YesNoCancelPopup result = YesNoCancelPopup.newYesNoCancelPopup(
@@ -72,8 +129,7 @@ public class DefaultWorkbenchErrorCallback {
                     DefaultWorkbenchConstants.INSTANCE.InvalidBusResponseProbablySessionTimeout(),
                     Window.Location::reload,
                     null,
-                    () -> {
-                    });
+                    this::dequeue);
 
             result.clearScrollHeight();
             result.show();
@@ -81,37 +137,52 @@ public class DefaultWorkbenchErrorCallback {
         }
 
         if (isKieServerForbiddenException(throwable)) {
-            ErrorPopup.showMessage(DefaultWorkbenchConstants.INSTANCE.KieServerError403());
+            ErrorPopup.showMessage(
+                    DefaultWorkbenchConstants.INSTANCE.KieServerError403(),
+                    () -> {},
+                    this::dequeue);
             return;
         }
 
         if (isKieServerUnauthorizedException(throwable)) {
-            ErrorPopup.showMessage(DefaultWorkbenchConstants.INSTANCE.KieServerError401());
+            ErrorPopup.showMessage(
+                    DefaultWorkbenchConstants.INSTANCE.KieServerError401(),
+                    () -> {},
+                    this::dequeue);
             return;
         }
 
         if (throwable instanceof DataSetLookupException) {
             DataSetLookupException ex = (DataSetLookupException) throwable;
-            ErrorPopup.showMessage(CommonConstants.INSTANCE.ExceptionGeneric0(ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage()));
+            ErrorPopup.showMessage(
+                    CommonConstants.INSTANCE.ExceptionGeneric0(ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage()),
+                    () -> {},
+                    this::dequeue);
             return;
         }
 
         if (throwable instanceof KieServicesHttpException) {
             KieServicesHttpException ex = (KieServicesHttpException) throwable;
-            ErrorPopup.showMessage(CommonConstants.INSTANCE.ExceptionGeneric0(ex.getExceptionMessage()));
+            ErrorPopup.showMessage(
+                    CommonConstants.INSTANCE.ExceptionGeneric0(ex.getExceptionMessage()),
+                    () -> {},
+                    this::dequeue);
             return;
         }
 
         if (throwable instanceof KieServicesException) {
             KieServicesException ex = (KieServicesException) throwable;
-            ErrorPopup.showMessage(CommonConstants.INSTANCE.ExceptionGeneric0(ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage()));
+            ErrorPopup.showMessage(
+                    CommonConstants.INSTANCE.ExceptionGeneric0(ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage()),
+                    () -> {},
+                    this::dequeue);
             return;
         }
 
         genericErrorPopup.show();
-        genericErrorPopup.setup("Uncaught exception: " + extractMessageRecursively(throwable));
+        genericErrorPopup.setup("Uncaught exception: " + extractMessageRecursively(throwable),
+                                this::dequeue);
     }
-
 
     private String extractMessageRecursively(final Throwable t) {
         if (t.getCause() == null) {

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallback.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallback.java
@@ -78,7 +78,8 @@ public class DefaultWorkbenchErrorCallback {
         String message = throwable.getMessage();
         List<String> messages = Arrays.asList(
                 "Script error. (:0)",
-                "Error parsing JSON: SyntaxError: Unexpected token � in JSON at position 1");
+                "Error parsing JSON: SyntaxError: Unexpected token � in JSON at position 1",
+                "Error parsing JSON: SyntaxError: JSON.parse: unexpected character at line 1 column 2 of the JSON data");
 
         return cause == null
             && message != null

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.java
@@ -178,4 +178,8 @@ public interface DefaultWorkbenchConstants
     String AccessDataTransfer();
 
     String AccessDataTransferHelp();
+
+    String DisconnectedFromServer();
+
+    String CouldNotConnectToServer();
 }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants.properties
@@ -90,3 +90,5 @@ ServiceTasksAdministration=Service Tasks Administration
 DataTransfer=Dashbuilder Data Transfer
 AccessDataTransfer=Access to Dashbuilder Data Transfer
 AccessDataTransferHelp=Permission to import and export dashbuilder data (datasets, perspectives and navigation).
+DisconnectedFromServer=Disconnected from server
+CouldNotConnectToServer=Could not connect to server. This very likely means a network problem. Do you want to reload the application?

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallbackTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallbackTest.java
@@ -94,6 +94,7 @@ public class DefaultWorkbenchErrorCallbackTest {
     public void testIsServerOfflineException() {
         assertTrue(isServerOfflineException(new Exception("Script error. (:0)")));
         assertTrue(isServerOfflineException(new Exception("Error parsing JSON: SyntaxError: Unexpected token � in JSON at position 1")));
+        assertTrue(isServerOfflineException(new Exception("Error parsing JSON: SyntaxError: JSON.parse: unexpected character at line 1 column 2 of the JSON data")));
         assertFalse(isServerOfflineException(new Exception("test")));
         assertFalse(isServerOfflineException(new Exception("")));
     }

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallbackTest.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/test/java/org/kie/workbench/common/workbench/client/error/DefaultWorkbenchErrorCallbackTest.java
@@ -29,10 +29,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback.isInvalidBusContentException;
+import static org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback.isServerOfflineException;
 import static org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback.isKieServerForbiddenException;
 import static org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback.isKieServerUnauthorizedException;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.eq;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultWorkbenchErrorCallbackTest {
@@ -42,7 +45,7 @@ public class DefaultWorkbenchErrorCallbackTest {
 
     @InjectMocks
     private DefaultWorkbenchErrorCallback callback;
-    
+
     @Test
     public void testForbiddenException() {
         assertTrue(isKieServerForbiddenException(new KieServicesHttpException(null,
@@ -84,16 +87,49 @@ public class DefaultWorkbenchErrorCallbackTest {
     @Test
     public void testInvalidBusContentException() {
         assertTrue(isInvalidBusContentException(new InvalidBusContentException("text/html", "content")));
-
         assertFalse(isInvalidBusContentException(new RuntimeException()));
     }
-    
+
     @Test
-    public void testGenericPopup(){
-        callback.error(new RuntimeException("ex"));
+    public void testIsServerOfflineException() {
+        assertTrue(isServerOfflineException(new Exception("Script error. (:0)")));
+        assertTrue(isServerOfflineException(new Exception("Error parsing JSON: SyntaxError: Unexpected token � in JSON at position 1")));
+        assertFalse(isServerOfflineException(new Exception("test")));
+        assertFalse(isServerOfflineException(new Exception("")));
+    }
+
+    @Test
+    public void testGenericPopup() {
+        callback.queue(new RuntimeException("ex"));
+        callback.processQueue();
 
         InOrder inOrder = inOrder(genericErrorPopup);
         inOrder.verify(genericErrorPopup).show();
-        inOrder.verify(genericErrorPopup).setup(any());
+        inOrder.verify(genericErrorPopup).setup(any(), any());
+    }
+
+    @Test
+    public void testQueue() {
+        callback.queue(new Exception("a"));
+        callback.queue(new Exception("b"));
+        callback.queue(new Exception("c"));
+
+        callback.processQueue();
+
+        InOrder inOrder = inOrder(genericErrorPopup);
+        inOrder.verify(genericErrorPopup, times(1)).show();
+        inOrder.verify(genericErrorPopup).setup(eq("Uncaught exception: a"), any());
+
+        callback.dequeue();
+        callback.processQueue();
+
+        inOrder.verify(genericErrorPopup, times(1)).show();
+        inOrder.verify(genericErrorPopup).setup(eq("Uncaught exception: b"), any());
+
+        callback.dequeue();
+        callback.processQueue();
+
+        inOrder.verify(genericErrorPopup, times(1)).show();
+        inOrder.verify(genericErrorPopup).setup(eq("Uncaught exception: c"), any());
     }
 }


### PR DESCRIPTION
**[AF-2216](https://issues.jboss.org/browse/AF-2216) Generic Error Pop Up when server is shutdown**

**Issue:**
A Generic Error Pop Up is show when server is shutdown

**Solution:**
Show an appropriated pop up to user when server is shutdown

**Edge Cases:**
* on HA environments
* when server is shutdown in the middle of some operation that shows Busy Pop Up (for example, when creating a new Project). In this case, Busy Pop Up is never closed and the application hangs

**Notes:**
* tested on HA environment and didn't find any issues
* created a new pop up "*Could not connect to server. This very likely means a network problem. Do you want to reload the application?*" similar to an existing pop up that is shown when session timeouts "*Invalid response received from the server. This very likely means that you have been logged out due to inactivity. Do you want to log in again?*"
* I could not find a better way to identify that server is shutdown inside Catch-All logic. Errai is able to identify that server got disconnected and to notify this event (see ClientMessageBusImpl.java), but this happens after Catch-All handle the exception
* created a queue system to avoid multiple popups to show one on top of another. This way, the next popup will shown when user closes the first one, as in a FIFO system