### PR TITLE
RHPAM-2413: Stunner - some end events have incorrect icons.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
@@ -527,7 +527,7 @@
     opacity: 1;
     fill: #a30000;
 }
-#endSignalEvent #signal-catching {
+#endSignalEvent #signal-throwing {
     opacity: 1;
     fill: #a30000;
 }
@@ -540,7 +540,7 @@
     opacity: 1;
     fill: #a30000;
 }
-#endEscalationEvent #escalation-catching {
+#endEscalationEvent #escalation-throwing {
     opacity: 1;
     fill: #a30000;
 }
@@ -553,7 +553,7 @@
     opacity: 1;
     fill: #a30000;
 }
-#endCompensationEvent #compensation-catching {
+#endCompensationEvent #compensation-throwing{
     opacity: 1;
     fill: #a30000;
 }
@@ -566,7 +566,7 @@
     opacity: 1;
     fill: #a30000;
 }
-#endMessageEvent #message-catching {
+#endMessageEvent #message-throwing {
     opacity: 1;
     fill: #a30000;
 }


### PR DESCRIPTION
Hey @hasys 

This is the cherry-pick for https://github.com/kiegroup/kie-wb-common/pull/2926 into `7.26.x` branch.

See [RHPAM-2413](https://issues.jboss.org/browse/RHPAM-2413)

Thanks!