### PR TITLE
DROOLS-4545: Do not show Analysis Complete for Illegal Verifier State

### DIFF
--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenView.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenView.java
@@ -36,4 +36,6 @@ public interface AnalysisReportScreenView
     void showStatusTitle(final int start,
                          final int end,
                          final int totalCheckCount);
+
+    void hideProgressStatus();
 }

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenViewImpl.html
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenViewImpl.html
@@ -16,7 +16,7 @@
   -->
 
 <div height="100%">
-    <div data-toggle="tooltip" title="" style="height: 25px; width: 100%; background-color: #ffc;">
+    <div id="progressTooltip" data-toggle="tooltip" title="" style="height: 25px; width: 100%; background-color: #ffc;">
         <div id="progressPanel" style="height: 25px; width: 100%; color:WHITE; text-align: center; padding-top: 3px;"></div>
     </div>
     <div style="height: 100px; overflow-y: scroll; padding: 3px 3px 3px 3px;">

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenViewImpl.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenViewImpl.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.cellview.client.CellList;
 import com.google.gwt.user.cellview.client.HasKeyboardPagingPolicy;
 import com.google.gwt.user.cellview.client.HasKeyboardSelectionPolicy;
@@ -44,6 +45,9 @@ public class AnalysisReportScreenViewImpl
                    RequiresResize {
 
     private AnalysisReportScreen presenter;
+
+    @DataField("progressTooltip")
+    Element progressTooltip = DOM.createDiv();
 
     @DataField("progressPanel")
     Element progressPanel = DOM.createDiv();
@@ -107,6 +111,7 @@ public class AnalysisReportScreenViewImpl
 
     @Override
     public void showStatusComplete() {
+        progressTooltip.getStyle().setVisibility(Style.Visibility.VISIBLE);
         progressPanel.getStyle().setColor("WHITE");
         progressPanel.getStyle().setBackgroundColor("GREEN");
         progressPanel.setInnerHTML(AnalysisConstants.INSTANCE.AnalysisComplete());
@@ -116,12 +121,17 @@ public class AnalysisReportScreenViewImpl
     public void showStatusTitle(final int start,
                                 final int end,
                                 final int totalCheckCount) {
-
+        progressTooltip.getStyle().setVisibility(Style.Visibility.VISIBLE);
         progressPanel.getStyle().setColor("BLACK");
         progressPanel.getStyle().setBackgroundColor("#ffc");
         progressPanel.setInnerHTML(AnalysisConstants.INSTANCE.AnalysingChecks0To1Of2(start,
                                                                                      end,
                                                                                      totalCheckCount));
+    }
+
+    @Override
+    public void hideProgressStatus() {
+        progressTooltip.getStyle().setVisibility(Style.Visibility.HIDDEN);
     }
 
     @Override

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenTest.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenTest.java
@@ -129,6 +129,22 @@ public class AnalysisReportScreenTest {
     }
 
     @Test
+    public void testShowReportIllegalState() {
+        final Issue illegalStateIssue = new Issue(Severity.ERROR,
+                                                  CheckType.ILLEGAL_VERIFIER_STATE,
+                                                  Collections.emptySet());
+        screen.showReport(getAnalysis(illegalStateIssue));
+
+        verify(placeManager).goTo(eq("org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen"));
+
+        assertEquals(1,
+                     dataProvider.getList().size());
+        assertTrue(dataProvider.getList().contains(illegalStateIssue));
+
+        verify(view).hideProgressStatus();
+    }
+
+    @Test
     public void testMergeEmptyRules() throws
             Exception {
         testMerge(CheckType.EMPTY_RULE);

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenViewImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/AnalysisReportScreenViewImplTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.verifier.reporting.client.panel;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class AnalysisReportScreenViewImplTest {
+
+    @Mock
+    private Element progressTooltip;
+
+    @Mock
+    private Style style;
+
+    private AnalysisReportScreenViewImpl view;
+
+    @Before
+    public void setUp() throws Exception {
+        view = new AnalysisReportScreenViewImpl();
+        view.progressTooltip = progressTooltip;
+
+        when(progressTooltip.getStyle()).thenReturn(style);
+    }
+
+    @Test
+    public void testHideProgressStatus() {
+        view.hideProgressStatus();
+
+        verify(style).setVisibility(Style.Visibility.HIDDEN);
+    }
+
+    @Test
+    public void testStatusComplete() {
+        view.showStatusComplete();
+
+        verify(style).setVisibility(Style.Visibility.VISIBLE);
+    }
+
+    @Test
+    public void testStatusTitle() {
+        view.showStatusTitle(0, 1, 1);
+
+        verify(style).setVisibility(Style.Visibility.VISIBLE);
+    }
+}


### PR DESCRIPTION
This PR is dependent on the #2909, if we decide merging, I will rebase once #2909 is merged.

This PR introduces "enhancement" of not showing "Analysis Complete" indicator for cases when verifier is in illegal state. For more details see the screenshots.

![Screenshot from 2019-09-26 09-33-29](https://user-images.githubusercontent.com/8044780/65668126-6a27cc80-e041-11e9-85e0-e55018e41b1a.png)

![Screenshot from 2019-09-26 09-32-56](https://user-images.githubusercontent.com/8044780/65668139-6dbb5380-e041-11e9-8149-e44609973c4b.png)


@manstis @Rikkola @karreiro @danielzhe what do you think?