### PR TITLE
[AF-2158]: Added observers to refresh spaces when contributors are modified

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.java
@@ -766,4 +766,7 @@ public class LibraryConstants {
 
     @TranslationKey(defaultValue = "")
     public static final String ErrorCreatingPoject = "ErrorCreatingProject";
+
+    @TranslationKey(defaultValue = "")
+    public static final String SpacePermissionsChanged = "SpacePermissionsChanged";
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/client/resources/i18n/LibraryConstants.properties
@@ -588,4 +588,5 @@ Today=today
 OneDayAgo=1 day ago
 DaysAgo={0} days ago
 ErrorCreatingProject=Project '{0}' couldn't be created due to an unexpected issue. Please close this popup and try again.
+SpacePermissionsChanged=Permissions changed for {0} Space
 ViewDeploymentDetails=View deployment details

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/src/spaces-screen/index.tsx
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/src/spaces-screen/index.tsx
@@ -30,7 +30,8 @@ export class SpacesScreenAppFormerComponent extends AppFormer.Screen {
       ["org.guvnor.structure.organizationalunit.RemoveOrganizationalUnitEvent", (e: any) => this.self.refreshSpaces()],
       ["org.kie.workbench.common.screens.library.api.sync.ClusterLibraryEvent", (e: any) => this.self.refreshSpaces()],
       ["org.guvnor.common.services.project.events.NewProjectEvent", (e: any) => this.self.refreshSpaces()],
-      ["org.guvnor.structure.repositories.RepositoryRemovedEvent", (e: any) => this.self.refreshSpaces()]
+      ["org.guvnor.structure.repositories.RepositoryRemovedEvent", (e: any) => this.self.refreshSpaces()],
+      ["org.guvnor.structure.contributors.SpaceContributorsUpdatedEvent", (e: any) => this.self.refreshSpaces()]
     ]);
   }
 


### PR DESCRIPTION
## Solution

When userA changes space contributors and and userB is on Spaces view or in Projects view (inside a space) the list of spaces is refreshed. And in case User permissions for that space where 
removed the user is redirected to Spaces view and a warning notification is sent.

@ederign @jakubschwan @paulovmr 
