### PR TITLE
DROOLS-4599: [DMN Designer] Decision Tables: Hit Policy select drop-down remains visible if popover closed

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.html
@@ -20,7 +20,7 @@
             <form id="#HitPolicyForm">
                 <label for="kieHitPolicy"><span data-field="hitPolicyLabel"></span></label>
                 <div id="kieHitPolicy">
-                    <div data-container="body" data-field="lstHitPolicies"></div>
+                    <div data-field="lstHitPolicies"></div>
                 </div>
                 <br/>
                 <label for="kieBuiltinAggregator"><span data-field="builtinAggregatorLabel"></span></label>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.html
@@ -25,7 +25,7 @@
                 <br/>
                 <label for="kieBuiltinAggregator"><span data-field="builtinAggregatorLabel"></span></label>
                 <div id="kieBuiltinAggregator">
-                    <div data-container="body" data-field="lstBuiltinAggregator"></div>
+                    <div data-field="lstBuiltinAggregator"></div>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4599

![2019-10-18 17 33 12](https://user-images.githubusercontent.com/1079279/67126518-a2987180-f1cd-11e9-907a-a3633191c981.gif)
