### PR TITLE
JBPM-8835 : Improve performance of response when user performs a click and Drag

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
@@ -233,7 +233,7 @@ public class LocationControlImpl
                         public void start(DragEvent event) {
                             if (Objects.nonNull(selectionEvent)) {
                                 //select the moving shape, if not
-                                selectionEvent.fire(new CanvasSelectionEvent(canvasHandler, shape.getUUID()));
+                                selectionEvent.fire(new CanvasSelectionEvent(canvasHandler, shape.getUUID(), true));
                             }
                         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/selection/CanvasSelectionEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/selection/CanvasSelectionEvent.java
@@ -28,19 +28,51 @@ public final class CanvasSelectionEvent
 
     private final Collection<String> identifiers;
 
+    private final boolean isDragging;
+
+    private final boolean scheduleFormRendering;
+
     public CanvasSelectionEvent(final CanvasHandler canvasHandler,
                                 final Collection<String> identifiers) {
         super(canvasHandler);
         this.identifiers = new LinkedList<>(identifiers);
+        this.isDragging = false;
+        scheduleFormRendering = true;
     }
 
     public CanvasSelectionEvent(final CanvasHandler canvasHandler,
                                 final String uuid) {
         super(canvasHandler);
         this.identifiers = new LinkedList<>(Arrays.asList(uuid));
+        this.isDragging = false;
+        scheduleFormRendering = true;
+    }
+
+    public CanvasSelectionEvent(final CanvasHandler canvasHandler,
+                                final String uuid, final boolean isDragging, final boolean scheduleFormRendering) {
+        super(canvasHandler);
+        this.identifiers = new LinkedList<>(Arrays.asList(uuid));
+        this.isDragging = isDragging;
+        this.scheduleFormRendering = scheduleFormRendering;
+    }
+
+    public CanvasSelectionEvent(final CanvasHandler canvasHandler,
+                                final String uuid, final boolean isDragging) {
+        super(canvasHandler);
+        this.identifiers = new LinkedList<>(Arrays.asList(uuid));
+        this.isDragging = isDragging;
+        scheduleFormRendering = true;
     }
 
     public Collection<String> getIdentifiers() {
         return identifiers;
+    }
+
+    public boolean isDragging() {
+        return isDragging;
+    }
+
+    public boolean isScheduleFormRendering() {
+        return scheduleFormRendering;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
@@ -263,6 +263,11 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
         if (null == canvasHandler) {
             return;
         }
+
+        if (event.isDragging()) {
+            return;
+        }
+
         final boolean isSameCtxt = canvasHandler.equals(event.getCanvasHandler());
         final boolean isSingleSelection = event.getIdentifiers().size() == 1;
         final boolean isCanvasRoot = isSingleSelection &&

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidget.java
@@ -56,6 +56,7 @@ public class FormPropertiesWidget implements IsElement,
     private final FormsCanvasSessionHandler formSessionHandler;
     private final FormsContainer formsContainer;
     private final TranslationService translationService;
+    private String lastId = "";
 
     protected FormPropertiesWidget() {
         this(null, null, null, null, null, null);
@@ -155,6 +156,11 @@ public class FormPropertiesWidget implements IsElement,
                       final Element<? extends Definition<?>> element,
                       final Command callback) {
         if (element != null) {
+
+            if (lastId.equals(element.getUUID())) {
+                return;
+            }
+
             final String uuid = element.getUUID();
             final Diagram<?, ?> diagram = formSessionHandler.getDiagram();
             if (Objects.isNull(diagram)) {
@@ -191,6 +197,7 @@ public class FormPropertiesWidget implements IsElement,
                                   }, renderMode);
             final String name = definitionUtils.getName(definition);
             propertiesOpenedEvent.fire(new FormPropertiesOpened(formSessionHandler.getSession(), uuid, name));
+            lastId = element.getUUID();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -24,6 +24,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import com.google.gwt.user.client.Timer;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -173,11 +174,27 @@ public class FormsCanvasSessionHandler {
     void onCanvasSelectionEvent(@Observes CanvasSelectionEvent event) {
         checkNotNull("event",
                      event);
+
+        if (event.isDragging()) {
+            return;
+        }
+
         if (!Objects.isNull(getCanvasHandler())) {
             if (event.getIdentifiers().size() == 1) {
                 final String uuid = event.getIdentifiers().iterator().next();
                 final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), uuid);
-                render(element);
+                if (event.isScheduleFormRendering()) {
+                    final Timer timer = new Timer() {
+                        @Override
+                        public void run() {
+                            render(element);
+                        }
+                    };
+
+                    timer.schedule(100);
+                } else {
+                    render(element);
+                }
             }
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
@@ -210,7 +210,7 @@ public class FormsCanvasSessionHandlerTest {
     public void testOnCanvasSelectionEventSameSession() {
         handler.bind(session);
 
-        canvasSelectionEvent = new CanvasSelectionEvent(abstractCanvasHandler, UUID);
+        canvasSelectionEvent = new CanvasSelectionEvent(abstractCanvasHandler, UUID, false, false);
 
         handler.onCanvasSelectionEvent(canvasSelectionEvent);
 


### PR DESCRIPTION
This changes accomplishes 3 things
1) Improves Form loading and rendering by checking if the previous form was already rendered if so, it will skil rendering
2) Improves Draging time, eliminates the 800 Millisecond delay when clicking and dragging a node, instead of calling form rendering once at the begining and one at the end, it does only at the end when the mouse is released
3) Improves Node click time to response, eliminates 800 MS delay to show toolbox, instead it shows it and the calls the Form Render at the end instead of at the begining

*** As a side note and as mentioned on call, Every once in a while a click event gets dropped, this is observed both before these improvements and after the improvements. Will research later