### PR TITLE
DROOLS-3652: DMN popover - Enter to apply

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/CanBeClosedByKeyboard.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/CanBeClosedByKeyboard.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types;
+
+import java.util.function.Consumer;
+
+public interface CanBeClosedByKeyboard {
+
+    void setOnClosedByKeyboardCallback(final Consumer callback);
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/CanBeClosedByKeyboard.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/CanBeClosedByKeyboard.java
@@ -20,5 +20,5 @@ import java.util.function.Consumer;
 
 public interface CanBeClosedByKeyboard {
 
-    void setOnClosedByKeyboardCallback(final Consumer callback);
+    void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImpl.java
@@ -85,7 +85,7 @@ public class NameAndDataTypePopoverImpl implements NameAndDataTypePopoverView.Pr
     }
 
     @Override
-    public void setOnClosedByKeyboardCallback(final Consumer callback) {
+    public void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback) {
         view.setOnClosedByKeyboardCallback(callback);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImpl.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.types;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -81,5 +82,10 @@ public class NameAndDataTypePopoverImpl implements NameAndDataTypePopoverView.Pr
     @Override
     public void hide() {
         binding.ifPresent(b -> view.hide());
+    }
+
+    @Override
+    public void setOnClosedByKeyboardCallback(final Consumer callback) {
+        view.setOnClosedByKeyboardCallback(callback);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverView.java
@@ -23,9 +23,10 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.Popover
 import org.uberfire.client.mvp.UberElement;
 
 public interface NameAndDataTypePopoverView extends PopoverView,
-                                                    UberElement<NameAndDataTypePopoverView.Presenter> {
+                                                    UberElement<NameAndDataTypePopoverView.Presenter>,
+                                                    CanBeClosedByKeyboard{
 
-    interface Presenter extends HasCellEditorControls.Editor<HasNameAndTypeRef> {
+    interface Presenter extends HasCellEditorControls.Editor<HasNameAndTypeRef>, CanBeClosedByKeyboard {
 
         void setName(final String name);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.html
@@ -13,7 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<div data-field="popover" data-toggle="popover" data-trigger="manual" data-container="#popover-container" title="i18ned" data-close="true">
+<div data-field="popover" data-toggle="popover" data-trigger="manual" data-container="#popover-container" title="i18ned" data-close="true" tabindex="0">
     <div id="popover-container"></div>
     <div id="popover-content">
         <div class="kie-dmn-name-and-data-type-container">

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
@@ -349,6 +349,7 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
         if (!Objects.isNull(previousTypeRef)) {
             typeRefEditor.setValue(previousTypeRef);
         }
+        currentName = previousName;
         previousTypeRef = null;
         currentTypeRef = null;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
@@ -27,6 +27,7 @@ import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
+import elemental2.dom.DomGlobal;
 import elemental2.dom.KeyboardEvent;
 import org.gwtbootstrap3.client.ui.DropDown;
 import org.gwtbootstrap3.extras.select.client.ui.Select;
@@ -62,6 +63,7 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
     static final String ESCAPE_KEY = "Escape";
     static final String ESC_KEY = "Esc";
     static final String ENTER_KEY = "Enter";
+    static final String DROPDOWN_ELEMENT_SELECTOR = ".bs-container.btn-group.bootstrap-select.show-tick.input-group-btn";
 
     @DataField("nameEditor")
     private Input nameEditor;
@@ -106,7 +108,7 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
 
         static final String BOOTSTRAP_SELECT_HIDDEN_EVENT = "hidden.bs.select";
 
-        boolean isSelectDropDownShown = false;
+        static final String OPEN_CLASS = "open";
 
         private final ParameterizedCommand<Optional<String>> commandShow;
 
@@ -120,19 +122,13 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
 
         void show(final Optional<String> editorTitle) {
             commandShow.execute(editorTitle);
-
-            //Track state of drop-down element
-            kieDataTypeSelect().on(BOOTSTRAP_SELECT_SHOWN_EVENT, (event) -> isSelectDropDownShown = true);
-            kieDataTypeSelect().on(BOOTSTRAP_SELECT_HIDDEN_EVENT, (event) -> isSelectDropDownShown = false);
-
-            isSelectDropDownShown = false;
         }
 
         void hide() {
             kieDataTypeSelect().off(BOOTSTRAP_SELECT_SHOWN_EVENT);
 
             //If drop-down is visible defer closure of popover until drop-down has closed.
-            if (isSelectDropDownShown) {
+            if (isVisible()) {
                 kieDataTypeSelect().on(BOOTSTRAP_SELECT_HIDDEN_EVENT, (event) -> onHide());
             } else {
                 onHide();
@@ -142,6 +138,18 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
         void onHide() {
             kieDataTypeSelect().off(BOOTSTRAP_SELECT_HIDDEN_EVENT);
             commandHide.execute();
+        }
+
+        boolean isVisible() {
+            final elemental2.dom.Element menuElement = getMenuElement();
+            return Optional
+                    .ofNullable(menuElement)
+                    .map(element -> element.classList.contains(OPEN_CLASS))
+                    .orElse(false);
+        }
+
+        elemental2.dom.Element getMenuElement() {
+            return DomGlobal.document.querySelector(DROPDOWN_ELEMENT_SELECTOR);
         }
 
         /**
@@ -316,6 +324,7 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
     @Override
     public void show(final Optional<String> editorTitle) {
         monitor.show(editorTitle);
+        nameEditor.focus();
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
@@ -59,7 +59,7 @@ import static org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker.$;
 public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl implements NameAndDataTypePopoverView {
 
     static final String TYPE_SELECTOR_BUTTON_SELECTOR = "button.dropdown-toggle.btn-default";
-    static final String MANAGER_BUTTON_SELECTOR = "#typeButton";
+    static final String MANAGE_BUTTON_SELECTOR = "#typeButton";
     static final String TAB_KEY = "Tab";
     static final String ESCAPE_KEY = "Escape";
     static final String ESC_KEY = "Esc";
@@ -94,11 +94,7 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
 
     @Override
     public void setOnClosedByKeyboardCallback(final Consumer callback) {
-        if (Objects.isNull(callback)) {
-            closedByKeyboardCallback = Optional.empty();
-        } else {
-            closedByKeyboardCallback = Optional.of(callback);
-        }
+        closedByKeyboardCallback = Optional.ofNullable(callback);
     }
 
     public void onClosedByKeyboard() {
@@ -237,10 +233,10 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
                                         getKeyDownEventListener(),
                                         false);
 
-        final Element managerButton = getManagerButton();
-        managerButton.addEventListener(BrowserEvents.KEYDOWN,
-                                       getManagerButtonKeyDownEventListener(),
-                                       false);
+        final Element manageButton = getManageButton();
+        manageButton.addEventListener(BrowserEvents.KEYDOWN,
+                                      getManageButtonKeyDownEventListener(),
+                                      false);
 
         final Element typeSelectorButton = getTypeSelectorButton();
         typeSelectorButton.addEventListener(BrowserEvents.KEYDOWN,
@@ -252,8 +248,8 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
         return (e) -> typeSelectorKeyDownEventListener(e);
     }
 
-    EventListener getManagerButtonKeyDownEventListener() {
-        return (e) -> managerButtonKeyDownEventListener(e);
+    EventListener getManageButtonKeyDownEventListener() {
+        return (e) -> manageButtonKeyDownEventListener(e);
     }
 
     EventListener getKeyDownEventListener() {
@@ -264,8 +260,8 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
         return (Button) getElement().querySelector(TYPE_SELECTOR_BUTTON_SELECTOR);
     }
 
-    Button getManagerButton() {
-        return (Button) getElement().querySelector(MANAGER_BUTTON_SELECTOR);
+    Button getManageButton() {
+        return (Button) getElement().querySelector(MANAGE_BUTTON_SELECTOR);
     }
 
     void typeSelectorKeyDownEventListener(final Object event) {
@@ -281,8 +277,8 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
                 onClosedByKeyboard();
             } else if (isTabKeyPressed(keyEvent)) {
                 if (keyEvent.shiftKey) {
-                    final Button managerButton = getManagerButton();
-                    managerButton.focus();
+                    final Button manageButton = getManageButton();
+                    manageButton.focus();
                 } else {
                     nameEditor.focus();
                 }
@@ -291,7 +287,7 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
         }
     }
 
-    void managerButtonKeyDownEventListener(final Object event) {
+    void manageButtonKeyDownEventListener(final Object event) {
         if (event instanceof KeyboardEvent) {
             final KeyboardEvent keyEvent = (KeyboardEvent) event;
             if (isEscapeKeyPressed(keyEvent)) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeShortcuts.java
@@ -123,6 +123,10 @@ public class DataTypeShortcuts {
 
     void keyDownListener(final Event e) {
 
+        if (!(e instanceof KeyboardEvent)) {
+            return;
+        }
+
         final KeyboardEvent event = (KeyboardEvent) e;
 
         if (isNotEnabled()) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.types;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -111,5 +113,14 @@ public class NameAndDataTypePopoverImplTest {
         editor.setTypeRef(typeRef);
 
         verify(bound).setTypeRef(eq(typeRef));
+    }
+
+    @Test
+    public void testSetOnClosedByKeyboardCallback(){
+        final Consumer callback = mock(Consumer.class);
+
+        editor.setOnClosedByKeyboardCallback(callback);
+
+        verify(view).setOnClosedByKeyboardCallback(callback);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.types;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import elemental2.dom.KeyboardEvent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.dmn.client.editors.types;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import elemental2.dom.KeyboardEvent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +29,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
@@ -26,6 +26,7 @@ import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Event;
 import elemental2.dom.KeyboardEvent;
 import org.jboss.errai.common.client.dom.Button;
 import org.jboss.errai.common.client.dom.Div;
@@ -54,6 +55,8 @@ import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypeP
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.MANAGE_BUTTON_SELECTOR;
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.TAB_KEY;
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.TYPE_SELECTOR_BUTTON_SELECTOR;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -223,6 +226,39 @@ public class NameAndDataTypePopoverViewImplTest {
     }
 
     @Test
+    public void testTypeSelectorKeyDownEventListenerWhenIsNotAHandledKey() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
+        doReturn(false).when(view).isEscapeKeyPressed(keyboardEvent);
+        doReturn(false).when(view).isTabKeyPressed(keyboardEvent);
+
+        view.typeSelectorKeyDownEventListener(keyboardEvent);
+
+        verify(view, never()).hide(anyBoolean());
+        verify(keyboardEvent, never()).preventDefault();
+        verify(view, never()).onClosedByKeyboard();
+        verify(view, never()).reset();
+        verify(manageButton, never()).focus();
+        verify(nameEditor, never()).focus();
+    }
+
+    @Test
+    public void testTypeSelectorKeyDownEventListenerWhenIsNotAKeyboardEvent() {
+
+        final Event event = mock(Event.class);
+
+        view.typeSelectorKeyDownEventListener(event);
+
+        verify(view, never()).hide(anyBoolean());
+        verify(event, never()).preventDefault();
+        verify(view, never()).onClosedByKeyboard();
+        verify(view, never()).reset();
+        verify(manageButton, never()).focus();
+        verify(nameEditor, never()).focus();
+    }
+
+    @Test
     public void testTypeSelectorKeyDownEventListenerTabKey() {
 
         final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
@@ -268,6 +304,31 @@ public class NameAndDataTypePopoverViewImplTest {
         verify(view).hide(false);
         verify(view).reset();
         verify(view).onClosedByKeyboard();
+    }
+
+    @Test
+    public void testManagerButtonKeyDownEventWhenIsNotEscapeKey() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        doReturn(false).when(view).isEscapeKeyPressed(keyboardEvent);
+
+        view.manageButtonKeyDownEventListener(keyboardEvent);
+
+        verify(view, never()).hide(false);
+        verify(view, never()).reset();
+        verify(view, never()).onClosedByKeyboard();
+    }
+
+    @Test
+    public void testManagerButtonKeyDownEventWhenIsNotKeyboardEvent() {
+
+        final Event event = mock(Event.class);
+
+        view.manageButtonKeyDownEventListener(event);
+
+        verify(view, never()).hide(false);
+        verify(view, never()).reset();
+        verify(view, never()).onClosedByKeyboard();
     }
 
     @Test
@@ -586,5 +647,34 @@ public class NameAndDataTypePopoverViewImplTest {
         verify(view).hide(false);
         verify(view).reset();
         verify(view).onClosedByKeyboard();
+    }
+
+    @Test
+    public void testKeyDownEventListenerWhenIsNotAHandledKey() {
+
+        final KeyboardEvent event = mock(KeyboardEvent.class);
+
+        doReturn(false).when(view).isEnterKeyPressed(event);
+        doReturn(false).when(view).isEscapeKeyPressed(event);
+
+        view.keyDownEventListener(event);
+
+        verify(view, never()).hide(anyBoolean());
+        verify(event, never()).stopPropagation();
+        verify(view, never()).onClosedByKeyboard();
+        verify(view, never()).reset();
+    }
+
+    @Test
+    public void testKeyDownEventListenerWhenIsNotKeyboardEvent() {
+
+        final Event event = mock(Event.class);
+        view.keyDownEventListener(event);
+
+        verify(view, never()).hide(anyBoolean());
+        verify(event, never()).stopPropagation();
+        verify(view, never()).onClosedByKeyboard();
+        verify(view, never()).isEscapeKeyPressed(any());
+        verify(view, never()).reset();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
@@ -18,11 +18,17 @@ package org.kie.workbench.common.dmn.client.editors.types;
 
 import java.util.Optional;
 
+import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.KeyboardEvent;
+import org.jboss.errai.common.client.dom.Button;
 import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.EventListener;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.Input;
 import org.jboss.errai.common.client.dom.Span;
@@ -38,9 +44,19 @@ import org.mockito.Mock;
 import org.uberfire.client.views.pfly.widgets.JQueryProducer;
 import org.uberfire.client.views.pfly.widgets.Popover;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.ENTER_KEY;
+import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.ESCAPE_KEY;
+import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.ESC_KEY;
+import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.MANAGER_BUTTON_SELECTOR;
+import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.TAB_KEY;
+import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.TYPE_SELECTOR_BUTTON_SELECTOR;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -97,6 +113,12 @@ public class NameAndDataTypePopoverViewImplTest {
     @Mock
     private TranslationService translationService;
 
+    @Mock
+    private Button managerButton;
+
+    @Mock
+    private Button typeSelectorButton;
+
     @Captor
     private ArgumentCaptor<ValueChangeHandler<QName>> valueChangeHandlerCaptor;
 
@@ -117,6 +139,10 @@ public class NameAndDataTypePopoverViewImplTest {
                 return element;
             }
         });
+
+        when(element.querySelector(MANAGER_BUTTON_SELECTOR)).thenReturn(managerButton);
+        when(element.querySelector(TYPE_SELECTOR_BUTTON_SELECTOR)).thenReturn(typeSelectorButton);
+
         view.init(presenter);
 
         when(valueChangeEvent.getValue()).thenReturn(typeRef);
@@ -131,7 +157,269 @@ public class NameAndDataTypePopoverViewImplTest {
 
         valueChangeHandlerCaptor.getValue().onValueChange(valueChangeEvent);
 
-        verify(presenter).setTypeRef(eq(typeRef));
+        assertEquals(view.getCurrentTypeRef(), typeRef);
+
+        verify(view).setKeyDownListeners();
+    }
+
+    @Test
+    public void testSetKeyDownListeners() {
+
+        final EventListener keyDownCallback = mock(EventListener.class);
+        final EventListener managerCallback = mock(EventListener.class);
+        final EventListener eventListenerCallback = mock(EventListener.class);
+
+        doReturn(keyDownCallback).when(view).getKeyDownEventListener();
+        doReturn(managerCallback).when(view).getManagerButtonKeyDownEventListener();
+        doReturn(eventListenerCallback).when(view).getTypeSelectorKeyDownEventListener();
+
+        view.setKeyDownListeners();
+
+        verify(popoverElement).addEventListener(BrowserEvents.KEYDOWN,
+                                                keyDownCallback,
+                                                false);
+
+        verify(managerButton).addEventListener(BrowserEvents.KEYDOWN,
+                                               managerCallback,
+                                               false);
+
+        verify(typeSelectorButton).addEventListener(BrowserEvents.KEYDOWN,
+                                                    eventListenerCallback,
+                                                    false);
+    }
+
+    @Test
+    public void testTypeSelectorKeyDownEventListenerEnterKey() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        doReturn(true).when(view).isEnterKeyPressed(keyboardEvent);
+
+        view.typeSelectorKeyDownEventListener(keyboardEvent);
+
+        verify(view).hide(true);
+        verify(keyboardEvent).preventDefault();
+    }
+
+    @Test
+    public void testTypeSelectorKeyDownEventListenerEscKey() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
+        doReturn(true).when(view).isEscapeKeyPressed(keyboardEvent);
+
+        view.typeSelectorKeyDownEventListener(keyboardEvent);
+
+        verify(view).reset();
+        verify(view).hide(false);
+    }
+
+    @Test
+    public void testTypeSelectorKeyDownEventListenerTabKey() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
+        doReturn(false).when(view).isEscapeKeyPressed(keyboardEvent);
+        doReturn(true).when(view).isTabKeyPressed(keyboardEvent);
+
+        view.typeSelectorKeyDownEventListener(keyboardEvent);
+
+        verify(nameEditor).focus();
+        verify(keyboardEvent).preventDefault();
+    }
+
+    @Test
+    public void testTypeSelectorKeyDownEventListenerShiftTabKey() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        keyboardEvent.shiftKey = true;
+
+        doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
+        doReturn(false).when(view).isEscapeKeyPressed(keyboardEvent);
+        doReturn(true).when(view).isTabKeyPressed(keyboardEvent);
+
+        view.typeSelectorKeyDownEventListener(keyboardEvent);
+
+        verify(managerButton).focus();
+        verify(keyboardEvent).preventDefault();
+    }
+
+    @Test
+    public void testManagerButtonKeyDownEventListenerEsc() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
+        doReturn(true).when(view).isEscapeKeyPressed(keyboardEvent);
+
+        view.managerButtonKeyDownEventListener(keyboardEvent);
+
+        verify(view).hide(false);
+        verify(view).reset();
+    }
+
+    @Test
+    public void testKeyDownEventListenerEsc() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
+        doReturn(true).when(view).isEscapeKeyPressed(keyboardEvent);
+
+        view.managerButtonKeyDownEventListener(keyboardEvent);
+
+        verify(view).hide(false);
+        verify(view).reset();
+    }
+
+    @Test
+    public void testIsTabKeyPressed() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        keyboardEvent.key = TAB_KEY;
+
+        boolean actual = view.isTabKeyPressed(keyboardEvent);
+        assertTrue(actual);
+        keyboardEvent.key = "A";
+
+        actual = view.isTabKeyPressed(keyboardEvent);
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testIsEscapeKeyPressed() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        keyboardEvent.key = ESC_KEY;
+
+        boolean actual = view.isEscapeKeyPressed(keyboardEvent);
+        assertTrue(actual);
+
+        keyboardEvent.key = "A";
+        actual = view.isEscapeKeyPressed(keyboardEvent);
+        assertFalse(actual);
+
+        keyboardEvent.key = ESCAPE_KEY;
+        actual = view.isEscapeKeyPressed(keyboardEvent);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testIsEnterKeyPressed() {
+
+        final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
+        keyboardEvent.key = ENTER_KEY;
+
+        boolean actual = view.isEnterKeyPressed(keyboardEvent);
+        assertTrue(actual);
+        keyboardEvent.key = "A";
+
+        actual = view.isEnterKeyPressed(keyboardEvent);
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testOnNameEditorKeyDownEnter() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+
+        doReturn(true).when(view).isEnter(keyDownEvent);
+
+        view.onNameEditorKeyDown(keyDownEvent);
+
+        verify(view).hide(true);
+    }
+
+    @Test
+    public void testOnNameEditorKeyDownEsc() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        doReturn(false).when(view).isEnter(keyDownEvent);
+        doReturn(true).when(view).isEsc(keyDownEvent);
+
+        view.onNameEditorKeyDown(keyDownEvent);
+
+        verify(view).reset();
+        verify(view).hide(false);
+    }
+
+    @Test
+    public void testOnNameEditorKeyDownShiftTab() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        doReturn(false).when(view).isEnter(keyDownEvent);
+        doReturn(false).when(view).isEsc(keyDownEvent);
+        doReturn(true).when(view).isTab(keyDownEvent);
+
+        when(keyDownEvent.isShiftKeyDown()).thenReturn(true);
+
+        view.onNameEditorKeyDown(keyDownEvent);
+
+        verify(typeSelectorButton).focus();
+        verify(keyDownEvent).preventDefault();
+    }
+
+    @Test
+    public void testIsTab() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        when(keyDownEvent.getNativeKeyCode()).thenReturn(KeyCodes.KEY_TAB);
+
+        final boolean actual = view.isTab(keyDownEvent);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testIsEsc() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        when(keyDownEvent.getNativeKeyCode()).thenReturn(KeyCodes.KEY_ESCAPE);
+
+        final boolean actual = view.isEsc(keyDownEvent);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testIsEnter() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        when(keyDownEvent.getNativeKeyCode()).thenReturn(KeyCodes.KEY_ENTER);
+
+        final boolean actual = view.isEnter(keyDownEvent);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testIsNotTab() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        when(keyDownEvent.getNativeKeyCode()).thenReturn(KeyCodes.KEY_A);
+
+        final boolean actual = view.isTab(keyDownEvent);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testIsNotEsc() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        when(keyDownEvent.getNativeKeyCode()).thenReturn(KeyCodes.KEY_A);
+
+        final boolean actual = view.isEsc(keyDownEvent);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testIsNotEnter() {
+
+        final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        when(keyDownEvent.getNativeKeyCode()).thenReturn(KeyCodes.KEY_A);
+
+        final boolean actual = view.isEnter(keyDownEvent);
+
+        assertFalse(actual);
     }
 
     @Test
@@ -186,7 +474,8 @@ public class NameAndDataTypePopoverViewImplTest {
 
         view.onNameChange(blurEvent);
 
-        verify(presenter).setName(eq(NAME));
+        verify(presenter, never()).setName(eq(NAME));
+        assertEquals(NAME, view.getCurrentName());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
@@ -552,4 +552,39 @@ public class NameAndDataTypePopoverViewImplTest {
         assertFalse(actual.isPresent());
         assertEquals(Optional.empty(), actual);
     }
+
+    @Test
+    public void testKeyDownEventListenerEnterKey() {
+        final KeyboardEvent event = mock(KeyboardEvent.class);
+
+        doNothing().when(view).hide(true);
+        doNothing().when(view).onClosedByKeyboard();
+
+        doReturn(true).when(view).isEnterKeyPressed(event);
+
+        view.keyDownEventListener(event);
+
+        verify(view).hide(true);
+        verify(event).stopPropagation();
+        verify(view).onClosedByKeyboard();
+        verify(view, never()).isEscapeKeyPressed(event);
+    }
+
+    @Test
+    public void testKeyDownEventListenerEscKey() {
+        final KeyboardEvent event = mock(KeyboardEvent.class);
+
+        doNothing().when(view).hide(false);
+        doNothing().when(view).reset();
+        doNothing().when(view).onClosedByKeyboard();
+
+        doReturn(false).when(view).isEnterKeyPressed(event);
+        doReturn(true).when(view).isEscapeKeyPressed(event);
+
+        view.keyDownEventListener(event);
+
+        verify(view).hide(false);
+        verify(view).reset();
+        verify(view).onClosedByKeyboard();
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.types;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.event.dom.client.BlurEvent;
@@ -56,6 +57,7 @@ import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypeP
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -193,11 +195,13 @@ public class NameAndDataTypePopoverViewImplTest {
 
         final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
         doReturn(true).when(view).isEnterKeyPressed(keyboardEvent);
+        doNothing().when(view).hide(true);
 
         view.typeSelectorKeyDownEventListener(keyboardEvent);
 
         verify(view).hide(true);
         verify(keyboardEvent).preventDefault();
+        verify(view).onClosedByKeyboard();
     }
 
     @Test
@@ -206,11 +210,16 @@ public class NameAndDataTypePopoverViewImplTest {
         final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
         doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
         doReturn(true).when(view).isEscapeKeyPressed(keyboardEvent);
+        final NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor monitor = mock(NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor.class);
+        doReturn(monitor).when(view).getMonitor();
+        final elemental2.dom.Element menuElement = mock(elemental2.dom.Element.class);
+        doReturn(menuElement).when(monitor).getMenuElement();
 
         view.typeSelectorKeyDownEventListener(keyboardEvent);
 
         verify(view).reset();
         verify(view).hide(false);
+        verify(view).onClosedByKeyboard();
     }
 
     @Test
@@ -249,11 +258,16 @@ public class NameAndDataTypePopoverViewImplTest {
         final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
         doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
         doReturn(true).when(view).isEscapeKeyPressed(keyboardEvent);
+        final NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor monitor = mock(NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor.class);
+        doReturn(monitor).when(view).getMonitor();
+        final elemental2.dom.Element menuElement = mock(elemental2.dom.Element.class);
+        doReturn(menuElement).when(monitor).getMenuElement();
 
         view.managerButtonKeyDownEventListener(keyboardEvent);
 
         verify(view).hide(false);
         verify(view).reset();
+        verify(view).onClosedByKeyboard();
     }
 
     @Test
@@ -262,11 +276,13 @@ public class NameAndDataTypePopoverViewImplTest {
         final KeyboardEvent keyboardEvent = mock(KeyboardEvent.class);
         doReturn(false).when(view).isEnterKeyPressed(keyboardEvent);
         doReturn(true).when(view).isEscapeKeyPressed(keyboardEvent);
+        doNothing().when(view).hide(false);
 
         view.managerButtonKeyDownEventListener(keyboardEvent);
 
         verify(view).hide(false);
         verify(view).reset();
+        verify(view).onClosedByKeyboard();
     }
 
     @Test
@@ -319,12 +335,14 @@ public class NameAndDataTypePopoverViewImplTest {
     public void testOnNameEditorKeyDownEnter() {
 
         final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
+        doNothing().when(view).hide(true);
 
         doReturn(true).when(view).isEnter(keyDownEvent);
 
         view.onNameEditorKeyDown(keyDownEvent);
 
         verify(view).hide(true);
+        verify(view).onClosedByKeyboard();
     }
 
     @Test
@@ -333,11 +351,16 @@ public class NameAndDataTypePopoverViewImplTest {
         final KeyDownEvent keyDownEvent = mock(KeyDownEvent.class);
         doReturn(false).when(view).isEnter(keyDownEvent);
         doReturn(true).when(view).isEsc(keyDownEvent);
+        final NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor monitor = mock(NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor.class);
+        doReturn(monitor).when(view).getMonitor();
+        final elemental2.dom.Element menuElement = mock(elemental2.dom.Element.class);
+        doReturn(menuElement).when(monitor).getMenuElement();
 
         view.onNameEditorKeyDown(keyDownEvent);
 
         verify(view).reset();
         verify(view).hide(false);
+        verify(view).onClosedByKeyboard();
     }
 
     @Test
@@ -354,6 +377,7 @@ public class NameAndDataTypePopoverViewImplTest {
 
         verify(typeSelectorButton).focus();
         verify(keyDownEvent).preventDefault();
+        verify(view, never()).onClosedByKeyboard();
     }
 
     @Test
@@ -452,6 +476,11 @@ public class NameAndDataTypePopoverViewImplTest {
 
     @Test
     public void testHideBeforeShown() {
+        final NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor monitor = mock(NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor.class);
+        doReturn(monitor).when(view).getMonitor();
+        final elemental2.dom.Element menuElement = mock(elemental2.dom.Element.class);
+        doReturn(menuElement).when(monitor).getMenuElement();
+
         view.hide();
 
         verify(popover, never()).hide();
@@ -460,12 +489,17 @@ public class NameAndDataTypePopoverViewImplTest {
 
     @Test
     public void testHideAfterShown() {
+
+        final NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor monitor = mock(NameAndDataTypePopoverViewImpl.BootstrapSelectDropDownMonitor.class);
+        doReturn(monitor).when(view).getMonitor();
+        final elemental2.dom.Element menuElement = mock(elemental2.dom.Element.class);
+        doReturn(menuElement).when(monitor).getMenuElement();
+
         view.show(Optional.empty());
         view.hide();
 
         verify(nameEditor).blur();
-        verify(popover).hide();
-        verify(popover).destroy();
+        verify(monitor).hide();
     }
 
     @Test
@@ -480,8 +514,42 @@ public class NameAndDataTypePopoverViewImplTest {
 
     @Test
     public void testOnDataTypePageNavTabActiveEvent() {
+        doNothing().when(view).hide(true);
+
         view.onDataTypePageNavTabActiveEvent(mock(DataTypePageTabActiveEvent.class));
 
         verify(view).hide();
+    }
+
+    @Test
+    public void testOnClosedByKeyboard() {
+        final Consumer consumer = mock(Consumer.class);
+        final Optional opt = Optional.of(consumer);
+        doReturn(opt).when(view).getClosedByKeyboardCallback();
+
+        view.onClosedByKeyboard();
+
+        verify(consumer).accept(view);
+    }
+
+    @Test
+    public void testSetOnClosedByKeyboardCallback() {
+        final Consumer consumer = mock(Consumer.class);
+        view.setOnClosedByKeyboardCallback(consumer);
+
+        final Optional<Consumer> actual = view.getClosedByKeyboardCallback();
+
+        assertTrue(actual.isPresent());
+        assertEquals(consumer, actual.get());
+    }
+
+    @Test
+    public void testSetOnClosedByKeyboardCallbackNullCallback() {
+        view.setOnClosedByKeyboardCallback(null);
+
+        final Optional<Consumer> actual = view.getClosedByKeyboardCallback();
+
+        assertFalse(actual.isPresent());
+        assertEquals(Optional.empty(), actual);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.ENTER_KEY;
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.ESCAPE_KEY;
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.ESC_KEY;
-import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.MANAGER_BUTTON_SELECTOR;
+import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.MANAGE_BUTTON_SELECTOR;
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.TAB_KEY;
 import static org.kie.workbench.common.dmn.client.editors.types.NameAndDataTypePopoverViewImpl.TYPE_SELECTOR_BUTTON_SELECTOR;
 import static org.mockito.Matchers.anyString;
@@ -116,7 +116,7 @@ public class NameAndDataTypePopoverViewImplTest {
     private TranslationService translationService;
 
     @Mock
-    private Button managerButton;
+    private Button manageButton;
 
     @Mock
     private Button typeSelectorButton;
@@ -142,7 +142,7 @@ public class NameAndDataTypePopoverViewImplTest {
             }
         });
 
-        when(element.querySelector(MANAGER_BUTTON_SELECTOR)).thenReturn(managerButton);
+        when(element.querySelector(MANAGE_BUTTON_SELECTOR)).thenReturn(manageButton);
         when(element.querySelector(TYPE_SELECTOR_BUTTON_SELECTOR)).thenReturn(typeSelectorButton);
 
         view.init(presenter);
@@ -172,7 +172,7 @@ public class NameAndDataTypePopoverViewImplTest {
         final EventListener eventListenerCallback = mock(EventListener.class);
 
         doReturn(keyDownCallback).when(view).getKeyDownEventListener();
-        doReturn(managerCallback).when(view).getManagerButtonKeyDownEventListener();
+        doReturn(managerCallback).when(view).getManageButtonKeyDownEventListener();
         doReturn(eventListenerCallback).when(view).getTypeSelectorKeyDownEventListener();
 
         view.setKeyDownListeners();
@@ -181,9 +181,9 @@ public class NameAndDataTypePopoverViewImplTest {
                                                 keyDownCallback,
                                                 false);
 
-        verify(managerButton).addEventListener(BrowserEvents.KEYDOWN,
-                                               managerCallback,
-                                               false);
+        verify(manageButton).addEventListener(BrowserEvents.KEYDOWN,
+                                              managerCallback,
+                                              false);
 
         verify(typeSelectorButton).addEventListener(BrowserEvents.KEYDOWN,
                                                     eventListenerCallback,
@@ -248,7 +248,7 @@ public class NameAndDataTypePopoverViewImplTest {
 
         view.typeSelectorKeyDownEventListener(keyboardEvent);
 
-        verify(managerButton).focus();
+        verify(manageButton).focus();
         verify(keyboardEvent).preventDefault();
     }
 
@@ -263,7 +263,7 @@ public class NameAndDataTypePopoverViewImplTest {
         final elemental2.dom.Element menuElement = mock(elemental2.dom.Element.class);
         doReturn(menuElement).when(monitor).getMenuElement();
 
-        view.managerButtonKeyDownEventListener(keyboardEvent);
+        view.manageButtonKeyDownEventListener(keyboardEvent);
 
         verify(view).hide(false);
         verify(view).reset();
@@ -278,7 +278,7 @@ public class NameAndDataTypePopoverViewImplTest {
         doReturn(true).when(view).isEscapeKeyPressed(keyboardEvent);
         doNothing().when(view).hide(false);
 
-        view.managerButtonKeyDownEventListener(keyboardEvent);
+        view.manageButtonKeyDownEventListener(keyboardEvent);
 
         verify(view).hide(false);
         verify(view).reset();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlsViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControlsViewImplTest.java
@@ -15,27 +15,38 @@
  */
 package org.kie.workbench.common.dmn.client.widgets.grid.controls.container;
 
+import java.util.Optional;
+
 import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.dom.Body;
+import org.jboss.errai.common.client.dom.CSSStyleDeclaration;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.Document;
 import org.jboss.errai.common.client.dom.EventListener;
+import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.PopupEditorControls;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
+import static org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsViewImpl.LEFT;
+import static org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsViewImpl.PX;
+import static org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsViewImpl.TOP;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class CellEditorControlsViewImplTest {
@@ -102,5 +113,69 @@ public class CellEditorControlsViewImplTest {
         verify(body).removeEventListener(eq(BrowserEvents.MOUSEWHEEL),
                                          eq(mouseWheelListenerCaptor.getValue()),
                                          eq(false));
+    }
+
+    @Test
+    public void testShow() {
+
+        final PopupEditorControls editor = mock(PopupEditorControls.class);
+        final Optional<String> title = Optional.of("title");
+        final int x = 10;
+        final int y = 20;
+
+        final HTMLElement element = mock(HTMLElement.class);
+        doReturn(element).when(view).getElement();
+        final CSSStyleDeclaration style = mock(CSSStyleDeclaration.class);
+        when(element.getStyle()).thenReturn(style);
+
+        view.show(editor, title, x, y);
+
+        verify(style).setProperty(LEFT, x + PX);
+        verify(style).setProperty(TOP, y + PX);
+        verify(view).setOnClosedByKeyboardCallback(editor);
+        verify(editor).show(title);
+    }
+
+    @Test
+    public void testSetOnClosedByKeyboardCallback() {
+        final PopupEditorControls editor = mock(PopupEditorControls.class, withSettings().extraInterfaces(CanBeClosedByKeyboard.class));
+
+        view.setOnClosedByKeyboardCallback(editor);
+
+        verify((CanBeClosedByKeyboard) editor).setOnClosedByKeyboardCallback(any());
+    }
+
+    @Test
+    public void testRemoveOnClosedByKeyboardCallback() {
+        final PopupEditorControls editor = mock(PopupEditorControls.class, withSettings().extraInterfaces(CanBeClosedByKeyboard.class));
+
+        view.removeOnClosedByKeyboardCallback(editor);
+
+        verify((CanBeClosedByKeyboard) editor).setOnClosedByKeyboardCallback(null);
+    }
+
+    @Test
+    public void testFocusOnDMNContainer() {
+        final elemental2.dom.Element dmnContainerElement = mock(elemental2.dom.Element.class);
+
+        doReturn(dmnContainerElement).when(view).getDMNContainer();
+
+        view.focusOnDMNContainer(null);
+
+        verify(dmnContainerElement).focus();
+    }
+
+    @Test
+    public void testHide() {
+        final PopupEditorControls editor = mock(PopupEditorControls.class);
+        final Optional<PopupEditorControls> activeEditor = Optional.of(editor);
+
+        doReturn(activeEditor).when(view).getActiveEditor();
+
+        view.hide();
+
+        verify(editor).hide();
+        verify(view).removeOnClosedByKeyboardCallback(editor);
+        verify(view).setActiveEditor(Optional.empty());
     }
 }


### PR DESCRIPTION
This PR also prevents that the TAB and SHIFT + TAB to exit from the pop-up, as discussed in the scrum meeting.

This PR also fixes this error, that I've found during the debug:
![error](https://user-images.githubusercontent.com/7305741/65718405-d9211780-e079-11e9-9218-00051d8244b9.gif)
