### PR TITLE
DROOLS-4484 / DROOLS-4615: [DMN Designer] Data Types - Refactor the Data Types list to use a drag and drop mechanism / Persist data type list order into the DMN model

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNDataTypesSubIndex.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/search/DMNDataTypesSubIndex.java
@@ -69,7 +69,7 @@ public class DMNDataTypesSubIndex implements DMNSubIndex {
 
     void highlight(final DataTypeListItem item) {
         expandParents(item);
-        dataTypeShortcuts.highlight(item.getElement());
+        dataTypeShortcuts.highlight(item.getDragAndDropElement());
     }
 
     private void expandParents(final DataTypeListItem item) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManager.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManager.java
@@ -221,10 +221,14 @@ public class DataTypeManager {
     }
 
     public DataTypeManager withNoName() {
-        return withUniqueName(none());
+        return withName(none());
     }
 
-    DataTypeManager withUniqueName(final String name) {
+    public DataTypeManager withUniqueName() {
+        return withUniqueName(dataType.getName());
+    }
+
+    public DataTypeManager withUniqueName(final String name) {
         return withUniqueName(name, 1);
     }
 
@@ -338,6 +342,19 @@ public class DataTypeManager {
 
     public String structure() {
         return translationService.format(DataTypeManager_Structure);
+    }
+
+    public String getTypeName() {
+
+        final String type = dataType.getType();
+        final String name = dataType.getName();
+        final String structure = structure();
+
+        if (Objects.equals(type, structure)) {
+            return name;
+        } else {
+            return type;
+        }
     }
 
     private List<DataType> createSubDataTypes(final List<ItemDefinition> itemComponent) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManager.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManager.java
@@ -207,12 +207,22 @@ public class DataTypeManager {
     }
 
     public DataTypeManager withSubDataTypes(final List<DataType> dataTypes) {
-        dataType.getSubDataTypes().forEach(dataType -> {
-            dataTypeStore.unIndex(dataType.getUUID());
-            itemDefinitionStore.unIndex(dataType.getUUID());
-        });
-        dataType.setSubDataTypes(dataTypes);
+        if (!isReadOnly(dataType)) {
+            dataType.getSubDataTypes().forEach(dataType -> {
+                dataTypeStore.unIndex(dataType.getUUID());
+                itemDefinitionStore.unIndex(dataType.getUUID());
+            });
+            dataType.setSubDataTypes(dataTypes);
+        }
         return this;
+    }
+
+    private boolean isReadOnly(final DataType dataType) {
+        return dataType.isReadOnly() || isReadyOnlyType(dataType.getType());
+    }
+
+    private boolean isReadyOnlyType(final String type) {
+        return itemDefinitionUtils.findByName(type).map(ItemDefinition::isAllowOnlyVisualChange).orElse(false);
     }
 
     DataTypeManager withUUID() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
@@ -238,7 +238,6 @@ public class DataTypeList {
         showListItems();
         listItem.refresh();
         listItem.enableEditMode();
-        fireOnDataTypeListItemUpdateCallback(listItem);
         refreshItemsCSSAndHTMLPosition();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import javax.annotation.PostConstruct;
@@ -27,7 +28,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import elemental2.dom.HTMLDivElement;
+import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
@@ -35,8 +36,12 @@ import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeStackHash;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.kie.workbench.common.dmn.client.editors.types.search.DataTypeSearchBar;
 import org.uberfire.client.mvp.UberElemental;
+
+import static java.util.Collections.singletonList;
 
 @ApplicationScoped
 public class DataTypeList {
@@ -51,28 +56,42 @@ public class DataTypeList {
 
     private final DataTypeStackHash dataTypeStackHash;
 
+    private final DNDListComponent dndListComponent;
+
+    private final DNDDataTypesHandler dndDataTypesHandler;
+
     private Consumer<DataTypeListItem> onDataTypeListItemUpdate = (e) -> { /* Nothing. */ };
 
-    private List<DataTypeListItem> items;
+    private List<DataTypeListItem> items = new ArrayList<>();
 
     private DataTypeListItem currentEditingItem;
 
     @Inject
-    public DataTypeList(final DataTypeList.View view,
+    public DataTypeList(final View view,
                         final ManagedInstance<DataTypeListItem> listItems,
                         final DataTypeManager dataTypeManager,
                         final DataTypeSearchBar searchBar,
-                        final DataTypeStackHash dataTypeStackHash) {
+                        final DNDListComponent dndListComponent,
+                        final DataTypeStackHash dataTypeStackHash,
+                        final DNDDataTypesHandler dndDataTypesHandler) {
         this.view = view;
         this.listItems = listItems;
         this.dataTypeManager = dataTypeManager;
         this.searchBar = searchBar;
+        this.dndListComponent = dndListComponent;
         this.dataTypeStackHash = dataTypeStackHash;
+        this.dndDataTypesHandler = dndDataTypesHandler;
     }
 
     @PostConstruct
     void setup() {
         view.init(this);
+        dndDataTypesHandler.init(this);
+        dndListComponent.setOnDropItem(getOnDropDataType());
+    }
+
+    BiConsumer<Element, Element> getOnDropDataType() {
+        return dndDataTypesHandler::onDropDataType;
     }
 
     public HTMLElement getElement() {
@@ -80,9 +99,20 @@ public class DataTypeList {
     }
 
     public void setupItems(final List<DataType> dataTypes) {
-        setListItems(makeDataTypeListItems(dataTypes));
-        setupViewItems();
+        setupItemsView(dataTypes);
+        setupViewElements();
         collapseItemsInTheFirstLevel();
+    }
+
+    private void setupItemsView(final List<DataType> dataTypes) {
+        getDNDListComponent().clear();
+        setListItems(makeDataTypeListItems(dataTypes));
+        getDNDListComponent().refreshItemsPosition();
+    }
+
+    private void setupViewElements() {
+        view.showOrHideNoCustomItemsMessage();
+        view.showReadOnlyMessage(hasReadOnlyDataTypes());
     }
 
     List<DataTypeListItem> makeDataTypeListItems(final List<DataType> dataTypes) {
@@ -160,19 +190,19 @@ public class DataTypeList {
                 refreshSubItemsFromListItem(listItem, dataType.getSubDataTypes());
             });
         }
-        searchBar.refresh();
+        refreshDragAndDropList();
+        refreshSearchBar();
     }
 
-    Optional<DataTypeListItem> findItem(final DataType dataType) {
+    public Optional<DataTypeListItem> findItem(final DataType dataType) {
         return getItems()
                 .stream()
                 .filter(item -> Objects.equals(item.getDataType().getUUID(), dataType.getUUID()))
                 .findFirst();
     }
 
-    void setupViewItems() {
-        view.setupListItems(getItems());
-        view.showReadOnlyMessage(hasReadOnlyDataTypes());
+    public DNDListComponent getDNDListComponent() {
+        return dndListComponent;
     }
 
     private boolean hasReadOnlyDataTypes() {
@@ -198,26 +228,31 @@ public class DataTypeList {
 
     void addDataType() {
 
+        resetSearchBar();
+
         final DataType dataType = dataTypeManager.fromNew().get();
         final DataTypeListItem listItem = makeListItem(dataType);
 
         dataType.create();
 
-        searchBar.reset();
-        view.addSubItem(listItem);
-
+        showListItems();
+        listItem.refresh();
         listItem.enableEditMode();
         fireOnDataTypeListItemUpdateCallback(listItem);
+        refreshItemsCSSAndHTMLPosition();
     }
 
     void insertBelow(final DataType dataType,
                      final DataType reference) {
-        view.insertBelow(makeListItem(dataType), reference);
+        final DataTypeListItem listItem = makeListItem(dataType);
+        view.insertBelow(listItem, reference);
+        refreshItemsByUpdatedDataTypes(singletonList(listItem.getDataType()));
     }
 
     void insertAbove(final DataType dataType,
                      final DataType reference) {
         view.insertAbove(makeListItem(dataType), reference);
+        refreshDragAndDropList();
     }
 
     public void showNoDataTypesFound() {
@@ -228,18 +263,10 @@ public class DataTypeList {
         view.showOrHideNoCustomItemsMessage();
     }
 
-    public HTMLElement getListItemsElement() {
-        return view.getListItems();
-    }
-
     DataTypeListItem makeListItem(final DataType dataType) {
-
-        final DataTypeListItem listItem = makeListItem();
-
-        listItem.setupDataType(dataType, 1);
-        getItems().add(listItem);
-
-        return listItem;
+        final List<DataTypeListItem> items = makeTreeListItems(dataType, 1);
+        getItems().addAll(items);
+        return items.get(0);
     }
 
     void expandAll() {
@@ -274,11 +301,11 @@ public class DataTypeList {
         findItemByDataTypeHash(dataTypeHash).ifPresent(this::fireOnDataTypeListItemUpdateCallback);
     }
 
-    private void fireOnDataTypeListItemUpdateCallback(final DataTypeListItem listItem) {
+    void fireOnDataTypeListItemUpdateCallback(final DataTypeListItem listItem) {
         onDataTypeListItemUpdate.accept(listItem);
     }
 
-    Optional<DataTypeListItem> findItemByDataTypeHash(final String dataTypeHash) {
+    public Optional<DataTypeListItem> findItemByDataTypeHash(final String dataTypeHash) {
         return getItems()
                 .stream()
                 .filter(item -> Objects.equals(calculateHash(item.getDataType()), dataTypeHash))
@@ -289,11 +316,12 @@ public class DataTypeList {
         return dataTypeStackHash.calculateParentHash(dataType);
     }
 
-    String calculateHash(final DataType dataType) {
+    public String calculateHash(final DataType dataType) {
         return dataTypeStackHash.calculateHash(dataType);
     }
 
     public void onDataTypeEditModeToggle(final @Observes DataTypeEditModeToggleEvent event) {
+        resetSearchBar();
         if (event.isEditModeEnabled()) {
             if (getCurrentEditingItem() != null && getItems().contains(getCurrentEditingItem())) {
                 getCurrentEditingItem().disableEditMode();
@@ -304,6 +332,11 @@ public class DataTypeList {
         }
     }
 
+    void refreshDragAndDropList() {
+        getDNDListComponent().consolidateYPosition();
+        getDNDListComponent().refreshItemsPosition();
+    }
+
     DataTypeListItem getCurrentEditingItem() {
         return currentEditingItem;
     }
@@ -312,21 +345,33 @@ public class DataTypeList {
         this.currentEditingItem = currentEditingItem;
     }
 
+    void refreshItemsCSSAndHTMLPosition() {
+        dndListComponent.refreshItemsCSSAndHTMLPosition();
+    }
+
+    public HTMLElement getListItems() {
+        return view.getListItems();
+    }
+
+    private void resetSearchBar() {
+        searchBar.reset();
+    }
+
+    private void refreshSearchBar() {
+        searchBar.refresh();
+    }
+
     public interface View extends UberElemental<DataTypeList>,
                                   IsElement {
-
-        void setupListItems(final List<DataTypeListItem> treeGridItems);
 
         void showOrHideNoCustomItemsMessage();
 
         void addSubItems(final DataType dataType,
                          final List<DataTypeListItem> treeGridItems);
 
-        void addSubItem(final DataTypeListItem listItem);
-
         void removeItem(final DataType dataType);
 
-        void cleanSubTypes(DataType dataType);
+        void cleanSubTypes(final DataType dataType);
 
         void insertBelow(final DataTypeListItem listItem,
                          final DataType reference);
@@ -336,8 +381,8 @@ public class DataTypeList {
 
         void showNoDataTypesFound();
 
-        HTMLDivElement getListItems();
+        void showReadOnlyMessage(final boolean show);
 
-        void showReadOnlyMessage(boolean show);
+        HTMLElement getListItems();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -252,6 +252,7 @@ public class DataTypeListItem {
         dataTypeConstraintComponent.enableEditMode();
 
         editModeToggleEvent.fire(new DataTypeEditModeToggleEvent(true, this));
+        dataTypeList.fireOnDataTypeListItemUpdateCallback(this);
     }
 
     public void disableEditMode() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -635,7 +635,7 @@ public class DataTypeListItem {
     }
 
     void setupIndentationLevel() {
-        setPositionX(getDragAndDropElement(), getLevel() - 1);
+        setPositionX(getDragAndDropElement(), getLevel() - 1d);
     }
 
     public interface View extends UberElemental<DataTypeListItem> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -379,18 +379,27 @@ public class DataTypeListItem {
     }
 
     public Command destroy() {
-        return () -> {
+        return this::destroyWithDependentTypes;
+    }
 
-            final List<DataType> destroyedDataTypes = getDataType().destroy();
-            final List<DataType> removedDataTypes = removeTopLevelDataTypes(destroyedDataTypes);
+    public void destroyWithDependentTypes() {
+        final List<DataType> destroyedDataTypes = getDataType().destroy();
+        destroy(destroyedDataTypes);
+    }
 
-            destroyedDataTypes.removeAll(removedDataTypes);
+    public void destroyWithoutDependentTypes() {
+        final List<DataType> destroyedDataTypes = getDataType().destroyWithoutDependentTypes();
+        destroy(destroyedDataTypes);
+    }
 
-            dataTypeList.refreshItemsByUpdatedDataTypes(destroyedDataTypes);
+    void destroy(final List<DataType> destroyedDataTypes) {
 
-            fireDataChangedEvent();
-            hideTooltips();
-        };
+        final List<DataType> removedDataTypes = removeTopLevelDataTypes(destroyedDataTypes);
+        destroyedDataTypes.removeAll(removedDataTypes);
+        dataTypeList.refreshItemsByUpdatedDataTypes(destroyedDataTypes);
+
+        fireDataChangedEvent();
+        hideTooltips();
     }
 
     List<DataType> removeTopLevelDataTypes(final List<DataType> destroyedDataTypes) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -500,7 +500,7 @@ public class DataTypeListItem {
         closeEditMode();
 
         final DataType newDataType = newDataType();
-        final String referenceDataTypeHash = insertFieldBelow(getDataType());
+        final String referenceDataTypeHash = insertFieldBelow(newDataType);
 
         enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -28,7 +28,9 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
+import elemental2.dom.NodeList;
 import org.kie.workbench.common.dmn.api.definition.model.ConstraintType;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypeChangedEvent;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
@@ -37,8 +39,10 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTyp
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.SmallSwitchComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.confirmation.DataTypeConfirmation;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.DataTypeConstraint;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.validation.DataTypeNameFormatValidator;
 import org.uberfire.client.mvp.UberElemental;
+import org.uberfire.client.views.pfly.selectpicker.ElementHelper;
 import org.uberfire.mvp.Command;
 
 import static org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType.BOOLEAN;
@@ -87,6 +91,8 @@ public class DataTypeListItem {
 
     private String[] canNotHaveConstraintTypes;
 
+    private HTMLElement dragAndDropElement;
+
     @Inject
     public DataTypeListItem(final View view,
                             final DataTypeSelect dataTypeSelectComponent,
@@ -123,20 +129,22 @@ public class DataTypeListItem {
         this.dataTypeList = dataTypeList;
     }
 
-    public HTMLElement getElement() {
-        return view.getElement();
-    }
-
     void setupDataType(final DataType dataType,
                        final int level) {
 
         this.dataType = dataType;
         this.level = level;
 
+        setupDragAndDropComponent();
         setupSelectComponent();
         setupListComponent();
         setupConstraintComponent();
         setupView();
+    }
+
+    void setupDragAndDropComponent() {
+        final DNDListComponent dragAndDropComponent = getDNDListComponent();
+        this.dragAndDropElement = dragAndDropComponent.registerNewItem(getContentElement());
     }
 
     void setupListComponent() {
@@ -154,10 +162,14 @@ public class DataTypeListItem {
     }
 
     void setupView() {
+
         view.setupSelectComponent(dataTypeSelectComponent);
         view.setupConstraintComponent(dataTypeConstraintComponent);
         view.setupListComponent(dataTypeListComponent);
         view.setDataType(getDataType());
+
+        setupIndentationLevel();
+        hideTooltips();
     }
 
     void refresh() {
@@ -167,6 +179,7 @@ public class DataTypeListItem {
         view.setName(getDataType().getName());
         setupListComponent();
         setupConstraintComponent();
+        hideTooltips();
     }
 
     public DataType getDataType() {
@@ -181,16 +194,20 @@ public class DataTypeListItem {
         return level;
     }
 
-    public String[] getCanNotHaveConstraintTypes() {
+    private String[] getCanNotHaveConstraintTypes() {
         return canNotHaveConstraintTypes;
     }
 
     void expandOrCollapseSubTypes() {
-        if (view.isCollapsed()) {
+        if (isCollapsed()) {
             expand();
         } else {
             collapse();
         }
+    }
+
+    public boolean isCollapsed() {
+        return view.isCollapsed();
     }
 
     public void expand() {
@@ -205,6 +222,9 @@ public class DataTypeListItem {
 
         dataTypeList.refreshSubItemsFromListItem(this, dataTypes);
 
+        expandOrCollapseSubTypes();
+
+        dataTypeList.refreshDragAndDropList();
         view.enableFocusMode();
         view.toggleArrow(!dataTypes.isEmpty());
     }
@@ -238,6 +258,15 @@ public class DataTypeListItem {
         if (view.isOnFocusMode()) {
             discardNewDataType();
             closeEditMode();
+            hideTooltips();
+        }
+    }
+
+    void hideTooltips() {
+        final String selector = ".tooltip";
+        final NodeList<Element> tooltips = getDataTypeList().getListItems().querySelectorAll(selector);
+        for (int i = 0; i < tooltips.length; i++) {
+            ElementHelper.remove(tooltips.getAt(i));
         }
     }
 
@@ -305,6 +334,7 @@ public class DataTypeListItem {
         setupListComponent();
         setupSelectComponent();
         setupConstraintComponent();
+        setupIndentationLevel();
         refreshSubItems(oldDataType.getSubDataTypes());
     }
 
@@ -344,10 +374,10 @@ public class DataTypeListItem {
     }
 
     public void remove() {
-        confirmation.ifIsNotReferencedDataType(getDataType(), doRemove());
+        confirmation.ifIsNotReferencedDataType(getDataType(), destroy());
     }
 
-    Command doRemove() {
+    public Command destroy() {
         return () -> {
 
             final List<DataType> destroyedDataTypes = getDataType().destroy();
@@ -358,6 +388,7 @@ public class DataTypeListItem {
             dataTypeList.refreshItemsByUpdatedDataTypes(destroyedDataTypes);
 
             fireDataChangedEvent();
+            hideTooltips();
         };
     }
 
@@ -443,16 +474,25 @@ public class DataTypeListItem {
         closeEditMode();
 
         final DataType newDataType = newDataType();
-        final String referenceDataTypeHash = dataTypeList.calculateParentHash(getDataType());
-        final List<DataType> updatedDataTypes = newDataType.create(getDataType(), ABOVE);
+        final String referenceDataTypeHash = insertFieldAbove(newDataType);
 
-        if (newDataType.isTopLevel()) {
-            dataTypeList.insertAbove(newDataType, getDataType());
+        enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+    }
+
+    public String insertFieldAbove(final DataType dataType) {
+
+        final String referenceDataTypeHash = dataTypeList.calculateParentHash(getDataType());
+        final List<DataType> updatedDataTypes = dataType.create(getDataType(), ABOVE);
+
+        if (dataType.isTopLevel()) {
+            dataTypeList.insertAbove(dataType, getDataType());
         } else {
             dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes);
         }
 
-        enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+        getDNDListComponent().refreshItemsCSSAndHTMLPosition();
+
+        return referenceDataTypeHash;
     }
 
     public void insertFieldBelow() {
@@ -460,29 +500,44 @@ public class DataTypeListItem {
         closeEditMode();
 
         final DataType newDataType = newDataType();
-        final String referenceDataTypeHash = dataTypeList.calculateParentHash(getDataType());
-        final List<DataType> updatedDataTypes = newDataType.create(getDataType(), BELOW);
-
-        if (newDataType.isTopLevel()) {
-            dataTypeList.insertBelow(newDataType, getDataType());
-        } else {
-            dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes);
-        }
+        final String referenceDataTypeHash = insertFieldBelow(getDataType());
 
         enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
     }
 
+    public String insertFieldBelow(final DataType dataType) {
+
+        final String referenceDataTypeHash = dataTypeList.calculateParentHash(getDataType());
+        final List<DataType> updatedDataTypes = dataType.create(getDataType(), BELOW);
+
+        if (dataType.isTopLevel()) {
+            dataTypeList.insertBelow(dataType, getDataType());
+        } else {
+            dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes);
+        }
+
+        getDNDListComponent().refreshItemsCSSAndHTMLPosition();
+
+        return referenceDataTypeHash;
+    }
+
     public void insertNestedField() {
+
+        final DataType newDataType = newDataType();
+        final String referenceDataTypeHash = dataTypeList.calculateHash(getDataType());
+
+        insertNestedField(newDataType);
+
+        enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+    }
+
+    public void insertNestedField(final DataType newDataType) {
 
         closeEditMode();
         expand();
 
-        final DataType newDataType = newDataType();
-        final String referenceDataTypeHash = dataTypeList.calculateHash(getDataType());
         final List<DataType> updatedDataTypes = newDataType.create(getDataType(), NESTED);
-        dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes);
-
-        enableEditModeAndUpdateCallbacks(getNewDataTypeHash(newDataType, referenceDataTypeHash));
+        dataTypeList.refreshItemsByUpdatedDataTypes(updatedDataTypes.stream().distinct().collect(Collectors.toList()));
     }
 
     void enableEditModeAndUpdateCallbacks(final String dataTypeHash) {
@@ -515,18 +570,11 @@ public class DataTypeListItem {
             return true;
         }
 
-        if (Stream.of(getCanNotHaveConstraintTypes())
-                .filter(type -> Objects.equals(type, getType()))
-                .findFirst()
-                .isPresent()) {
+        if (Stream.of(getCanNotHaveConstraintTypes()).anyMatch(type -> Objects.equals(type, getType()))) {
             return true;
         }
 
-        if (isIndirectCanNotHaveConstraintType()) {
-            return true;
-        }
-
-        return false;
+        return isIndirectCanNotHaveConstraintType();
     }
 
     boolean isStructureType() {
@@ -546,10 +594,48 @@ public class DataTypeListItem {
 
         if (customType.isPresent()) {
             final String type = customType.get().getType();
-            return Arrays.stream(types).anyMatch(t -> t.equals(type)) || isIndirectTypeOf(type, types);
+            return Arrays.asList(types).contains(type) || isIndirectTypeOf(type, types);
         }
 
         return false;
+    }
+
+    HTMLElement getContentElement() {
+        return view.getElement();
+    }
+
+    void refreshItemsCSSAndHTMLPosition() {
+        dataTypeList.refreshItemsCSSAndHTMLPosition();
+    }
+
+    HTMLElement getDragAndDropListElement() {
+        return getDNDListComponent().getElement();
+    }
+
+    void setPositionX(final Element element,
+                      final double positionX) {
+        getDNDListComponent().setPositionX(element, positionX);
+    }
+
+    void setPositionY(final Element element,
+                      final double positionY) {
+        getDNDListComponent().setPositionY(element, positionY);
+    }
+
+    int getPositionY(final Element element) {
+        return getDNDListComponent().getPositionY(element);
+    }
+
+    private DNDListComponent getDNDListComponent() {
+        return dataTypeList.getDNDListComponent();
+    }
+
+    public HTMLElement getDragAndDropElement() {
+        return dragAndDropElement;
+    }
+
+    void setupIndentationLevel() {
+        setPositionX(getDragAndDropElement(), getLevel() - 1);
     }
 
     public interface View extends UberElemental<DataTypeListItem> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.html
@@ -16,9 +16,9 @@
 
 <div data-field="view" class="list-group-item">
     <div class="list-view-pf-actions">
-        <button data-type-field="edit-button" class="btn btn-sm btn-default" data-i18n-key="Edit" data-toggle="tooltip" data-delay="500" data-placement="bottom"></button>
-        <button data-type-field="save-button" class="btn btn-sm btn-primary" data-i18n-key="Save" data-toggle="tooltip" data-delay="500" data-placement="bottom"></button>
-        <button data-type-field="close-button" class="btn btn-sm btn-default" data-i18n-key="Cancel" data-toggle="tooltip" data-delay="500" data-placement="bottom"></button>
+        <button data-type-field="edit-button" class="btn btn-sm btn-default" data-i18n-key="Edit" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="bottom"></button>
+        <button data-type-field="save-button" class="btn btn-sm btn-primary" data-i18n-key="Save" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="bottom"></button>
+        <button data-type-field="close-button" class="btn btn-sm btn-default" data-i18n-key="Cancel" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="bottom"></button>
         <div data-type-field="kebab-menu" class="dropdown-kebab-container">
             <div class="dropdown pull-right dropdown-kebab-pf">
                 <button class="btn btn-link dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
@@ -26,23 +26,19 @@
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right">
                     <li>
-                        <a data-type-field="remove-button" href="#" data-i18n-key="Remove" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
+                        <a data-type-field="remove-button" href="#" data-i18n-key="Remove" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="left"></a>
                     </li>
                     <li role="separator" class="divider"></li>
                     <li>
-                        <a data-type-field="insert-field-above" href="#" data-i18n-key="InsertFieldAbove" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
+                        <a data-type-field="insert-field-above" href="#" data-i18n-key="InsertFieldAbove" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="left"></a>
                     </li>
                     <li>
-                        <a data-type-field="insert-field-below" href="#" data-i18n-key="InsertFieldBelow" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
+                        <a data-type-field="insert-field-below" href="#" data-i18n-key="InsertFieldBelow" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="left"></a>
                     </li>
                     <li role="separator" class="divider"></li>
                     <li>
-                        <a data-type-field="insert-nested-field" href="#" data-i18n-key="InsertNestedField" data-toggle="tooltip" data-delay="500" data-placement="left"></a>
+                        <a data-type-field="insert-nested-field" href="#" data-i18n-key="InsertNestedField" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="left"></a>
                     </li>
-                    <!-- TODO: https://issues.jboss.org/browse/DROOLS-3083 -->
-                    <!--<li role="separator" class="divider"></li>-->
-                    <!--<li><a href="#" data-i18n-key="MoveUp"></a></li>-->
-                    <!--<li><a href="#" data-i18n-key="MoveDown"></a></li>-->
                 </ul>
             </div>
         </div>
@@ -50,10 +46,7 @@
 
     <div class="list-view-pf-main-info">
         <div class="list-view-pf-body">
-            <span class="nesting-level"></span>
-            <span data-type-field="arrow-button" class="icon expand-icon fa fa-caret-down" data-toggle="tooltip" data-delay="500" data-placement="right">
-                <span class="data-type-icon fa fa-object-group"></span>
-            </span>
+            <span data-type-field="arrow-button" class="icon expand-icon fa fa-chevron-down" data-toggle="tooltip" data-container="[data-field='list-items']" data-delay="500" data-placement="right"></span>
             <div>
                 <span class="data-type-label hidden" data-i18n-key="Name"></span>
                 <input class="name-input" data-type-field="name-input"/>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.listview;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -66,8 +67,6 @@ public class DataTypeListItemView implements DataTypeListItem.View {
 
     static final String ARROW_BUTTON_SELECTOR = "[data-type-field=\"arrow-button\"]";
 
-    private static final int PIXELS_PER_LEVEL = 35;
-
     @DataField("view")
     private final HTMLDivElement view;
 
@@ -99,8 +98,8 @@ public class DataTypeListItemView implements DataTypeListItem.View {
 
     void setupRowMetadata(final DataType dataType) {
 
-        getElement().setAttribute(UUID_ATTR, dataType.getUUID());
-        getElement().setAttribute(PARENT_UUID_ATTR, dataType.getParentUUID());
+        getDragAndDropElement().setAttribute(UUID_ATTR, dataType.getUUID());
+        getDragAndDropElement().setAttribute(PARENT_UUID_ATTR, dataType.getParentUUID());
 
         setupRowCSSClass(dataType);
     }
@@ -114,9 +113,9 @@ public class DataTypeListItemView implements DataTypeListItem.View {
         final String hasSubDataTypesCSSClass = "has-sub-data-types";
 
         if (dataType.hasSubDataTypes()) {
-            getElement().classList.add(hasSubDataTypesCSSClass);
+            getDragAndDropElement().classList.add(hasSubDataTypesCSSClass);
         } else {
-            getElement().classList.remove(hasSubDataTypesCSSClass);
+            getDragAndDropElement().classList.remove(hasSubDataTypesCSSClass);
         }
     }
 
@@ -125,31 +124,14 @@ public class DataTypeListItemView implements DataTypeListItem.View {
         final String readOnlyCSSClass = "read-only";
 
         if (dataType.isReadOnly()) {
-            getElement().classList.add(readOnlyCSSClass);
+            getDragAndDropElement().classList.add(readOnlyCSSClass);
         } else {
-            getElement().classList.remove(readOnlyCSSClass);
+            getDragAndDropElement().classList.remove(readOnlyCSSClass);
         }
     }
 
     void setupArrow(final DataType dataType) {
         toggleArrow(dataType.hasSubDataTypes());
-    }
-
-    void setupIndentationLevel() {
-
-        final int indentationLevel = presenter.getLevel();
-        final int marginPixels = PIXELS_PER_LEVEL * indentationLevel;
-        final String nestingLevelSelector = ".nesting-level";
-        final NodeList<Element> levelElements = getElement().querySelectorAll(nestingLevelSelector);
-
-        for (int i = 0; i < levelElements.length; i++) {
-
-            final Element element = levelElements.getAt(i);
-            final String propertyName = "style";
-            final String propertyValue = "margin-left: " + marginPixels + "px";
-
-            element.setAttribute(propertyName, propertyValue);
-        }
     }
 
     void setupReadOnly(final DataType dataType) {
@@ -174,12 +156,21 @@ public class DataTypeListItemView implements DataTypeListItem.View {
     public void expand() {
 
         final Element parent = getRowElement(getDataType());
+        final int parentPositionY = presenter.getPositionY(parent);
+
+        final AtomicInteger i = new AtomicInteger(1);
 
         asDownArrow(getArrow());
         forEachChildElement(parent, child -> {
+
             show(child);
+            double positionY = parentPositionY + (i.getAndIncrement() / 10.0);
+            presenter.setPositionY(child, positionY);
+
             return !isCollapsed(child.querySelector(ARROW_BUTTON_SELECTOR));
         });
+
+        presenter.refreshItemsCSSAndHTMLPosition();
     }
 
     @Override
@@ -188,7 +179,14 @@ public class DataTypeListItemView implements DataTypeListItem.View {
         final Element parent = getRowElement(getDataType());
 
         asRightArrow(getArrow());
-        forEachChildElement(parent, HiddenHelper::hide);
+        forEachChildElement(parent, element -> {
+
+            presenter.setPositionY(element, -2);
+
+            HiddenHelper.hide(element);
+        });
+
+        presenter.refreshItemsCSSAndHTMLPosition();
     }
 
     @Override
@@ -363,16 +361,12 @@ public class DataTypeListItemView implements DataTypeListItem.View {
     }
 
     private Element getRowElement(final String uuid) {
-        return dataTypeListElement().querySelector("[" + UUID_ATTR + "=\"" + uuid + "\"]");
+        return getDragAndDropListElement().querySelector("[" + UUID_ATTR + "=\"" + uuid + "\"]");
     }
 
     private NodeList<Element> getChildren(final Element parent) {
         final String childrenSelector = "[" + PARENT_UUID_ATTR + "=\"" + parent.getAttribute(UUID_ATTR) + "\"]";
-        return dataTypeListElement().querySelectorAll(childrenSelector);
-    }
-
-    HTMLElement dataTypeListElement() {
-        return presenter.getDataTypeList().getElement();
+        return getDragAndDropListElement().querySelectorAll(childrenSelector);
     }
 
     DataType getDataType() {
@@ -383,7 +377,6 @@ public class DataTypeListItemView implements DataTypeListItem.View {
     public void setDataType(final DataType dataType) {
         setupRowMetadata(dataType);
         setupArrow(dataType);
-        setupIndentationLevel();
         setupReadOnly(dataType);
         setupActionButtons();
         setupEventHandlers();
@@ -424,6 +417,14 @@ public class DataTypeListItemView implements DataTypeListItem.View {
         getInsertFieldBelow().onclick = getOnInsertFieldBelowAction();
         getInsertNestedField().onclick = getOnInsertNestedFieldAction();
         getRemoveButton().onclick = getOnRemoveButtonAction();
+    }
+
+    private HTMLElement getDragAndDropListElement() {
+        return presenter.getDragAndDropListElement();
+    }
+
+    private HTMLElement getDragAndDropElement() {
+        return presenter.getDragAndDropElement();
     }
 
     OnclickCallbackFn getOnEditAction() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
@@ -26,14 +26,6 @@
     padding-left: 25px;
   }
 
-  &.read-only {
-    cursor: not-allowed;
-
-    .list-view-pf-actions {
-      pointer-events: none;
-    }
-  }
-
   [data-type-field="arrow-button"] {
     cursor: pointer;
   }
@@ -153,6 +145,19 @@
 [data-i18n-prefix="DNDListComponentView."] {
 
   div[data-row-uuid] {
+
+    &.read-only {
+      cursor: not-allowed;
+      pointer-events: none;
+      filter: brightness(.98);
+      opacity: .75;
+
+      &.kie-dnd-hover {
+        .list-group-item {
+          background-color: #FFF;
+        }
+      }
+    }
 
     &.focused-data-type {
       .list-group-item {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
@@ -16,13 +16,10 @@
 
 [data-i18n-prefix="DataTypeListItemView."] {
 
-  &.list-group-item:hover {
-    background: #eff8ff;
-  }
-
   &.list-group-item {
-    border: 1px solid #e2e4e3;
-    height: 71px;
+    height: 70px;
+    background: none;
+    border: none;
     padding-left: 25px;
   }
 
@@ -146,6 +143,13 @@
 
   div[data-row-uuid] {
 
+    border: 1px solid #e2e4e3;
+    height: 71px;
+
+    &:hover {
+      background: #eff8ff;
+    }
+
     &.read-only {
       cursor: not-allowed;
       pointer-events: none;
@@ -153,17 +157,15 @@
       opacity: .75;
 
       &.kie-dnd-hover {
-        .list-group-item {
-          background-color: #FFF;
-        }
+        background-color: #FFF;
       }
     }
 
     &.focused-data-type {
-      .list-group-item {
-        background: #eff8ff;
-        height: 72px;
+      background: #eff8ff;
+      height: 72px;
 
+      .list-group-item {
         .constraint-component {
           padding-top: 5px;
         }
@@ -175,9 +177,7 @@
     }
 
     &.key-highlight {
-      .list-group-item {
-        background: #E5EEF5;
-      }
+      background: #E5EEF5;
     }
   }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.less
@@ -15,24 +15,15 @@
  */
 
 [data-i18n-prefix="DataTypeListItemView."] {
-  height: 50px;
 
   &.list-group-item:hover {
     background: #eff8ff;
   }
 
   &.list-group-item {
-    border-color: #e2e4e3;
-    padding: 0 5px 0 0;
-  }
-
-  &.list-group-item.key-highlight {
-    background: #E5EEF5;
-  }
-
-  &.focused-data-type {
-    background: #eff8ff;
-    height: 72px;
+    border: 1px solid #e2e4e3;
+    height: 71px;
+    padding-left: 25px;
   }
 
   &.read-only {
@@ -78,23 +69,23 @@
   }
 
   .list-view-pf-main-info {
-    padding-top: 8px;
-    padding-bottom: 12px;
+    padding: 0;
+    height: 100%;
+
+    .list-view-pf-body {
+      padding-left: 24px;
+      position: relative;
+    }
 
     [data-type-field="arrow-button"] {
-      margin-left: -20px;
-      width: 55px;
-      display: inline-block
+      position: absolute;
+      left: 3px;
     }
 
     [data-type-field="type"] {
       display: inline-block;
       padding-right: 30px;
     }
-  }
-
-  .nesting-level {
-    height: 32px;
   }
 
   .collection-component {
@@ -114,16 +105,6 @@
     margin-top: -8px;
     padding-top: 2px;
     height: 40px;
-  }
-
-  &.focused-data-type {
-    .constraint-component {
-      padding-top: 5px;
-    }
-
-    .collection-component {
-      padding-top: 10px;
-    }
   }
 
   .list-view-pf-actions {
@@ -146,11 +127,12 @@
     font-weight: initial;
     opacity: .75;
     padding-bottom: 3px;
+    margin-top: -10px;
   }
 
   [data-type-field="save-button"],
   [data-type-field="close-button"] {
-    margin-top: 12px;
+    margin-top: 2px;
   }
 
   ul.dropdown-menu {
@@ -165,5 +147,32 @@
 
   button {
     outline: none;
+  }
+}
+
+[data-i18n-prefix="DNDListComponentView."] {
+
+  div[data-row-uuid] {
+
+    &.focused-data-type {
+      .list-group-item {
+        background: #eff8ff;
+        height: 72px;
+
+        .constraint-component {
+          padding-top: 5px;
+        }
+
+        .collection-component {
+          padding-top: 10px;
+        }
+      }
+    }
+
+    &.key-highlight {
+      .list-group-item {
+        background: #E5EEF5;
+      }
+    }
   }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/ListItemViewCssHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/common/ListItemViewCssHelper.java
@@ -20,9 +20,9 @@ import elemental2.dom.Element;
 
 public class ListItemViewCssHelper {
 
-    public static final String RIGHT_ARROW_CSS_CLASS = "fa-caret-right";
+    public static final String RIGHT_ARROW_CSS_CLASS = "fa-chevron-right";
 
-    public static final String DOWN_ARROW_CSS_CLASS = "fa-caret-down";
+    public static final String DOWN_ARROW_CSS_CLASS = "fa-chevron-down";
 
     public static final String FOCUSED_CSS_CLASS = "focused-data-type";
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/confirmation/ReferencedDataTypeWarningMessage.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/confirmation/ReferencedDataTypeWarningMessage.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 
+import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItemView.UUID_ATTR;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.ReferencedDataTypeWarningMessage_RegularMessage;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.ReferencedDataTypeWarningMessage_StrongMessage;
 
@@ -39,5 +40,10 @@ public class ReferencedDataTypeWarningMessage extends WarningMessage {
     @Override
     String getRegularMessage() {
         return translationService.format(ReferencedDataTypeWarningMessage_RegularMessage);
+    }
+
+    @Override
+    String getErrorElementSelector(final DataType dataType) {
+        return "[" + UUID_ATTR + "=\"" + dataType.getUUID() + "\"] select";
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/confirmation/WarningMessage.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/confirmation/WarningMessage.java
@@ -38,7 +38,7 @@ abstract class WarningMessage {
         return new FlashMessage(WARNING, getStrongMessage(dataType), getRegularMessage(), getErrorElementSelector(dataType), onSuccess, onError);
     }
 
-    private String getErrorElementSelector(final DataType dataType) {
+    String getErrorElementSelector(final DataType dataType) {
         return "[" + UUID_ATTR + "=\"" + dataType.getUUID() + "\"] .bootstrap-select";
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
@@ -88,13 +88,24 @@ public class DNDDataTypesHandler {
 
         final String referenceHash = getDataTypeList().calculateHash(reference);
         final DataType clone = cloneDataType(current);
+        final Optional<DataTypeListItem> currentItem = getDataTypeList().findItem(current);
+        final Boolean isCurrentItemCollapsed = currentItem.map(DataTypeListItem::isCollapsed).orElse(false);
 
         // destroy current data type
-        getDataTypeList().findItem(current).ifPresent(item -> item.destroy().execute());
+        currentItem.ifPresent(item -> item.destroy().execute());
 
-        // create new by using shift strategy
+        // create new data type by using shift strategy
         getDataTypeList().findItemByDataTypeHash(referenceHash).ifPresent(ref -> {
             shiftStrategy.consumer.accept(ref, clone);
+        });
+
+        // keep the state of the new data type item consistent
+        getDataTypeList().findItem(clone).ifPresent(item -> {
+            if (isCurrentItemCollapsed) {
+                item.collapse();
+            } else {
+                item.expand();
+            }
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
@@ -176,11 +176,7 @@ public class DNDDataTypesHandler {
                 return getPreviousDataType();
             }
 
-            if (getCurrentDataType().isPresent()) {
-                return getFirstDataType(getCurrentDataType().get());
-            }
-
-            return Optional.empty();
+            return getCurrentDataType().flatMap(this::getFirstDataType);
         }
 
         ShiftStrategy getStrategy() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import javax.inject.Inject;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Element;
+import elemental2.dom.Node;
+import elemental2.dom.NodeList;
+import org.kie.workbench.common.dmn.api.definition.model.ItemDefinition;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
+import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeList;
+import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItem;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Position;
+import org.kie.workbench.common.dmn.client.editors.types.persistence.DataTypeStore;
+import org.kie.workbench.common.dmn.client.editors.types.persistence.ItemDefinitionStore;
+
+import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItemView.UUID_ATTR;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_INTO_HOVERED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_NESTED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_SIBLING_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.HIDDEN_Y_POSITION;
+
+public class DNDDataTypesHandler {
+
+    private final DataTypeStore dataTypeStore;
+
+    private final DataTypeManager dataTypeManager;
+
+    private final ItemDefinitionStore itemDefinitionStore;
+
+    private DataTypeList dataTypeList;
+
+    @Inject
+    public DNDDataTypesHandler(final DataTypeStore dataTypeStore,
+                               final DataTypeManager dataTypeManager,
+                               final ItemDefinitionStore itemDefinitionStore) {
+        this.dataTypeStore = dataTypeStore;
+        this.dataTypeManager = dataTypeManager;
+        this.itemDefinitionStore = itemDefinitionStore;
+    }
+
+    public void init(final DataTypeList dataTypeList) {
+        this.dataTypeList = dataTypeList;
+    }
+
+    public void onDropDataType(final Element currentElement,
+                               final Element hoverElement) {
+        try {
+
+            final DNDContext dndContext = makeDndContext(currentElement, hoverElement);
+            final Optional<DataType> current = dndContext.getCurrentDataType();
+            final Optional<DataType> reference = dndContext.getReference();
+
+            if (current.isPresent() && reference.isPresent()) {
+                shiftCurrentByReference(current.get(), reference.get(), dndContext.getStrategy());
+            }
+        } catch (final Exception e) {
+            logError("Drag-n-Drop error. Check '" + DNDDataTypesHandler.class.getSimpleName() + "'.");
+        }
+    }
+
+    void shiftCurrentByReference(final DataType current,
+                                 final DataType reference,
+                                 final ShiftStrategy shiftStrategy) {
+
+        final String referenceHash = getDataTypeList().calculateHash(reference);
+        final DataType clone = cloneDataType(current);
+
+        // destroy current data type
+        getDataTypeList().findItem(current).ifPresent(item -> item.destroy().execute());
+
+        // create new by using shift strategy
+        getDataTypeList().findItemByDataTypeHash(referenceHash).ifPresent(ref -> {
+            shiftStrategy.consumer.accept(ref, clone);
+        });
+    }
+
+    DataType cloneDataType(final DataType current) {
+
+        final String currentUUID = current.getUUID();
+        final ItemDefinition itemDefinition = itemDefinitionStore.get(currentUUID);
+
+        return dataTypeManager.from(itemDefinition).get();
+    }
+
+    DNDContext makeDndContext(final Element currentElement,
+                              final Element hoverElement) {
+        return new DNDContext(currentElement, hoverElement);
+    }
+
+    private DataTypeList getDataTypeList() {
+        return Optional
+                .ofNullable(dataTypeList)
+                .orElseThrow(() -> {
+                    final String errorMessage = "'DNDDataTypesHandler' must be initialized with a 'DataTypeList' instance.";
+                    return new UnsupportedOperationException(errorMessage);
+                });
+    }
+
+    private DNDListComponent getDndListComponent() {
+        return Optional
+                .ofNullable(getDataTypeList().getDNDListComponent())
+                .orElseThrow(() -> {
+                    final String errorMessage = "'DNDDataTypesHandler' must be initialized with a 'DNDListComponent' instance.";
+                    return new UnsupportedOperationException(errorMessage);
+                });
+    }
+
+    void logError(final String message) {
+        DomGlobal.console.error(message);
+    }
+
+    class DNDContext {
+
+        private final Element currentElement;
+
+        private final Element hoverElement;
+
+        private Element previousElement;
+
+        private DataType current;
+
+        private DataType hovered;
+
+        private DataType previous;
+
+        DNDContext(final Element currentElement,
+                   final Element hoverElement) {
+
+            this.currentElement = currentElement;
+            this.hoverElement = hoverElement;
+            this.current = getDataType(currentElement);
+        }
+
+        Optional<DataType> getReference() {
+
+            if (reloadHoveredDataType().isPresent()) {
+                return getHoveredDataType();
+            }
+
+            if (reloadPreviousDataType().isPresent()) {
+                return getPreviousDataType();
+            }
+
+            if (getCurrentDataType().isPresent()) {
+                return getFirstDataType(getCurrentDataType().get());
+            }
+
+            return Optional.empty();
+        }
+
+        ShiftStrategy getStrategy() {
+
+            if (getHoveredDataType().isPresent()) {
+                return INSERT_INTO_HOVERED_DATA_TYPE;
+            }
+
+            if (!getPreviousDataType().isPresent()) {
+                return INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+            }
+
+            final int currentElementLevel = Position.getX(currentElement);
+            final int previousElementLevel = Position.getX(previousElement);
+
+            if (currentElementLevel == 0) {
+                return INSERT_TOP_LEVEL_DATA_TYPE;
+            } else if (previousElementLevel < currentElementLevel) {
+                return INSERT_NESTED_DATA_TYPE;
+            } else {
+                return INSERT_SIBLING_DATA_TYPE;
+            }
+        }
+
+        private Optional<DataType> reloadHoveredDataType() {
+            hovered = getDataType(hoverElement);
+            return getHoveredDataType();
+        }
+
+        private Optional<DataType> reloadPreviousDataType() {
+            previousElement = getPreviousElement(currentElement);
+            previous = getDataType(previousElement);
+            return getPreviousDataType();
+        }
+
+        Optional<DataType> getCurrentDataType() {
+            return Optional.ofNullable(current);
+        }
+
+        private Optional<DataType> getHoveredDataType() {
+            return Optional.ofNullable(hovered);
+        }
+
+        private Optional<DataType> getPreviousDataType() {
+            return Optional.ofNullable(previous);
+        }
+
+        private DataType getDataType(final Element element) {
+            return element == null ? null : dataTypeStore.get(element.getAttribute(UUID_ATTR));
+        }
+
+        private Optional<DataType> getFirstDataType(final DataType current) {
+
+            final NodeList<Node> nodes = getDndListComponent().getDragArea().childNodes;
+
+            for (int i = 0; i < nodes.length; i++) {
+                final Element element = (Element) nodes.getAt(i);
+                if (Position.getY(element) > HIDDEN_Y_POSITION && Position.getX(element) == 0) {
+                    final DataType dataType = getDataType(element);
+                    if (dataType != null && !Objects.equals(current.getName(), dataType.getName())) {
+                        return Optional.of(dataType);
+                    }
+                }
+            }
+
+            return Optional.empty();
+        }
+
+        private Element getPreviousElement(final Element reference) {
+            return getDndListComponent()
+                    .getPreviousElement(reference, element -> Position.getX(element) <= Position.getX(reference))
+                    .orElse(null);
+        }
+    }
+
+    enum ShiftStrategy {
+
+        INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP(DataTypeListItem::insertFieldAbove),
+        INSERT_INTO_HOVERED_DATA_TYPE(DataTypeListItem::insertNestedField),
+        INSERT_TOP_LEVEL_DATA_TYPE(DataTypeListItem::insertFieldBelow),
+        INSERT_SIBLING_DATA_TYPE(DataTypeListItem::insertFieldBelow),
+        INSERT_NESTED_DATA_TYPE(DataTypeListItem::insertNestedField);
+
+        private final BiConsumer<DataTypeListItem, DataType> consumer;
+
+        ShiftStrategy(final BiConsumer<DataTypeListItem, DataType> consumer) {
+            this.consumer = consumer;
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandler.java
@@ -181,7 +181,7 @@ public class DNDDataTypesHandler {
 
         Optional<DataType> getReference() {
 
-            if (reloadHoveredDataType().isPresent()) {
+            if (reloadHoveredDataType().isPresent() && hoveredDataTypeIsNotReadOnly()) {
                 return getHoveredDataType();
             }
 
@@ -194,7 +194,7 @@ public class DNDDataTypesHandler {
 
         ShiftStrategy getStrategy() {
 
-            if (getHoveredDataType().isPresent()) {
+            if (getHoveredDataType().isPresent() && hoveredDataTypeIsNotReadOnly()) {
                 return INSERT_INTO_HOVERED_DATA_TYPE;
             }
 
@@ -207,7 +207,7 @@ public class DNDDataTypesHandler {
 
             if (currentElementLevel == 0) {
                 return INSERT_TOP_LEVEL_DATA_TYPE;
-            } else if (previousElementLevel < currentElementLevel) {
+            } else if (previousElementLevel < currentElementLevel && previousDataTypeIsNotReadOnly()) {
                 return INSERT_NESTED_DATA_TYPE;
             } else {
                 return INSERT_SIBLING_DATA_TYPE;
@@ -223,6 +223,14 @@ public class DNDDataTypesHandler {
             previousElement = getPreviousElement(currentElement);
             previous = getDataType(previousElement);
             return getPreviousDataType();
+        }
+
+        private boolean previousDataTypeIsNotReadOnly() {
+            return !getPreviousDataType().map(DataType::isReadOnly).orElse(false);
+        }
+
+        private boolean hoveredDataTypeIsNotReadOnly() {
+            return !getHoveredDataType().map(DataType::isReadOnly).orElse(false);
         }
 
         Optional<DataType> getCurrentDataType() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerContext.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerContext.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import elemental2.dom.Element;
+import elemental2.dom.Node;
+import elemental2.dom.NodeList;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+
+import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItemView.UUID_ATTR;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_INTO_HOVERED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_NESTED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_SIBLING_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.HIDDEN_Y_POSITION;
+
+class DNDDataTypesHandlerContext {
+
+    private final Element currentElement;
+
+    private final Element hoverElement;
+
+    private DNDDataTypesHandler dndDataTypesHandler;
+
+    private Element previousElement;
+
+    private DataType current;
+
+    private DataType hovered;
+
+    private DataType previous;
+
+    DNDDataTypesHandlerContext(final DNDDataTypesHandler dndDataTypesHandler,
+                               final Element currentElement,
+                               final Element hoverElement) {
+
+        this.dndDataTypesHandler = dndDataTypesHandler;
+        this.currentElement = currentElement;
+        this.hoverElement = hoverElement;
+        this.current = getDataType(currentElement);
+    }
+
+    Optional<DataType> getReference() {
+
+        if (reloadHoveredDataType().isPresent() && hoveredDataTypeIsNotReadOnly()) {
+            return getHoveredDataType();
+        }
+
+        if (reloadPreviousDataType().isPresent()) {
+            return getPreviousDataType();
+        }
+
+        return getCurrentDataType().flatMap(this::getFirstDataType);
+    }
+
+    DNDDataTypesHandlerShiftStrategy getStrategy() {
+
+        if (getHoveredDataType().isPresent() && hoveredDataTypeIsNotReadOnly()) {
+            return INSERT_INTO_HOVERED_DATA_TYPE;
+        }
+
+        if (!getPreviousDataType().isPresent()) {
+            return INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+        }
+
+        final int currentElementLevel = DNDListDOMHelper.Position.getX(currentElement);
+        final int previousElementLevel = DNDListDOMHelper.Position.getX(previousElement);
+
+        if (currentElementLevel == 0) {
+            return INSERT_TOP_LEVEL_DATA_TYPE;
+        } else if (previousElementLevel < currentElementLevel && previousDataTypeIsNotReadOnly()) {
+            return INSERT_NESTED_DATA_TYPE;
+        } else {
+            return INSERT_SIBLING_DATA_TYPE;
+        }
+    }
+
+    private Optional<DataType> reloadHoveredDataType() {
+        hovered = getDataType(hoverElement);
+        return getHoveredDataType();
+    }
+
+    private Optional<DataType> reloadPreviousDataType() {
+        previousElement = getPreviousElement(currentElement);
+        previous = getDataType(previousElement);
+        return getPreviousDataType();
+    }
+
+    private boolean previousDataTypeIsNotReadOnly() {
+        return !getPreviousDataType().map(DataType::isReadOnly).orElse(false);
+    }
+
+    private boolean hoveredDataTypeIsNotReadOnly() {
+        return !getHoveredDataType().map(DataType::isReadOnly).orElse(false);
+    }
+
+    Optional<DataType> getCurrentDataType() {
+        return Optional.ofNullable(current);
+    }
+
+    private Optional<DataType> getHoveredDataType() {
+        return Optional.ofNullable(hovered);
+    }
+
+    private Optional<DataType> getPreviousDataType() {
+        return Optional.ofNullable(previous);
+    }
+
+    private DataType getDataType(final Element element) {
+        return element == null ? null : dndDataTypesHandler.getDataTypeStore().get(element.getAttribute(UUID_ATTR));
+    }
+
+    private Optional<DataType> getFirstDataType(final DataType current) {
+
+        final NodeList<Node> nodes = dndDataTypesHandler.getDndListComponent().getDragArea().childNodes;
+
+        for (int i = 0; i < nodes.length; i++) {
+            final Element element = (Element) nodes.getAt(i);
+            if (DNDListDOMHelper.Position.getY(element) > HIDDEN_Y_POSITION && DNDListDOMHelper.Position.getX(element) == 0) {
+                final DataType dataType = getDataType(element);
+                if (dataType != null && !Objects.equals(current.getName(), dataType.getName())) {
+                    return Optional.of(dataType);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Element getPreviousElement(final Element reference) {
+        return dndDataTypesHandler
+                .getDndListComponent()
+                .getPreviousElement(reference, element -> DNDListDOMHelper.Position.getX(element) <= DNDListDOMHelper.Position.getX(reference))
+                .orElse(null);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerShiftStrategy.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerShiftStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.function.BiConsumer;
+
+import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItem;
+
+enum DNDDataTypesHandlerShiftStrategy {
+
+    INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP(DataTypeListItem::insertFieldAbove),
+    INSERT_INTO_HOVERED_DATA_TYPE(DataTypeListItem::insertNestedField),
+    INSERT_TOP_LEVEL_DATA_TYPE(DataTypeListItem::insertFieldBelow),
+    INSERT_SIBLING_DATA_TYPE(DataTypeListItem::insertFieldBelow),
+    INSERT_NESTED_DATA_TYPE(DataTypeListItem::insertNestedField);
+
+    private final BiConsumer<DataTypeListItem, DataType> consumer;
+
+    DNDDataTypesHandlerShiftStrategy(final BiConsumer<DataTypeListItem, DataType> consumer) {
+        this.consumer = consumer;
+    }
+
+    BiConsumer<DataTypeListItem, DataType> getConsumer() {
+        return consumer;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponent.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponent.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import elemental2.dom.Element;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Position;
+import org.uberfire.client.mvp.UberElemental;
+
+public class DNDListComponent {
+
+    private final View view;
+
+    private BiConsumer<Element, Element> onDropItem = (current, hover) -> {/* Nothing. */};
+
+    static int DEFAULT_ITEM_HEIGHT = 70;
+
+    static int DEFAULT_INDENTATION_SIZE = 60;
+
+    @Inject
+    public DNDListComponent(final View view) {
+        this.view = view;
+    }
+
+    @PostConstruct
+    void init() {
+        view.init(this);
+    }
+
+    public void refreshItemsPosition() {
+        view.refreshItemsPosition();
+    }
+
+    public void refreshItemsCSSAndHTMLPosition() {
+        consolidateHierarchicalLevel();
+        refreshItemsPosition();
+    }
+
+    public HTMLElement registerNewItem(final HTMLElement htmlElement) {
+        return view.registerItem(htmlElement);
+    }
+
+    public HTMLElement getElement() {
+        return view.getElement();
+    }
+
+    public HTMLElement getDragArea() {
+        return view.getDragArea();
+    }
+
+    public void consolidateYPosition() {
+        view.consolidateYPosition();
+    }
+
+    public void clear() {
+        view.clear();
+    }
+
+    public void setPositionX(final Element element,
+                             final double positionX) {
+        Position.setX(element, positionX);
+    }
+
+    public void setPositionY(final Element element,
+                             final double positionY) {
+        Position.setY(element, positionY);
+    }
+
+    public int getPositionY(final Element element) {
+        return Position.getY(element);
+    }
+
+    public void setOnDropItem(final BiConsumer<Element, Element> onDropItem) {
+        this.onDropItem = onDropItem;
+    }
+
+    void executeOnDropItemCallback(final Element current,
+                                   final Element hover) {
+        onDropItem.accept(current, hover);
+    }
+
+    int getItemHeight() {
+        return DEFAULT_ITEM_HEIGHT;
+    }
+
+    int getIndentationSize() {
+        return DEFAULT_INDENTATION_SIZE;
+    }
+
+    Optional<Element> getPreviousElement(final Element reference,
+                                         final Predicate<? super Element> predicate) {
+        if (reference == null) {
+            return Optional.empty();
+        }
+
+        return view
+                .getPreviousElement(reference)
+                .map(previousElement -> {
+                    if (predicate.test(previousElement)) {
+                        return previousElement;
+                    } else {
+                        return getPreviousElement(previousElement, predicate).orElse(null);
+                    }
+                });
+    }
+
+    private void consolidateHierarchicalLevel() {
+        view.consolidateHierarchicalLevel();
+    }
+
+    public interface View extends UberElemental<DNDListComponent>,
+                                  IsElement {
+
+        HTMLElement registerItem(final HTMLElement htmlElement);
+
+        Optional<HTMLElement> getPreviousElement(final Element reference);
+
+        void refreshItemsPosition();
+
+        void refreshItemsHTML();
+
+        void consolidateHierarchicalLevel();
+
+        void clear();
+
+        void consolidateYPosition();
+
+        HTMLDivElement getDragArea();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponent.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponent.java
@@ -75,6 +75,10 @@ public class DNDListComponent {
         view.consolidateYPosition();
     }
 
+    public Optional<HTMLElement> getPreviousElement(final Element reference) {
+        return view.getPreviousElement(reference);
+    }
+
     public void clear() {
         view.clear();
     }
@@ -116,8 +120,7 @@ public class DNDListComponent {
             return Optional.empty();
         }
 
-        return view
-                .getPreviousElement(reference)
+        return getPreviousElement(reference)
                 .map(previousElement -> {
                     if (predicate.test(previousElement)) {
                         return previousElement;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    <div data-field="drag-area" class="kie-dnd-drag-area"></div>
+</div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
@@ -78,7 +78,7 @@ public class DNDListComponentView implements DNDListComponent.View {
 
         final HTMLElement item = createItem(htmlElement);
 
-        Position.setY(item, getMaxPositionY() + 1);
+        Position.setY(item, getMaxPositionY() + 1d);
         Position.setX(item, 0);
 
         getDragArea().appendChild(item);
@@ -145,7 +145,7 @@ public class DNDListComponentView implements DNDListComponent.View {
             }
 
             Position.setY(current, i);
-            Position.setY(next, i + 1);
+            Position.setY(next, i + 1d);
         }
     }
 
@@ -232,7 +232,7 @@ public class DNDListComponentView implements DNDListComponent.View {
         final Optional<HTMLElement> previousElement = getPreviousElement(draggingElement);
         final boolean hasChildren = previousElement.map(this::hasChildren).orElse(false);
         final int currentXPosition = getCurrentXPosition(draggingElement);
-        final int numberOfExtraLevels = hasChildren ? 1 : 0;
+        final double numberOfExtraLevels = hasChildren ? 1 : 0;
 
         Position.setX(draggingElement, currentXPosition + numberOfExtraLevels);
         getDependentElements().forEach(el -> Position.setX(el, numberOfExtraLevels + getCurrentXPosition(el)));
@@ -261,12 +261,10 @@ public class DNDListComponentView implements DNDListComponent.View {
             final int currentXPosition = Position.getX(hover);
             final int minimalLevel = currentXPosition + 1;
             final int numberOfExtraLevels = Position.getX(getDragging()) - minimalLevel;
+            final List<HTMLElement> children = new ArrayList<>(getDependentElements());
 
-            final List<HTMLElement> children = new ArrayList<HTMLElement>(getDependentElements()) {{
-                add(getDragging());
-            }};
-
-            Position.setX(getDragging(), currentXPosition + 1);
+            children.add(getDragging());
+            Position.setX(getDragging(), currentXPosition + 1d);
             fixChildrenPosition(minimalLevel, numberOfExtraLevels, children);
         });
 
@@ -274,7 +272,7 @@ public class DNDListComponentView implements DNDListComponent.View {
     }
 
     private int getDraggingYCoordinate() {
-        return (int) (getDragging().offsetTop + (getItemHeight() / 2));
+        return (int) (getDragging().offsetTop + (getItemHeight() / 2d));
     }
 
     void hover(final int hoverPosition) {
@@ -426,7 +424,7 @@ public class DNDListComponentView implements DNDListComponent.View {
             clearHover();
 
             for (int i = 0; i < getDependentElements().size(); i++) {
-                Position.setY(getDependentElements().get(i), mouseYPosition + i + 1);
+                Position.setY(getDependentElements().get(i), mouseYPosition + i + 1d);
             }
 
             refreshItemsPosition();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
@@ -1,0 +1,590 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.inject.Inject;
+
+import elemental2.dom.Element;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.MouseEvent;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Factory;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Position;
+
+import static java.util.Collections.emptyList;
+import static org.kie.workbench.common.dmn.client.editors.common.RemoveHelper.removeChildren;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.HIDDEN_Y_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asDraggable;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asDragging;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asHover;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonDragging;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSMargin;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSTop;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isGrip;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.querySelector;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSMargin;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSTop;
+
+@Templated
+public class DNDListComponentView implements DNDListComponent.View {
+
+    @DataField("drag-area")
+    private final HTMLDivElement dragArea;
+
+    private List<HTMLElement> dependentElements = emptyList();
+
+    private HTMLElement dragging;
+
+    private DNDListComponent presenter;
+
+    @Inject
+    public DNDListComponentView(final HTMLDivElement dragArea) {
+        this.dragArea = dragArea;
+    }
+
+    @Override
+    public void init(final DNDListComponent presenter) {
+
+        this.presenter = presenter;
+
+        setupDragAreaHandlers();
+    }
+
+    @Override
+    public HTMLElement registerItem(final HTMLElement htmlElement) {
+
+        final HTMLElement item = createItem(htmlElement);
+
+        Position.setY(item, getMaxPositionY() + 1);
+        Position.setX(item, 0);
+
+        getDragArea().appendChild(item);
+
+        return item;
+    }
+
+    @Override
+    public void refreshItemsPosition() {
+
+        int numberOfVisibleElements = 0;
+
+        for (final HTMLElement draggable : querySelector(getDragArea()).getDraggableElements()) {
+
+            final int positionY = Position.getY(draggable);
+            final int positionX = Position.getX(draggable);
+            final int top = positionY * getItemHeight();
+            final int margin = positionX * getLevelSize();
+
+            setCSSTop(draggable, top);
+            setCSSMargin(draggable, margin);
+
+            if (positionY > HIDDEN_Y_POSITION) {
+                numberOfVisibleElements++;
+            }
+        }
+
+        refreshDragAreaSize(numberOfVisibleElements);
+    }
+
+    @Override
+    public void refreshItemsHTML() {
+
+        final List<HTMLElement> draggableElements = querySelector(getDragArea()).getSortedDraggableElements();
+
+        removeChildren(getDragArea());
+        draggableElements.forEach(getDragArea()::appendChild);
+    }
+
+    @Override
+    public void consolidateHierarchicalLevel() {
+
+        final List<HTMLElement> draggableElements = querySelector(getDragArea()).getVisibleAndSortedDraggableElements();
+
+        if (!draggableElements.isEmpty()) {
+            Position.setX(draggableElements.get(0), 0);
+        }
+
+        if (draggableElements.size() < 2) {
+            return;
+        }
+
+        for (int i = 0; i < draggableElements.size() - 1; i++) {
+
+            final HTMLElement current = draggableElements.get(i);
+            final HTMLElement next = draggableElements.get(i + 1);
+            final int currentXPosition = Position.getX(current);
+            final int minimalLevel = currentXPosition + 1;
+            final int nextElementLevel = Position.getX(next);
+            final int numberOfExtraLevels = nextElementLevel - minimalLevel;
+
+            if (nextElementLevel > minimalLevel) {
+                fixChildrenPosition(minimalLevel, numberOfExtraLevels, getDependentElements(current));
+            }
+
+            Position.setY(current, i);
+            Position.setY(next, i + 1);
+        }
+    }
+
+    @Override
+    public void consolidateYPosition() {
+
+        final List<HTMLElement> draggableElements = querySelector(getDragArea()).getVisibleDraggableElements();
+
+        for (int i = 0; i < draggableElements.size(); i++) {
+            Position.setY(draggableElements.get(i), i);
+        }
+    }
+
+    @Override
+    public void clear() {
+        removeChildren(getDragArea());
+    }
+
+    @Override
+    public Optional<HTMLElement> getPreviousElement(final Element reference) {
+        final int positionY = Position.getY(reference);
+        return querySelector(getDragArea()).getDraggableElement(positionY - 1);
+    }
+
+    void setupDragAreaHandlers() {
+        getDragArea().onmousedown = (e) -> {
+            onStartDrag(e);
+            return true;
+        };
+        getDragArea().onmousemove = (e) -> {
+            onDrag(e);
+            return true;
+        };
+        getDragArea().onmouseup = (e) -> {
+            onDrop();
+            return true;
+        };
+        getDragArea().onmouseout = (e) -> {
+            onDrop();
+            return true;
+        };
+    }
+
+    void onStartDrag(final Event event) {
+
+        final HTMLElement target = (HTMLElement) event.target;
+        final HTMLElement parent = (HTMLElement) target.parentNode;
+
+        if (isGrip(target)) {
+            holdDraggingElement(parent);
+        }
+    }
+
+    void onDrag(final Event event) {
+
+        if (isNotDragging()) {
+            return;
+        }
+
+        updateDraggingElementY(event);
+        updateDraggingElementX(event);
+        updateHoverElement();
+        updateDependentsPosition();
+    }
+
+    void onDrop() {
+
+        if (isNotDragging()) {
+            return;
+        }
+
+        updateDraggingElementsPosition();
+        executeOnDropItemCallback();
+        releaseDraggingElement();
+        consolidateHierarchicalLevel();
+        refreshItemsPosition();
+        refreshItemsHTML();
+        clearHover();
+    }
+
+    void updateDraggingElementsPosition() {
+
+        final HTMLElement draggingElement = getDragging();
+        final Optional<HTMLElement> previousElement = getPreviousElement(draggingElement);
+        final boolean hasChildren = previousElement.map(this::hasChildren).orElse(false);
+        final int currentXPosition = getCurrentXPosition(draggingElement);
+        final int numberOfExtraLevels = hasChildren ? 1 : 0;
+
+        Position.setX(draggingElement, currentXPosition + numberOfExtraLevels);
+        getDependentElements().forEach(el -> Position.setX(el, numberOfExtraLevels + getCurrentXPosition(el)));
+    }
+
+    int getMaxPositionY() {
+        return querySelector(getDragArea())
+                .getDraggableElements()
+                .stream()
+                .mapToInt(Position::getY)
+                .max()
+                .orElse(HIDDEN_Y_POSITION);
+    }
+
+    private int getCurrentXPosition(final HTMLElement element) {
+        final int margin = getCSSMargin(element) / getLevelSize();
+        return margin > 0 ? margin : 0;
+    }
+
+    void executeOnDropItemCallback() {
+
+        final Optional<HTMLElement> hoverElement = querySelector(getDragArea()).getHoverElement();
+
+        hoverElement.ifPresent(hover -> {
+
+            final int currentXPosition = Position.getX(hover);
+            final int minimalLevel = currentXPosition + 1;
+            final int numberOfExtraLevels = Position.getX(getDragging()) - minimalLevel;
+
+            final List<HTMLElement> children = new ArrayList<HTMLElement>(getDependentElements()) {{
+                add(getDragging());
+            }};
+
+            Position.setX(getDragging(), currentXPosition + 1);
+            fixChildrenPosition(minimalLevel, numberOfExtraLevels, children);
+        });
+
+        presenter.executeOnDropItemCallback(getDragging(), hoverElement.orElse(null));
+    }
+
+    private int getDraggingYCoordinate() {
+        return (int) (getDragging().offsetTop + (getItemHeight() / 2));
+    }
+
+    void hover(final int hoverPosition) {
+
+        final Optional<HTMLElement> hoverElement = querySelector(getDragArea()).getDraggableElement(hoverPosition);
+
+        clearHover();
+
+        hoverElement.ifPresent(hover -> {
+
+            final boolean isNotDragging = !DNDListDOMHelper.isDraggingElement(hover);
+            if (isNotDragging) {
+                asHover(hover);
+            }
+        });
+    }
+
+    void clearHover() {
+        querySelector(getDragArea())
+                .getHoverElement()
+                .ifPresent(DNDListDOMHelper::asNonHover);
+    }
+
+    void updateDependentsPosition() {
+
+        final List<HTMLElement> elements = Optional.ofNullable(getDependentElements()).orElse(emptyList());
+
+        for (int i = 0; i < elements.size(); i++) {
+
+            final HTMLElement dependent = elements.get(i);
+            final int dependentTop = getCSSTop(getDragging()) + (getItemHeight() * (i + 1));
+            final int dependentMargin = getCSSMargin(getDragging()) + ((Position.getX(dependent) - Position.getX(getDragging())) * getLevelSize());
+
+            setCSSTop(dependent, dependentTop);
+            setCSSMargin(dependent, dependentMargin);
+        }
+    }
+
+    boolean hasChildren(final Element element) {
+
+        final Element next = getNextElement(element, nextElement -> {
+            final boolean isNotDragging = !Objects.equals(nextElement, getDragging());
+            final boolean isNotDependentElement = !getDependentElements().contains(nextElement);
+            return isNotDragging && isNotDependentElement;
+        });
+
+        if (next == null) {
+            return false;
+        }
+
+        final int currentPositionX = Position.getX(element);
+        final int nextPositionX = Position.getX(next);
+
+        return currentPositionX == nextPositionX - 1;
+    }
+
+    private Element getNextElement(final Element element,
+                                   final Function<HTMLElement, Boolean> function) {
+
+        final int nextElementPosition = Position.getY(element) + 1;
+        final HTMLElement next = querySelector(getDragArea()).getDraggableElement(nextElementPosition).orElse(null);
+
+        if (function.apply(next) || next == null) {
+            return next;
+        }
+
+        return getNextElement(next, function);
+    }
+
+    private void refreshDragAreaSize(final int numberOfElements) {
+
+        final int border = 1;
+        final int elementHeight = getItemHeight();
+        final int height = numberOfElements * elementHeight + border;
+
+        getDragArea().style.setProperty("height", height + "px");
+    }
+
+    void fixChildrenPosition(final int minimalXPosition,
+                             final int numberOfExtraLevels,
+                             final List<HTMLElement> children) {
+
+        for (int i = 0; i < children.size(); i++) {
+
+            final HTMLElement dependentElement = children.get(i);
+            final int elementPosition = Position.getX(dependentElement);
+            final boolean isElementPositionValid = i > 0 && elementPosition >= Position.getX(children.get(i - 1));
+
+            if (!isElementPositionValid) {
+                final int positionX = elementPosition - numberOfExtraLevels;
+                final int newElementPosition = positionX < minimalXPosition ? minimalXPosition : positionX;
+                Position.setX(dependentElement, newElementPosition);
+            }
+        }
+    }
+
+    private DNDMinMaxTuple getMinMaxDraggingYCoordinates() {
+
+        final int draggingYCoordinate = getDraggingYCoordinate();
+        final int padding = getDragPadding();
+        final int max = (draggingYCoordinate + padding) / getItemHeight();
+        final int min = (draggingYCoordinate - padding) / getItemHeight();
+
+        return new DNDMinMaxTuple(max, min);
+    }
+
+    void updateHoverElement() {
+
+        final int draggingYPosition = Position.getY(getDragging());
+        final int hoverPosition = getDraggingYCoordinate() / getItemHeight();
+        final DNDMinMaxTuple minMaxTuple = getMinMaxDraggingYCoordinates();
+
+        if (draggingYPosition < minMaxTuple.max || draggingYPosition > minMaxTuple.min) {
+            hover(hoverPosition);
+        }
+    }
+
+    void updateDraggingElementY(final Event event) {
+
+        final int draggingYPosition = Position.getY(getDragging());
+        final int mouseYPosition = getDraggingYCoordinate() / getItemHeight();
+        final DNDMinMaxTuple minMaxTuple = getMinMaxDraggingYCoordinates();
+
+        if (draggingYPosition < minMaxTuple.min) {
+            updateDraggingElementY(mouseYPosition, draggingYPosition, mouseYPosition + getDependentElements().size());
+        }
+
+        if (draggingYPosition > minMaxTuple.max) {
+            updateDraggingElementY(mouseYPosition, mouseYPosition + getDependentElements().size() + 1, mouseYPosition);
+        }
+
+        setCSSTop(getDragging(), getNewDraggingYPosition(event));
+    }
+
+    void updateDraggingElementX(final Event event) {
+        setCSSMargin(getDragging(), getNewDraggingXPosition(event));
+    }
+
+    private void updateDraggingElementY(final int mouseYPosition,
+                                        final int newSiblingYPosition,
+                                        final int oldSiblingYPosition) {
+
+        Optional<HTMLElement> draggableElement = querySelector(getDragArea()).getDraggableElement(oldSiblingYPosition);
+        draggableElement.ifPresent(siblingElement -> {
+
+            Position.setY(siblingElement, newSiblingYPosition);
+            Position.setY(getDragging(), mouseYPosition);
+
+            clearHover();
+
+            for (int i = 0; i < getDependentElements().size(); i++) {
+                Position.setY(getDependentElements().get(i), mouseYPosition + i + 1);
+            }
+
+            refreshItemsPosition();
+        });
+    }
+
+    int getNewDraggingYPosition(final Event event) {
+
+        final Double absoluteMouseY = getAbsoluteMouseY(event);
+        final Double newYPosition = absoluteMouseY - (getItemHeight() / 2d);
+        final Double maxYPosition = getDragAreaY() + getDragArea().offsetHeight;
+
+        if (newYPosition > maxYPosition) {
+            return maxYPosition.intValue();
+        }
+
+        return newYPosition.intValue();
+    }
+
+    private int getNewDraggingXPosition(final Event event) {
+
+        // Represents the "padding" between the dragging element border and the cursor
+        final int padding = 10;
+        final double absoluteMouseX = getAbsoluteMouseX(event);
+        final int newXPosition = (int) absoluteMouseX - padding;
+        final int maxXPosition = getItemWidth() - getLevelSize();
+
+        if (newXPosition < 0) {
+            return 0;
+        }
+
+        if (newXPosition > maxXPosition) {
+            return maxXPosition;
+        }
+
+        return newXPosition;
+    }
+
+    boolean isNotDragging() {
+        return !Optional.ofNullable(getDragging()).isPresent();
+    }
+
+    private double getAbsoluteMouseX(final Event event) {
+        final MouseEvent mouseEvent = (MouseEvent) event;
+        return mouseEvent.x - getDragAreaX();
+    }
+
+    private double getAbsoluteMouseY(final Event event) {
+        final MouseEvent mouseEvent = (MouseEvent) event;
+        return mouseEvent.y - getDragAreaY();
+    }
+
+    void holdDraggingElement(final HTMLElement element) {
+
+        setDragging(element);
+        setDependentElements(getDependentElements(element));
+
+        asDragging(getDragging());
+        getDependentElements().forEach(DNDListDOMHelper::asDragging);
+    }
+
+    void releaseDraggingElement() {
+
+        asNonDragging(getDragging());
+        getDependentElements().forEach(DNDListDOMHelper::asNonDragging);
+
+        setDependentElements(emptyList());
+        setDragging(null);
+    }
+
+    List<HTMLElement> getDependentElements(final HTMLElement element) {
+
+        final int minimalLevel = Position.getX(element) + 1;
+        final List<HTMLElement> initial = new ArrayList<>();
+
+        return getNextDependents(initial, element, minimalLevel);
+    }
+
+    private List<HTMLElement> getNextDependents(final List<HTMLElement> dependents,
+                                                final Element element,
+                                                final int minimalLevel) {
+
+        final int positionY = Position.getY(element);
+        final HTMLElement next = querySelector(getDragArea()).getDraggableElement(positionY + 1).orElse(null);
+
+        if (next == null || Position.getX(next) < minimalLevel) {
+            return dependents;
+        } else {
+            dependents.add(next);
+            return getNextDependents(dependents, next, minimalLevel);
+        }
+    }
+
+    private int getItemWidth() {
+        return (int) getDragArea().offsetWidth;
+    }
+
+    private double getDragAreaY() {
+        return getDragArea().getBoundingClientRect().top;
+    }
+
+    private double getDragAreaX() {
+        return getDragArea().getBoundingClientRect().left;
+    }
+
+    private int getLevelSize() {
+        return presenter.getIndentationSize();
+    }
+
+    private int getItemHeight() {
+        return presenter.getItemHeight();
+    }
+
+    private int getDragPadding() {
+        return getItemHeight() / 3;
+    }
+
+    HTMLElement createItem(final HTMLElement htmlElement) {
+
+        final HTMLElement item = Factory.createDiv();
+        final HTMLElement gripElement = Factory.createGripElement();
+
+        item.appendChild(gripElement);
+        item.appendChild(htmlElement);
+
+        return asDraggable(item);
+    }
+
+    HTMLElement getDragging() {
+        return dragging;
+    }
+
+    List<HTMLElement> getDependentElements() {
+        return dependentElements;
+    }
+
+    @Override
+    public HTMLDivElement getDragArea() {
+        return dragArea;
+    }
+
+    private void setDependentElements(final List<HTMLElement> dependentElements) {
+        this.dependentElements = dependentElements;
+    }
+
+    private void setDragging(HTMLElement dragging) {
+        this.dragging = dragging;
+    }
+
+    private class DNDMinMaxTuple {
+
+        private final int min;
+        private final int max;
+
+        DNDMinMaxTuple(final int max,
+                       final int min) {
+            this.max = max;
+            this.min = min;
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
@@ -41,12 +41,13 @@ import static org.kie.workbench.common.dmn.client.editors.types.listview.dragand
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asDragging;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asHover;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonDragging;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSMargin;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSTop;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSWidth;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isGrip;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.querySelector;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSMargin;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSPaddingLeft;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSTop;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSWidth;
 
 @Templated
 public class DNDListComponentView implements DNDListComponent.View {
@@ -99,7 +100,7 @@ public class DNDListComponentView implements DNDListComponent.View {
             final int margin = positionX * getLevelSize();
 
             setCSSTop(draggable, top);
-            setCSSMargin(draggable, margin);
+            setCSSPaddingLeft(draggable, margin);
 
             if (positionY > HIDDEN_Y_POSITION) {
                 numberOfVisibleElements++;
@@ -248,7 +249,7 @@ public class DNDListComponentView implements DNDListComponent.View {
     }
 
     private int getCurrentXPosition(final HTMLElement element) {
-        final int margin = getCSSMargin(element) / getLevelSize();
+        final int margin = getCSSWidth(element) / getLevelSize();
         return margin > 0 ? margin : 0;
     }
 
@@ -304,10 +305,9 @@ public class DNDListComponentView implements DNDListComponent.View {
 
             final HTMLElement dependent = elements.get(i);
             final int dependentTop = getCSSTop(getDragging()) + (getItemHeight() * (i + 1));
-            final int dependentMargin = getCSSMargin(getDragging()) + ((Position.getX(dependent) - Position.getX(getDragging())) * getLevelSize());
 
             setCSSTop(dependent, dependentTop);
-            setCSSMargin(dependent, dependentMargin);
+            setCSSWidth(dependent, getCSSWidth(getDragging()));
         }
     }
 
@@ -408,7 +408,7 @@ public class DNDListComponentView implements DNDListComponent.View {
     }
 
     void updateDraggingElementX(final Event event) {
-        setCSSMargin(getDragging(), getNewDraggingXPosition(event));
+        setCSSWidth(getDragging(), getNewDraggingXPosition(event));
     }
 
     private void updateDraggingElementY(final int mouseYPosition,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.less
@@ -39,8 +39,7 @@
       user-select: none;
       margin: 0;
       padding: 0;
-      background: #e8e8e8;
-      box-shadow: 0 0 2px inset #000;
+      background: #FFF;
 
       &.kie-dnd-current-dragging {
         z-index: 9;
@@ -49,10 +48,7 @@
 
       &.kie-dnd-hover {
         opacity: .75;
-
-        .list-group-item {
-          background-color: #dce7ef;
-        }
+        background-color: #dce7ef;
       }
 
       &:hover .kie-dnd-grip,
@@ -69,6 +65,7 @@
         cursor: grab;
         z-index: 1;
         color: #AAA;
+        left: 0;
 
         .fa.fa-ellipsis-v {
           top: ~"calc(50% - 8px)";

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.less
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+[data-i18n-prefix="DNDListComponentView."] {
+
+  height: 100%;
+
+  .kie-dnd-drag-area {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    background: #F7F7F7;
+    box-shadow: 0 0 0 1px inset #e2e4e3;
+
+    .kie-dnd-draggable {
+      width: 100%;
+      right: 0;
+      height: 70px;
+      position: absolute;
+      z-index: 1;
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: -moz-none;
+      -ms-user-select: none;
+      user-select: none;
+      margin: 0;
+      padding: 0;
+      background: #e8e8e8;
+      box-shadow: 0 0 2px inset #000;
+
+      &.kie-dnd-current-dragging {
+        z-index: 9;
+        box-shadow: rgba(0, 0, 0, 0.25) 3px 3px 3px;
+      }
+
+      &.kie-dnd-hover {
+        opacity: .75;
+
+        .list-group-item {
+          background-color: #dce7ef;
+        }
+      }
+
+      &:hover .kie-dnd-grip,
+      &.kie-dnd-current-dragging .kie-dnd-grip {
+        display: block;
+      }
+
+      .kie-dnd-grip {
+        display: none;
+        position: absolute;
+        font-size: 18px;
+        height: 100%;
+        width: 30px;
+        cursor: grab;
+        z-index: 1;
+        color: #AAA;
+
+        .fa.fa-ellipsis-v {
+          top: ~"calc(50% - 8px)";
+          pointer-events: none;
+          position: absolute;
+          left: 11px;
+        }
+
+        .fa.fa-ellipsis-v + .fa.fa-ellipsis-v {
+          left: 17px;
+        }
+
+        &:active {
+          cursor: grabbing;
+        }
+      }
+    }
+  }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelper.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLDocument;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.NodeList;
+
+import static java.util.stream.Collectors.toList;
+
+class DNDListDOMHelper {
+
+    static final String DRAGGABLE = "kie-dnd-draggable";
+
+    static final String DRAGGING = "kie-dnd-current-dragging";
+
+    static final String HOVER = "kie-dnd-hover";
+
+    static final String GRIP = "kie-dnd-grip";
+
+    static final String DATA_Y_POSITION = "data-y-position";
+
+    static final int HIDDEN_Y_POSITION = -1;
+
+    static final String DATA_X_POSITION = "data-x-position";
+
+    // -- Position
+
+    static class Position {
+
+        static void setX(final Element element,
+                         final double positionX) {
+            element.setAttribute(DATA_X_POSITION, positionX);
+        }
+
+        static Integer getX(final Element element) {
+            return parseInt(element.getAttribute(DATA_X_POSITION));
+        }
+
+        static void setY(final Element element,
+                         final double positionY) {
+            element.setAttribute(DATA_Y_POSITION, positionY);
+        }
+
+        static Integer getY(final Element element) {
+            return parseInt(element.getAttribute(DATA_Y_POSITION));
+        }
+
+        static Double getDoubleY(final Element element) {
+            return parseDouble(element.getAttribute(DATA_Y_POSITION));
+        }
+    }
+
+    // -- QuerySelector
+
+    static QuerySelector querySelector(final Element container) {
+        return new QuerySelector(container);
+    }
+
+    static class QuerySelector {
+
+        private final Element container;
+
+        QuerySelector(final Element container) {
+            this.container = container;
+        }
+
+        Optional<HTMLElement> getDraggableElement(final int yPosition) {
+            final String selector = "." + DRAGGABLE + "[" + DATA_Y_POSITION + "=\"" + yPosition + "\"]";
+            return Optional.ofNullable(container.querySelector(selector)).map(e -> (HTMLElement) e);
+        }
+
+        Optional<HTMLElement> getHoverElement() {
+            final String selector = "." + HOVER;
+            return Optional.ofNullable(container.querySelector(selector)).map(e -> (HTMLElement) e);
+        }
+
+        List<HTMLElement> getDraggableElements() {
+            final String selector = "." + DRAGGABLE;
+            return asList(container.querySelectorAll(selector));
+        }
+
+        List<HTMLElement> getSortedDraggableElements() {
+            return getDraggableElements()
+                    .stream()
+                    .sorted(Comparator.comparing(Position::getDoubleY))
+                    .collect(toList());
+        }
+
+        List<HTMLElement> getVisibleDraggableElements() {
+            return getDraggableElements()
+                    .stream()
+                    .filter(e -> Position.getY(e) > HIDDEN_Y_POSITION)
+                    .collect(toList());
+        }
+
+        List<HTMLElement> getVisibleAndSortedDraggableElements() {
+            return getDraggableElements()
+                    .stream()
+                    .filter(e -> Position.getY(e) > HIDDEN_Y_POSITION)
+                    .sorted(Comparator.comparing(Position::getDoubleY))
+                    .collect(toList());
+        }
+
+        private List<HTMLElement> asList(final NodeList<Element> nodeList) {
+            final List<HTMLElement> list = new ArrayList<>();
+            for (int i = 0; i < nodeList.length; i++) {
+                list.add((HTMLElement) nodeList.getAt(i));
+            }
+            return list;
+        }
+    }
+
+    // -- Property handlers
+
+    static void setCSSTop(final HTMLElement element,
+                          final int value) {
+        element.style.setProperty("top", value + "px");
+    }
+
+    static void setCSSMargin(final HTMLElement element,
+                             final int value) {
+        element.style.setProperty("width", "calc(100% - " + value + "px)");
+    }
+
+    static int getCSSTop(final HTMLElement element) {
+        return parseInt(element.style.getPropertyValue("top"));
+    }
+
+    static int getCSSMargin(final HTMLElement element) {
+        final String width = element.style.getPropertyValue("width");
+        return parseInt(width.replace("calc(100% - ", "").replace("px)", ""));
+    }
+
+    // -- Class handlers
+
+    static HTMLElement asHover(final HTMLElement element) {
+        element.classList.add(HOVER);
+        return element;
+    }
+
+    static HTMLElement asNonHover(final HTMLElement element) {
+        element.classList.remove(HOVER);
+        return element;
+    }
+
+    static HTMLElement asDragging(final HTMLElement element) {
+        element.classList.add(DRAGGING);
+        return element;
+    }
+
+    static HTMLElement asNonDragging(final HTMLElement element) {
+        element.classList.remove(DRAGGING);
+        return element;
+    }
+
+    static HTMLElement asDraggable(final HTMLElement element) {
+        element.classList.add(DRAGGABLE);
+        return element;
+    }
+
+    static boolean isDraggingElement(final HTMLElement element) {
+        return element.classList.contains(DRAGGING);
+    }
+
+    static boolean isGrip(final HTMLElement element) {
+        return element.classList.contains(GRIP);
+    }
+
+    // -- Factory
+
+    static class Factory {
+
+        static final String ICON_CLASS = "fa";
+
+        static final String ELLIPSIS_CLASS = "fa-ellipsis-v";
+
+        static HTMLDocument DOCUMENT = DomGlobal.document;
+
+        static HTMLElement createGripElement() {
+            final HTMLElement grip = createDiv();
+            grip.classList.add(GRIP);
+            grip.appendChild(createEllipsisElement());
+            grip.appendChild(createEllipsisElement());
+            return grip;
+        }
+
+        static HTMLElement createDiv() {
+            return createElement("div");
+        }
+
+        private static HTMLElement createEllipsisElement() {
+            final HTMLElement i = createElement("i");
+            i.classList.add(ICON_CLASS);
+            i.classList.add(ELLIPSIS_CLASS);
+            return i;
+        }
+
+        private static HTMLElement createElement(final String tagName) {
+            return (HTMLElement) DOCUMENT.createElement(tagName);
+        }
+    }
+
+    // -- Parsers
+
+    static Integer parseInt(final String value) {
+        return parseDouble(value).intValue();
+    }
+
+    static Double parseDouble(final String value) {
+        try {
+            return Double.valueOf(withoutPX(value));
+        } catch (final NumberFormatException e) {
+            return 0d;
+        }
+    }
+
+    private static String withoutPX(final String value) {
+        return Optional
+                .ofNullable(value)
+                .map(e -> e.replaceAll("px", ""))
+                .orElse("");
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelper.java
@@ -139,8 +139,13 @@ class DNDListDOMHelper {
         element.style.setProperty("top", value + "px");
     }
 
-    static void setCSSMargin(final HTMLElement element,
-                             final int value) {
+    static void setCSSPaddingLeft(final HTMLElement element,
+                                  final int value) {
+        element.style.setProperty("padding-left", value + "px");
+    }
+
+    static void setCSSWidth(final HTMLElement element,
+                            final int value) {
         element.style.setProperty("width", "calc(100% - " + value + "px)");
     }
 
@@ -148,7 +153,7 @@ class DNDListDOMHelper {
         return parseInt(element.style.getPropertyValue("top"));
     }
 
-    static int getCSSMargin(final HTMLElement element) {
+    static int getCSSWidth(final HTMLElement element) {
         final String width = element.style.getPropertyValue("width");
         return parseInt(width.replace("calc(100% - ", "").replace("px)", ""));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/DataTypeActiveRecord.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/DataTypeActiveRecord.java
@@ -36,6 +36,10 @@ public abstract class DataTypeActiveRecord extends ActiveRecord<DataType> {
         return getDataTypeRecordEngine().create(getRecord(), reference, creationType);
     }
 
+    public List<DataType> destroyWithoutDependentTypes() {
+        return getDataTypeRecordEngine().destroyWithoutDependentTypes(getRecord());
+    }
+
     private DataTypeRecordEngine getDataTypeRecordEngine() {
         return (DataTypeRecordEngine) getRecordEngine();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/DataTypeRecordEngine.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/DataTypeRecordEngine.java
@@ -26,7 +26,23 @@ import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
  */
 public interface DataTypeRecordEngine extends RecordEngine<DataType> {
 
+    /**
+     * Create record by using {@link CreationType} strategy. The new record can be created above, below, or even
+     * nested to the reference.
+     * @param record represents the new {@link DataType}
+     * @param reference represents the reference {@link DataType} used by the 'creationType'
+     * @param creationType represents the strategy for creating a new type.
+     * @return a list of all affected records by the create operation.
+     */
     List<DataType> create(final DataType record,
                           final DataType reference,
-                          final CreationType nested);
+                          final CreationType creationType);
+
+    /**
+     * Destroy record, but keep all references
+     * nested to the reference.
+     * @param record represents the destroyed {@link DataType}
+     * @return a list of all affected records by the destroy operation.
+     */
+    List<DataType> destroyWithoutDependentTypes(final DataType record);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
@@ -116,11 +116,9 @@ public class ItemDefinitionRecordEngine implements DataTypeRecordEngine {
                                  final CreationType creationType) {
 
         if (creationType == NESTED) {
-            final ItemDefinition nestedItemDefinition = itemDefinitionCreateHandler.insertNestedItemDefinition(reference);
-            return dataTypeCreateHandler.insertNested(record, reference, nestedItemDefinition);
+            return insertNested(record, reference);
         } else {
-            final ItemDefinition itemDefinition = itemDefinitionCreateHandler.insertItemDefinition(reference, creationType);
-            return dataTypeCreateHandler.insert(record, reference, creationType, itemDefinition);
+            return insertSibling(record, reference, creationType);
         }
     }
 
@@ -149,5 +147,22 @@ public class ItemDefinitionRecordEngine implements DataTypeRecordEngine {
 
     private List<DataType> refreshDependentDataTypesFromDestroyOperation(final DataType dataType) {
         return dataTypeDestroyHandler.refreshDependentDataTypes(dataType);
+    }
+
+    private List<DataType> insertNested(final DataType record,
+                                        final DataType reference) {
+
+        final ItemDefinition nestedItemDefinition = itemDefinitionCreateHandler.insertNested(record, reference);
+
+        return dataTypeCreateHandler.insertNested(record, reference, nestedItemDefinition);
+    }
+
+    private List<DataType> insertSibling(final DataType record,
+                                         final DataType reference,
+                                         final CreationType creationType) {
+
+        final ItemDefinition siblingItemDefinition = itemDefinitionCreateHandler.insertSibling(record, reference, creationType);
+
+        return dataTypeCreateHandler.insertSibling(record, reference, creationType, siblingItemDefinition);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.persistence;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -103,6 +104,17 @@ public class ItemDefinitionRecordEngine implements DataTypeRecordEngine {
         doDestroy(dataType);
 
         return refreshDependentDataTypesFromDestroyOperation(dataType);
+    }
+
+    @Override
+    public List<DataType> destroyWithoutDependentTypes(final DataType dataType) {
+
+        final List<DataType> affectedDataTypes = new ArrayList<>();
+        affectedDataTypes.add(dataType);
+
+        doDestroy(dataType);
+
+        return affectedDataTypes;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeHandler.java
@@ -78,7 +78,7 @@ public class DataTypeHandler {
     }
 
     void refreshSubDataTypes(final DataType dataType) {
-        final String type = Objects.equals(dataType.getType(), dataTypeManager.structure()) ? dataType.getName() : dataType.getType();
+        final String type = dataTypeManager.withDataType(dataType).getTypeName();
         refreshSubDataTypes(dataType, type);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeUpdateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeUpdateHandler.java
@@ -46,7 +46,7 @@ public class DataTypeUpdateHandler extends DataTypeHandler {
 
     public void update(final DataType dataType) {
 
-        final String type = dataType.getType();
+        final String type = getTypeName(dataType);
 
         if (!isBuiltInType(type)) {
             dataTypeManager
@@ -123,5 +123,9 @@ public class DataTypeUpdateHandler extends DataTypeHandler {
         recordEngine.doUpdate(dataType, itemDefinition);
 
         refreshSubDataTypes(dataType, dataType.getType());
+    }
+
+    private String getTypeName(final DataType dataType) {
+        return dataTypeManager.withDataType(dataType).getTypeName();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandler.java
@@ -48,10 +48,11 @@ public class ItemDefinitionCreateHandler {
         return itemDefinition;
     }
 
-    public ItemDefinition insertNestedItemDefinition(final DataType reference) {
+    public ItemDefinition insertNested(final DataType record,
+                                       final DataType reference) {
 
-        final ItemDefinition itemDefinition = new ItemDefinition();
-        final ItemDefinition relativeParent = getItemDefinition(reference.getUUID());
+        final ItemDefinition itemDefinition = getItemDefinition(record);
+        final ItemDefinition relativeParent = getIndexedItemDefinition(reference.getUUID());
         final Optional<ItemDefinition> absoluteParent = lookupAbsoluteParent(reference.getUUID());
         final List<ItemDefinition> itemComponent;
 
@@ -67,11 +68,12 @@ public class ItemDefinitionCreateHandler {
         return itemDefinition;
     }
 
-    public ItemDefinition insertItemDefinition(final DataType reference,
-                                               final CreationType creationType) {
+    public ItemDefinition insertSibling(final DataType record,
+                                        final DataType reference,
+                                        final CreationType creationType) {
 
-        final ItemDefinition itemDefinition = new ItemDefinition();
-        final ItemDefinition itemDefinitionReference = getItemDefinition(reference.getUUID());
+        final ItemDefinition itemDefinition = getItemDefinition(record);
+        final ItemDefinition itemDefinitionReference = getIndexedItemDefinition(reference.getUUID());
         final List<ItemDefinition> siblings = getItemDefinitionSiblings(reference);
 
         siblings.add(siblings.indexOf(itemDefinitionReference) + creationType.getIndexIncrement(), itemDefinition);
@@ -90,7 +92,7 @@ public class ItemDefinitionCreateHandler {
     }
 
     Optional<ItemDefinition> lookupAbsoluteParent(final String parentUUID) {
-        final Optional<ItemDefinition> optionalParent = Optional.ofNullable(getItemDefinition(parentUUID));
+        final Optional<ItemDefinition> optionalParent = Optional.ofNullable(getIndexedItemDefinition(parentUUID));
 
         if (optionalParent.isPresent()) {
 
@@ -115,7 +117,13 @@ public class ItemDefinitionCreateHandler {
         return itemDefinitionUtils.all();
     }
 
-    private ItemDefinition getItemDefinition(final String uuid) {
+    private ItemDefinition getIndexedItemDefinition(final String uuid) {
         return itemDefinitionStore.get(uuid);
+    }
+
+    private ItemDefinition getItemDefinition(final DataType dataType) {
+        return Optional
+                .ofNullable(getIndexedItemDefinition(dataType.getUUID()))
+                .orElse(new ItemDefinition());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/search/DataTypeSearchBar.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/search/DataTypeSearchBar.java
@@ -16,7 +16,11 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.search;
 
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -25,7 +29,10 @@ import javax.inject.Inject;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper;
 import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeList;
+import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItem;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.uberfire.client.mvp.UberElemental;
 
 import static org.kie.workbench.common.stunner.core.util.StringUtils.isEmpty;
@@ -40,6 +47,8 @@ public class DataTypeSearchBar {
     private final DataTypeList dataTypeList;
 
     private String currentSearch;
+
+    private final Map<String, Integer> dataTypeListPositionsStore = new HashMap<>();
 
     @Inject
     public DataTypeSearchBar(final View view,
@@ -67,12 +76,14 @@ public class DataTypeSearchBar {
         setCurrentSearch("");
         dataTypeList.showListItems();
         view.resetSearchBar();
+        restoreDataTypeListPositions();
     }
 
     void search(final String keyword) {
 
         final List<DataType> results = searchEngine.search(keyword);
 
+        storeDataTypeListPositions();
         showEmptyView(results.isEmpty());
         setCurrentSearch(keyword);
 
@@ -84,7 +95,7 @@ public class DataTypeSearchBar {
     }
 
     HTMLElement getResultsContainer() {
-        return dataTypeList.getListItemsElement();
+        return dataTypeList.getElement();
     }
 
     String getCurrentSearch() {
@@ -95,12 +106,75 @@ public class DataTypeSearchBar {
         this.currentSearch = currentSearch;
     }
 
+    DNDListComponent getDNDListComponent() {
+        return dataTypeList.getDNDListComponent();
+    }
+
+    void restoreDataTypeListPositions() {
+
+        if (!hasDataTypeListPositionsStored()) {
+            return;
+        }
+
+        getDataTypeListItems().forEach(item -> {
+
+            final HTMLElement element = item.getDragAndDropElement();
+            final String uuid = item.getDataType().getUUID();
+            final Integer positionY = getDataTypeListPositionsStore().get(uuid);
+
+            getDNDListComponent().setPositionY(element, positionY);
+
+            if (positionY > -1) {
+                HiddenHelper.show(element);
+            } else {
+                HiddenHelper.hide(element);
+            }
+        });
+
+        getDNDListComponent().refreshItemsPosition();
+        getDataTypeListPositionsStore().clear();
+    }
+
+    void storeDataTypeListPositions() {
+
+        if (hasDataTypeListPositionsStored()) {
+            return;
+        }
+
+        getDataTypeListItems().forEach(listItem -> {
+
+            final String dataTypeUUID = listItem.getDataType().getUUID();
+            final Integer dataTypeYPosition = getDNDListComponent().getPositionY(listItem.getDragAndDropElement());
+
+            getDataTypeListPositionsStore().put(dataTypeUUID, dataTypeYPosition);
+        });
+    }
+
+    Map<String, Integer> getDataTypeListPositionsStore() {
+        return dataTypeListPositionsStore;
+    }
+
+    private boolean hasDataTypeListPositionsStored() {
+        return !getDataTypeListPositionsStore().isEmpty();
+    }
+
+    private List<DataTypeListItem> getDataTypeListItems() {
+        return dataTypeList.getItems();
+    }
+
     private void showEmptyView(final boolean show) {
         if (show) {
             dataTypeList.showNoDataTypesFound();
         } else {
             dataTypeList.showListItems();
         }
+    }
+
+    List<DataTypeListItem> getDataTypeListItemsSortedByPositionY() {
+        return getDataTypeListItems()
+                .stream()
+                .sorted(Comparator.comparing(item -> getDNDListComponent().getPositionY(item.getDragAndDropElement())))
+                .collect(Collectors.toList());
     }
 
     public boolean isEnabled() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/search/DataTypeSearchBarView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/search/DataTypeSearchBarView.less
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,28 +37,27 @@
   }
 }
 
-[data-i18n-prefix="DataTypeListView."] {
-  [data-field="list-items"].kie-search-engine-enabled {
+[data-i18n-prefix="DataTypeListView."].kie-search-engine-enabled {
 
-    & > div.list-group-item {
-      display: none;
+  [data-i18n-prefix="DNDListComponentView."] {
+    .kie-dnd-drag-area {
+      .kie-dnd-draggable:hover {
+        .kie-dnd-grip {
+          display: none
+        }
+      }
     }
+  }
 
-    & > div.list-group-item.kie-search-engine-result {
-      /* The default Bootstrap/PatternFly  ".hidden" CSS class relies in the use of "display: none !important".
-       * Since the collapse/expand uses the ".hidden" class, the ".kie-search-engine-result" needs to override
-       * ".hidden" with a even more specific selector. */
-      display: block !important;
-    }
-
-    & > div.list-group-item.kie-search-engine-result {
+  [data-i18n-prefix="DataTypeListItemView."].list-group-item {
+    .list-view-pf-main-info {
       [data-type-field="arrow-button"] {
         pointer-events: none;
         cursor: default;
         text-decoration: none;
 
         &:before {
-          opacity: .25;
+          opacity: .25
         }
       }
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
@@ -130,7 +130,7 @@ public class DataTypeListShortcuts {
     }
 
     private void onDataTypeListItemUpdate(final DataTypeListItem dataTypeListItem) {
-        view.highlight(dataTypeListItem.getElement());
+        view.highlight(dataTypeListItem.getDragAndDropElement());
     }
 
     private void consumeIfDataTypeIsNotReadOnly(final Consumer<DataTypeListItem> dataTypeListItemConsumer) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsView.java
@@ -29,6 +29,7 @@ import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.NodeList;
 import org.kie.workbench.common.dmn.client.editors.types.common.ScrollHelper;
+import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeList;
 import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItem;
 import org.uberfire.client.views.pfly.selectpicker.JQueryList;
 
@@ -112,14 +113,14 @@ public class DataTypeListShortcutsView implements DataTypeListShortcuts.View {
     @Override
     public void focusIn() {
         if (isEmpty(getCurrentUUID())) {
-            getDataTypeListItem(getPreviousUUID()).ifPresent(listItem -> highlight(listItem.getElement()));
+            getDataTypeListItem(getPreviousUUID()).ifPresent(listItem -> highlight(listItem.getDragAndDropElement()));
         }
     }
 
     void scrollTo(final Element target) {
 
         final int padding = 20;
-        final HTMLElement container = presenter.getDataTypeList().getListItemsElement();
+        final HTMLElement container = getDataTypeList().getListItems();
 
         scrollHelper.scrollTo(target, container, padding);
     }
@@ -137,7 +138,7 @@ public class DataTypeListShortcutsView implements DataTypeListShortcuts.View {
     }
 
     NodeList<Element> querySelectorAll(final String selector) {
-        return presenter.getDataTypeList().getListItemsElement().querySelectorAll(selector);
+        return getDataTypeList().getElement().querySelectorAll(selector);
     }
 
     void addHighlightClass(final Element element) {
@@ -145,8 +146,7 @@ public class DataTypeListShortcutsView implements DataTypeListShortcuts.View {
     }
 
     Optional<DataTypeListItem> getDataTypeListItem(final String uuid) {
-        return presenter
-                .getDataTypeList()
+        return getDataTypeList()
                 .getItems()
                 .stream()
                 .filter(item -> Objects.equals(item.getDataType().getUUID(), uuid))
@@ -176,6 +176,10 @@ public class DataTypeListShortcutsView implements DataTypeListShortcuts.View {
     void setCurrentUUID(final String currentUUID) {
         this.previousUUID = this.currentUUID;
         this.currentUUID = currentUUID;
+    }
+
+    private DataTypeList getDataTypeList() {
+        return presenter.getDataTypeList();
     }
 
     private List<Element> getVisibleDataTypeRows() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNDataTypesSubIndexTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/search/DMNDataTypesSubIndexTest.java
@@ -73,9 +73,9 @@ public class DMNDataTypesSubIndexTest {
         final HTMLElement htmlElement3 = mock(HTMLElement.class);
         final List<DataTypeListItem> dataTypeListItems = asList(listItem1, listItem2, listItem3);
 
-        when(listItem1.getElement()).thenReturn(htmlElement1);
-        when(listItem2.getElement()).thenReturn(htmlElement2);
-        when(listItem3.getElement()).thenReturn(htmlElement3);
+        when(listItem1.getDragAndDropElement()).thenReturn(htmlElement1);
+        when(listItem2.getDragAndDropElement()).thenReturn(htmlElement2);
+        when(listItem3.getDragAndDropElement()).thenReturn(htmlElement3);
         when(listItem1.getDataType()).thenReturn(dataType1);
         when(listItem2.getDataType()).thenReturn(dataType2);
         when(listItem3.getDataType()).thenReturn(dataType3);
@@ -119,7 +119,7 @@ public class DMNDataTypesSubIndexTest {
 
         when(listItem.getDataType()).thenReturn(dataType);
         when(parentListItem.getDataType()).thenReturn(parent);
-        when(listItem.getElement()).thenReturn(htmlElement);
+        when(listItem.getDragAndDropElement()).thenReturn(htmlElement);
         when(dataType.getParentUUID()).thenReturn(parentUUID);
         when(dataType.getUUID()).thenReturn(dataTypeUUID);
         when(parent.getUUID()).thenReturn(parentUUID);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerTest.java
@@ -103,6 +103,10 @@ public class DataTypeManagerTest {
     @Mock
     private DataTypeNameIsDefaultTypeMessage nameIsDefaultTypeMessage;
 
+    private static final String NONE = "Insert a name";
+
+    private static final String STRUCTURE = "Structure";
+
     private DataTypeNameValidator dataTypeNameValidator;
 
     private DataTypeManager manager;
@@ -110,8 +114,8 @@ public class DataTypeManagerTest {
     @Before
     public void setup() {
 
-        when(translationService.format(DataTypeManager_None)).thenReturn("--");
-        when(translationService.format(DataTypeManager_Structure)).thenReturn("Structure");
+        when(translationService.format(DataTypeManager_None)).thenReturn(NONE);
+        when(translationService.format(DataTypeManager_Structure)).thenReturn(STRUCTURE);
         when(itemDefinitionStore.get("uuid")).thenReturn(mock(ItemDefinition.class));
 
         dataTypeNameValidator = spy(new DataTypeNameValidator(flashMessageEvent, blankErrorMessage, notUniqueErrorMessage, nameIsDefaultTypeMessage, dataTypeStore));
@@ -146,6 +150,34 @@ public class DataTypeManagerTest {
         final String actualName = dataType.getName();
 
         assertEquals(expectedName, actualName);
+    }
+
+    @Test
+    public void testWithNoName() {
+
+        final String expectedName = NONE;
+        final DataType dataType = manager.from(makeDataType("uuid")).withNoName().get();
+        final String actualName = dataType.getName();
+
+        assertEquals(expectedName, actualName);
+    }
+
+    @Test
+    public void testGetTypeNameWhenTypeIsNotStructure() {
+
+        final String expectedTypeName = "tPerson";
+        final String actualTypeName = manager.from(makeDataType("uuid", "person", "tPerson")).getTypeName();
+
+        assertEquals(expectedTypeName, actualTypeName);
+    }
+
+    @Test
+    public void testGetTypeNameWhenTypeIsStructure() {
+
+        final String expectedTypeName = "tPerson";
+        final String actualTypeName = manager.from(makeDataType("uuid", "tPerson", STRUCTURE)).getTypeName();
+
+        assertEquals(expectedTypeName, actualTypeName);
     }
 
     @Test
@@ -222,7 +254,7 @@ public class DataTypeManagerTest {
 
         assertFalse(tPerson.getUUID().isEmpty());
         assertEquals("tPerson", tPerson.getName());
-        assertEquals("Structure", tPerson.getType());
+        assertEquals(STRUCTURE, tPerson.getType());
         assertEquals(3, tPerson.getSubDataTypes().size());
         assertTrue(tPerson.hasSubDataTypes());
 
@@ -276,7 +308,7 @@ public class DataTypeManagerTest {
 
         assertFalse(employee.getUUID().isEmpty());
         assertEquals("employee", employee.getName());
-        assertEquals("Structure", employee.getType());
+        assertEquals(STRUCTURE, employee.getType());
         assertEquals("", employee.getConstraint());
         assertSame(tPerson.getUUID(), address.getParentUUID());
         assertEquals(1, employee.getSubDataTypes().size());
@@ -323,7 +355,7 @@ public class DataTypeManagerTest {
         final DataType dataType = manager.from(builtInType).get();
 
         assertFalse(dataType.getUUID().isEmpty());
-        assertEquals("--", dataType.getName());
+        assertEquals(NONE, dataType.getName());
         assertEquals("number", dataType.getType());
         assertEquals(emptyList(), dataType.getSubDataTypes());
         assertFalse(dataType.hasSubDataTypes());
@@ -335,7 +367,7 @@ public class DataTypeManagerTest {
         final DataType dataType = manager.fromNew().get();
 
         assertFalse(dataType.getUUID().isEmpty());
-        assertEquals("--", dataType.getName());
+        assertEquals(NONE, dataType.getName());
         assertEquals("Any", dataType.getType());
         assertEquals("", dataType.getConstraint());
         assertEquals(emptyList(), dataType.getSubDataTypes());
@@ -473,7 +505,7 @@ public class DataTypeManagerTest {
     public void testGetStackTypeWhenDataTypeIsNotTopLevelAndStructureType() {
 
         final DataType parent = mock(DataType.class);
-        final String type = "Structure";
+        final String type = STRUCTURE;
 
         when(parent.isTopLevel()).thenReturn(false);
         when(parent.getType()).thenReturn(type);
@@ -596,7 +628,7 @@ public class DataTypeManagerTest {
 
         manager.withDataType(dataType).asStructure();
 
-        verify(manager).withType("Structure");
+        verify(manager).withType(STRUCTURE);
     }
 
     @Test
@@ -656,6 +688,14 @@ public class DataTypeManagerTest {
         when(itemDefinition.getAllowedValues()).thenReturn(unaryTests);
 
         return itemDefinition;
+    }
+
+    private DataType makeDataType(final String uuid,
+                                  final String name,
+                                  final String type) {
+        final DataType dataType = makeDataType(uuid, name);
+        doReturn(type).when(dataType).getType();
+        return dataType;
     }
 
     private DataType makeDataType(final String uuid,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -724,6 +724,39 @@ public class DataTypeListItemTest {
     }
 
     @Test
+    public void testDestroyWithDependentTypes() {
+
+        final DataType dataType = mock(DataType.class);
+        final DataType dataType0 = mock(DataType.class);
+        final DataType dataType1 = mock(DataType.class);
+        final List<DataType> removedDataTypes = asList(dataType0, dataType1);
+
+        when(dataType.destroy()).thenReturn(removedDataTypes);
+        doReturn(dataType).when(listItem).getDataType();
+        doNothing().when(listItem).destroy(any());
+
+        listItem.destroyWithDependentTypes();
+
+        verify(listItem).destroy(removedDataTypes);
+    }
+
+    @Test
+    public void testDestroyWithoutDependentTypes() {
+
+        final DataType dataType = mock(DataType.class);
+        final DataType dataType0 = mock(DataType.class);
+        final List<DataType> removedDataTypes = asList(dataType0);
+
+        when(dataType.destroyWithoutDependentTypes()).thenReturn(removedDataTypes);
+        doReturn(dataType).when(listItem).getDataType();
+        doNothing().when(listItem).destroy(any());
+
+        listItem.destroyWithoutDependentTypes();
+
+        verify(listItem).destroy(removedDataTypes);
+    }
+
+    @Test
     public void testRemoveTopLevelDataTypesWhenItemDataTypeIsDestroyedDataType() {
 
         final DataType dataType = mock(DataType.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -22,7 +22,9 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
+import elemental2.dom.NodeList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +36,7 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTyp
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.SmallSwitchComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.confirmation.DataTypeConfirmation;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.DataTypeConstraint;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.validation.DataTypeNameFormatValidator;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.ItemDefinitionStore;
 import org.mockito.ArgumentCaptor;
@@ -129,13 +132,13 @@ public class DataTypeListItemTest {
     }
 
     @Test
-    public void testGetElement() {
+    public void testGetContentElement() {
 
         final HTMLElement expectedElement = mock(HTMLElement.class);
 
         when(view.getElement()).thenReturn(expectedElement);
 
-        HTMLElement actualElement = listItem.getElement();
+        HTMLElement actualElement = listItem.getContentElement();
 
         assertEquals(expectedElement, actualElement);
     }
@@ -146,9 +149,14 @@ public class DataTypeListItemTest {
         final DataType expectedDataType = this.dataType;
         final int expectedLevel = 1;
 
+        doNothing().when(listItem).setupDragAndDropComponent();
+        doNothing().when(listItem).setupView();
+
         listItem.setupDataType(expectedDataType, expectedLevel);
 
         final InOrder inOrder = inOrder(listItem);
+
+        inOrder.verify(listItem).setupDragAndDropComponent();
         inOrder.verify(listItem).setupSelectComponent();
         inOrder.verify(listItem).setupListComponent();
         inOrder.verify(listItem).setupConstraintComponent();
@@ -156,6 +164,24 @@ public class DataTypeListItemTest {
 
         assertEquals(expectedDataType, listItem.getDataType());
         assertEquals(expectedLevel, listItem.getLevel());
+    }
+
+    @Test
+    public void testSetupDragAndDropComponent() {
+
+        final DNDListComponent dragAndDropComponent = mock(DNDListComponent.class);
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+        final HTMLElement expectedElement = mock(HTMLElement.class);
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(dragAndDropComponent);
+        when(listItem.getContentElement()).thenReturn(htmlElement);
+        when(dragAndDropComponent.registerNewItem(htmlElement)).thenReturn(expectedElement);
+
+        listItem.setupDragAndDropComponent();
+
+        final HTMLElement actualElement = listItem.getDragAndDropElement();
+
+        assertEquals(expectedElement, actualElement);
     }
 
     @Test
@@ -216,6 +242,8 @@ public class DataTypeListItemTest {
 
         final DataType dataType = mock(DataType.class);
         when(listItem.getDataType()).thenReturn(dataType);
+        doNothing().when(listItem).setupIndentationLevel();
+        doNothing().when(listItem).hideTooltips();
 
         listItem.setupView();
 
@@ -223,6 +251,8 @@ public class DataTypeListItemTest {
         verify(view).setupConstraintComponent(dataTypeConstraintComponent);
         verify(view).setupListComponent(dataTypeListComponent);
         verify(view).setDataType(dataType);
+        verify(listItem).setupIndentationLevel();
+        verify(listItem).hideTooltips();
     }
 
     @Test
@@ -270,6 +300,7 @@ public class DataTypeListItemTest {
         listItem.refreshSubItems(dataTypes);
 
         verify(dataTypeList).refreshSubItemsFromListItem(listItem, dataTypes);
+        verify(listItem).expandOrCollapseSubTypes();
         verify(view).enableFocusMode();
         verify(view).toggleArrow(anyBoolean());
     }
@@ -336,11 +367,13 @@ public class DataTypeListItemTest {
         when(view.isOnFocusMode()).thenReturn(true);
         doNothing().when(listItem).discardNewDataType();
         doNothing().when(listItem).closeEditMode();
+        doNothing().when(listItem).hideTooltips();
 
         listItem.disableEditMode();
 
         verify(listItem).discardNewDataType();
         verify(listItem).closeEditMode();
+        verify(listItem).hideTooltips();
     }
 
     @Test
@@ -352,6 +385,7 @@ public class DataTypeListItemTest {
 
         verify(listItem, never()).discardNewDataType();
         verify(listItem, never()).closeEditMode();
+        verify(listItem, never()).hideTooltips();
     }
 
     @Test
@@ -517,6 +551,7 @@ public class DataTypeListItemTest {
 
         doNothing().when(listItem).setupSelectComponent();
         doNothing().when(listItem).setupListComponent();
+        doNothing().when(listItem).setupIndentationLevel();
         doNothing().when(listItem).refreshSubItems(subDataTypes);
         doReturn(subDataTypes).when(dataType).getSubDataTypes();
         doReturn(dataType).when(listItem).discardDataTypeProperties();
@@ -528,6 +563,7 @@ public class DataTypeListItemTest {
         verify(listItem).setupSelectComponent();
         verify(listItem).setupConstraintComponent();
         verify(listItem).refreshSubItems(subDataTypes);
+        verify(listItem).setupIndentationLevel();
     }
 
     @Test
@@ -635,6 +671,7 @@ public class DataTypeListItemTest {
         doReturn(expectedConstraint).when(dataType).getConstraint();
         doReturn(expectedName).when(dataType).getName();
         doReturn(dataType).when(listItem).getDataType();
+        doNothing().when(listItem).hideTooltips();
 
         listItem.refresh();
 
@@ -644,6 +681,7 @@ public class DataTypeListItemTest {
         verify(view).setName(expectedName);
         verify(listItem).setupListComponent();
         verify(listItem).setupConstraintComponent();
+        verify(listItem).hideTooltips();
     }
 
     @Test
@@ -653,7 +691,7 @@ public class DataTypeListItemTest {
         final Command command = mock(Command.class);
 
         doReturn(dataType).when(listItem).getDataType();
-        doReturn(command).when(listItem).doRemove();
+        doReturn(command).when(listItem).destroy();
 
         listItem.remove();
 
@@ -661,7 +699,7 @@ public class DataTypeListItemTest {
     }
 
     @Test
-    public void testDoRemove() {
+    public void testDestroy() {
 
         final DataType dataType = mock(DataType.class);
         final DataType dataType0 = mock(DataType.class);
@@ -674,11 +712,13 @@ public class DataTypeListItemTest {
         doReturn(destroyedDataTypes).when(dataType).destroy();
         doReturn(removedDataTypes).when(listItem).removeTopLevelDataTypes(destroyedDataTypes);
         doReturn(dataType).when(listItem).getDataType();
+        doNothing().when(listItem).hideTooltips();
 
-        listItem.doRemove().execute();
+        listItem.destroy().execute();
 
         verify(dataTypeList).refreshItemsByUpdatedDataTypes(asList(dataType0, dataType3));
         verify(listItem).fireDataChangedEvent();
+        verify(listItem).hideTooltips();
     }
 
     @Test
@@ -752,14 +792,18 @@ public class DataTypeListItemTest {
     @Test
     public void testInsertFieldAboveWhenTheNewDataTypeIsTopLevel() {
 
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
         final DataType newDataType = mock(DataType.class);
         final DataType reference = mock(DataType.class);
+        final DataTypeListItem newListItem = mock(DataTypeListItem.class);
         final List<DataType> updatedDataTypes = asList(mock(DataType.class), mock(DataType.class));
         final String referenceDataTypeHash = "tDataType.id";
         final String newDataTypeHash = "tDataType.name";
 
         when(newDataType.isTopLevel()).thenReturn(true);
         when(newDataType.create(reference, ABOVE)).thenReturn(updatedDataTypes);
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+        when(dataTypeList.findItemByDataTypeHash(newDataTypeHash)).thenReturn(Optional.of(newListItem));
         when(dataTypeList.calculateParentHash(reference)).thenReturn(referenceDataTypeHash);
         doReturn(newDataTypeHash).when(listItem).getNewDataTypeHash(newDataType, referenceDataTypeHash);
         doReturn(dataTypeManager).when(dataTypeManager).fromNew();
@@ -769,21 +813,26 @@ public class DataTypeListItemTest {
         listItem.insertFieldAbove();
 
         verify(listItem).closeEditMode();
-        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
         verify(dataTypeList).insertAbove(newDataType, reference);
+        verify(dndListComponent).refreshItemsCSSAndHTMLPosition();
+        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
     }
 
     @Test
     public void testInsertFieldAboveWhenTheNewDataTypeIsNotTopLevel() {
 
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
         final DataType newDataType = mock(DataType.class);
         final DataType reference = mock(DataType.class);
+        final DataTypeListItem newListItem = mock(DataTypeListItem.class);
         final List<DataType> updatedDataTypes = asList(mock(DataType.class), mock(DataType.class));
         final String referenceDataTypeHash = "tDataType.id";
         final String newDataTypeHash = "tDataType.name";
 
         when(newDataType.isTopLevel()).thenReturn(false);
         when(newDataType.create(reference, ABOVE)).thenReturn(updatedDataTypes);
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+        when(dataTypeList.findItemByDataTypeHash(newDataTypeHash)).thenReturn(Optional.of(newListItem));
         when(dataTypeList.calculateParentHash(reference)).thenReturn(referenceDataTypeHash);
         doReturn(newDataTypeHash).when(listItem).getNewDataTypeHash(newDataType, referenceDataTypeHash);
         doReturn(dataTypeManager).when(dataTypeManager).fromNew();
@@ -793,13 +842,15 @@ public class DataTypeListItemTest {
         listItem.insertFieldAbove();
 
         verify(listItem).closeEditMode();
-        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
         verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
+        verify(dndListComponent).refreshItemsCSSAndHTMLPosition();
+        verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
     }
 
     @Test
     public void testInsertFieldBelowWhenTheNewDataTypeIsTopLevel() {
 
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
         final DataType newDataType = mock(DataType.class);
         final DataType reference = mock(DataType.class);
         final List<DataType> updatedDataTypes = asList(mock(DataType.class), mock(DataType.class));
@@ -809,6 +860,7 @@ public class DataTypeListItemTest {
         when(newDataType.isTopLevel()).thenReturn(true);
         when(newDataType.create(reference, BELOW)).thenReturn(updatedDataTypes);
         when(dataTypeList.calculateParentHash(reference)).thenReturn(referenceDataTypeHash);
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
         doReturn(newDataTypeHash).when(listItem).getNewDataTypeHash(newDataType, referenceDataTypeHash);
         doReturn(dataTypeManager).when(dataTypeManager).fromNew();
         doReturn(newDataType).when(dataTypeManager).get();
@@ -818,12 +870,12 @@ public class DataTypeListItemTest {
 
         verify(listItem).closeEditMode();
         verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
-        verify(dataTypeList).insertBelow(newDataType, reference);
     }
 
     @Test
     public void testInsertFieldBelowWhenTheNewDataTypeIsNotTopLevel() {
 
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
         final DataType newDataType = mock(DataType.class);
         final DataType reference = mock(DataType.class);
         final List<DataType> updatedDataTypes = asList(mock(DataType.class), mock(DataType.class));
@@ -833,6 +885,7 @@ public class DataTypeListItemTest {
         when(newDataType.isTopLevel()).thenReturn(false);
         when(newDataType.create(reference, BELOW)).thenReturn(updatedDataTypes);
         when(dataTypeList.calculateParentHash(reference)).thenReturn(referenceDataTypeHash);
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
         doReturn(newDataTypeHash).when(listItem).getNewDataTypeHash(newDataType, referenceDataTypeHash);
         doReturn(dataTypeManager).when(dataTypeManager).fromNew();
         doReturn(newDataType).when(dataTypeManager).get();
@@ -842,7 +895,6 @@ public class DataTypeListItemTest {
 
         verify(listItem).closeEditMode();
         verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
-        verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
     }
 
     @Test
@@ -1124,6 +1176,107 @@ public class DataTypeListItemTest {
         when(dataType.isReadOnly()).thenReturn(false);
 
         assertFalse(listItem.isReadOnly());
+    }
+
+    @Test
+    public void testRefreshItemsCSSAndHTMLPosition() {
+        listItem.refreshItemsCSSAndHTMLPosition();
+        verify(dataTypeList).refreshItemsCSSAndHTMLPosition();
+    }
+
+    @Test
+    public void testSetPositionX() {
+
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
+        final Element element = mock(Element.class);
+        final int positionX = 2;
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+
+        listItem.setPositionX(element, positionX);
+
+        verify(dndListComponent).setPositionX(element, positionX);
+    }
+
+    @Test
+    public void testSetPositionY() {
+
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
+        final Element element = mock(Element.class);
+        final int positionY = 2;
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+
+        listItem.setPositionY(element, positionY);
+
+        verify(dndListComponent).setPositionY(element, positionY);
+    }
+
+    @Test
+    public void testGetPositionY() {
+
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
+        final Element element = mock(Element.class);
+        final Integer expectedPositionY = 2;
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+        when(dndListComponent.getPositionY(element)).thenReturn(expectedPositionY);
+
+        final Integer actualPositionY = listItem.getPositionY(element);
+
+        assertEquals(expectedPositionY, actualPositionY);
+    }
+
+    @Test
+    public void testGetDragAndDropListElement() {
+
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
+        final HTMLElement expectedHTMLElement = mock(HTMLElement.class);
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+        when(dndListComponent.getElement()).thenReturn(expectedHTMLElement);
+
+        final HTMLElement actualHTMLElement = listItem.getDragAndDropListElement();
+
+        assertEquals(expectedHTMLElement, actualHTMLElement);
+    }
+
+    @Test
+    public void testSetupIndentationLevel() {
+
+        final HTMLElement dragAndDropElement = mock(HTMLElement.class);
+        final DNDListComponent dndListComponent = mock(DNDListComponent.class);
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+        doReturn(dragAndDropElement).when(listItem).getDragAndDropElement();
+        doReturn(5).when(listItem).getLevel();
+
+        listItem.setupIndentationLevel();
+
+        verify(dndListComponent).setPositionX(dragAndDropElement, 4);
+    }
+
+    @Test
+    public void testHideTooltips() {
+
+        final HTMLElement listItems = mock(HTMLElement.class);
+        final NodeList<Element> tooltips = spy(new NodeList<>());
+        final Element element0 = mock(Element.class);
+        final Element element1 = mock(Element.class);
+
+        when(tooltips.getAt(0)).thenReturn(element0);
+        when(tooltips.getAt(1)).thenReturn(element1);
+        tooltips.length = 2;
+        element0.parentNode = listItems;
+        element1.parentNode = listItems;
+
+        when(dataTypeList.getListItems()).thenReturn(listItems);
+        when(listItems.querySelectorAll(".tooltip")).thenReturn(tooltips);
+
+        listItem.hideTooltips();
+
+        verify(listItems).removeChild(element0);
+        verify(listItems).removeChild(element1);
     }
 
     private DataType makeDataType() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -339,6 +339,7 @@ public class DataTypeListItemTest {
         verify(dataTypeSelectComponent).enableEditMode();
         verify(dataTypeConstraintComponent).enableEditMode();
         verify(editModeToggleEvent).fire(eventArgumentCaptor.capture());
+        verify(dataTypeList).fireOnDataTypeListItemUpdateCallback(listItem);
 
         assertTrue(eventArgumentCaptor.getValue().isEditModeEnabled());
     }
@@ -359,6 +360,7 @@ public class DataTypeListItemTest {
         verify(dataTypeSelectComponent, never()).enableEditMode();
         verify(dataTypeConstraintComponent, never()).enableEditMode();
         verify(editModeToggleEvent, never()).fire(any());
+        verify(dataTypeList, never()).fireOnDataTypeListItemUpdateCallback(any(DataTypeListItem.class));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -870,6 +870,7 @@ public class DataTypeListItemTest {
 
         verify(listItem).closeEditMode();
         verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
+        verify(dataTypeList).insertBelow(newDataType, reference);
     }
 
     @Test
@@ -895,6 +896,7 @@ public class DataTypeListItemTest {
 
         verify(listItem).closeEditMode();
         verify(listItem).enableEditModeAndUpdateCallbacks(newDataTypeHash);
+        verify(dataTypeList).refreshItemsByUpdatedDataTypes(updatedDataTypes);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
@@ -99,6 +99,9 @@ public class DataTypeListItemViewTest {
     private HTMLElement dataTypeListElement;
 
     @Mock
+    private HTMLElement dragAndDropElement;
+
+    @Mock
     private TranslationService translationService;
 
     private DataTypeListItemView view;
@@ -108,7 +111,8 @@ public class DataTypeListItemViewTest {
         view = spy(new DataTypeListItemView(row, translationService));
         view.init(presenter);
 
-        doReturn(dataTypeListElement).when(view).dataTypeListElement();
+        when(presenter.getDragAndDropElement()).thenReturn(dragAndDropElement);
+        doReturn(dataTypeListElement).when(presenter).getDragAndDropListElement();
     }
 
     @Test
@@ -118,7 +122,6 @@ public class DataTypeListItemViewTest {
 
         doNothing().when(view).setupRowMetadata(dataType);
         doNothing().when(view).setupArrow(dataType);
-        doNothing().when(view).setupIndentationLevel();
         doNothing().when(view).setupReadOnly(dataType);
         doNothing().when(view).setupActionButtons();
         doNothing().when(view).setupEventHandlers();
@@ -128,7 +131,6 @@ public class DataTypeListItemViewTest {
 
         verify(view).setupRowMetadata(dataType);
         verify(view).setupArrow(dataType);
-        verify(view).setupIndentationLevel();
         verify(view).setupReadOnly(dataType);
         verify(view).setupActionButtons();
         verify(view).setupEventHandlers();
@@ -142,12 +144,12 @@ public class DataTypeListItemViewTest {
 
         when(dataType.getUUID()).thenReturn("1234");
         when(dataType.getParentUUID()).thenReturn("4567");
-        row.classList = classList;
+        dragAndDropElement.classList = classList;
 
         view.setupRowMetadata(dataType);
 
-        verify(row).setAttribute(UUID_ATTR, "1234");
-        verify(row).setAttribute(PARENT_UUID_ATTR, "4567");
+        verify(dragAndDropElement).setAttribute(UUID_ATTR, "1234");
+        verify(dragAndDropElement).setAttribute(PARENT_UUID_ATTR, "4567");
         verify(view).setupRowCSSClass(dataType);
     }
 
@@ -156,12 +158,12 @@ public class DataTypeListItemViewTest {
 
         final DataType dataType = mock(DataType.class);
 
-        row.classList = mock(DOMTokenList.class);
+        dragAndDropElement.classList = mock(DOMTokenList.class);
         when(dataType.hasSubDataTypes()).thenReturn(true);
 
         view.setupSubDataTypesCSSClass(dataType);
 
-        verify(row.classList).add("has-sub-data-types");
+        verify(dragAndDropElement.classList).add("has-sub-data-types");
     }
 
     @Test
@@ -169,12 +171,12 @@ public class DataTypeListItemViewTest {
 
         final DataType dataType = mock(DataType.class);
 
-        row.classList = mock(DOMTokenList.class);
+        dragAndDropElement.classList = mock(DOMTokenList.class);
         when(dataType.hasSubDataTypes()).thenReturn(false);
 
         view.setupSubDataTypesCSSClass(dataType);
 
-        verify(row.classList).remove("has-sub-data-types");
+        verify(dragAndDropElement.classList).remove("has-sub-data-types");
     }
 
     @Test
@@ -182,12 +184,12 @@ public class DataTypeListItemViewTest {
 
         final DataType dataType = mock(DataType.class);
 
-        row.classList = mock(DOMTokenList.class);
+        dragAndDropElement.classList = mock(DOMTokenList.class);
         when(dataType.isReadOnly()).thenReturn(true);
 
         view.setupReadOnlyCSSClass(dataType);
 
-        verify(row.classList).add("read-only");
+        verify(dragAndDropElement.classList).add("read-only");
     }
 
     @Test
@@ -195,12 +197,12 @@ public class DataTypeListItemViewTest {
 
         final DataType dataType = mock(DataType.class);
 
-        row.classList = mock(DOMTokenList.class);
+        dragAndDropElement.classList = mock(DOMTokenList.class);
         when(dataType.isReadOnly()).thenReturn(false);
 
         view.setupReadOnlyCSSClass(dataType);
 
-        verify(row.classList).remove("read-only");
+        verify(dragAndDropElement.classList).remove("read-only");
     }
 
     @Test
@@ -257,27 +259,6 @@ public class DataTypeListItemViewTest {
         view.setupArrow(dataType);
 
         verify(view).toggleArrow(false);
-    }
-
-    @Test
-    public void testSetupIndentationLevel() {
-
-        final int indentationLevel = 3;
-        final NodeList<Element> levelElements = spy(new NodeList<>());
-        final Element element0 = mock(Element.class);
-        final Element element1 = mock(Element.class);
-
-        levelElements.length = 2;
-        doReturn(element0).when(levelElements).getAt(0);
-        doReturn(element1).when(levelElements).getAt(1);
-
-        when(presenter.getLevel()).thenReturn(indentationLevel);
-        when(row.querySelectorAll(".nesting-level")).thenReturn(levelElements);
-
-        view.setupIndentationLevel();
-
-        verify(element0).setAttribute("style", "margin-left: 105px");
-        verify(element1).setAttribute("style", "margin-left: 105px");
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
@@ -503,7 +503,6 @@ public class DataTypeListTest {
         verify(view).showOrHideNoCustomItemsMessage();
         verify(listItem).refresh();
         verify(listItem).enableEditMode();
-        verify(dataTypeList).fireOnDataTypeListItemUpdateCallback(listItem);
         verify(dndListComponent).refreshItemsCSSAndHTMLPosition();
         verify(listItem).enableEditMode();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
@@ -17,12 +17,13 @@
 package org.kie.workbench.common.dmn.client.editors.types.listview;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
@@ -32,6 +33,8 @@ import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeStackHash;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.DataTypeStore;
 import org.kie.workbench.common.dmn.client.editors.types.search.DataTypeSearchBar;
 import org.mockito.ArgumentCaptor;
@@ -40,9 +43,9 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import static freemarker.template.utility.Collections12.singletonList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -83,6 +86,12 @@ public class DataTypeListTest {
     @Mock
     private Consumer<DataTypeListItem> listItemConsumer;
 
+    @Mock
+    private DNDListComponent dndListComponent;
+
+    @Mock
+    private DNDDataTypesHandler dndDataTypesHandler;
+
     private DataTypeStore dataTypeStore;
 
     private DataTypeStackHash dataTypeStackHash;
@@ -96,15 +105,33 @@ public class DataTypeListTest {
     public void setup() {
         dataTypeStore = new DataTypeStore();
         dataTypeStackHash = new DataTypeStackHash(dataTypeStore);
-        dataTypeList = spy(new DataTypeList(view, listItems, dataTypeManager, searchBar, dataTypeStackHash));
+        dataTypeList = spy(new DataTypeList(view, listItems, dataTypeManager, searchBar, dndListComponent, dataTypeStackHash, dndDataTypesHandler));
         when(listItems.get()).thenReturn(treeGridItem);
     }
 
     @Test
     public void testSetup() {
+
+        final BiConsumer<Element, Element> consumer = (a, b) -> {/* Nothing. */};
+
+        doReturn(consumer).when(dataTypeList).getOnDropDataType();
+
         dataTypeList.setup();
 
         verify(view).init(dataTypeList);
+        verify(dndDataTypesHandler).init(dataTypeList);
+        verify(dndListComponent).setOnDropItem(consumer);
+    }
+
+    @Test
+    public void testGetOnDropDataType() {
+
+        final Element e1 = mock(Element.class);
+        final Element e2 = mock(Element.class);
+
+        dataTypeList.getOnDropDataType().accept(e1, e2);
+
+        verify(dndDataTypesHandler).onDropDataType(e1, e2);
     }
 
     @Test
@@ -131,11 +158,16 @@ public class DataTypeListTest {
 
         dataTypeList.setupItems(dataTypes);
 
-        final InOrder inOrder = Mockito.inOrder(dataTypeList);
+        final InOrder inOrder = Mockito.inOrder(dndListComponent, dataTypeList, view);
 
-        inOrder.verify(dataTypeList).setListItems(listItems);
-        inOrder.verify(dataTypeList).setupViewItems();
+        inOrder.verify(dndListComponent).clear();
+        inOrder.verify(dataTypeList).makeDataTypeListItems(dataTypes);
+        inOrder.verify(dndListComponent).refreshItemsPosition();
+        inOrder.verify(view).showOrHideNoCustomItemsMessage();
+        inOrder.verify(view).showReadOnlyMessage(false);
         inOrder.verify(dataTypeList).collapseItemsInTheFirstLevel();
+
+        assertEquals(listItems, dataTypeList.getItems());
     }
 
     @Test
@@ -234,40 +266,6 @@ public class DataTypeListTest {
     }
 
     @Test
-    public void testSetViewItemsWhenSomeDataTypeListItemIsReadOnly() {
-
-        final DataTypeListItem listItem1 = mock(DataTypeListItem.class);
-        final DataTypeListItem listItem2 = mock(DataTypeListItem.class);
-        final List<DataTypeListItem> listItems = asList(listItem1, listItem2);
-
-        doReturn(listItems).when(dataTypeList).getItems();
-        when(listItem1.isReadOnly()).thenReturn(false);
-        when(listItem2.isReadOnly()).thenReturn(true);
-
-        dataTypeList.setupViewItems();
-
-        verify(view).setupListItems(listItems);
-        verify(view).showReadOnlyMessage(true);
-    }
-
-    @Test
-    public void testSetViewItemsWhenNoDataTypeListItemIsReadOnly() {
-
-        final DataTypeListItem listItem1 = mock(DataTypeListItem.class);
-        final DataTypeListItem listItem2 = mock(DataTypeListItem.class);
-        final List<DataTypeListItem> listItems = asList(listItem1, listItem2);
-
-        doReturn(listItems).when(dataTypeList).getItems();
-        when(listItem1.isReadOnly()).thenReturn(false);
-        when(listItem2.isReadOnly()).thenReturn(false);
-
-        dataTypeList.setupViewItems();
-
-        verify(view).setupListItems(listItems);
-        verify(view).showReadOnlyMessage(false);
-    }
-
-    @Test
     public void testMakeDataTypeListItemsWithoutSubItems() {
 
         final DataType dataType1 = makeDataType("item", "iITem");
@@ -288,7 +286,7 @@ public class DataTypeListTest {
         final DataType subDataType1 = makeDataType("subItem1", "subItemType1");
         final DataType subDataType2 = makeDataType("subItem2", "subItemType2", subDataType3);
         final DataType dataType = makeDataType("item", "iITem", subDataType1, subDataType2);
-        final List<DataType> dataTypes = Collections.singletonList(dataType);
+        final List<DataType> dataTypes = singletonList(dataType);
 
         dataTypeList.makeDataTypeListItems(dataTypes);
 
@@ -483,6 +481,8 @@ public class DataTypeListTest {
 
         verify(listItem).refresh();
         verify(dataTypeList).refreshSubItemsFromListItem(listItem, subDataTypes);
+        verify(dndListComponent).consolidateYPosition();
+        verify(dndListComponent).refreshItemsPosition();
         verify(searchBar).refresh();
     }
 
@@ -498,8 +498,13 @@ public class DataTypeListTest {
 
         dataTypeList.addDataType();
 
+        verify(searchBar).reset();
         verify(dataType).create();
-        verify(view).addSubItem(listItem);
+        verify(view).showOrHideNoCustomItemsMessage();
+        verify(listItem).refresh();
+        verify(listItem).enableEditMode();
+        verify(dataTypeList).fireOnDataTypeListItemUpdateCallback(listItem);
+        verify(dndListComponent).refreshItemsCSSAndHTMLPosition();
         verify(listItem).enableEditMode();
     }
 
@@ -511,10 +516,12 @@ public class DataTypeListTest {
         final DataTypeListItem listItem = mock(DataTypeListItem.class);
 
         doReturn(listItem).when(dataTypeList).makeListItem(dataType);
+        when(listItem.getDataType()).thenReturn(dataType);
 
         dataTypeList.insertBelow(dataType, reference);
 
         verify(view).insertBelow(listItem, reference);
+        verify(dataTypeList).refreshItemsByUpdatedDataTypes(singletonList(dataType));
     }
 
     @Test
@@ -529,6 +536,8 @@ public class DataTypeListTest {
         dataTypeList.insertAbove(dataType, reference);
 
         verify(view).insertAbove(listItem, reference);
+        verify(dndListComponent).consolidateYPosition();
+        verify(dndListComponent).refreshItemsPosition();
     }
 
     @Test
@@ -628,6 +637,68 @@ public class DataTypeListTest {
         assertFalse(item.isPresent());
     }
 
+    @Test
+    public void testOnDataTypeEditModeToggleStartEditing() {
+
+        final DataTypeListItem currentEditingItem = mock(DataTypeListItem.class);
+        final DataTypeEditModeToggleEvent event = new DataTypeEditModeToggleEvent(true, currentEditingItem);
+
+        dataTypeList.onDataTypeEditModeToggle(event);
+
+        final DataTypeListItem actual = dataTypeList.getCurrentEditingItem();
+
+        verify(searchBar).reset();
+        assertEquals(currentEditingItem, actual);
+    }
+
+    @Test
+    public void testOnDataTypeEditModeToggleStopEditing() {
+
+        final DataTypeListItem currentEditingItem = mock(DataTypeListItem.class);
+        final DataTypeEditModeToggleEvent event = new DataTypeEditModeToggleEvent(false, currentEditingItem);
+
+        dataTypeList.onDataTypeEditModeToggle(event);
+
+        final DataTypeListItem actual = dataTypeList.getCurrentEditingItem();
+
+        verify(searchBar).reset();
+        assertEquals(null, actual);
+    }
+
+    @Test
+    public void testOnDataTypeEditModeToggleChangedCurrentEditingItem() {
+
+        final DataTypeListItem currentEditingItem = mock(DataTypeListItem.class);
+        final DataTypeListItem previousEditingItem = mock(DataTypeListItem.class);
+        final List<DataTypeListItem> listItems = asList(currentEditingItem, previousEditingItem);
+
+        doReturn(listItems).when(dataTypeList).getItems();
+
+        final DataTypeEditModeToggleEvent event = new DataTypeEditModeToggleEvent(true, currentEditingItem);
+
+        dataTypeList.setCurrentEditingItem(previousEditingItem);
+
+        dataTypeList.onDataTypeEditModeToggle(event);
+
+        final DataTypeListItem actual = dataTypeList.getCurrentEditingItem();
+
+        verify(searchBar).reset();
+        assertEquals(currentEditingItem, actual);
+        verify(previousEditingItem).disableEditMode();
+    }
+
+    @Test
+    public void testGetListElement() {
+
+        final HTMLElement expectedElement = mock(HTMLElement.class);
+
+        when(view.getListItems()).thenReturn(expectedElement);
+
+        final HTMLElement actualElement = dataTypeList.getListItems();
+
+        assertEquals(expectedElement, actualElement);
+    }
+
     private DataTypeListItem listItem(final DataType dataType) {
         final DataTypeListItem listItem = mock(DataTypeListItem.class);
         when(listItem.getDataType()).thenReturn(dataType);
@@ -659,52 +730,5 @@ public class DataTypeListTest {
         dataTypeStore.index(dataType.getUUID(), dataType);
 
         return dataType;
-    }
-
-    @Test
-    public void testOnDataTypeEditModeToggleStartEditing() {
-
-        final DataTypeListItem currentEditingItem = mock(DataTypeListItem.class);
-        final DataTypeEditModeToggleEvent event = new DataTypeEditModeToggleEvent(true, currentEditingItem);
-
-        dataTypeList.onDataTypeEditModeToggle(event);
-
-        final DataTypeListItem actual = dataTypeList.getCurrentEditingItem();
-
-        assertEquals(currentEditingItem, actual);
-    }
-
-    @Test
-    public void testOnDataTypeEditModeToggleStopEditing() {
-
-        final DataTypeListItem currentEditingItem = mock(DataTypeListItem.class);
-        final DataTypeEditModeToggleEvent event = new DataTypeEditModeToggleEvent(false, currentEditingItem);
-
-        dataTypeList.onDataTypeEditModeToggle(event);
-
-        final DataTypeListItem actual = dataTypeList.getCurrentEditingItem();
-
-        assertEquals(null, actual);
-    }
-
-    @Test
-    public void testOnDataTypeEditModeToggleChangedCurrentEditingItem() {
-
-        final DataTypeListItem currentEditingItem = mock(DataTypeListItem.class);
-        final DataTypeListItem previousEditingItem = mock(DataTypeListItem.class);
-        final List<DataTypeListItem> listItems = asList(currentEditingItem, previousEditingItem);
-
-        doReturn(listItems).when(dataTypeList).getItems();
-
-        final DataTypeEditModeToggleEvent event = new DataTypeEditModeToggleEvent(true, currentEditingItem);
-
-        dataTypeList.setCurrentEditingItem(previousEditingItem);
-
-        dataTypeList.onDataTypeEditModeToggle(event);
-
-        final DataTypeListItem actual = dataTypeList.getCurrentEditingItem();
-
-        assertEquals(currentEditingItem, actual);
-        verify(previousEditingItem).disableEditMode();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.listview;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,6 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.ScrollHelper;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.kie.workbench.common.dmn.client.editors.types.search.DataTypeSearchBar;
 import org.mockito.Mock;
 
@@ -48,7 +48,6 @@ import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTyp
 import static org.kie.workbench.common.dmn.client.editors.types.listview.common.ListItemViewCssHelper.RIGHT_ARROW_CSS_CLASS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -112,6 +111,12 @@ public class DataTypeListViewTest {
     private ScrollHelper scrollHelper;
 
     @Mock
+    private DNDListComponent dndListComponent;
+
+    @Mock
+    private HTMLElement dndListComponentElement;
+
+    @Mock
     private DataTypeList presenter;
 
     private DataTypeListView view;
@@ -121,6 +126,8 @@ public class DataTypeListViewTest {
 
         when(presenter.getSearchBar()).thenReturn(searchBar);
         when(searchBar.getElement()).thenReturn(searchBarElement);
+        when(presenter.getDNDListComponent()).thenReturn(dndListComponent);
+        when(dndListComponent.getElement()).thenReturn(dndListComponentElement);
 
         placeholder.classList = mock(DOMTokenList.class);
         noDataTypesFound.classList = mock(DOMTokenList.class);
@@ -137,6 +144,7 @@ public class DataTypeListViewTest {
     public void testInit() {
         // "view.init(..)" called in the setup.
         verify(searchBarContainer).appendChild(searchBarElement);
+        verify(listItems).appendChild(dndListComponentElement);
     }
 
     @Test
@@ -218,24 +226,6 @@ public class DataTypeListViewTest {
     }
 
     @Test
-    public void testSetupGridItems() {
-
-        final DataTypeListItem gridItem1 = mock(DataTypeListItem.class);
-        final DataTypeListItem gridItem2 = mock(DataTypeListItem.class);
-        final HTMLElement element1 = mock(HTMLElement.class);
-        final HTMLElement element2 = mock(HTMLElement.class);
-
-        when(gridItem1.getElement()).thenReturn(element1);
-        when(gridItem2.getElement()).thenReturn(element2);
-
-        view.setupListItems(Arrays.asList(gridItem1, gridItem2));
-
-        verify(listItems).appendChild(eq(element1));
-        verify(listItems).appendChild(eq(element2));
-        verify(view).showOrHideNoCustomItemsMessage();
-    }
-
-    @Test
     public void testCleanSubTypesByDataType() {
 
         final DataType dataType = mock(DataType.class);
@@ -296,8 +286,8 @@ public class DataTypeListViewTest {
 
         when(this.listItems.querySelector("[data-row-uuid=\"" + dataTypeUUID + "\"]")).thenReturn(dataTypeRow);
         when(dataType.getUUID()).thenReturn(dataTypeUUID);
-        when(listItem1.getElement()).thenReturn(listItemElement1);
-        when(listItem2.getElement()).thenReturn(listItemElement2);
+        when(listItem1.getDragAndDropElement()).thenReturn(listItemElement1);
+        when(listItem2.getDragAndDropElement()).thenReturn(listItemElement2);
 
         doNothing().when(view).cleanSubTypes(anyString());
         doNothing().when(view).hideItemElementIfParentIsCollapsed(any(), any());
@@ -311,20 +301,6 @@ public class DataTypeListViewTest {
 
         verify(dataTypeRow.parentNode).insertBefore(listItemElement1, dataTypeRow.nextSibling);
         verify(listItemElement1.parentNode).insertBefore(listItemElement2, listItemElement1.nextSibling);
-        verify(view).showOrHideNoCustomItemsMessage();
-    }
-
-    @Test
-    public void testAddSubItem() {
-
-        final DataTypeListItem listItem = mock(DataTypeListItem.class);
-        final HTMLElement element = mock(HTMLElement.class);
-
-        when(listItem.getElement()).thenReturn(element);
-
-        view.addSubItem(listItem);
-
-        verify(listItems).appendChild(element);
         verify(view).showOrHideNoCustomItemsMessage();
     }
 
@@ -348,33 +324,6 @@ public class DataTypeListViewTest {
         view.onReadOnlyMessageCloseButtonClick(event);
 
         verify(readOnlyMessage.classList).add(HIDDEN_CSS_CLASS);
-    }
-
-    @Test
-    public void testHideNoCustomItemsMessageWhenThereIsCustomItem() {
-
-        final DataTypeListItem gridItem1 = mock(DataTypeListItem.class);
-        final DataTypeListItem gridItem2 = mock(DataTypeListItem.class);
-        final HTMLElement element1 = mock(HTMLElement.class);
-        final HTMLElement element2 = mock(HTMLElement.class);
-
-        when(gridItem1.getElement()).thenReturn(element1);
-        when(gridItem2.getElement()).thenReturn(element2);
-
-        when(view.hasCustomDataType()).thenReturn(true);
-        view.setupListItems(Arrays.asList(gridItem1, gridItem2));
-
-        verify(listItems.classList).remove(HIDDEN_CSS_CLASS);
-        verify(placeholder.classList).add(HIDDEN_CSS_CLASS);
-    }
-
-    @Test
-    public void testShowNoCustomItemsMessageWhenThereIsNoCustomItem() {
-
-        view.setupListItems(new ArrayList<>());
-
-        verify(placeholder.classList).remove(HIDDEN_CSS_CLASS);
-        verify(listItems.classList).add(HIDDEN_CSS_CLASS);
     }
 
     @Test
@@ -566,7 +515,7 @@ public class DataTypeListViewTest {
         lastElement.parentNode = parentElement;
         lastElement.nextSibling = siblingElement;
 
-        when(listItem.getElement()).thenReturn(listItemElement);
+        when(listItem.getDragAndDropElement()).thenReturn(listItemElement);
         doReturn(lastElement).when(view).getLastSubDataTypeElement(reference);
 
         view.insertBelow(listItem, reference);
@@ -585,7 +534,7 @@ public class DataTypeListViewTest {
         final Element parentElement = mock(Element.class);
         element.parentNode = parentElement;
 
-        when(listItem.getElement()).thenReturn(listItemElement);
+        when(listItem.getDragAndDropElement()).thenReturn(listItemElement);
         doReturn(element).when(view).getDataTypeRow(reference);
 
         view.insertAbove(listItem, reference);
@@ -601,13 +550,18 @@ public class DataTypeListViewTest {
         final NodeList<Element> children = spy(new NodeList<>());
         final Element child1 = makeElement("uuid1");
         final Element child2 = makeElement("uuid2");
+        final Element child3 = makeElement("uuid3");
 
         child1.parentNode = parentElement;
         child2.parentNode = parentElement;
 
+        when(dndListComponent.getPositionY(child1)).thenReturn(0);
+        when(dndListComponent.getPositionY(child2)).thenReturn(0);
+        when(dndListComponent.getPositionY(child3)).thenReturn(-1);
         doReturn(child1).when(children).getAt(0);
         doReturn(child2).when(children).getAt(1);
-        children.length = 2;
+        doReturn(child3).when(children).getAt(2);
+        children.length = 3;
 
         mockDOMElementsByParentUUID(parentUUID, children);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/confirmation/ReferencedDataTypeWarningMessageTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/confirmation/ReferencedDataTypeWarningMessageTest.java
@@ -63,4 +63,17 @@ public class ReferencedDataTypeWarningMessageTest {
 
         assertEquals(expectedWarningMessage, actualWarningMessage);
     }
+
+    @Test
+    public void testGetErrorElementSelector() {
+
+        final DataType dataType = mock(DataType.class);
+
+        when(dataType.getUUID()).thenReturn("1111-1111-1111-1111");
+
+        final String expectedSelector = "[data-row-uuid=\"1111-1111-1111-1111\"] select";
+        final String actualSelector = new ReferencedDataTypeWarningMessage(translationService).getErrorElementSelector(dataType);
+
+        assertEquals(expectedSelector, actualSelector);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerContextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerContextTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.NodeList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.client.editors.types.persistence.DataTypeStore;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItemView.UUID_ATTR;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_INTO_HOVERED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_NESTED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_SIBLING_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_X_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_Y_POSITION;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DNDDataTypesHandlerContextTest {
+
+    @Mock
+    private DataTypeStore dataTypeStore;
+
+    @Mock
+    private DNDListComponent dndListComponent;
+
+    @Mock
+    private DNDDataTypesHandler dndDataTypesHandler;
+
+    @Mock
+    private Element currentElement;
+
+    @Mock
+    private Element hoverElement;
+
+    private DNDDataTypesHandlerContext context;
+
+    @Before
+    public void setup() {
+
+        when(dndDataTypesHandler.getDataTypeStore()).thenReturn(dataTypeStore);
+        when(dndDataTypesHandler.getDndListComponent()).thenReturn(dndListComponent);
+
+        context = new DNDDataTypesHandlerContext(dndDataTypesHandler, currentElement, hoverElement);
+    }
+
+    @Test
+    public void testGetReferenceWhenHoveredDataTypeIsPresent() {
+
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
+
+        final Optional<DataType> reference = context.getReference();
+
+        assertEquals(hoverDataType, reference);
+    }
+
+    @Test
+    public void testGetReferenceWhenHoveredDataTypeIsPresentButHoveredDataTypeIsReadOnly() {
+
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String hoverUUID = "0000-0000-0000-0000";
+        final String previousUUID = "1111-1111-1111-1111";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(previousUUID)).thenReturn(previousDataType.get());
+        when(dataTypeStore.get(hoverUUID)).thenReturn(hoverDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(previousUUID);
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(hoverUUID);
+        when(hoverDataType.get().isReadOnly()).thenReturn(true);
+
+        final Optional<DataType> reference = context.getReference();
+
+        assertEquals(previousDataType, reference);
+    }
+
+    @Test
+    public void testGetReferenceWhenPreviousDataTypeIsPresent() {
+
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+
+        final Optional<DataType> reference = context.getReference();
+
+        assertEquals(previousDataType, reference);
+    }
+
+    @Test
+    public void testGetReferenceWhenCurrentDataTypeIsPresent() {
+
+        final Element firstElement = mock(Element.class);
+        final Element hiddenElement = mock(Element.class);
+        final HTMLElement dragArea = mock(HTMLElement.class);
+        final Optional<DataType> currentDataType = Optional.of(mock(DataType.class));
+        final Optional<DataType> firstDataType = Optional.of(mock(DataType.class));
+        final String currentUUID = "0000-0000-0000-0000";
+        final String firstUUID = "1111-1111-1111-1111";
+
+        dragArea.childNodes = spy(new NodeList<>());
+        dragArea.childNodes.length = 3;
+
+        doReturn(hiddenElement).when(dragArea.childNodes).getAt(0);
+        doReturn(currentElement).when(dragArea.childNodes).getAt(1);
+        doReturn(firstElement).when(dragArea.childNodes).getAt(2);
+
+        when(hiddenElement.getAttribute(DATA_Y_POSITION)).thenReturn("-1");
+        when(currentElement.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(firstElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(hiddenElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(firstElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(dndListComponent.getDragArea()).thenReturn(dragArea);
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+        when(dataTypeStore.get(currentUUID)).thenReturn(currentDataType.get());
+        when(dataTypeStore.get(firstUUID)).thenReturn(firstDataType.get());
+        when(currentDataType.get().getName()).thenReturn("Current Data Type");
+        when(firstDataType.get().getName()).thenReturn("First Data Type");
+        when(currentElement.getAttribute(UUID_ATTR)).thenReturn(currentUUID);
+        when(firstElement.getAttribute(UUID_ATTR)).thenReturn(firstUUID);
+
+        // The current element is loaded into constructor.
+        // So re-instantiating context here, since this test mock the current element behavior.
+        final DNDDataTypesHandlerContext context = new DNDDataTypesHandlerContext(dndDataTypesHandler, currentElement, hoverElement);
+        final Optional<DataType> reference = context.getReference();
+
+        assertEquals(firstDataType, reference);
+    }
+
+    @Test
+    public void testGetReferenceWhenItIsNotPresent() {
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+        assertFalse(context.getReference().isPresent());
+    }
+
+    @Test
+    public void testGetStrategyInsertIntoHoveredDataType() {
+
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
+        loadReferenceContext();
+
+        final DNDDataTypesHandlerShiftStrategy actualShiftStrategy = context.getStrategy();
+        final DNDDataTypesHandlerShiftStrategy expectedShiftStrategy = INSERT_INTO_HOVERED_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertIntoHoveredDataTypeWhenHoveredDataTypeIsReadOnly() {
+
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(hoverDataType.get().isReadOnly()).thenReturn(true);
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+        loadReferenceContext();
+
+        final DNDDataTypesHandlerShiftStrategy actualShiftStrategy = context.getStrategy();
+        final DNDDataTypesHandlerShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertTopLevelDataTypeAtTheTop() {
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+        loadReferenceContext();
+
+        final DNDDataTypesHandlerShiftStrategy actualShiftStrategy = context.getStrategy();
+        final DNDDataTypesHandlerShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertTopLevelDataType() {
+
+        final Element previousElement = mock(Element.class);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext();
+
+        final DNDDataTypesHandlerShiftStrategy actualShiftStrategy = context.getStrategy();
+        final DNDDataTypesHandlerShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertNestedDataType() {
+
+        final Element previousElement = mock(Element.class);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext();
+
+        final DNDDataTypesHandlerShiftStrategy actualShiftStrategy = context.getStrategy();
+        final DNDDataTypesHandlerShiftStrategy expectedShiftStrategy = INSERT_NESTED_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertNestedDataTypeWhenPreviousDataTypeIsReadOnly() {
+
+        final Element previousElement = mock(Element.class);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(previousDataType.get().isReadOnly()).thenReturn(true);
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext();
+
+        final DNDDataTypesHandlerShiftStrategy actualShiftStrategy = context.getStrategy();
+        final DNDDataTypesHandlerShiftStrategy expectedShiftStrategy = INSERT_SIBLING_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertSiblingDataType() {
+
+        final Element previousElement = mock(Element.class);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext();
+
+        final DNDDataTypesHandlerShiftStrategy actualShiftStrategy = context.getStrategy();
+        final DNDDataTypesHandlerShiftStrategy expectedShiftStrategy = INSERT_SIBLING_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    private void loadReferenceContext() {
+        context.getReference();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
@@ -226,6 +226,29 @@ public class DNDDataTypesHandlerTest {
     }
 
     @Test
+    public void testDNDContextGetReferenceWhenHoveredDataTypeIsPresentButHoveredDataTypeIsReadOnly() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String hoverUUID = "0000-0000-0000-0000";
+        final String previousUUID = "1111-1111-1111-1111";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(previousUUID)).thenReturn(previousDataType.get());
+        when(dataTypeStore.get(hoverUUID)).thenReturn(hoverDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(previousUUID);
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(hoverUUID);
+        when(hoverDataType.get().isReadOnly()).thenReturn(true);
+
+        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
+
+        assertEquals(previousDataType, reference);
+    }
+
+    @Test
     public void testDNDContextGetReferenceWhenPreviousDataTypeIsPresent() {
 
         final Element currentElement = mock(Element.class);
@@ -356,6 +379,27 @@ public class DNDDataTypesHandlerTest {
     }
 
     @Test
+    public void testGetStrategyInsertIntoHoveredDataTypeWhenHoveredDataTypeIsReadOnly() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(hoverDataType.get().isReadOnly()).thenReturn(true);
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+        loadReferenceContext(context);
+
+        final ShiftStrategy actualShiftStrategy = context.getStrategy();
+        final ShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
     public void testGetStrategyInsertTopLevelDataTypeAtTheTop() {
 
         final Element currentElement = mock(Element.class);
@@ -413,6 +457,30 @@ public class DNDDataTypesHandlerTest {
 
         final ShiftStrategy actualShiftStrategy = context.getStrategy();
         final ShiftStrategy expectedShiftStrategy = INSERT_NESTED_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertNestedDataTypeWhenPreviousDataTypeIsReadOnly() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(previousDataType.get().isReadOnly()).thenReturn(true);
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext(context);
+
+        final ShiftStrategy actualShiftStrategy = context.getStrategy();
+        final ShiftStrategy expectedShiftStrategy = INSERT_SIBLING_DATA_TYPE;
 
         assertEquals(expectedShiftStrategy, actualShiftStrategy);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.NodeList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
+import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeList;
+import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItem;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.DNDContext;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy;
+import org.kie.workbench.common.dmn.client.editors.types.persistence.DataTypeStore;
+import org.kie.workbench.common.dmn.client.editors.types.persistence.ItemDefinitionStore;
+import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItemView.UUID_ATTR;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_INTO_HOVERED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_NESTED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_SIBLING_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_X_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_Y_POSITION;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DNDDataTypesHandlerTest {
+
+    @Mock
+    private DataTypeStore dataTypeStore;
+
+    @Mock
+    private DataTypeManager dataTypeManager;
+
+    @Mock
+    private ItemDefinitionStore itemDefinitionStore;
+
+    @Mock
+    private DataTypeList dataTypeList;
+
+    @Mock
+    private DNDListComponent dndListComponent;
+
+    private DNDDataTypesHandler handler;
+
+    @Before
+    public void setup() {
+        handler = spy(new DNDDataTypesHandler(dataTypeStore, dataTypeManager, itemDefinitionStore));
+        handler.init(dataTypeList);
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(dndListComponent);
+    }
+
+    @Test
+    public void testOnDropDataType() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final DataType current = mock(DataType.class);
+        final DataType reference = mock(DataType.class);
+        final DNDContext context = mock(DNDContext.class);
+        final ShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
+
+        doNothing().when(handler).logError(anyString());
+        doReturn(context).when(handler).makeDndContext(currentElement, hoverElement);
+        when(context.getCurrentDataType()).thenReturn(Optional.of(current));
+        when(context.getReference()).thenReturn(Optional.of(reference));
+        when(context.getStrategy()).thenReturn(strategy);
+
+        handler.onDropDataType(currentElement, hoverElement);
+
+        verify(handler).shiftCurrentByReference(current, reference, strategy);
+    }
+
+    @Test
+    public void testOnDropDataTypeWhenCurrentIsNotPresent() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final DataType reference = mock(DataType.class);
+        final DNDContext context = mock(DNDContext.class);
+
+        doNothing().when(handler).logError(anyString());
+        doReturn(context).when(handler).makeDndContext(currentElement, hoverElement);
+        when(context.getCurrentDataType()).thenReturn(Optional.empty());
+        when(context.getReference()).thenReturn(Optional.of(reference));
+
+        handler.onDropDataType(currentElement, hoverElement);
+
+        verify(handler, never()).shiftCurrentByReference(any(), any(), any());
+    }
+
+    @Test
+    public void testOnDropDataTypeWhenReferenceIsNotPresent() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final DataType current = mock(DataType.class);
+        final DNDContext context = mock(DNDContext.class);
+
+        doNothing().when(handler).logError(anyString());
+        doReturn(context).when(handler).makeDndContext(currentElement, hoverElement);
+        when(context.getCurrentDataType()).thenReturn(Optional.of(current));
+        when(context.getReference()).thenReturn(Optional.empty());
+
+        handler.onDropDataType(currentElement, hoverElement);
+
+        verify(handler, never()).shiftCurrentByReference(any(), any(), any());
+    }
+
+    @Test
+    public void testOnDropDataTypeWhenAnErrorIsRaised() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+
+        doNothing().when(handler).logError(anyString());
+
+        handler.onDropDataType(currentElement, hoverElement);
+
+        verify(handler).logError("Drag-n-Drop error. Check 'DNDDataTypesHandler'.");
+    }
+
+    @Test
+    public void testShiftCurrentByReference() {
+
+        final DataType current = mock(DataType.class);
+        final DataType clone = mock(DataType.class);
+        final DataType reference = mock(DataType.class);
+        final ShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
+        final String referenceHash = "referenceHash";
+        final DataTypeListItem oldItem = mock(DataTypeListItem.class);
+        final DataTypeListItem referenceItem = mock(DataTypeListItem.class);
+        final Command oldItemDestroyCommand = mock(Command.class);
+
+        doReturn(clone).when(handler).cloneDataType(current);
+        when(dataTypeList.calculateHash(reference)).thenReturn(referenceHash);
+        when(dataTypeList.findItem(current)).thenReturn(Optional.of(oldItem));
+        when(dataTypeList.findItemByDataTypeHash(referenceHash)).thenReturn(Optional.of(referenceItem));
+        when(oldItem.destroy()).thenReturn(oldItemDestroyCommand);
+
+        handler.shiftCurrentByReference(current, reference, strategy);
+
+        verify(oldItemDestroyCommand).execute();
+        verify(referenceItem).insertNestedField(clone);
+    }
+
+    @Test
+    public void testDNDContextGetReferenceWhenHoveredDataTypeIsPresent() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
+
+        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
+
+        assertEquals(hoverDataType, reference);
+    }
+
+    @Test
+    public void testDNDContextGetReferenceWhenPreviousDataTypeIsPresent() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+
+        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
+
+        assertEquals(previousDataType, reference);
+    }
+
+    @Test
+    public void testDNDContextGetReferenceWhenCurrentDataTypeIsPresent() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element firstElement = mock(Element.class);
+        final Element hiddenElement = mock(Element.class);
+        final HTMLElement dragArea = mock(HTMLElement.class);
+        final Optional<DataType> currentDataType = Optional.of(mock(DataType.class));
+        final Optional<DataType> firstDataType = Optional.of(mock(DataType.class));
+        final String currentUUID = "0000-0000-0000-0000";
+        final String firstUUID = "1111-1111-1111-1111";
+
+        dragArea.childNodes = spy(new NodeList<>());
+        dragArea.childNodes.length = 3;
+
+        doReturn(hiddenElement).when(dragArea.childNodes).getAt(0);
+        doReturn(currentElement).when(dragArea.childNodes).getAt(1);
+        doReturn(firstElement).when(dragArea.childNodes).getAt(2);
+
+        when(hiddenElement.getAttribute(DATA_Y_POSITION)).thenReturn("-1");
+        when(currentElement.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(firstElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(hiddenElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(firstElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(dndListComponent.getDragArea()).thenReturn(dragArea);
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+        when(dataTypeStore.get(currentUUID)).thenReturn(currentDataType.get());
+        when(dataTypeStore.get(firstUUID)).thenReturn(firstDataType.get());
+        when(currentDataType.get().getName()).thenReturn("Current Data Type");
+        when(firstDataType.get().getName()).thenReturn("First Data Type");
+        when(currentElement.getAttribute(UUID_ATTR)).thenReturn(currentUUID);
+        when(firstElement.getAttribute(UUID_ATTR)).thenReturn(firstUUID);
+
+        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
+
+        assertEquals(firstDataType, reference);
+    }
+
+    @Test
+    public void testDNDContextGetReferenceWhenDataTypeListIsNotInitialized() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+
+        handler.init(null);
+
+        assertThatThrownBy(() -> handler.makeDndContext(currentElement, hoverElement).getReference())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("'DNDDataTypesHandler' must be initialized with a 'DataTypeList' instance.");
+    }
+
+    @Test
+    public void testDNDContextGetReferenceWhenDNDListComponentIsNotInitialized() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(null);
+
+        assertThatThrownBy(() -> handler.makeDndContext(currentElement, hoverElement).getReference())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("'DNDDataTypesHandler' must be initialized with a 'DNDListComponent' instance.");
+    }
+
+    @Test
+    public void testDNDContextGetReferenceWhenItIsNotPresent() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+
+        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
+
+        assertFalse(reference.isPresent());
+    }
+
+    @Test
+    public void testGetStrategyInsertIntoHoveredDataType() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
+        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
+        loadReferenceContext(context);
+
+        final ShiftStrategy actualShiftStrategy = context.getStrategy();
+        final ShiftStrategy expectedShiftStrategy = INSERT_INTO_HOVERED_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertTopLevelDataTypeAtTheTop() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
+        loadReferenceContext(context);
+
+        final ShiftStrategy actualShiftStrategy = context.getStrategy();
+        final ShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertTopLevelDataType() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext(context);
+
+        final ShiftStrategy actualShiftStrategy = context.getStrategy();
+        final ShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertNestedDataType() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext(context);
+
+        final ShiftStrategy actualShiftStrategy = context.getStrategy();
+        final ShiftStrategy expectedShiftStrategy = INSERT_NESTED_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    @Test
+    public void testGetStrategyInsertSiblingDataType() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
+        final String uuid = "0000-1111-2222-3333";
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+        loadReferenceContext(context);
+
+        final ShiftStrategy actualShiftStrategy = context.getStrategy();
+        final ShiftStrategy expectedShiftStrategy = INSERT_SIBLING_DATA_TYPE;
+
+        assertEquals(expectedShiftStrategy, actualShiftStrategy);
+    }
+
+    private void loadReferenceContext(final DNDContext context) {
+        context.getReference();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
@@ -156,7 +156,7 @@ public class DNDDataTypesHandlerTest {
     }
 
     @Test
-    public void testShiftCurrentByReference() {
+    public void testShiftCurrentByReferenceWhenCurrentIsCollapsed() {
 
         final DataType current = mock(DataType.class);
         final DataType clone = mock(DataType.class);
@@ -165,16 +165,48 @@ public class DNDDataTypesHandlerTest {
         final String referenceHash = "referenceHash";
         final DataTypeListItem oldItem = mock(DataTypeListItem.class);
         final DataTypeListItem referenceItem = mock(DataTypeListItem.class);
+        final DataTypeListItem newItem = mock(DataTypeListItem.class);
         final Command oldItemDestroyCommand = mock(Command.class);
 
         doReturn(clone).when(handler).cloneDataType(current);
         when(dataTypeList.calculateHash(reference)).thenReturn(referenceHash);
         when(dataTypeList.findItem(current)).thenReturn(Optional.of(oldItem));
+        when(dataTypeList.findItem(clone)).thenReturn(Optional.of(newItem));
         when(dataTypeList.findItemByDataTypeHash(referenceHash)).thenReturn(Optional.of(referenceItem));
         when(oldItem.destroy()).thenReturn(oldItemDestroyCommand);
+        when(oldItem.isCollapsed()).thenReturn(true);
 
         handler.shiftCurrentByReference(current, reference, strategy);
 
+        verify(newItem).collapse();
+        verify(oldItemDestroyCommand).execute();
+        verify(referenceItem).insertNestedField(clone);
+    }
+
+    @Test
+    public void testShiftCurrentByReferenceWhenCurrentIsNotCollapsed() {
+
+        final DataType current = mock(DataType.class);
+        final DataType clone = mock(DataType.class);
+        final DataType reference = mock(DataType.class);
+        final ShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
+        final String referenceHash = "referenceHash";
+        final DataTypeListItem oldItem = mock(DataTypeListItem.class);
+        final DataTypeListItem referenceItem = mock(DataTypeListItem.class);
+        final DataTypeListItem newItem = mock(DataTypeListItem.class);
+        final Command oldItemDestroyCommand = mock(Command.class);
+
+        doReturn(clone).when(handler).cloneDataType(current);
+        when(dataTypeList.calculateHash(reference)).thenReturn(referenceHash);
+        when(dataTypeList.findItem(current)).thenReturn(Optional.of(oldItem));
+        when(dataTypeList.findItem(clone)).thenReturn(Optional.of(newItem));
+        when(dataTypeList.findItemByDataTypeHash(referenceHash)).thenReturn(Optional.of(referenceItem));
+        when(oldItem.destroy()).thenReturn(oldItemDestroyCommand);
+        when(oldItem.isCollapsed()).thenReturn(false);
+
+        handler.shiftCurrentByReference(current, reference, strategy);
+
+        verify(newItem).expand();
         verify(oldItemDestroyCommand).execute();
         verify(referenceItem).insertNestedField(clone);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDDataTypesHandlerTest.java
@@ -20,8 +20,6 @@ import java.util.Optional;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.Element;
-import elemental2.dom.HTMLElement;
-import elemental2.dom.NodeList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,28 +27,24 @@ import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
 import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeList;
 import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItem;
-import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.DNDContext;
-import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.DataTypeStore;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.ItemDefinitionStore;
 import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItemView.UUID_ATTR;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_INTO_HOVERED_DATA_TYPE;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_NESTED_DATA_TYPE;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_SIBLING_DATA_TYPE;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler.ShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_X_POSITION;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_Y_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_INTO_HOVERED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_NESTED_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_SIBLING_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandlerShiftStrategy.INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -92,8 +86,8 @@ public class DNDDataTypesHandlerTest {
         final Element hoverElement = mock(Element.class);
         final DataType current = mock(DataType.class);
         final DataType reference = mock(DataType.class);
-        final DNDContext context = mock(DNDContext.class);
-        final ShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
+        final DNDDataTypesHandlerContext context = mock(DNDDataTypesHandlerContext.class);
+        final DNDDataTypesHandlerShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
 
         doNothing().when(handler).logError(anyString());
         doReturn(context).when(handler).makeDndContext(currentElement, hoverElement);
@@ -112,7 +106,7 @@ public class DNDDataTypesHandlerTest {
         final Element currentElement = mock(Element.class);
         final Element hoverElement = mock(Element.class);
         final DataType reference = mock(DataType.class);
-        final DNDContext context = mock(DNDContext.class);
+        final DNDDataTypesHandlerContext context = mock(DNDDataTypesHandlerContext.class);
 
         doNothing().when(handler).logError(anyString());
         doReturn(context).when(handler).makeDndContext(currentElement, hoverElement);
@@ -130,7 +124,7 @@ public class DNDDataTypesHandlerTest {
         final Element currentElement = mock(Element.class);
         final Element hoverElement = mock(Element.class);
         final DataType current = mock(DataType.class);
-        final DNDContext context = mock(DNDContext.class);
+        final DNDDataTypesHandlerContext context = mock(DNDDataTypesHandlerContext.class);
 
         doNothing().when(handler).logError(anyString());
         doReturn(context).when(handler).makeDndContext(currentElement, hoverElement);
@@ -149,10 +143,11 @@ public class DNDDataTypesHandlerTest {
         final Element hoverElement = mock(Element.class);
 
         doNothing().when(handler).logError(anyString());
+        doThrow(new UnsupportedOperationException("Error")).when(handler).makeDndContext(any(), any());
 
         handler.onDropDataType(currentElement, hoverElement);
 
-        verify(handler).logError("Drag-n-Drop error. Check 'DNDDataTypesHandler'.");
+        verify(handler).logError("Drag-n-Drop error (Error). Check 'DNDDataTypesHandler'.");
     }
 
     @Test
@@ -161,7 +156,7 @@ public class DNDDataTypesHandlerTest {
         final DataType current = mock(DataType.class);
         final DataType clone = mock(DataType.class);
         final DataType reference = mock(DataType.class);
-        final ShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
+        final DNDDataTypesHandlerShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
         final String referenceHash = "referenceHash";
         final DataTypeListItem oldItem = mock(DataTypeListItem.class);
         final DataTypeListItem referenceItem = mock(DataTypeListItem.class);
@@ -188,7 +183,7 @@ public class DNDDataTypesHandlerTest {
         final DataType current = mock(DataType.class);
         final DataType clone = mock(DataType.class);
         final DataType reference = mock(DataType.class);
-        final ShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
+        final DNDDataTypesHandlerShiftStrategy strategy = INSERT_INTO_HOVERED_DATA_TYPE;
         final String referenceHash = "referenceHash";
         final DataTypeListItem oldItem = mock(DataTypeListItem.class);
         final DataTypeListItem referenceItem = mock(DataTypeListItem.class);
@@ -210,309 +205,10 @@ public class DNDDataTypesHandlerTest {
     }
 
     @Test
-    public void testDNDContextGetReferenceWhenHoveredDataTypeIsPresent() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
-        final String uuid = "0000-1111-2222-3333";
-
-        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
-
-        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
-
-        assertEquals(hoverDataType, reference);
-    }
-
-    @Test
-    public void testDNDContextGetReferenceWhenHoveredDataTypeIsPresentButHoveredDataTypeIsReadOnly() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-        final String hoverUUID = "0000-0000-0000-0000";
-        final String previousUUID = "1111-1111-1111-1111";
-
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(dataTypeStore.get(previousUUID)).thenReturn(previousDataType.get());
-        when(dataTypeStore.get(hoverUUID)).thenReturn(hoverDataType.get());
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(previousUUID);
-        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(hoverUUID);
-        when(hoverDataType.get().isReadOnly()).thenReturn(true);
-
-        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
-
-        assertEquals(previousDataType, reference);
-    }
-
-    @Test
-    public void testDNDContextGetReferenceWhenPreviousDataTypeIsPresent() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-        final String uuid = "0000-1111-2222-3333";
-
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-
-        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
-
-        assertEquals(previousDataType, reference);
-    }
-
-    @Test
-    public void testDNDContextGetReferenceWhenCurrentDataTypeIsPresent() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element firstElement = mock(Element.class);
-        final Element hiddenElement = mock(Element.class);
-        final HTMLElement dragArea = mock(HTMLElement.class);
-        final Optional<DataType> currentDataType = Optional.of(mock(DataType.class));
-        final Optional<DataType> firstDataType = Optional.of(mock(DataType.class));
-        final String currentUUID = "0000-0000-0000-0000";
-        final String firstUUID = "1111-1111-1111-1111";
-
-        dragArea.childNodes = spy(new NodeList<>());
-        dragArea.childNodes.length = 3;
-
-        doReturn(hiddenElement).when(dragArea.childNodes).getAt(0);
-        doReturn(currentElement).when(dragArea.childNodes).getAt(1);
-        doReturn(firstElement).when(dragArea.childNodes).getAt(2);
-
-        when(hiddenElement.getAttribute(DATA_Y_POSITION)).thenReturn("-1");
-        when(currentElement.getAttribute(DATA_Y_POSITION)).thenReturn("0");
-        when(firstElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
-        when(hiddenElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
-        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
-        when(firstElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
-        when(dndListComponent.getDragArea()).thenReturn(dragArea);
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
-        when(dataTypeStore.get(currentUUID)).thenReturn(currentDataType.get());
-        when(dataTypeStore.get(firstUUID)).thenReturn(firstDataType.get());
-        when(currentDataType.get().getName()).thenReturn("Current Data Type");
-        when(firstDataType.get().getName()).thenReturn("First Data Type");
-        when(currentElement.getAttribute(UUID_ATTR)).thenReturn(currentUUID);
-        when(firstElement.getAttribute(UUID_ATTR)).thenReturn(firstUUID);
-
-        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
-
-        assertEquals(firstDataType, reference);
-    }
-
-    @Test
-    public void testDNDContextGetReferenceWhenDataTypeListIsNotInitialized() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-        final String uuid = "0000-1111-2222-3333";
-
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-
-        handler.init(null);
-
-        assertThatThrownBy(() -> handler.makeDndContext(currentElement, hoverElement).getReference())
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("'DNDDataTypesHandler' must be initialized with a 'DataTypeList' instance.");
-    }
-
-    @Test
-    public void testDNDContextGetReferenceWhenDNDListComponentIsNotInitialized() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-        final String uuid = "0000-1111-2222-3333";
-
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-
-        when(dataTypeList.getDNDListComponent()).thenReturn(null);
-
-        assertThatThrownBy(() -> handler.makeDndContext(currentElement, hoverElement).getReference())
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("'DNDDataTypesHandler' must be initialized with a 'DNDListComponent' instance.");
-    }
-
-    @Test
-    public void testDNDContextGetReferenceWhenItIsNotPresent() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
-
-        final Optional<DataType> reference = handler.makeDndContext(currentElement, hoverElement).getReference();
-
-        assertFalse(reference.isPresent());
-    }
-
-    @Test
-    public void testGetStrategyInsertIntoHoveredDataType() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
-        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
-        final String uuid = "0000-1111-2222-3333";
-
-        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
-        loadReferenceContext(context);
-
-        final ShiftStrategy actualShiftStrategy = context.getStrategy();
-        final ShiftStrategy expectedShiftStrategy = INSERT_INTO_HOVERED_DATA_TYPE;
-
-        assertEquals(expectedShiftStrategy, actualShiftStrategy);
-    }
-
-    @Test
-    public void testGetStrategyInsertIntoHoveredDataTypeWhenHoveredDataTypeIsReadOnly() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
-        final Optional<DataType> hoverDataType = Optional.of(mock(DataType.class));
-        final String uuid = "0000-1111-2222-3333";
-
-        when(hoverDataType.get().isReadOnly()).thenReturn(true);
-        when(hoverElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-        when(dataTypeStore.get(uuid)).thenReturn(hoverDataType.get());
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
-        loadReferenceContext(context);
-
-        final ShiftStrategy actualShiftStrategy = context.getStrategy();
-        final ShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
-
-        assertEquals(expectedShiftStrategy, actualShiftStrategy);
-    }
-
-    @Test
-    public void testGetStrategyInsertTopLevelDataTypeAtTheTop() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
-
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.empty());
-        loadReferenceContext(context);
-
-        final ShiftStrategy actualShiftStrategy = context.getStrategy();
-        final ShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
-
-        assertEquals(expectedShiftStrategy, actualShiftStrategy);
-    }
-
-    @Test
-    public void testGetStrategyInsertTopLevelDataType() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
-        final String uuid = "0000-1111-2222-3333";
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-
-        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
-        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-        loadReferenceContext(context);
-
-        final ShiftStrategy actualShiftStrategy = context.getStrategy();
-        final ShiftStrategy expectedShiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE;
-
-        assertEquals(expectedShiftStrategy, actualShiftStrategy);
-    }
-
-    @Test
-    public void testGetStrategyInsertNestedDataType() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
-        final String uuid = "0000-1111-2222-3333";
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-
-        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
-        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-        loadReferenceContext(context);
-
-        final ShiftStrategy actualShiftStrategy = context.getStrategy();
-        final ShiftStrategy expectedShiftStrategy = INSERT_NESTED_DATA_TYPE;
-
-        assertEquals(expectedShiftStrategy, actualShiftStrategy);
-    }
-
-    @Test
-    public void testGetStrategyInsertNestedDataTypeWhenPreviousDataTypeIsReadOnly() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
-        final String uuid = "0000-1111-2222-3333";
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-
-        when(previousDataType.get().isReadOnly()).thenReturn(true);
-        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
-        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-        loadReferenceContext(context);
-
-        final ShiftStrategy actualShiftStrategy = context.getStrategy();
-        final ShiftStrategy expectedShiftStrategy = INSERT_SIBLING_DATA_TYPE;
-
-        assertEquals(expectedShiftStrategy, actualShiftStrategy);
-    }
-
-    @Test
-    public void testGetStrategyInsertSiblingDataType() {
-
-        final Element currentElement = mock(Element.class);
-        final Element hoverElement = mock(Element.class);
-        final Element previousElement = mock(Element.class);
-        final DNDContext context = handler.makeDndContext(currentElement, hoverElement);
-        final String uuid = "0000-1111-2222-3333";
-        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
-
-        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
-        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
-        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
-        when(previousElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
-        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
-        loadReferenceContext(context);
-
-        final ShiftStrategy actualShiftStrategy = context.getStrategy();
-        final ShiftStrategy expectedShiftStrategy = INSERT_SIBLING_DATA_TYPE;
-
-        assertEquals(expectedShiftStrategy, actualShiftStrategy);
-    }
-
-    @Test
     public void testIsTopLevelShiftOperationWhenDataTypeIsNotTopLevel() {
 
         final DataType dataType = mock(DataType.class);
-        final ShiftStrategy shiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
+        final DNDDataTypesHandlerShiftStrategy shiftStrategy = INSERT_TOP_LEVEL_DATA_TYPE_AT_THE_TOP;
 
         when(dataType.isTopLevel()).thenReturn(false);
 
@@ -542,7 +238,43 @@ public class DNDDataTypesHandlerTest {
         assertTrue(handler.isTopLevelShiftOperation(dataType, INSERT_TOP_LEVEL_DATA_TYPE));
     }
 
-    private void loadReferenceContext(final DNDContext context) {
-        context.getReference();
+    @Test
+    public void testGetReferenceWhenDataTypeListIsNotInitialized() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+
+        handler.init(null);
+
+        assertThatThrownBy(() -> handler.makeDndContext(currentElement, hoverElement).getReference())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("'DNDDataTypesHandler' must be initialized with a 'DataTypeList' instance.");
+    }
+
+    @Test
+    public void testGetReferenceWhenDNDListComponentIsNotInitialized() {
+
+        final Element currentElement = mock(Element.class);
+        final Element hoverElement = mock(Element.class);
+        final Element previousElement = mock(Element.class);
+        final Optional<DataType> previousDataType = Optional.of(mock(DataType.class));
+        final String uuid = "0000-1111-2222-3333";
+
+        when(dndListComponent.getPreviousElement(any(), any())).thenReturn(Optional.of(previousElement));
+        when(dataTypeStore.get(uuid)).thenReturn(previousDataType.get());
+        when(previousElement.getAttribute(UUID_ATTR)).thenReturn(uuid);
+
+        when(dataTypeList.getDNDListComponent()).thenReturn(null);
+
+        assertThatThrownBy(() -> handler.makeDndContext(currentElement, hoverElement).getReference())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("'DNDDataTypesHandler' must be initialized with a 'DNDListComponent' instance.");
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent.View;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent.DEFAULT_INDENTATION_SIZE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent.DEFAULT_ITEM_HEIGHT;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_X_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_Y_POSITION;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DNDListComponentTest {
+
+    @Mock
+    private View view;
+
+    private DNDListComponent dndListComponent;
+
+    @Before
+    public void setup() {
+        dndListComponent = spy(new DNDListComponent(view));
+    }
+
+    @Test
+    public void testInit() {
+        dndListComponent.init();
+        verify(view).init(dndListComponent);
+    }
+
+    @Test
+    public void testRefreshItemsPosition() {
+        dndListComponent.refreshItemsPosition();
+        verify(view).refreshItemsPosition();
+    }
+
+    @Test
+    public void testRefreshItemsCSSAndHTMLPosition() {
+        dndListComponent.refreshItemsCSSAndHTMLPosition();
+        verify(view).consolidateHierarchicalLevel();
+        verify(view).refreshItemsPosition();
+    }
+
+    @Test
+    public void testRegisterNewItem() {
+
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+        final HTMLElement expectedElement = mock(HTMLElement.class);
+
+        when(view.registerItem(htmlElement)).thenReturn(expectedElement);
+
+        final HTMLElement actualElement = dndListComponent.registerNewItem(htmlElement);
+
+        assertEquals(expectedElement, actualElement);
+    }
+
+    @Test
+    public void testGetElement() {
+
+        final HTMLElement expectedElement = mock(HTMLElement.class);
+
+        when(view.getElement()).thenReturn(expectedElement);
+
+        final HTMLElement actualElement = dndListComponent.getElement();
+
+        assertEquals(expectedElement, actualElement);
+    }
+
+    @Test
+    public void testClear() {
+        dndListComponent.clear();
+        verify(view).clear();
+    }
+
+    @Test
+    public void testConsolidateYPosition() {
+        dndListComponent.consolidateYPosition();
+        verify(view).consolidateYPosition();
+    }
+
+    @Test
+    public void testGetItemHeight() {
+        assertEquals(DEFAULT_ITEM_HEIGHT, dndListComponent.getItemHeight());
+    }
+
+    @Test
+    public void testGetIndentationSize() {
+        assertEquals(DEFAULT_INDENTATION_SIZE, dndListComponent.getIndentationSize());
+    }
+
+    @Test
+    public void testSetPositionX() {
+
+        final Element element = mock(Element.class);
+        final int positionX = 1;
+
+        dndListComponent.setPositionX(element, positionX);
+
+        verify(element).setAttribute(DATA_X_POSITION, positionX);
+    }
+
+    @Test
+    public void testSetPositionY() {
+
+        final Element element = mock(Element.class);
+        final int positionY = 1;
+
+        dndListComponent.setPositionY(element, positionY);
+
+        verify(element).setAttribute(DATA_Y_POSITION, positionY);
+    }
+
+    @Test
+    public void testGetPositionY() {
+
+        final Element element = mock(Element.class);
+        final int expectedPositionY = 1;
+
+        when(element.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+
+        final int actualPositionY = dndListComponent.getPositionY(element);
+
+        assertEquals(expectedPositionY, actualPositionY);
+    }
+
+    @Test
+    public void testOnDropItem() {
+
+        final HTMLElement current = mock(HTMLElement.class);
+        final HTMLElement hover = mock(HTMLElement.class);
+
+        dndListComponent.setOnDropItem((c, h) -> {
+            assertEquals(current, c);
+            assertEquals(hover, h);
+        });
+
+        dndListComponent.executeOnDropItemCallback(current, hover);
+    }
+
+    @Test
+    public void testGetPreviousElement() {
+
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+
+        when(view.getPreviousElement(element0)).thenReturn(Optional.of(element1));
+        when(view.getPreviousElement(element1)).thenReturn(Optional.of(element2));
+
+        final Optional<Element> actual = dndListComponent.getPreviousElement(element0, element -> element == element2);
+
+        assertTrue(actual.isPresent());
+        assertEquals(element2, actual.get());
+    }
+
+    @Test
+    public void testGetPreviousElementWhenReferenceIsNull() {
+        assertFalse(dndListComponent.getPreviousElement(null, null).isPresent());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentViewTest.java
@@ -1,0 +1,1052 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.CSSStyleDeclaration;
+import elemental2.dom.ClientRect;
+import elemental2.dom.DOMTokenList;
+import elemental2.dom.Element;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLDocument;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.MouseEvent;
+import elemental2.dom.NodeList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_X_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_Y_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DRAGGABLE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DRAGGING;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.GRIP;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.HOVER;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DNDListComponentViewTest {
+
+    @Mock
+    private HTMLDivElement dragArea;
+
+    @Mock
+    private DNDListComponent presenter;
+
+    private DNDListComponentView view;
+
+    @Before
+    public void setup() {
+        view = spy(new DNDListComponentView(dragArea));
+        view.init(presenter);
+    }
+
+    @Test
+    public void testInit() {
+        // init is called by @Before
+        verify(view).setupDragAreaHandlers();
+    }
+
+    @Test
+    public void testRegisterItem() {
+
+        final HTMLElement expectedItem = mock(HTMLElement.class);
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+
+        doReturn(expectedItem).when(view).createItem(htmlElement);
+        doReturn(2).when(view).getMaxPositionY();
+
+        final HTMLElement actualItem = view.registerItem(htmlElement);
+
+        verify(actualItem).setAttribute(DATA_Y_POSITION, 3);
+        verify(actualItem).setAttribute(DATA_X_POSITION, 0);
+        verify(dragArea).appendChild(actualItem);
+        assertEquals(expectedItem, actualItem);
+    }
+
+    @Test
+    public void testGetMaxPositionY() {
+
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+
+        when(element0.getAttribute(DATA_Y_POSITION)).thenReturn("2");
+        when(element1.getAttribute(DATA_Y_POSITION)).thenReturn("4");
+        when(element2.getAttribute(DATA_Y_POSITION)).thenReturn("8");
+
+        mockDragAreaWithChildren(element0, element1, element2);
+
+        final int expectedMaxPosition = 8;
+        final int actualMaxPosition = view.getMaxPositionY();
+
+        assertEquals(expectedMaxPosition, actualMaxPosition);
+    }
+
+    @Test
+    public void testRefreshItemsPosition() {
+
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+
+        element0.style = mock(CSSStyleDeclaration.class);
+        element1.style = mock(CSSStyleDeclaration.class);
+        element2.style = mock(CSSStyleDeclaration.class);
+
+        dragArea.style = mock(CSSStyleDeclaration.class);
+
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(presenter.getIndentationSize()).thenReturn(75);
+
+        when(element0.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element1.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(element2.getAttribute(DATA_Y_POSITION)).thenReturn("2");
+
+        when(element0.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(element1.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(element2.getAttribute(DATA_X_POSITION)).thenReturn("1");
+
+        mockDragAreaWithChildren(element0, element1, element2);
+
+        view.refreshItemsPosition();
+
+        verify(element0.style).setProperty("top", "0px");
+        verify(element1.style).setProperty("top", "50px");
+        verify(element2.style).setProperty("top", "100px");
+
+        verify(element0.style).setProperty("width", "calc(100% - 0px)");
+        verify(element1.style).setProperty("width", "calc(100% - 75px)");
+        verify(element2.style).setProperty("width", "calc(100% - 75px)");
+
+        verify(dragArea.style).setProperty("height", "151px");
+    }
+
+    @Test
+    public void testRefreshItemsHTML() {
+
+        final HTMLElement element = mock(HTMLElement.class);
+        dragArea.firstChild = element;
+
+        mockDragAreaWithChildren(element);
+        when(dragArea.removeChild(element)).then(a -> {
+            dragArea.firstChild = null;
+            return element;
+        });
+
+        view.refreshItemsHTML();
+
+        verify(dragArea).removeChild(element);
+        verify(dragArea).appendChild(element);
+    }
+
+    @Test
+    public void testConsolidateHierarchicalLevel() {
+
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+
+        element0.style = mock(CSSStyleDeclaration.class);
+        element1.style = mock(CSSStyleDeclaration.class);
+        element2.style = mock(CSSStyleDeclaration.class);
+
+        dragArea.style = mock(CSSStyleDeclaration.class);
+
+        when(element0.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element1.getAttribute(DATA_Y_POSITION)).thenReturn("2");
+        when(element2.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+
+        when(element0.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(element1.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(element2.getAttribute(DATA_X_POSITION)).thenReturn("3");
+
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"0\"]")).thenReturn(element0);
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"2\"]")).thenReturn(element1);
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"1\"]")).thenReturn(element2);
+
+        mockDragAreaWithChildren(element0, element1, element2);
+
+        view.consolidateHierarchicalLevel();
+
+        verify(element0).setAttribute(DATA_Y_POSITION, 0);
+        verify(element2, times(2)).setAttribute(DATA_Y_POSITION, 1);
+        verify(element1).setAttribute(DATA_Y_POSITION, 2);
+
+        verify(element0).setAttribute(DATA_X_POSITION, 0);
+        verify(element2).setAttribute(DATA_X_POSITION, 1);
+        verify(element1, never()).setAttribute(anyString(), anyString());
+    }
+
+    @Test
+    public void testConsolidateHierarchicalLevelWhenListHasOneInvalidItem() {
+
+        final HTMLElement element = mock(HTMLElement.class);
+
+        element.style = mock(CSSStyleDeclaration.class);
+        dragArea.style = mock(CSSStyleDeclaration.class);
+
+        when(element.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element.getAttribute(DATA_X_POSITION)).thenReturn("9");
+
+        mockDragAreaWithChildren(element);
+
+        view.consolidateHierarchicalLevel();
+
+        verify(element).setAttribute(DATA_X_POSITION, 0);
+    }
+
+    @Test
+    public void testConsolidateHierarchicalLevelWhenListHasOneValidItem() {
+
+        final HTMLElement element = mock(HTMLElement.class);
+
+        element.style = mock(CSSStyleDeclaration.class);
+        dragArea.style = mock(CSSStyleDeclaration.class);
+
+        when(element.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element.getAttribute(DATA_X_POSITION)).thenReturn("1");
+
+        mockDragAreaWithChildren(element);
+
+        view.consolidateHierarchicalLevel();
+
+        verify(element, never()).setAttribute(anyString(), anyString());
+    }
+
+    @Test
+    public void testConsolidateYPosition() {
+
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+
+        element0.style = mock(CSSStyleDeclaration.class);
+        element1.style = mock(CSSStyleDeclaration.class);
+
+        dragArea.style = mock(CSSStyleDeclaration.class);
+
+        when(element0.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element1.getAttribute(DATA_Y_POSITION)).thenReturn("2");
+
+        mockDragAreaWithChildren(element0, element1);
+
+        view.consolidateYPosition();
+
+        verify(element0).setAttribute(DATA_Y_POSITION, 0);
+        verify(element1).setAttribute(DATA_Y_POSITION, 1);
+    }
+
+    @Test
+    public void testClear() {
+
+        final HTMLElement element = mock(HTMLElement.class);
+        dragArea.firstChild = element;
+
+        mockDragAreaWithChildren(element);
+        when(dragArea.removeChild(element)).then(a -> {
+            dragArea.firstChild = null;
+            return element;
+        });
+
+        view.clear();
+
+        verify(dragArea).removeChild(element);
+    }
+
+    @Test
+    public void testGetPreviousElementWhenElementIsFound() {
+
+        final HTMLElement current = mock(HTMLElement.class);
+        final HTMLElement expectedPrevious = mock(HTMLElement.class);
+
+        when(expectedPrevious.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(current.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"0\"]")).thenReturn(expectedPrevious);
+
+        final Optional<HTMLElement> actualPrevious = view.getPreviousElement(current);
+
+        assertTrue(actualPrevious.isPresent());
+        assertEquals(expectedPrevious, actualPrevious.get());
+    }
+
+    @Test
+    public void testGetPreviousElementWhenElementIsNotFound() {
+
+        final HTMLElement current = mock(HTMLElement.class);
+
+        when(current.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"0\"]")).thenReturn(null);
+
+        final Optional<HTMLElement> actualPrevious = view.getPreviousElement(current);
+
+        assertFalse(actualPrevious.isPresent());
+    }
+
+    @Test
+    public void testCreateItem() {
+
+        final HTMLDocument document = mock(HTMLDocument.class);
+        final HTMLElement expectedItem = mock(HTMLElement.class);
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+        final HTMLElement grip = mock(HTMLElement.class);
+        final HTMLElement i0 = mock(HTMLElement.class);
+        final HTMLElement i1 = mock(HTMLElement.class);
+
+        DNDListDOMHelper.Factory.DOCUMENT = document;
+        expectedItem.classList = mock(DOMTokenList.class);
+        grip.classList = mock(DOMTokenList.class);
+        i0.classList = mock(DOMTokenList.class);
+        i1.classList = mock(DOMTokenList.class);
+        when(document.createElement("div")).thenReturn(expectedItem, grip);
+        when(document.createElement("i")).thenReturn(i0, i1);
+
+        final HTMLElement actualItem = view.createItem(htmlElement);
+
+        verify(actualItem).appendChild(grip);
+        verify(actualItem).appendChild(htmlElement);
+        verify(actualItem.classList).add(DRAGGABLE);
+
+        assertEquals(expectedItem, actualItem);
+    }
+
+    @Test
+    public void testSetupDragAreaHandlers() {
+
+        final Event event = mock(Event.class);
+
+        doNothing().when(view).onStartDrag(any());
+        doNothing().when(view).onDrag(any());
+        doNothing().when(view).onDrop();
+
+        dragArea.onmousedown.onInvoke(event);
+        dragArea.onmousemove.onInvoke(event);
+        dragArea.onmouseup.onInvoke(event);
+        dragArea.onmouseout.onInvoke(event);
+
+        final InOrder inOrder = Mockito.inOrder(view);
+
+        inOrder.verify(view).onStartDrag(event);
+        inOrder.verify(view).onDrag(event);
+        inOrder.verify(view, times(2)).onDrop();
+    }
+
+    @Test
+    public void testOnStartDragWhenTargetIsGrip() {
+
+        final Event event = mock(Event.class);
+        final HTMLElement parent = mock(HTMLElement.class);
+        final HTMLElement target = mock(HTMLElement.class);
+
+        event.target = target;
+        target.parentNode = parent;
+        target.classList = mock(DOMTokenList.class);
+
+        when(target.classList.contains(GRIP)).thenReturn(true);
+        doNothing().when(view).holdDraggingElement(any());
+
+        view.onStartDrag(event);
+
+        verify(view).holdDraggingElement(parent);
+    }
+
+    @Test
+    public void testOnStartDragWhenTargetIsNotGrip() {
+
+        final Event event = mock(Event.class);
+        final HTMLElement parent = mock(HTMLElement.class);
+        final HTMLElement target = mock(HTMLElement.class);
+
+        event.target = target;
+        target.parentNode = parent;
+        target.classList = mock(DOMTokenList.class);
+
+        when(target.classList.contains(GRIP)).thenReturn(false);
+
+        view.onStartDrag(event);
+
+        verify(view, never()).holdDraggingElement(parent);
+    }
+
+    @Test
+    public void testOnDragWhenUserIsDragging() {
+
+        final Event event = mock(Event.class);
+
+        doReturn(false).when(view).isNotDragging();
+        doNothing().when(view).updateDraggingElementY(event);
+        doNothing().when(view).updateDraggingElementX(event);
+        doNothing().when(view).updateHoverElement();
+        doNothing().when(view).updateDependentsPosition();
+
+        view.onDrag(event);
+
+        verify(view).updateDraggingElementY(event);
+        verify(view).updateDraggingElementX(event);
+        verify(view).updateHoverElement();
+        verify(view).updateDependentsPosition();
+    }
+
+    @Test
+    public void testOnDragWhenUserIsNotDragging() {
+
+        final Event event = mock(Event.class);
+
+        doReturn(true).when(view).isNotDragging();
+
+        view.onDrag(event);
+
+        verify(view, never()).updateDraggingElementY(event);
+        verify(view, never()).updateDraggingElementX(event);
+        verify(view, never()).updateHoverElement();
+        verify(view, never()).updateDependentsPosition();
+    }
+
+    @Test
+    public void testOnDropWhenUserIsDragging() {
+
+        doReturn(false).when(view).isNotDragging();
+        doNothing().when(view).updateDraggingElementsPosition();
+        doNothing().when(view).executeOnDropItemCallback();
+        doNothing().when(view).releaseDraggingElement();
+        doNothing().when(view).consolidateHierarchicalLevel();
+        doNothing().when(view).refreshItemsPosition();
+        doNothing().when(view).refreshItemsHTML();
+        doNothing().when(view).clearHover();
+
+        view.onDrop();
+
+        verify(view).updateDraggingElementsPosition();
+        verify(view).executeOnDropItemCallback();
+        verify(view).releaseDraggingElement();
+        verify(view).consolidateHierarchicalLevel();
+        verify(view).refreshItemsPosition();
+        verify(view).refreshItemsHTML();
+        verify(view).clearHover();
+    }
+
+    @Test
+    public void testOnDropWhenUserIsNotDragging() {
+
+        doReturn(true).when(view).isNotDragging();
+
+        view.onDrop();
+
+        verify(view, never()).updateDraggingElementsPosition();
+        verify(view, never()).executeOnDropItemCallback();
+        verify(view, never()).releaseDraggingElement();
+        verify(view, never()).consolidateHierarchicalLevel();
+        verify(view, never()).refreshItemsPosition();
+        verify(view, never()).refreshItemsHTML();
+        verify(view, never()).clearHover();
+    }
+
+    @Test
+    public void testUpdateDraggingElementsPositionWhenPreviousElementHasChildren() {
+
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final HTMLElement previousElement = mock(HTMLElement.class);
+        final HTMLElement getDependentElement0 = mock(HTMLElement.class);
+        final HTMLElement getDependentElement1 = mock(HTMLElement.class);
+        final HTMLElement getDependentElement2 = mock(HTMLElement.class);
+        final List<HTMLElement> dependentElements = asList(getDependentElement0, getDependentElement1, getDependentElement2);
+
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+        getDependentElement0.style = mock(CSSStyleDeclaration.class);
+        getDependentElement1.style = mock(CSSStyleDeclaration.class);
+        getDependentElement2.style = mock(CSSStyleDeclaration.class);
+
+        doReturn(draggingElement).when(view).getDragging();
+        doReturn(Optional.of(previousElement)).when(view).getPreviousElement(draggingElement);
+        doReturn(dependentElements).when(view).getDependentElements();
+        doReturn(true).when(view).hasChildren(previousElement);
+
+        when(presenter.getIndentationSize()).thenReturn(50);
+        when(draggingElement.style.getPropertyValue("width")).thenReturn("calc(100% - 100px)");
+        when(getDependentElement0.style.getPropertyValue("width")).thenReturn("calc(100% - 150px)");
+        when(getDependentElement1.style.getPropertyValue("width")).thenReturn("calc(100% - 200px)");
+        when(getDependentElement2.style.getPropertyValue("width")).thenReturn("calc(100% - 250px)");
+
+        view.updateDraggingElementsPosition();
+
+        verify(draggingElement).setAttribute(DATA_X_POSITION, 3);
+        verify(getDependentElement0).setAttribute(DATA_X_POSITION, 4);
+        verify(getDependentElement1).setAttribute(DATA_X_POSITION, 5);
+        verify(getDependentElement2).setAttribute(DATA_X_POSITION, 6);
+    }
+
+    @Test
+    public void testUpdateDraggingElementsPositionWhenPreviousElementDoesNotHaveChildren() {
+
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final HTMLElement previousElement = mock(HTMLElement.class);
+        final HTMLElement dependentElement0 = mock(HTMLElement.class);
+        final HTMLElement dependentElement1 = mock(HTMLElement.class);
+        final HTMLElement dependentElement2 = mock(HTMLElement.class);
+        final List<HTMLElement> dependentElements = asList(dependentElement0, dependentElement1, dependentElement2);
+
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+        dependentElement0.style = mock(CSSStyleDeclaration.class);
+        dependentElement1.style = mock(CSSStyleDeclaration.class);
+        dependentElement2.style = mock(CSSStyleDeclaration.class);
+
+        doReturn(draggingElement).when(view).getDragging();
+        doReturn(Optional.of(previousElement)).when(view).getPreviousElement(draggingElement);
+        doReturn(dependentElements).when(view).getDependentElements();
+        doReturn(false).when(view).hasChildren(previousElement);
+
+        when(presenter.getIndentationSize()).thenReturn(50);
+        when(draggingElement.style.getPropertyValue("width")).thenReturn("calc(100% - 100px)");
+        when(dependentElement0.style.getPropertyValue("width")).thenReturn("calc(100% - 150px)");
+        when(dependentElement1.style.getPropertyValue("width")).thenReturn("calc(100% - 200px)");
+        when(dependentElement2.style.getPropertyValue("width")).thenReturn("calc(100% - 250px)");
+
+        view.updateDraggingElementsPosition();
+
+        verify(draggingElement).setAttribute(DATA_X_POSITION, 2);
+        verify(dependentElement0).setAttribute(DATA_X_POSITION, 3);
+        verify(dependentElement1).setAttribute(DATA_X_POSITION, 4);
+        verify(dependentElement2).setAttribute(DATA_X_POSITION, 5);
+    }
+
+    @Test
+    public void testExecuteOnDropItemCallbackWhenHoverElementIsPresent() {
+
+        final HTMLElement hoverElement = mock(HTMLElement.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final HTMLElement dependentElement0 = mock(HTMLElement.class);
+        final HTMLElement dependentElement1 = mock(HTMLElement.class);
+        final HTMLElement dependentElement2 = mock(HTMLElement.class);
+        final List<HTMLElement> dependentElements = asList(dependentElement0, dependentElement1, dependentElement2);
+        final List<HTMLElement> expectedChildren = asList(dependentElement0, dependentElement1, dependentElement2, draggingElement);
+
+        doReturn(draggingElement).when(view).getDragging();
+        doReturn(dependentElements).when(view).getDependentElements();
+        doNothing().when(view).fixChildrenPosition(anyInt(), anyInt(), anyListOf(HTMLElement.class));
+        when(dragArea.querySelector(".kie-dnd-hover")).thenReturn(hoverElement);
+        when(hoverElement.getAttribute(DATA_X_POSITION)).thenReturn("3");
+        when(draggingElement.getAttribute(DATA_X_POSITION)).thenReturn("4");
+
+        view.executeOnDropItemCallback();
+
+        verify(draggingElement).setAttribute(DATA_X_POSITION, 4);
+        verify(view).fixChildrenPosition(4, 0, expectedChildren);
+        verify(presenter).executeOnDropItemCallback(draggingElement, hoverElement);
+    }
+
+    @Test
+    public void testExecuteOnDropItemCallbackWhenHoverElementIsNotPresent() {
+
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+
+        doReturn(draggingElement).when(view).getDragging();
+        when(dragArea.querySelector(".kie-dnd-hover")).thenReturn(null);
+
+        view.executeOnDropItemCallback();
+
+        verifyNoMoreInteractions(draggingElement);
+        verify(view, never()).fixChildrenPosition(anyInt(), anyInt(), anyListOf(HTMLElement.class));
+        verify(presenter).executeOnDropItemCallback(draggingElement, null);
+    }
+
+    @Test
+    public void testFixChildrenPosition() {
+
+        final HTMLElement dependentElement0 = mock(HTMLElement.class);
+        final HTMLElement dependentElement1 = mock(HTMLElement.class);
+        final HTMLElement dependentElement2 = mock(HTMLElement.class);
+        final int minimalXPosition = 4;
+        final int numberOfExtraLevels = 6;
+        final List<HTMLElement> children = asList(dependentElement0, dependentElement1, dependentElement2);
+
+        when(dependentElement0.getAttribute(DATA_X_POSITION)).thenReturn("8");
+        when(dependentElement1.getAttribute(DATA_X_POSITION)).thenReturn("2");
+        when(dependentElement2.getAttribute(DATA_X_POSITION)).thenReturn("5");
+
+        view.fixChildrenPosition(minimalXPosition, numberOfExtraLevels, children);
+
+        verify(dependentElement0).setAttribute(DATA_X_POSITION, 4);
+        verify(dependentElement1).setAttribute(DATA_X_POSITION, 4);
+    }
+
+    @Test
+    public void testUpdateHoverElementWhenPositionIsInNotTheRange() {
+
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+
+        draggingElement.offsetTop = 75;
+
+        doNothing().when(view).hover(anyInt());
+        doReturn(draggingElement).when(view).getDragging();
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(draggingElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+
+        view.updateHoverElement();
+
+        verify(view).hover(2);
+    }
+
+    @Test
+    public void testUpdateHoverElementWhenPositionIsInTheRange() {
+
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+
+        draggingElement.offsetTop = 45;
+
+        doNothing().when(view).hover(anyInt());
+        doReturn(draggingElement).when(view).getDragging();
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(draggingElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+
+        view.updateHoverElement();
+
+        verify(view, never()).hover(anyInt());
+    }
+
+    @Test
+    public void testHoverWhenHoverElementIsBeingDragged() {
+
+        final HTMLElement hoverElement = mock(HTMLElement.class);
+
+        hoverElement.classList = mock(DOMTokenList.class);
+        when(hoverElement.classList.contains(DRAGGING)).thenReturn(true);
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"42\"]")).thenReturn(hoverElement);
+
+        doNothing().when(view).clearHover();
+
+        view.hover(42);
+
+        verify(view).clearHover();
+        verify(hoverElement.classList, never()).add(HOVER);
+    }
+
+    @Test
+    public void testHoverWhenHoverElementIsNotBeingDragged() {
+
+        final HTMLElement hoverElement = mock(HTMLElement.class);
+
+        hoverElement.classList = mock(DOMTokenList.class);
+        when(hoverElement.classList.contains(DRAGGING)).thenReturn(false);
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"42\"]")).thenReturn(hoverElement);
+
+        doNothing().when(view).clearHover();
+
+        view.hover(42);
+
+        verify(view).clearHover();
+        verify(hoverElement.classList).add(HOVER);
+    }
+
+    @Test
+    public void testClearHover() {
+
+        final HTMLElement hoverElement = mock(HTMLElement.class);
+
+        hoverElement.classList = mock(DOMTokenList.class);
+        when(dragArea.querySelector(".kie-dnd-hover")).thenReturn(hoverElement);
+
+        view.clearHover();
+
+        verify(hoverElement.classList).remove(HOVER);
+    }
+
+    @Test
+    public void testUpdateDependentsPosition() {
+
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final HTMLElement dependentElement0 = mock(HTMLElement.class);
+        final HTMLElement dependentElement1 = mock(HTMLElement.class);
+        final HTMLElement dependentElement2 = mock(HTMLElement.class);
+        final List<HTMLElement> dependentElements = asList(dependentElement0, dependentElement1, dependentElement2);
+
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+
+        dependentElement0.style = mock(CSSStyleDeclaration.class);
+        dependentElement1.style = mock(CSSStyleDeclaration.class);
+        dependentElement2.style = mock(CSSStyleDeclaration.class);
+
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(presenter.getIndentationSize()).thenReturn(50);
+
+        when(draggingElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(dependentElement0.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(dependentElement1.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(dependentElement2.getAttribute(DATA_X_POSITION)).thenReturn("2");
+
+        when(draggingElement.style.getPropertyValue("top")).thenReturn("50px");
+        when(draggingElement.style.getPropertyValue("width")).thenReturn("calc(100% - 100px)");
+
+        doReturn(draggingElement).when(view).getDragging();
+        doReturn(dependentElements).when(view).getDependentElements();
+
+        view.updateDependentsPosition();
+
+        verify(dependentElement0.style).setProperty("top", "100px");
+        verify(dependentElement0.style).setProperty("width", "calc(100% - 150px)");
+        verify(dependentElement1.style).setProperty("top", "150px");
+        verify(dependentElement1.style).setProperty("width", "calc(100% - 150px)");
+        verify(dependentElement2.style).setProperty("top", "200px");
+        verify(dependentElement2.style).setProperty("width", "calc(100% - 200px)");
+    }
+
+    @Test
+    public void testHasChildrenWhenElementHasChildren() {
+
+        final HTMLElement currentElement = mock(HTMLElement.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final HTMLElement nextElement = mock(HTMLElement.class);
+
+        doReturn(draggingElement).when(view).getDragging();
+
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"1\"]")).thenReturn(draggingElement);
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"2\"]")).thenReturn(nextElement);
+
+        when(currentElement.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(draggingElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(nextElement.getAttribute(DATA_Y_POSITION)).thenReturn("2");
+
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(draggingElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+        when(nextElement.getAttribute(DATA_X_POSITION)).thenReturn("1");
+
+        assertTrue(view.hasChildren(currentElement));
+    }
+
+    @Test
+    public void testHasChildrenWhenElementDoesNotHaveChildren() {
+
+        final HTMLElement currentElement = mock(HTMLElement.class);
+        final HTMLElement nextElement = mock(HTMLElement.class);
+
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"1\"]")).thenReturn(nextElement);
+
+        when(currentElement.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(nextElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+        when(nextElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+
+        assertFalse(view.hasChildren(currentElement));
+    }
+
+    @Test
+    public void testHasChildrenWhenNextElementIsNull() {
+
+        final HTMLElement currentElement = mock(HTMLElement.class);
+
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"1\"]")).thenReturn(null);
+
+        when(currentElement.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(currentElement.getAttribute(DATA_X_POSITION)).thenReturn("0");
+
+        assertFalse(view.hasChildren(currentElement));
+    }
+
+    @Test
+    public void testUpdateDraggingElementYWhenDraggingYPositionIsLessThanMin() {
+
+        final Event event = mock(Event.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final HTMLElement siblingElement = mock(HTMLElement.class);
+        final HTMLElement getDependentElement0 = mock(HTMLElement.class);
+        final HTMLElement getDependentElement1 = mock(HTMLElement.class);
+        final HTMLElement getDependentElement2 = mock(HTMLElement.class);
+        final List<HTMLElement> dependentElements = asList(getDependentElement0, getDependentElement1, getDependentElement2);
+        final int newDraggingYPosition = 10;
+
+        draggingElement.offsetTop = 130;
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+
+        when(draggingElement.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"6\"]")).thenReturn(siblingElement);
+
+        doNothing().when(view).clearHover();
+        doNothing().when(view).refreshItemsPosition();
+        doReturn(draggingElement).when(view).getDragging();
+        doReturn(newDraggingYPosition).when(view).getNewDraggingYPosition(event);
+        doReturn(dependentElements).when(view).getDependentElements();
+
+        view.updateDraggingElementY(event);
+
+        // update dragging element y
+        verify(siblingElement).setAttribute(DATA_Y_POSITION, 1);
+        verify(draggingElement).setAttribute(DATA_Y_POSITION, 3);
+        verify(getDependentElement0).setAttribute(DATA_Y_POSITION, 4);
+        verify(getDependentElement1).setAttribute(DATA_Y_POSITION, 5);
+        verify(getDependentElement2).setAttribute(DATA_Y_POSITION, 6);
+        verify(view).clearHover();
+        verify(view).refreshItemsPosition();
+
+        // set CSS top
+        verify(draggingElement.style).setProperty("top", "10px");
+    }
+
+    @Test
+    public void testUpdateDraggingElementYWhenDraggingYPositionIsGreaterThanMin() {
+
+        final Event event = mock(Event.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final HTMLElement siblingElement = mock(HTMLElement.class);
+        final HTMLElement getDependentElement0 = mock(HTMLElement.class);
+        final HTMLElement getDependentElement1 = mock(HTMLElement.class);
+        final HTMLElement getDependentElement2 = mock(HTMLElement.class);
+        final List<HTMLElement> dependentElements = asList(getDependentElement0, getDependentElement1, getDependentElement2);
+        final int newDraggingYPosition = 10;
+
+        draggingElement.offsetTop = 30;
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+
+        when(draggingElement.getAttribute(DATA_Y_POSITION)).thenReturn("2");
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(dragArea.querySelector(".kie-dnd-draggable[data-y-position=\"1\"]")).thenReturn(siblingElement);
+
+        doNothing().when(view).clearHover();
+        doNothing().when(view).refreshItemsPosition();
+        doReturn(draggingElement).when(view).getDragging();
+        doReturn(newDraggingYPosition).when(view).getNewDraggingYPosition(event);
+        doReturn(dependentElements).when(view).getDependentElements();
+
+        view.updateDraggingElementY(event);
+
+        // update dragging element y
+        verify(siblingElement).setAttribute(DATA_Y_POSITION, 5);
+        verify(draggingElement).setAttribute(DATA_Y_POSITION, 1);
+        verify(getDependentElement0).setAttribute(DATA_Y_POSITION, 2);
+        verify(getDependentElement1).setAttribute(DATA_Y_POSITION, 3);
+        verify(getDependentElement2).setAttribute(DATA_Y_POSITION, 4);
+        verify(view).clearHover();
+        verify(view).refreshItemsPosition();
+
+        // set CSS top
+        verify(draggingElement.style).setProperty("top", "10px");
+    }
+
+    @Test
+    public void testUpdateDraggingElementX() {
+
+        final MouseEvent event = mock(MouseEvent.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final ClientRect clientRect = mock(ClientRect.class);
+
+        event.x = 100;
+        clientRect.left = 25;
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+        dragArea.offsetWidth = 300;
+
+        when(presenter.getIndentationSize()).thenReturn(50);
+        when(dragArea.getBoundingClientRect()).thenReturn(clientRect);
+        doReturn(draggingElement).when(view).getDragging();
+
+        view.updateDraggingElementX(event);
+
+        verify(draggingElement.style).setProperty("width", "calc(100% - 65px)");
+    }
+
+    @Test
+    public void testUpdateDraggingElementXWhenNewDraggingXPositionIsGreaterThanMax() {
+
+        final MouseEvent event = mock(MouseEvent.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final ClientRect clientRect = mock(ClientRect.class);
+
+        event.x = 1000;
+        clientRect.left = 25;
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+        dragArea.offsetWidth = 300;
+
+        when(presenter.getIndentationSize()).thenReturn(50);
+        when(dragArea.getBoundingClientRect()).thenReturn(clientRect);
+        doReturn(draggingElement).when(view).getDragging();
+
+        view.updateDraggingElementX(event);
+
+        verify(draggingElement.style).setProperty("width", "calc(100% - 250px)");
+    }
+
+    @Test
+    public void testUpdateDraggingElementXWhenNewDraggingXPositionIsLessThanZero() {
+
+        final MouseEvent event = mock(MouseEvent.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final ClientRect clientRect = mock(ClientRect.class);
+
+        event.x = -1000;
+        clientRect.left = 25;
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+        dragArea.offsetWidth = 300;
+
+        when(presenter.getIndentationSize()).thenReturn(50);
+        when(dragArea.getBoundingClientRect()).thenReturn(clientRect);
+        doReturn(draggingElement).when(view).getDragging();
+
+        view.updateDraggingElementX(event);
+
+        verify(draggingElement.style).setProperty("width", "calc(100% - 0px)");
+    }
+
+    @Test
+    public void testGetNewDraggingYPosition() {
+
+        final MouseEvent event = mock(MouseEvent.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final ClientRect clientRect = mock(ClientRect.class);
+
+        event.y = 100;
+        clientRect.top = 25;
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+        dragArea.offsetHeight = 300;
+
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(dragArea.getBoundingClientRect()).thenReturn(clientRect);
+        doReturn(draggingElement).when(view).getDragging();
+
+        final int actualYPosition = view.getNewDraggingYPosition(event);
+        final int expectedYPosition = 50;
+
+        assertEquals(expectedYPosition, actualYPosition);
+    }
+
+    @Test
+    public void testGetNewDraggingYPositionWhenNewYPositionIsGreaterThanMax() {
+
+        final MouseEvent event = mock(MouseEvent.class);
+        final HTMLElement draggingElement = mock(HTMLElement.class);
+        final ClientRect clientRect = mock(ClientRect.class);
+
+        event.y = 1000;
+        clientRect.top = 25;
+        draggingElement.style = mock(CSSStyleDeclaration.class);
+        dragArea.offsetHeight = 300;
+
+        when(presenter.getItemHeight()).thenReturn(50);
+        when(dragArea.getBoundingClientRect()).thenReturn(clientRect);
+        doReturn(draggingElement).when(view).getDragging();
+
+        final int actualYPosition = view.getNewDraggingYPosition(event);
+        final int expectedYPosition = 325;
+
+        assertEquals(expectedYPosition, actualYPosition);
+    }
+
+    @Test
+    public void testIsNotDraggingWhenItsDragging() {
+        doReturn(mock(HTMLElement.class)).when(view).getDragging();
+        assertFalse(view.isNotDragging());
+    }
+
+    @Test
+    public void testIsNotDraggingWhenItsNotDragging() {
+        doReturn(null).when(view).getDragging();
+        assertTrue(view.isNotDragging());
+    }
+
+    @Test
+    public void testHoldDraggingElement() {
+
+        final HTMLElement expectedDragging = mock(HTMLElement.class);
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+        final List<HTMLElement> expectedDependentElements = asList(element0, element1, element2);
+
+        expectedDragging.classList = mock(DOMTokenList.class);
+        element0.classList = mock(DOMTokenList.class);
+        element1.classList = mock(DOMTokenList.class);
+        element2.classList = mock(DOMTokenList.class);
+
+        doReturn(expectedDependentElements).when(view).getDependentElements(expectedDragging);
+
+        view.holdDraggingElement(expectedDragging);
+
+        final HTMLElement actualDragging = view.getDragging();
+        final List<HTMLElement> actualDependentElements = view.getDependentElements();
+
+        expectedDragging.classList.add(DRAGGING);
+        element0.classList.add(DRAGGING);
+        element1.classList.add(DRAGGING);
+        element2.classList.add(DRAGGING);
+        assertEquals(expectedDragging, actualDragging);
+        assertEquals(expectedDependentElements, actualDependentElements);
+    }
+
+    @Test
+    public void testReleaseDraggingElement() {
+
+        final HTMLElement dragging = mock(HTMLElement.class);
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+        final List<HTMLElement> dependentElements = asList(element0, element1, element2);
+
+        dragging.classList = mock(DOMTokenList.class);
+        element0.classList = mock(DOMTokenList.class);
+        element1.classList = mock(DOMTokenList.class);
+        element2.classList = mock(DOMTokenList.class);
+
+        doReturn(dependentElements).when(view).getDependentElements(dragging);
+        view.holdDraggingElement(dragging);
+
+        view.releaseDraggingElement();
+
+        final HTMLElement actualDragging = view.getDragging();
+        final List<HTMLElement> actualDependentElements = view.getDependentElements();
+
+        dragging.classList.remove(DRAGGING);
+        element0.classList.remove(DRAGGING);
+        element1.classList.remove(DRAGGING);
+        element2.classList.remove(DRAGGING);
+        assertNull(actualDragging);
+        assertEquals(emptyList(), actualDependentElements);
+    }
+
+    private void mockDragAreaWithChildren(final HTMLElement... children) {
+
+        final NodeList<Element> nodeList = spy(new NodeList<>());
+
+        nodeList.length = children.length;
+        for (int i = 0; i < children.length; i++) {
+            doReturn(children[i]).when(nodeList).getAt(i);
+        }
+
+        when(dragArea.querySelectorAll(any())).thenReturn(nodeList);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentViewTest.java
@@ -154,9 +154,9 @@ public class DNDListComponentViewTest {
         verify(element1.style).setProperty("top", "50px");
         verify(element2.style).setProperty("top", "100px");
 
-        verify(element0.style).setProperty("width", "calc(100% - 0px)");
-        verify(element1.style).setProperty("width", "calc(100% - 75px)");
-        verify(element2.style).setProperty("width", "calc(100% - 75px)");
+        verify(element0.style).setProperty("padding-left", "0px");
+        verify(element1.style).setProperty("padding-left", "75px");
+        verify(element2.style).setProperty("padding-left", "75px");
 
         verify(dragArea.style).setProperty("height", "151px");
     }
@@ -720,11 +720,11 @@ public class DNDListComponentViewTest {
         view.updateDependentsPosition();
 
         verify(dependentElement0.style).setProperty("top", "100px");
-        verify(dependentElement0.style).setProperty("width", "calc(100% - 150px)");
         verify(dependentElement1.style).setProperty("top", "150px");
-        verify(dependentElement1.style).setProperty("width", "calc(100% - 150px)");
         verify(dependentElement2.style).setProperty("top", "200px");
-        verify(dependentElement2.style).setProperty("width", "calc(100% - 200px)");
+        verify(dependentElement0.style).setProperty("width", "calc(100% - 100px)");
+        verify(dependentElement1.style).setProperty("width", "calc(100% - 100px)");
+        verify(dependentElement2.style).setProperty("width", "calc(100% - 100px)");
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelperTest.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.CSSStyleDeclaration;
+import elemental2.dom.DOMTokenList;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLDocument;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.NodeList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Position;
+import org.mockito.Mock;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_X_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DATA_Y_POSITION;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DRAGGABLE;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.DRAGGING;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Factory.ELLIPSIS_CLASS;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Factory.ICON_CLASS;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Factory.createDiv;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.Factory.createGripElement;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.GRIP;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.HOVER;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asDraggable;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asDragging;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asHover;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonDragging;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonHover;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSMargin;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSTop;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isDraggingElement;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isGrip;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.parseDouble;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.parseInt;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.querySelector;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSMargin;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSTop;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DNDListDOMHelperTest {
+
+    @Mock
+    private HTMLElement element;
+
+    // -- Position
+
+    @Test
+    public void testGetX() {
+
+        when(element.getAttribute(DATA_X_POSITION)).thenReturn("42.5px");
+
+        final Integer actual = Position.getX(element);
+        final Integer expected = 42;
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSetX() {
+
+        Position.setX(element, 42);
+
+        verify(element).setAttribute(DATA_X_POSITION, 42);
+    }
+
+    @Test
+    public void testGetY() {
+
+        when(element.getAttribute(DATA_Y_POSITION)).thenReturn("42.5px");
+
+        final Integer actual = Position.getY(element);
+        final Integer expected = 42;
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetDoubleY() {
+
+        when(element.getAttribute(DATA_Y_POSITION)).thenReturn("42.5px");
+
+        final Double actual = Position.getDoubleY(element);
+        final Double expected = 42.5;
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSetY() {
+
+        Position.setY(element, 42);
+
+        verify(element).setAttribute(DATA_Y_POSITION, 42);
+    }
+
+    // -- QuerySelector
+
+    @Test
+    public void testGetDraggableElement() {
+
+        final String selector = ".kie-dnd-draggable[data-y-position=\"42\"]";
+        final HTMLElement expectedElement = mock(HTMLElement.class);
+
+        when(element.querySelector(selector)).thenReturn(expectedElement);
+
+        final HTMLElement actualElement = querySelector(element).getDraggableElement(42).orElseThrow(RuntimeException::new);
+
+        assertEquals(expectedElement, actualElement);
+    }
+
+    @Test
+    public void testGetHoverElement() {
+
+        final String selector = ".kie-dnd-hover";
+        final HTMLElement expectedElement = mock(HTMLElement.class);
+
+        when(element.querySelector(selector)).thenReturn(expectedElement);
+
+        final HTMLElement actualElement = querySelector(element).getHoverElement().orElseThrow(RuntimeException::new);
+
+        assertEquals(expectedElement, actualElement);
+    }
+
+    @Test
+    public void testGetDraggableElements() {
+
+        final String selector = ".kie-dnd-draggable";
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+        final NodeList<Element> nodeList = spy(new NodeList<>());
+
+        nodeList.length = 3;
+        when(nodeList.getAt(0)).thenReturn(element0);
+        when(nodeList.getAt(1)).thenReturn(element1);
+        when(nodeList.getAt(2)).thenReturn(element2);
+
+        when(element.querySelectorAll(selector)).thenReturn(nodeList);
+
+        final List<HTMLElement> actualElements = querySelector(element).getDraggableElements();
+        final List<HTMLElement> expectElements = asList(element0, element1, element2);
+
+        assertEquals(expectElements, actualElements);
+    }
+
+    @Test
+    public void testGetSortedDraggableElements() {
+
+        final String selector = ".kie-dnd-draggable";
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+        final NodeList<Element> nodeList = spy(new NodeList<>());
+
+        nodeList.length = 3;
+        when(nodeList.getAt(0)).thenReturn(element0);
+        when(nodeList.getAt(1)).thenReturn(element1);
+        when(nodeList.getAt(2)).thenReturn(element2);
+        when(element0.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(element1.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element2.getAttribute(DATA_Y_POSITION)).thenReturn("-1");
+
+        when(element.querySelectorAll(selector)).thenReturn(nodeList);
+
+        final List<HTMLElement> actualElements = querySelector(element).getSortedDraggableElements();
+        final List<HTMLElement> expectElements = asList(element2, element1, element0);
+
+        assertEquals(expectElements, actualElements);
+    }
+
+    @Test
+    public void testGetVisibleDraggableElements() {
+
+        final String selector = ".kie-dnd-draggable";
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+        final NodeList<Element> nodeList = spy(new NodeList<>());
+
+        nodeList.length = 3;
+        when(nodeList.getAt(0)).thenReturn(element0);
+        when(nodeList.getAt(1)).thenReturn(element1);
+        when(nodeList.getAt(2)).thenReturn(element2);
+        when(element0.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(element1.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element2.getAttribute(DATA_Y_POSITION)).thenReturn("-1");
+
+        when(element.querySelectorAll(selector)).thenReturn(nodeList);
+
+        final List<HTMLElement> actualElements = querySelector(element).getVisibleDraggableElements();
+        final List<HTMLElement> expectElements = asList(element0, element1);
+
+        assertEquals(expectElements, actualElements);
+    }
+
+    @Test
+    public void testGetVisibleAndSortedDraggableElements() {
+
+        final String selector = ".kie-dnd-draggable";
+        final HTMLElement element0 = mock(HTMLElement.class);
+        final HTMLElement element1 = mock(HTMLElement.class);
+        final HTMLElement element2 = mock(HTMLElement.class);
+        final NodeList<Element> nodeList = spy(new NodeList<>());
+
+        nodeList.length = 3;
+        when(nodeList.getAt(0)).thenReturn(element0);
+        when(nodeList.getAt(1)).thenReturn(element1);
+        when(nodeList.getAt(2)).thenReturn(element2);
+        when(element0.getAttribute(DATA_Y_POSITION)).thenReturn("1");
+        when(element1.getAttribute(DATA_Y_POSITION)).thenReturn("0");
+        when(element2.getAttribute(DATA_Y_POSITION)).thenReturn("-1");
+
+        when(element.querySelectorAll(selector)).thenReturn(nodeList);
+
+        final List<HTMLElement> actualElements = querySelector(element).getVisibleAndSortedDraggableElements();
+        final List<HTMLElement> expectElements = asList(element1, element0);
+
+        assertEquals(expectElements, actualElements);
+    }
+
+    // -- Property handlers
+
+    @Test
+    public void testSetCSSTop() {
+
+        element.style = mock(CSSStyleDeclaration.class);
+
+        setCSSTop(element, 123);
+
+        verify(element.style).setProperty("top", "123px");
+    }
+
+    @Test
+    public void testSetCSSMargin() {
+
+        element.style = mock(CSSStyleDeclaration.class);
+
+        setCSSMargin(element, 321);
+
+        verify(element.style).setProperty("width", "calc(100% - 321px)");
+    }
+
+    @Test
+    public void testGetCSSTop() {
+
+        element.style = mock(CSSStyleDeclaration.class);
+        when(element.style.getPropertyValue("top")).thenReturn("123px");
+
+        final int actualTop = getCSSTop(element);
+        final int expectedTop = 123;
+
+        assertEquals(expectedTop, actualTop);
+    }
+
+    @Test
+    public void testGetCSSMargin() {
+
+        element.style = mock(CSSStyleDeclaration.class);
+        when(element.style.getPropertyValue("width")).thenReturn("calc(100% - 321px)");
+
+        final int actualWidth = getCSSMargin(element);
+        final int expectedWidth = 321;
+
+        assertEquals(expectedWidth, actualWidth);
+    }
+
+    // -- Class handlers
+
+    @Test
+    public void testAsHover() {
+
+        element.classList = mock(DOMTokenList.class);
+
+        final HTMLElement actual = asHover(element);
+        final HTMLElement expected = element;
+
+        verify(element.classList).add(HOVER);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAsNonHover() {
+
+        element.classList = mock(DOMTokenList.class);
+
+        final HTMLElement actual = asNonHover(element);
+        final HTMLElement expected = element;
+
+        verify(element.classList).remove(HOVER);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAsDragging() {
+
+        element.classList = mock(DOMTokenList.class);
+
+        final HTMLElement actual = asDragging(element);
+        final HTMLElement expected = element;
+
+        verify(element.classList).add(DRAGGING);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAsNonDragging() {
+
+        element.classList = mock(DOMTokenList.class);
+
+        final HTMLElement actual = asNonDragging(element);
+        final HTMLElement expected = element;
+
+        verify(element.classList).remove(DRAGGING);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAsDraggable() {
+
+        element.classList = mock(DOMTokenList.class);
+
+        final HTMLElement actual = asDraggable(element);
+        final HTMLElement expected = element;
+
+        verify(element.classList).add(DRAGGABLE);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testIsDraggingElementWhenItsDragging() {
+
+        element.classList = mock(DOMTokenList.class);
+        when(element.classList.contains(DRAGGING)).thenReturn(true);
+
+        assertTrue(isDraggingElement(element));
+    }
+
+    @Test
+    public void testIsDraggingElementWhenItsNotDragging() {
+
+        element.classList = mock(DOMTokenList.class);
+        when(element.classList.contains(DRAGGING)).thenReturn(false);
+
+        assertFalse(isDraggingElement(element));
+    }
+
+    @Test
+    public void testIsGripWhenItsGrip() {
+
+        element.classList = mock(DOMTokenList.class);
+        when(element.classList.contains(GRIP)).thenReturn(true);
+
+        assertTrue(isGrip(element));
+    }
+
+    @Test
+    public void testIsGripWhenItsNotGrip() {
+
+        element.classList = mock(DOMTokenList.class);
+        when(element.classList.contains(GRIP)).thenReturn(false);
+
+        assertFalse(isGrip(element));
+    }
+
+    // -- Factory
+
+    @Test
+    public void testCreateDiv() {
+
+        final HTMLDocument document = mock(HTMLDocument.class);
+        final HTMLElement expectedDiv = mock(HTMLElement.class);
+        final String tagName = "div";
+
+        DNDListDOMHelper.Factory.DOCUMENT = document;
+        when(document.createElement(tagName)).thenReturn(expectedDiv);
+
+        final HTMLElement actualDiv = createDiv();
+
+        assertEquals(expectedDiv, actualDiv);
+    }
+
+    @Test
+    public void testCreateGripElement() {
+
+        final HTMLDocument document = mock(HTMLDocument.class);
+        final HTMLElement expectedGrip = mock(HTMLElement.class);
+        final HTMLElement firstI = mock(HTMLElement.class);
+        final HTMLElement secondI = mock(HTMLElement.class);
+        final String div = "div";
+        final String i = "i";
+
+        DNDListDOMHelper.Factory.DOCUMENT = document;
+        expectedGrip.classList = mock(DOMTokenList.class);
+        firstI.classList = mock(DOMTokenList.class);
+        secondI.classList = mock(DOMTokenList.class);
+        when(document.createElement(div)).thenReturn(expectedGrip);
+        when(document.createElement(i)).thenReturn(firstI, secondI);
+
+        final HTMLElement actualGrip = createGripElement();
+
+        verify(expectedGrip).appendChild(firstI);
+        verify(expectedGrip).appendChild(secondI);
+
+        verify(expectedGrip.classList).add(GRIP);
+
+        verify(firstI.classList).add(ICON_CLASS);
+        verify(secondI.classList).add(ICON_CLASS);
+
+        verify(firstI.classList).add(ELLIPSIS_CLASS);
+        verify(secondI.classList).add(ELLIPSIS_CLASS);
+
+        assertEquals(expectedGrip, actualGrip);
+    }
+
+    // -- Parsers
+
+    @Test
+    public void testParseDouble() {
+        assertEquals(parseDouble("10"), new Double(10));
+        assertEquals(parseDouble("10.5"), new Double(10.5));
+        assertEquals(parseDouble("10.5px"), new Double(10.5));
+        assertEquals(parseDouble("something..."), new Double(0));
+    }
+
+    @Test
+    public void testParseInt() {
+        assertEquals(parseInt("10"), new Integer(10));
+        assertEquals(parseInt("10.5"), new Integer(10));
+        assertEquals(parseInt("10.5px"), new Integer(10));
+        assertEquals(parseInt("something..."), new Integer(0));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelperTest.java
@@ -49,15 +49,16 @@ import static org.kie.workbench.common.dmn.client.editors.types.listview.dragand
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asHover;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonDragging;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonHover;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSMargin;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSTop;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSWidth;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isDraggingElement;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isGrip;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.parseDouble;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.parseInt;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.querySelector;
-import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSMargin;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSPaddingLeft;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSTop;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.setCSSWidth;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -258,13 +259,23 @@ public class DNDListDOMHelperTest {
     }
 
     @Test
-    public void testSetCSSMargin() {
+    public void testSetCSSWidth() {
 
         element.style = mock(CSSStyleDeclaration.class);
 
-        setCSSMargin(element, 321);
+        setCSSWidth(element, 321);
 
         verify(element.style).setProperty("width", "calc(100% - 321px)");
+    }
+
+    @Test
+    public void testSetCSSPaddingLeft() {
+
+        element.style = mock(CSSStyleDeclaration.class);
+
+        setCSSPaddingLeft(element, 321);
+
+        verify(element.style).setProperty("padding-left", "321px");
     }
 
     @Test
@@ -280,12 +291,12 @@ public class DNDListDOMHelperTest {
     }
 
     @Test
-    public void testGetCSSMargin() {
+    public void testGetCSSWidth() {
 
         element.style = mock(CSSStyleDeclaration.class);
         when(element.style.getPropertyValue("width")).thenReturn("calc(100% - 321px)");
 
-        final int actualWidth = getCSSMargin(element);
+        final int actualWidth = getCSSWidth(element);
         final int expectedWidth = 321;
 
         assertEquals(expectedWidth, actualWidth);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/DataTypeActiveRecordTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/DataTypeActiveRecordTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -44,6 +45,20 @@ public class DataTypeActiveRecordTest {
         doReturn(expectedDataTypes).when(engine).create(record, reference, creationType);
 
         final List<DataType> actualDataTypes = record.create(reference, creationType);
+
+        assertEquals(expectedDataTypes, actualDataTypes);
+    }
+
+    @Test
+    public void testDestroyWithoutDependentTypes() {
+
+        final DataTypeRecordEngine engine = makeRecordEngine();
+        final DataType record = spy(new DataType(engine));
+        final List<DataType> expectedDataTypes = singletonList(mock(DataType.class));
+
+        doReturn(expectedDataTypes).when(engine).destroyWithoutDependentTypes(record);
+
+        final List<DataType> actualDataTypes = record.destroyWithoutDependentTypes();
 
         assertEquals(expectedDataTypes, actualDataTypes);
     }
@@ -74,7 +89,12 @@ public class DataTypeActiveRecordTest {
             @Override
             public List<DataType> create(final DataType record,
                                          final DataType reference,
-                                         final CreationType nested) {
+                                         final CreationType creationType) {
+                return null;
+            }
+
+            @Override
+            public List<DataType> destroyWithoutDependentTypes(final DataType record) {
                 return null;
             }
         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.dmn.client.editors.types.persistence.validation.
 import org.mockito.Mock;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -145,6 +146,21 @@ public class ItemDefinitionRecordEngineTest {
         when(dataTypeDestroyHandler.refreshDependentDataTypes(dataType)).thenReturn(expectedDependentDataTypes);
 
         final List<DataType> actualDependentDataTypes = recordEngine.destroy(dataType);
+
+        verify(recordEngine).doDestroy(dataType);
+        assertEquals(expectedDependentDataTypes, actualDependentDataTypes);
+    }
+
+    @Test
+    public void testDestroyWithoutDependentTypes() {
+
+        final DataType dataType = mock(DataType.class);
+        final List<DataType> dependentDataTypes = asList(mock(DataType.class), mock(DataType.class));
+
+        when(dataTypeDestroyHandler.refreshDependentDataTypes(dataType)).thenReturn(dependentDataTypes);
+
+        final List<DataType> actualDependentDataTypes = recordEngine.destroyWithoutDependentTypes(dataType);
+        final List<DataType> expectedDependentDataTypes = singletonList(dataType);
 
         verify(recordEngine).doDestroy(dataType);
         assertEquals(expectedDependentDataTypes, actualDependentDataTypes);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
@@ -174,8 +174,8 @@ public class ItemDefinitionRecordEngineTest {
         final ItemDefinition itemDefinition = mock(ItemDefinition.class);
         final CreationType creationType = ABOVE;
 
-        when(itemDefinitionCreateHandler.insertItemDefinition(reference, creationType)).thenReturn(itemDefinition);
-        when(dataTypeCreateHandler.insert(dataType, reference, creationType, itemDefinition)).thenReturn(expectedAffectedDataTypes);
+        when(itemDefinitionCreateHandler.insertSibling(dataType, reference, creationType)).thenReturn(itemDefinition);
+        when(dataTypeCreateHandler.insertSibling(dataType, reference, creationType, itemDefinition)).thenReturn(expectedAffectedDataTypes);
 
         final List<DataType> actualAffectedDataTypes = recordEngine.create(dataType, reference, creationType);
 
@@ -190,7 +190,7 @@ public class ItemDefinitionRecordEngineTest {
         final List<DataType> expectedAffectedDataTypes = asList(mock(DataType.class), mock(DataType.class));
         final ItemDefinition itemDefinition = mock(ItemDefinition.class);
 
-        when(itemDefinitionCreateHandler.insertNestedItemDefinition(reference)).thenReturn(itemDefinition);
+        when(itemDefinitionCreateHandler.insertNested(dataType, reference)).thenReturn(itemDefinition);
         when(dataTypeCreateHandler.insertNested(dataType, reference, itemDefinition)).thenReturn(expectedAffectedDataTypes);
 
         final List<DataType> actualAffectedDataTypes = recordEngine.create(dataType, reference, NESTED);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeHandlerTest.java
@@ -187,29 +187,15 @@ public class DataTypeHandlerTest {
     }
 
     @Test
-    public void testRefreshSubDataTypesWhenDataTypeIsTopLevel() {
+    public void testRefreshSubDataTypes() {
 
-        final DataType dataType = makeDataType();
-        final String name = "name";
-
-        when(dataType.getName()).thenReturn(name);
-        when(dataType.isTopLevel()).thenReturn(true);
-        doNothing().when(handler).refreshSubDataTypes(any(), anyString());
-
-        handler.refreshSubDataTypes(dataType);
-
-        verify(handler).refreshSubDataTypes(dataType, name);
-    }
-
-    @Test
-    public void testRefreshSubDataTypesWhenDataTypeIsNotTopLevel() {
-
+        final DataTypeManager dataTypeManagerWithDataType = mock(DataTypeManager.class);
         final DataType dataType = makeDataType();
         final String type = "type";
 
-        when(dataType.getType()).thenReturn(type);
-        when(dataType.isTopLevel()).thenReturn(false);
         doNothing().when(handler).refreshSubDataTypes(any(), anyString());
+        when(dataTypeManager.withDataType(dataType)).thenReturn(dataTypeManagerWithDataType);
+        when(dataTypeManagerWithDataType.getTypeName()).thenReturn(type);
 
         handler.refreshSubDataTypes(dataType);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeUpdateHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/DataTypeUpdateHandlerTest.java
@@ -68,6 +68,9 @@ public class DataTypeUpdateHandlerTest {
     public void setup() {
         handler = spy(new DataTypeUpdateHandler(itemDefinitionStore, dataTypeStore, dataTypeManager));
         handler.init(recordEngine);
+
+        when(dataTypeManager.withDataType(any())).thenCallRealMethod();
+        when(dataTypeManager.getTypeName()).thenCallRealMethod();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionCreateHandlerTest.java
@@ -71,6 +71,7 @@ public class ItemDefinitionCreateHandlerTest {
     @Test
     public void testInsertNestedItemDefinitionWhenAbsoluteParentIsPresent() {
 
+        final DataType record = mock(DataType.class);
         final DataType reference = mock(DataType.class);
         final ItemDefinition relativeParent = mock(ItemDefinition.class);
         final Optional<ItemDefinition> absoluteParent = Optional.of(mock(ItemDefinition.class));
@@ -82,7 +83,7 @@ public class ItemDefinitionCreateHandlerTest {
         when(absoluteParent.get().getItemComponent()).thenReturn(itemDefinitions);
         doReturn(absoluteParent).when(handler).lookupAbsoluteParent(referenceUUID);
 
-        final ItemDefinition nestedItemDefinition = handler.insertNestedItemDefinition(reference);
+        final ItemDefinition nestedItemDefinition = handler.insertNested(record, reference);
 
         assertEquals(nestedItemDefinition, itemDefinitions.get(0));
     }
@@ -90,6 +91,7 @@ public class ItemDefinitionCreateHandlerTest {
     @Test
     public void testInsertNestedItemDefinitionWhenAbsoluteParentIsNotPresent() {
 
+        final DataType record = mock(DataType.class);
         final DataType reference = mock(DataType.class);
         final ItemDefinition relativeParent = mock(ItemDefinition.class);
         final Optional<ItemDefinition> absoluteParent = Optional.empty();
@@ -101,7 +103,7 @@ public class ItemDefinitionCreateHandlerTest {
         when(relativeParent.getItemComponent()).thenReturn(itemDefinitions);
         doReturn(absoluteParent).when(handler).lookupAbsoluteParent(referenceUUID);
 
-        final ItemDefinition nestedItemDefinition = handler.insertNestedItemDefinition(reference);
+        final ItemDefinition nestedItemDefinition = handler.insertNested(record, reference);
 
         verify(relativeParent).setTypeRef(null);
 
@@ -111,6 +113,7 @@ public class ItemDefinitionCreateHandlerTest {
     @Test
     public void testInsertItemDefinition() {
 
+        final DataType record = mock(DataType.class);
         final DataType reference = mock(DataType.class);
         final ItemDefinition itemDefinitionReference = mock(ItemDefinition.class);
         final ItemDefinition item = mock(ItemDefinition.class);
@@ -126,7 +129,7 @@ public class ItemDefinitionCreateHandlerTest {
         when(itemDefinitionStore.get(uuid)).thenReturn(itemDefinitionReference);
         doReturn(actualItemDefinitions).when(handler).getItemDefinitionSiblings(reference);
 
-        final ItemDefinition itemDefinition = handler.insertItemDefinition(reference, BELOW);
+        final ItemDefinition itemDefinition = handler.insertSibling(record, reference, BELOW);
         final List<ItemDefinition> expectedItemDefinitions = asList(item, item, itemDefinitionReference, itemDefinition, item);
 
         assertEquals(expectedItemDefinitions, actualItemDefinitions);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
@@ -74,7 +74,7 @@ public class DataTypeListShortcutsTest {
         final DataTypeList actualDataTypeList = shortcuts.getDataTypeList();
         final DataTypeList expectedDataTypeList = shortcuts.getDataTypeList();
 
-        when(listItem.getElement()).thenReturn(htmlElement);
+        when(listItem.getDragAndDropElement()).thenReturn(htmlElement);
 
         assertEquals(expectedDataTypeList, actualDataTypeList);
         verify(expectedDataTypeList).registerDataTypeListItemUpdateCallback(onDataTypeListItemUpdateArgumentCaptor.capture());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsViewTest.java
@@ -308,7 +308,7 @@ public class DataTypeListShortcutsViewTest {
         final DataTypeList dataTypeList = mock(DataTypeList.class);
 
         when(presenter.getDataTypeList()).thenReturn(dataTypeList);
-        when(dataTypeList.getListItemsElement()).thenReturn(container);
+        when(dataTypeList.getListItems()).thenReturn(container);
 
         view.scrollTo(element);
 
@@ -365,7 +365,7 @@ public class DataTypeListShortcutsViewTest {
         final DataTypeListItem listItem = mock(DataTypeListItem.class);
         final HTMLElement element = mock(HTMLElement.class);
 
-        when(listItem.getElement()).thenReturn(element);
+        when(listItem.getDragAndDropElement()).thenReturn(element);
         doReturn("").when(view).getCurrentUUID();
         doReturn("uuid").when(view).getPreviousUUID();
         doReturn(Optional.of(listItem)).when(view).getDataTypeListItem("uuid");


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/DROOLS-4484
- https://issues.jboss.org/browse/DROOLS-4615

![2019-10-18 16 59 35](https://user-images.githubusercontent.com/1079279/67124921-fa34de00-f1c9-11e9-94ef-fcd072a3553d.gif)

Since this is a big PR, I've split it into small meaningful commits.

Another approach for reviewing it is to start with the `DNDDataTypesHandler` class (every time that a user drops an element, this handler is called).

Please let me know if you have any question :-)