### PR TITLE
DROOLS-4563: managing validation-api for GWT based code to 1.0.0.GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
   </modules>
 
   <properties>
+      <!-- Version 2.0.1.Final which is coming from kie-parent is not compatible with appformer validation components -->
+    <version.javax.validation>1.0.0.GA</version.javax.validation>
     <spotbugs.failOnViolation>true</spotbugs.failOnViolation>
     <checkstyle.header.template><![CDATA[
 ^\/\*$\n^
@@ -55,7 +57,6 @@
 
   <dependencyManagement>
     <dependencies>
-
       <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>wildfly-dist</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4563

Parent PR:
- kiegroup/droolsjbpm-build-bootstrap#1075

Dependent PRs:

-    kiegroup/appformer#814
-    kiegroup/kie-wb-common#2934
-    kiegroup/drools-wb#1238
