### PR TITLE
JBPM-8825: Resets current page when user searches by term.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/PopulatedAssetsView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/PopulatedAssetsView.java
@@ -150,6 +150,7 @@ public class PopulatedAssetsView implements PopulatedAssetsScreen.View,
     }
 
     private void doSearch() {
+        presenter.setCurrentPage(1);
         presenter.search(this.filterText.value);
     }
 


### PR DESCRIPTION
The current page is not resetting when the user searches by term. It can cause an error if the page does not exist.

You can find the steps to reproduce this issue at JBPM-8825.
