### PR TITLE
JBPM-8680: Stunner - Process with Reusable sub-process print errors to the server log.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriter.java
@@ -63,39 +63,40 @@ public class ActivityPropertyWriter extends PropertyWriter {
 
     public void setAssignmentsInfo(AssignmentsInfo info) {
         final ParsedAssignmentsInfo assignmentsInfo = ParsedAssignmentsInfo.of(info);
-        final InputOutputSpecification ioSpec = getIoSpecification();
+        final List<InitializedInputVariable> inputs = assignmentsInfo.createInitializedInputVariables(getId(),
+                                                                                                      variableScope);
+        if (!inputs.isEmpty()) {
+            final InputOutputSpecification ioSpec = getIoSpecification();
+            for (InitializedInputVariable input : inputs) {
+                if (isReservedIdentifier(input.getIdentifier())) {
+                    continue;
+                }
 
-        List<InitializedInputVariable> inputs =
-                assignmentsInfo.createInitializedInputVariables(getId(), variableScope);
+                DataInput dataInput = input.getDataInput();
+                getInputSet(ioSpec).getDataInputRefs().add(dataInput);
+                ioSpec.getDataInputs().add(dataInput);
 
-        for (InitializedInputVariable input : inputs) {
-            if (isReservedIdentifier(input.getIdentifier())) {
-                continue;
-            }
-
-            DataInput dataInput = input.getDataInput();
-            getInputSet(ioSpec).getDataInputRefs().add(dataInput);
-            ioSpec.getDataInputs().add(dataInput);
-
-            this.addItemDefinition(input.getItemDefinition());
-            DataInputAssociation dataInputAssociation = input.getDataInputAssociation();
-            if (dataInputAssociation != null) {
-                activity.getDataInputAssociations().add(dataInputAssociation);
+                this.addItemDefinition(input.getItemDefinition());
+                DataInputAssociation dataInputAssociation = input.getDataInputAssociation();
+                if (dataInputAssociation != null) {
+                    activity.getDataInputAssociations().add(dataInputAssociation);
+                }
             }
         }
+        final List<InitializedOutputVariable> outputs = assignmentsInfo.createInitializedOutputVariables(getId(),
+                                                                                                         variableScope);
+        if (!outputs.isEmpty()) {
+            final InputOutputSpecification ioSpec = getIoSpecification();
+            for (InitializedOutputVariable output : outputs) {
+                DataOutput dataOutput = output.getDataOutput();
+                getOutputSet(ioSpec).getDataOutputRefs().add(dataOutput);
+                ioSpec.getDataOutputs().add(dataOutput);
 
-        List<InitializedOutputVariable> outputs =
-                assignmentsInfo.createInitializedOutputVariables(getId(), variableScope);
-
-        for (InitializedOutputVariable output : outputs) {
-            DataOutput dataOutput = output.getDataOutput();
-            getOutputSet(ioSpec).getDataOutputRefs().add(dataOutput);
-            ioSpec.getDataOutputs().add(dataOutput);
-
-            this.addItemDefinition(output.getItemDefinition());
-            DataOutputAssociation dataOutputAssociation = output.getDataOutputAssociation();
-            if (dataOutputAssociation != null) {
-                activity.getDataOutputAssociations().add(dataOutputAssociation);
+                this.addItemDefinition(output.getItemDefinition());
+                DataOutputAssociation dataOutputAssociation = output.getDataOutputAssociation();
+                if (dataOutputAssociation != null) {
+                    activity.getDataOutputAssociations().add(dataOutputAssociation);
+                }
             }
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
@@ -23,13 +23,53 @@ import org.eclipse.bpmn2.Task;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
 
 public class ActivityPropertyWriterTest {
 
     @Test
-    public void shouldCreateOneInputSet() {
+    public void testEmptyInputOutputSet() {
+        Task task = bpmn2.createTask();
+        ActivityPropertyWriter activityPropertyWriter =
+                new ActivityPropertyWriter(task, new FlatVariableScope());
+        activityPropertyWriter.setAssignmentsInfo(new AssignmentsInfo(
+                "||||"
+        ));
+        assertNull(task.getIoSpecification());
+    }
+
+    @Test
+    public void testNotEmptyInputSet() {
+        Task task = bpmn2.createTask();
+        ActivityPropertyWriter activityPropertyWriter =
+                new ActivityPropertyWriter(task, new FlatVariableScope());
+        activityPropertyWriter.setAssignmentsInfo(new AssignmentsInfo(
+                "|A:String|||"
+        ));
+        assertNotNull(task.getIoSpecification());
+        assertTrue(task.getIoSpecification().getOutputSets().isEmpty());
+        assertEquals(1, task.getIoSpecification().getInputSets().size());
+    }
+
+    @Test
+    public void testNotEmptyOutputSet() {
+        Task task = bpmn2.createTask();
+        ActivityPropertyWriter activityPropertyWriter =
+                new ActivityPropertyWriter(task, new FlatVariableScope());
+        activityPropertyWriter.setAssignmentsInfo(new AssignmentsInfo(
+                "||A:String||"
+        ));
+        assertNotNull(task.getIoSpecification());
+        assertTrue(task.getIoSpecification().getInputSets().isEmpty());
+        assertEquals(1, task.getIoSpecification().getOutputSets().size());
+    }
+
+    @Test
+    public void testItShouldCreateOneInputSet() {
         Task task = bpmn2.createTask();
         ActivityPropertyWriter activityPropertyWriter =
                 new ActivityPropertyWriter(task, new FlatVariableScope());


### PR DESCRIPTION
Hey @hasys 

See [JBPM-8680](https://issues.jboss.org/browse/JBPM-8680)

PS: Some actions to take after this gets merged:
* Include this fix in the kogito bpmn client side marshallers ( CC @tiagodolphine )
* Include this fix in the RHPAM 7.5.1 branch ( see [RHPAM-2412](https://issues.jboss.org/browse/RHPAM-2412) )

Thanks!