### PR TITLE
Updating Spanish translation

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants_es.properties
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/client/resources/i18n/DefaultWorkbenchConstants_es.properties
@@ -1,23 +1,94 @@
-# translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/AppConstants, author tkobayashi
+#
+# Copyright 2019 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 Role=Rol
-# translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/AppConstants, author tkobayashi
 LogOut=Salir
-# translation auto-copied from project KIE webapp distributions, version 6.2.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/AppConstants, author angela.garcia
+HomePage=Inicio
 Timeline=Línea de tiempo
-# translation auto-copied from project KIE webapp distributions, version 6.2.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/AppConstants, author angela.garcia
 People=Personas
-# translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/AppConstants, author tkobayashi
+SecurityManagement=Seguridad
+ProjectAuthoring=Proyectos
+ArtifactRepository=Artefactos
 Administration=Administración
+DroolsAdministration=Administración Drools
+PlannerAdministration=Administración Planner
+Plugins=Gestión de Plugins
+Apps=Panel de Negocio
 DataSets=Grupos de datos
+DataSources=Origen de Datos
+ProcessDefinitions=Definición de procesos
+ProcessInstances=Instancias de Procesos
 # ctx::sourcefile::Navigation Menu (system details)
 Provisioning=Aprovisionamiento
+Rule_Deployments=Servidores de ejecución
 Jobs=Trabajos
+ExecutionErrors=Errores de ejecución
+Task_Inbox=Bandeja de entrada
+Process_Reports=Informes de Procesos
+Task_Reports=Informes de Tareas
+Content_Management=Autoría de Páginas
 Group=Grupo
-# translation auto-copied from project Drools Workbench, version 6.0.0, document org.drools/drools-wb-guided-rule-editor-client/org/drools/workbench/screens/guided/rule/client/resources/i18n/Constants, author angela.garcia
+DocksOptaPlannerTitle=OptaPlanner
+DocksProjectExplorerTitle=Explorador de Proyectos
+DocksDroolsJBPMTitle=Drools & jBPM
+DocksPersistenceTitle=Persistencia
+DocksAdvancedTitle=Avanzado
+DocksStunnerPropertiesTitle=Propiedades del diagrama
+DocksStunnerExplorerTitle=Explorar diagrama
+WorkbenchRootNodeName=Zona de trabajo
+DataModelerEditSources=Editar código fuente
+ResourcePlanner=Planificador de recursos
+WorkbenchRootNodeHelp=Permisos generales del banco de trabajo, no relacionado con recursos de ningún tipo especifico.
+DataModelerEditSourcesHelp=Permitir la edición de código fuente generado por el Modelador de datos. El código fuente está disponible en la pestaña "Fuente" en el editor de modelado de datos.
+ResourcePlannerHelp="Permitir soporte para Planificador, como anotaciones de dominio, editor de resolutor, ...
+PermissionAllow=Permitir
+PermissionDeny=Denegar
 Admin=Administrador
 Settings=Configuraciones
 Groups=Grupos
 Users=Usuarios
+Library=Proyectos
+MavenRepositoryPagedJarTableDownloadJar=Descargar JAR
+MavenRepositoryPagedJarTableDownloadJarHelp=Permitir descarga de JARs desde el Repositorio de artefactos
+KieServerError403=Tu no tienes acceso para cargar datos desde el servidor remoto. Contacte con su administrador de sistema.
+KieServerError401=Credenciales inválidas para cargar desde el servidor remoto. Contacte con su administrador de sistema.
 # ctx::sourcefile::Navigation Menu
 Help=Ayuda
+Artifacts=Artefactos
+EditGlobalPreferences=Editar Preferencias Globales
+EditGlobalPreferencesHelp=Habilitar la edición de preferencias globales, la cual define los valores por defecto para todos los usuarios.
+GuidedDecisionTableEditColumns=Editar columnas de Tablas de Decisión Guiada
+GuidedDecisionTableEditColumnsHelp=Habilitar la edición de columnas de Tablas de Decisión Guiada.
+Languages=Lenguajes
 Tasks=Tareas
+GuidedDecisionTree=Editor de Árbol de Decisión Guiada
+GuidedScoreCard=Editor de Puntuación Guiada
+XLSScoreCard=Editor de Tarjeta de Puntuación XLS
+StunnerDesigner=(Nuevo) Editor de diseño jBPM
+SSHKeys=Claves SSH
+StunnerDesignerPreferences=Diseñador de Procesos
+SessionTimeout=Expirado de Sesión
+InvalidBusResponseProbablySessionTimeout=Respuesta Invalida recibida desde el servidor. Esto seguramente significa que has sido desconectado por inactividad. ¿Desea logearse de nuevo?
+LayoutEditorComponentPalette=Componentes
+ExperimentalSettings=Experimental
+ErrorDetailsSuccessfullyCopiedToClipboard=Los detalles del error fueron copiados al portapapeles.
+ErrorDetailsFailedToBeCopiedToClipboard=Los detalles del error no pudieron ser copiados al portapapeles porque el navegador no lo soporta.
+CaseModeller=Gestión de Casos (Vista Previa)
+ScenarioSimulationEditor=Escenarios de Test
+ProcessAdministration=Administración de Procesos
+TestReport=Informe de Test
+EditProfilePreferences=Editar Preferencias del perfil
+EditProfilePreferencesHelp=Permitir a los usuarios seleccionar que perfil será usado por la zona de trabajo
+ServiceTasksAdministration=Administración de Tareas de Servicio


### PR DESCRIPTION
Now Zanata is decommissioned, looking for a temporal way to update translations. Starting from Spanish as it is my native language.

I was not sure about lines like:

    # ctx::sourcefile::Navigation Menu (system details)

so I prefer to keep it. @manstis  Let me know if they don't make sense, I can rework and remove it.