### PR TITLE
[7.26.x] DROOLS-4545 : GDST V&V: Clean up situations where the webworker fails

### DIFF
--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnectionImpl.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnectionImpl.java
@@ -26,13 +26,11 @@ public class VerifierWebWorkerConnectionImpl
         implements VerifierWebWorkerConnection {
 
     private static final Logger LOGGER = Logger.getLogger("DTable Analyzer");
-
-    private Worker worker = null;
-
     private final Poster poster;
     private final Receiver receiver;
     private final Initialize initialize;
     private final String pathToVerifier;
+    private Worker worker = null;
 
     public VerifierWebWorkerConnectionImpl(final Initialize initialize,
                                            final String pathToVerifier,
@@ -53,10 +51,14 @@ public class VerifierWebWorkerConnectionImpl
     }
 
     private void startWorker() {
-        worker = Worker.create(pathToVerifier);
+        worker = createWorker();
 
         poster.setUp(worker);
         receiver.setUp(worker);
+    }
+
+    protected Worker createWorker() {
+        return Worker.create(pathToVerifier);
     }
 
     @Override

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/reporting/ExplanationProvider.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/reporting/ExplanationProvider.java
@@ -40,6 +40,11 @@ public class ExplanationProvider {
         }
 
         switch (issue.getCheckType()) {
+            case ILLEGAL_VERIFIER_STATE:
+                return new Explanation()
+                        .addParagraph(AnalysisConstants.INSTANCE.VerifierFailed())
+                        .toHTML();
+
             case CONFLICTING_ROWS:
                 return new Explanation()
                         .addParagraph(AnalysisConstants.INSTANCE.ConflictingRowsP1())
@@ -191,6 +196,8 @@ public class ExplanationProvider {
         }
 
         switch (issue.getCheckType()) {
+            case ILLEGAL_VERIFIER_STATE:
+                return AnalysisConstants.INSTANCE.VerifierFailedTitle();
             case CONFLICTING_ROWS:
                 return AnalysisConstants.INSTANCE.ConflictingRows();
             case DEFICIENT_ROW:

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/resources/i18n/AnalysisConstants.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/resources/i18n/AnalysisConstants.java
@@ -132,4 +132,9 @@ public interface AnalysisConstants
     String ProvideAtLeastOneConditionAndOneActionForTheRule();
 
     String Analysis();
+
+    String VerifierFailedTitle();
+
+    String VerifierFailed();
+
 }

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/resources/i18n/AnalysisConstants.properties
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/resources/i18n/AnalysisConstants.properties
@@ -61,3 +61,5 @@ SingleHitP1=Lines {0} and {1} can be satisfied with the same facts. This means m
 AnalysisComplete=Analysis complete
 EmptyRule=Rule is empty
 Analysis=Analysis
+VerifierFailedTitle=Verifier error
+VerifierFailed=Verifier failed to run. This can be caused by a table that does not compile.

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/AnalysisReporterTest.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/AnalysisReporterTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+import java.util.HashSet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReport;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mvp.PlaceRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AnalysisReporterTest {
+
+    @Mock
+    private PlaceRequest place;
+    @Mock
+    private AnalysisReportScreen reportScreen;
+    @Captor
+    private ArgumentCaptor<AnalysisReport> analysisReportArgumentCaptor;
+
+    @Test
+    public void sendReport() {
+        new AnalysisReporter(place,
+                             reportScreen).sendReport(new HashSet<>());
+
+        verify(reportScreen).showReport(analysisReportArgumentCaptor.capture());
+        final AnalysisReport report = analysisReportArgumentCaptor.getValue();
+
+        assertTrue(report.getAnalysisData().isEmpty());
+        assertEquals(place, report.getPlace());
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/ReceiverTest.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/ReceiverTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.gwt.webworker.client.MessageEvent;
+import com.google.gwt.webworker.client.MessageHandler;
+import com.google.gwt.webworker.client.Worker;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.verifier.api.Status;
+import org.drools.verifier.api.reporting.IllegalVerifierStateIssue;
+import org.drools.verifier.api.reporting.Issue;
+import org.drools.verifier.api.reporting.Issues;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.verifier.api.client.api.WebWorkerException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ReceiverTest {
+
+    @Mock
+    private Worker worker;
+    @Captor
+    private ArgumentCaptor<MessageHandler> messageHandlerArgumentCaptor;
+    @Captor
+    private ArgumentCaptor<Set> setArgumentCaptor;
+    @Mock
+    private AnalysisReporter reporter;
+    private Receiver receiver;
+
+    private Object returnObject;
+
+    @Before
+    public void setUp() {
+
+        receiver = new Receiver(reporter) {
+            @Override
+            public Object fromJSON(final String json) {
+                return returnObject;
+            }
+        };
+
+        receiver.setUp(worker);
+        verify(worker).setOnMessage(messageHandlerArgumentCaptor.capture());
+    }
+
+    @Test
+    public void status() {
+        returnObject = new Status();
+
+        messageHandlerArgumentCaptor.getValue().onMessage(mock(MessageEvent.class));
+
+        verify(reporter).sendStatus((Status) returnObject);
+    }
+
+    @Test
+    public void issues() {
+        returnObject = new Issues("id",
+                                  new HashSet<>());
+
+        messageHandlerArgumentCaptor.getValue().onMessage(mock(MessageEvent.class));
+
+        verify(reporter).sendReport(anySet());
+    }
+
+    @Test
+    public void webWorkerException() {
+        returnObject = new WebWorkerException("error");
+
+        messageHandlerArgumentCaptor.getValue().onMessage(mock(MessageEvent.class));
+
+        verify(reporter, never()).sendStatus(any());
+        verify(reporter).sendReport(setArgumentCaptor.capture());
+        verify(worker).terminate();
+
+        final Set<Issue> issues = setArgumentCaptor.getValue();
+        assertEquals(1, issues.size());
+        assertTrue(issues.iterator().next() instanceof IllegalVerifierStateIssue);
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnectionImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/analysis/VerifierWebWorkerConnectionImplTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.verifier.reporting.client.analysis;
+
+import com.google.gwt.webworker.client.Worker;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.verifier.api.client.api.Initialize;
+import org.kie.workbench.common.services.verifier.api.client.api.RequestStatus;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class VerifierWebWorkerConnectionImplTest {
+
+    private VerifierWebWorkerConnection verifierWebWorkerConnection;
+
+    @Mock
+    private Initialize initialize;
+
+    @Mock
+    private Poster poster;
+
+    @Mock
+    private Receiver receiver;
+
+    @Mock
+    private Worker worker;
+
+    @Before
+    public void setUp() {
+        verifierWebWorkerConnection = spy(new VerifierWebWorkerConnectionImpl(initialize,
+                                                                              "verifier/dtableVerifier/dtableVerifier.nocache.js",
+                                                                              poster,
+                                                                              receiver) {
+            @Override
+            protected Worker createWorker() {
+                return worker;
+            }
+        });
+    }
+
+    @Test
+    public void firstActivationStartWebWorker() throws
+            Exception {
+        verifierWebWorkerConnection.activate();
+
+        verify(receiver).activate();
+        verify(receiver).setUp(any());
+
+        verify(poster).setUp(any());
+        verify(poster).post(any(Initialize.class));
+    }
+
+    @Test
+    public void secondActivationDoesNotStartWebWorker() throws
+            Exception {
+        verifierWebWorkerConnection.activate();
+
+        reset(receiver,
+              poster);
+
+        verifierWebWorkerConnection.activate();
+
+        verify(receiver).activate();
+        verify(receiver,
+               never()).setUp(any());
+
+        verify(poster,
+               never()).setUp(any());
+        verify(poster).post(any(RequestStatus.class));
+    }
+
+    @Test
+    public void terminateCanBeCalledEvenIfWorkerHasNotBeenActivated() throws
+            Exception {
+
+        verifierWebWorkerConnection.activate();
+
+        verifierWebWorkerConnection.terminate();
+
+        verify(worker).terminate();
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/IssuePresenterTest.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/IssuePresenterTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.verifier.api.reporting.CheckType;
+import org.drools.verifier.api.reporting.IllegalVerifierStateIssue;
 import org.drools.verifier.api.reporting.Issue;
 import org.drools.verifier.api.reporting.Severity;
 import org.junit.Before;
@@ -66,6 +67,21 @@ public class IssuePresenterTest {
                      safeHtmlArgumentCaptor.getValue()
                              .asString());
         verify(view).setLines("1, 2, 3");
+    }
+
+    @Test
+    public void testIllegalVerifierState() {
+
+        final Issue issue = new IllegalVerifierStateIssue();
+
+        screen.show(issue);
+
+        verify(view).setIssueTitle("VerifierFailedTitle");
+        ArgumentCaptor<SafeHtml> safeHtmlArgumentCaptor = ArgumentCaptor.forClass(SafeHtml.class);
+        verify(view).setExplanation(safeHtmlArgumentCaptor.capture());
+        assertEquals("<p>VerifierFailed</p>",
+                     safeHtmlArgumentCaptor.getValue().asString());
+        verify(view).setLines("");
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4545

https://github.com/kiegroup/drools/pull/2592
https://github.com/kiegroup/kie-wb-common/pull/2952
https://github.com/kiegroup/drools-wb/pull/1244

* DROOLS-4545 : GDST V&V: Clean up situations where the webworker fails

* DROOLS-4545 : GDST V&V: Clean up situations where the webworker fails
- Improve reporting when V&V fails

* DROOLS-4545: Increase coverage

(cherry picked from commit 841c768a68dd6f3c946dafe85c7ddbd9a26664b8)