### PR TITLE
[AF-2058] Fixing the OpenShift client API compatibility issue after upgraded io.fabric8 kubernetes client to 4.6.0

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-provider/src/main/java/org/guvnor/ala/openshift/config/OpenShiftProperty.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-provider/src/main/java/org/guvnor/ala/openshift/config/OpenShiftProperty.java
@@ -67,7 +67,7 @@ public enum OpenShiftProperty {
     /* ---------- Provider properties: OpenShift Client ---------- */
     KUBERNETES_OAPI_VERSION(OpenShiftConfig.KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY),
     OPENSHIFT_BUILD_TIMEOUT(OpenShiftConfig.OPENSHIFT_BUILD_TIMEOUT_SYSTEM_PROPERTY),
-    OPENSHIFT_URL(OpenShiftConfig.OPENSHIFT_URL_SYTEM_PROPERTY),
+    OPENSHIFT_URL(OpenShiftConfig.OPENSHIFT_URL_SYSTEM_PROPERTY),
 
     /* ---------- Provider properties: Guvnor ALA API ---------- */
     PROVIDER_NAME(ProviderConfig.PROVIDER_NAME.replaceAll("-", ".")),


### PR DESCRIPTION
Followed by the original PR for [AF-2058] Provide alternative implementation of uberfire-nio2-impls b…acked by OCP/K8S

Signed-off-by: Evan Zhang <evan.zhang@redhat.com>