### PR TITLE
[JBPM-8884] integration test maven resolver

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
@@ -424,6 +424,27 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <id>copy-dependencies-transitive</id> 
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <finalName>web-lib</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/assembly/assembly.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
@@ -493,6 +514,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/assembly/assembly.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/assembly/assembly.xml
@@ -1,0 +1,41 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+
+  <id>java-archive</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <dependencySets>
+    <dependencySet>
+      <scope>test</scope>
+      <includes>
+        <include>org.kie.workbench.screens:kie-wb-common-workbench-backend</include>
+        <include>org.kie.workbench.services:kie-wb-common-services-backend</include>
+        <include>org.uberfire:uberfire-nio2-fs</include>
+        <include>org.uberfire:uberfire-nio2-jgit</include>
+        <include>org.uberfire:uberfire-ssh-api</include>
+        <include>org.uberfire:uberfire-ssh-backend</include>
+        <include>org.uberfire:uberfire-servlet-security</include>
+        <include>org.uberfire:uberfire-rest-backend</include>
+        <include>org.uberfire:uberfire-backend-server</include>
+        <include>org.uberfire:uberfire-backend-cdi</include>
+        <include>org.jboss.errai:errai-jboss-as-support</include>
+        <include>org.jboss.errai:errai-security-server</include>
+        <include>org.jboss.errai:errai-cdi-server</include>
+        <include>org.mockito:mockito-core</include>
+        <include>org.uberfire:uberfire-metadata-backend-lucene</include>
+        <include>org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api</include>
+      </includes>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+    </dependencySet>
+    <dependencySet>
+      <scope>runtime</scope>
+      <includes />
+    </dependencySet>
+  </dependencySets>
+
+</assembly>


### PR DESCRIPTION
maven resolver skinwrap does not resolve offline transtive dependencies
so if we are depending from a transitive dependency that it has not been
downloaded previously it would fail. Maven build can resolve those through
assembly descriptor file.