### PR TITLE
managing java validation-api for 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
   </modules>
 
   <properties>
+      <!-- Version 2.0.1.Final which is coming from kie-parent is not compatible with appformer validation components -->
+    <version.javax.validation>1.0.0.GA</version.javax.validation>
     <spotbugs.failOnViolation>true</spotbugs.failOnViolation>
     <checkstyle.header.template><![CDATA[
 ^\/\*$\n^
@@ -55,6 +57,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>${version.javax.validation}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.jboss.errai</groupId>


### PR DESCRIPTION
this is dependent PR for: 
* kiegroup/droolsjbpm-build-bootstrap#1055
* https://github.com/kiegroup/appformer/pull/806