### PR TITLE
JBPM 8836 : Improve Performance of Copy/Cut and Paste Operations

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
@@ -91,7 +91,7 @@ public class LocationControlImpl
     private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     private final Event<ShapeLocationsChangedEvent> shapeLocationsChangedEvent;
     private CommandManagerProvider<AbstractCanvasHandler> commandManagerProvider;
-    public final Collection<String> selectedIDs = new LinkedList<>();
+    private final Collection<String> selectedIDs = new LinkedList<>();
     private final Event<CanvasSelectionEvent> selectionEvent;
 
     protected LocationControlImpl() {
@@ -107,6 +107,10 @@ public class LocationControlImpl
         this.canvasCommandFactory = canvasCommandFactory;
         this.shapeLocationsChangedEvent = shapeLocationsChangedEvent;
         this.selectionEvent = selectionEvent;
+    }
+
+    public Collection<String> getSelectedIDs() {
+        return selectedIDs;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImpl.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -92,7 +91,7 @@ public class LocationControlImpl
     private final CanvasCommandFactory<AbstractCanvasHandler> canvasCommandFactory;
     private final Event<ShapeLocationsChangedEvent> shapeLocationsChangedEvent;
     private CommandManagerProvider<AbstractCanvasHandler> commandManagerProvider;
-    private final Collection<String> selectedIDs = new LinkedList<>();
+    public final Collection<String> selectedIDs = new LinkedList<>();
     private final Event<CanvasSelectionEvent> selectionEvent;
 
     protected LocationControlImpl() {
@@ -125,8 +124,7 @@ public class LocationControlImpl
         handleArrowKeys(keys);
     }
 
-    private void handleArrowKeys(final KeyboardEvent.Key... keys) {
-
+    public void handleArrowKeys(final KeyboardEvent.Key... keys) {
         final int selectedIDsCount = selectedIDs.size();
 
         if (selectedIDsCount == 0) {
@@ -231,20 +229,16 @@ public class LocationControlImpl
                     final DragHandler dragHandler = new DragHandler() {
                         @Override
                         public void start(DragEvent event) {
-                            if (Objects.nonNull(selectionEvent)) {
-                                //select the moving shape, if not
-                                selectionEvent.fire(new CanvasSelectionEvent(canvasHandler, shape.getUUID()));
-                            }
+                            // Instead of firing the event on Drag start, now will be fired at the end, hence improving performance
                         }
 
                         @Override
                         public void end(DragEvent event) {
-
+                            selectionEvent.fire(new CanvasSelectionEvent(canvasHandler, shape.getUUID()));
                         }
 
                         @Override
                         public void handle(DragEvent event) {
-
                         }
                     };
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/PrimitiveDragProxyImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/PrimitiveDragProxyImpl.java
@@ -50,7 +50,7 @@ public class PrimitiveDragProxyImpl implements PrimitiveDragProxy<Layer, IPrimit
                                                                                               item,
                                                                                               x,
                                                                                               y,
-                                                                                              200,
+                                                                                              1,
                                                                                               new org.kie.workbench.common.stunner.lienzo.primitive.PrimitiveDragProxy.Callback() {
 
                                                                                                   @Override
@@ -63,6 +63,7 @@ public class PrimitiveDragProxyImpl implements PrimitiveDragProxy<Layer, IPrimit
                                                                                                   @Override
                                                                                                   public void onMove(final int x,
                                                                                                                      final int y) {
+
                                                                                                       callback.onMove(x,
                                                                                                                       y);
                                                                                                   }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/ShapeViewDragProxyImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/drag/ShapeViewDragProxyImpl.java
@@ -72,21 +72,25 @@ public class ShapeViewDragProxyImpl implements ShapeViewDragProxy<AbstractCanvas
                                     y);
             }
         };
+
         if (item instanceof WiresShape) {
+
             final WiresShape wiresShape = (WiresShape) item;
             this.proxy = new WiresShapeDragProxy(getLayer().getLienzoLayer(),
                                                  wiresShape,
                                                  x,
                                                  y,
-                                                 100,
+                                                 1,
                                                  c);
         } else if (item instanceof WiresConnector) {
+
             final WiresConnector wiresConnector = (WiresConnector) item;
+
             this.proxy = new WiresConnectorDragProxy(getLayer().getLienzoLayer(),
                                                      wiresConnector,
                                                      x,
                                                      y,
-                                                     100,
+                                                     1,
                                                      c);
         }
         return this;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
@@ -147,7 +147,7 @@ public class ShapeGlyphDragHandlerImpl implements ShapeGlyphDragHandler<Abstract
                     root.addDomHandler(event -> onMouseUp(event, callback),
                                        MouseUpEvent.getType())
             );
-        }, 1000);
+        }, 200);
 
         // Keyboard event registration & handling..
         register(root.addDomHandler(this::onKeyDown,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerImpl.java
@@ -147,7 +147,7 @@ public class ShapeGlyphDragHandlerImpl implements ShapeGlyphDragHandler<Abstract
                     root.addDomHandler(event -> onMouseUp(event, callback),
                                        MouseUpEvent.getType())
             );
-        }, 200);
+        }, 1000);
 
         // Keyboard event registration & handling..
         register(root.addDomHandler(this::onKeyDown,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
@@ -343,7 +343,7 @@ public class LocationControlImplTest {
 
         when (canvasHandler.getGraphIndex().getNode(any())).thenReturn(element);
 
-        tested.selectedIDs.add(element.getUUID());
+        tested.getSelectedIDs().add(element.getUUID());
         tested.handleArrowKeys(KeyboardEvent.Key.ARROW_DOWN);
 
         verify(commandManager, atLeastOnce()).execute(any(), any());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LocationControlImplTest.java
@@ -50,6 +50,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactoryStub;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.ShapeViewExtStub;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasControlPoints;
@@ -140,6 +141,12 @@ public class LocationControlImplTest {
 
     @Mock
     private Node element;
+
+    @Mock
+    private Node<View<?>, Edge> node;
+
+    @Mock
+    private View nodeContent;
 
     @Mock
     private View elementContent;
@@ -234,6 +241,8 @@ public class LocationControlImplTest {
         ArgumentCaptor<DragHandler> dragHandlerArgumentCaptor = forClass(DragHandler.class);
         verify(shapeEventHandler).addHandler(eq(ViewEventType.DRAG), dragHandlerArgumentCaptor.capture());
         dragHandlerArgumentCaptor.getValue().start(mock(DragEvent.class));
+        dragHandlerArgumentCaptor.getValue().end(mock(DragEvent.class));
+
         ArgumentCaptor<CanvasSelectionEvent> canvasSelectionEventArgumentCaptor = forClass(CanvasSelectionEvent.class);
         verify(canvasSelectionEvent).fire(canvasSelectionEventArgumentCaptor.capture());
         assertTrue(canvasSelectionEventArgumentCaptor.getValue().getIdentifiers().contains(element.getUUID()));
@@ -325,6 +334,19 @@ public class LocationControlImplTest {
         UpdateElementPositionCommand updateElementPositionCommand = (UpdateElementPositionCommand) command.getCommands().get(0);
         assertEquals(element, updateElementPositionCommand.getElement());
         assertEquals(new Point2D(40d, 50d), updateElementPositionCommand.getLocation());
+    }
+
+    @Test
+    public void testHandleKeys() {
+        tested.init(canvasHandler);
+        tested.register(element);
+
+        when (canvasHandler.getGraphIndex().getNode(any())).thenReturn(element);
+
+        tested.selectedIDs.add(element.getUUID());
+        tested.handleArrowKeys(KeyboardEvent.Key.ARROW_DOWN);
+
+        verify(commandManager, atLeastOnce()).execute(any(), any());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/CanvasElementListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/CanvasElementListener.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.listener;
 
+import java.util.List;
+
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.graph.Element;
 
@@ -25,5 +27,12 @@ public interface CanvasElementListener extends CanvasListener<CanvasHandler, Ele
      * An element has been updated on the canvas.
      */
     default void update(Element item) {
+    }
+
+    /**
+     * Batch Updates Elements
+     * @param queue Queue of Items to be updated
+     */
+    default void  updateBatch(final List<List<Element>> queue, final long numberOfItems) {
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/CanvasElementListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/listener/CanvasElementListener.java
@@ -33,6 +33,6 @@ public interface CanvasElementListener extends CanvasListener<CanvasHandler, Ele
      * Batch Updates Elements
      * @param queue Queue of Items to be updated
      */
-    default void  updateBatch(final List<List<Element>> queue, final long numberOfItems) {
+    default void  updateBatch(final List<Element> queue) {
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/preferences/StunnerPreferences.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/preferences/StunnerPreferences.java
@@ -31,7 +31,7 @@ public class StunnerPreferences implements BasePreference<StunnerPreferences>,
     @Override
     public StunnerPreferences defaultValue(final StunnerPreferences defaultValue) {
         defaultValue.diagramEditorPreferences.setAutoHidePalettePanel(false);
-        defaultValue.diagramEditorPreferences.setEnableHiDPI(false);
+        defaultValue.diagramEditorPreferences.setEnableHiDPI(true);
         return defaultValue;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
@@ -426,11 +426,10 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
     /**
      * Does Batch update
      * @param queue Queue to be sent to be updated
-     * @param numberOfItems Number of actual elements to be updated
      */
-    public void doBatchUpdate(final List<List<Element>> queue, final long numberOfItems) {
+    public void doBatchUpdate(final List<Element> queue) {
         for (final CanvasElementListener instance : listeners) {
-            instance.updateBatch(queue, numberOfItems);
+            instance.updateBatch(queue);
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
@@ -399,6 +399,10 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
 
     private GraphCommandExecutionContext graphContext = null;
 
+    /**
+     * Sets the Graphic Context to be used for multiple operations
+     * @param graphContext Graph context to be set
+     */
     public void setStaticContext(GraphCommandExecutionContext graphContext) {
         this.graphContext = graphContext;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/AbstractCanvasHandler.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasElemen
 import org.kie.workbench.common.stunner.core.client.canvas.listener.HasCanvasListeners;
 import org.kie.workbench.common.stunner.core.client.canvas.listener.HasDomainObjectListeners;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
+import org.kie.workbench.common.stunner.core.client.command.QueueGraphExecutionContext;
 import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
@@ -396,12 +397,36 @@ public abstract class AbstractCanvasHandler<D extends Diagram, C extends Abstrac
         }
     }
 
+    private GraphCommandExecutionContext graphContext = null;
+
+    public void setStaticContext(GraphCommandExecutionContext graphContext) {
+        this.graphContext = graphContext;
+    }
+
     /**
      * Notifies an element updated to the listeners.
      */
     public void notifyCanvasElementUpdated(final Element candidate) {
+
+        if (graphContext != null) {
+            if (graphContext instanceof QueueGraphExecutionContext) {
+                ((QueueGraphExecutionContext) graphContext).addElement(candidate);
+            } else {
+                for (final CanvasElementListener instance : listeners) {
+                    instance.update(candidate);
+                }
+            }
+        }
+    }
+
+    /**
+     * Does Batch update
+     * @param queue Queue to be sent to be updated
+     * @param numberOfItems Number of actual elements to be updated
+     */
+    public void doBatchUpdate(final List<List<Element>> queue, final long numberOfItems) {
         for (final CanvasElementListener instance : listeners) {
-            instance.update(candidate);
+            instance.updateBatch(queue, numberOfItems);
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AbstractCanvasGraphCommand.java
@@ -124,6 +124,8 @@ public abstract class AbstractCanvasGraphCommand
         getCanvasCommand(context);
         // Obtain the graph execution context and execute the graph command updates.
         final GraphCommandExecutionContext graphContext = context.getGraphExecutionContext();
+        context.setStaticContext(graphContext);
+
         if (Objects.isNull(graphContext)) {
             //skipping command in case there is no graph execution context
             return CanvasCommandResultBuilder.SUCCESS;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasConnectorCommand.java
@@ -59,6 +59,7 @@ public class AddCanvasConnectorCommand extends AbstractCanvasCommand {
         applyConnections(candidate, context, MutationContext.STATIC);
         context.applyElementMutation(candidate, MutationContext.STATIC);
         final Node source = candidate.getSourceNode();
+
         if (null != source) {
             context.notifyCanvasElementUpdated(source);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/AddCanvasConnectorCommand.java
@@ -59,7 +59,6 @@ public class AddCanvasConnectorCommand extends AbstractCanvasCommand {
         applyConnections(candidate, context, MutationContext.STATIC);
         context.applyElementMutation(candidate, MutationContext.STATIC);
         final Node source = candidate.getSourceNode();
-
         if (null != source) {
             context.notifyCanvasElementUpdated(source);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
@@ -41,6 +41,7 @@ public class SetCanvasConnectionCommand extends AbstractCanvasCommand {
         ShapeUtils.applyConnections(edge,
                                     context,
                                     MutationContext.STATIC);
+
         if (null != source) {
             context.notifyCanvasElementUpdated(source);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/SetCanvasConnectionCommand.java
@@ -41,7 +41,6 @@ public class SetCanvasConnectionCommand extends AbstractCanvasCommand {
         ShapeUtils.applyConnections(edge,
                                     context,
                                     MutationContext.STATIC);
-
         if (null != source) {
             context.notifyCanvasElementUpdated(source);
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
@@ -82,6 +82,7 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
                     final String canvasRootUUID = getRootUUID();
                     fireCanvasClear();
                     if (null != canvasRootUUID) {
+                        lastSelected = "";
                         selectionEventConsumer.accept(new CanvasSelectionEvent(canvasHandler,
                                                                                canvasRootUUID));
                     }
@@ -254,6 +255,7 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
         }
         if (getCanvas().equals(shapeRemovedEvent.getCanvas())) {
             items.remove(shapeRemovedEvent.getShape().getUUID());
+            lastSelected = "";
         }
     }
 
@@ -263,6 +265,7 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
         if (null == canvasHandler) {
             return;
         }
+
         final boolean isSameCtxt = canvasHandler.equals(event.getCanvasHandler());
         final boolean isSingleSelection = event.getIdentifiers().size() == 1;
         final boolean isCanvasRoot = isSingleSelection &&
@@ -301,9 +304,21 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
         return canvasHandler.getDiagram().getMetadata().getCanvasRootUUID();
     }
 
+    private String lastSelected = "";
+
     private void fireSelectedItemsEvent() {
         final Collection<String> selectedItems = getSelectedItems();
         if (!selectedItems.isEmpty()) {
+            if (selectedItems.size() == 1) {
+
+                final String next = selectedItems.iterator().next();
+
+                if (lastSelected.equals(next)) {
+                    return;
+                }
+
+                lastSelected = next;
+            }
             selectionEventConsumer.accept(new CanvasSelectionEvent(canvasHandler,
                                                                    selectedItems));
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/AbstractToolboxControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/AbstractToolboxControl.java
@@ -109,10 +109,16 @@ public abstract class AbstractToolboxControl
         handleCanvasShapeRemovedEvent(event);
     }
 
+    private String lastSelected = "";
+
     protected void handleCanvasSelectionEvent(final CanvasSelectionEvent event) {
         if (checkEventContext(event)) {
             if (1 == event.getIdentifiers().size()) {
                 final String uuid = event.getIdentifiers().iterator().next();
+                if (lastSelected.equals(uuid)) {
+                    return;
+                }
+                lastSelected = uuid;
                 show(uuid);
             } else {
                 showMultiple(event.getIdentifiers());
@@ -123,12 +129,14 @@ public abstract class AbstractToolboxControl
     protected void handleCanvasClearSelectionEvent(final CanvasClearSelectionEvent event) {
         if (checkEventContext(event)) {
             toolboxControl.destroyToolboxes();
+            lastSelected = "";
             clear();
         }
     }
 
     protected void handleCanvasShapeRemovedEvent(final CanvasShapeRemovedEvent event) {
         if (checkEventContext(event)) {
+            lastSelected = "";
             clear();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandManagerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandManagerImpl.java
@@ -36,7 +36,6 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.HasCommandListener;
 import org.kie.workbench.common.stunner.core.command.impl.CommandManagerImpl;
 import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.command.ContextualGraphCommandExecutionContext;
 
 /**
  * The default canvas command manager implementation.
@@ -134,20 +133,12 @@ public class CanvasCommandManagerImpl<H extends AbstractCanvasHandler>
         return result;
     }
 
-    private QueueGraphExecutionContext newQueueGraphExecutionContext(final AbstractCanvasHandler context) {
+    public QueueGraphExecutionContext newQueueGraphExecutionContext(final AbstractCanvasHandler context) {
         return new QueueGraphExecutionContext(context.getDefinitionManager(),
                                               clientFactoryManager,
                                               context.getRuleManager(),
                                               context.getGraphIndex(),
                                               context.getRuleSet());
-    }
-
-    private ContextualGraphCommandExecutionContext newGraphExecutionContext(final AbstractCanvasHandler context) {
-        return new ContextualGraphCommandExecutionContext(context.getDefinitionManager(),
-                                                          clientFactoryManager,
-                                                          context.getRuleManager(),
-                                                          context.getGraphIndex(),
-                                                          context.getRuleSet());
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/QueueGraphExecutionContext.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/QueueGraphExecutionContext.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.errai.common.client.api.annotations.NonPortable;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.command.AbstractGraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.kie.workbench.common.stunner.core.rule.RuleManager;
+import org.kie.workbench.common.stunner.core.rule.RuleSet;
+import org.kie.workbench.common.stunner.core.rule.RuleViolations;
+import org.kie.workbench.common.stunner.core.rule.context.GraphEvaluationContext;
+import org.kie.workbench.common.stunner.core.rule.context.impl.AbstractGraphEvaluationContext;
+import org.kie.workbench.common.stunner.core.rule.context.impl.RuleEvaluationContextBuilder;
+import org.kie.workbench.common.stunner.core.rule.context.impl.StatefulGraphEvaluationContexts;
+import org.kie.workbench.common.stunner.core.rule.context.impl.StatefulGraphEvaluationState;
+
+/**
+ * This Queued graph execution context type provides composite rule context evaluations.
+ * Each evaluations accumulates the state in the actual context, so composite operations
+ * can share evaluation states.
+ * It delays the updating of the Elements in the end and sends the Batch Update
+ */
+@NonPortable
+public class QueueGraphExecutionContext extends AbstractGraphCommandExecutionContext {
+
+    private final transient RuleManager ruleManager;
+    private final transient RuleSet ruleSet;
+    private final transient RuleEvaluationContextBuilder.StatefulGraphContextBuilder contextBuilder;
+
+    public QueueGraphExecutionContext(final DefinitionManager definitionManager,
+                                      final FactoryManager factoryManager,
+                                      final RuleManager ruleManager,
+                                      final Index<?, ?> graphIndex,
+                                      final RuleSet ruleSet) {
+        this(definitionManager,
+             factoryManager,
+             ruleManager,
+             new RuleEvaluationContextBuilder.StatefulGraphContextBuilder(graphIndex.getGraph()),
+             graphIndex,
+             ruleSet);
+    }
+
+    QueueGraphExecutionContext(final DefinitionManager definitionManager,
+                               final FactoryManager factoryManager,
+                               final RuleManager ruleManager,
+                               final RuleEvaluationContextBuilder.StatefulGraphContextBuilder contextBuilder,
+                               final Index<?, ?> graphIndex,
+                               final RuleSet ruleSet) {
+        super(definitionManager,
+              factoryManager,
+              graphIndex);
+        this.contextBuilder = contextBuilder;
+        this.ruleManager = ruleManager;
+        this.ruleSet = ruleSet;
+    }
+
+    public void clear() {
+        getState().clear();
+    }
+
+    @Override
+    public RuleViolations evaluate(final GraphEvaluationContext context) {
+        ((AbstractGraphEvaluationContext) context).setState(this::getState);
+        return StatefulGraphEvaluationContexts.evaluate(context,
+                                                        c -> ruleManager.evaluate(ruleSet, c));
+    }
+
+    @Override
+    public RuleSet getRuleSet() {
+        return ruleSet;
+    }
+
+    private StatefulGraphEvaluationState getState() {
+        return contextBuilder.getState();
+    }
+
+    @Override
+    protected RuleEvaluationContextBuilder.GraphContextBuilder getContextBuilder() {
+        return contextBuilder;
+    }
+
+    private List<Element> updatedElements = new ArrayList<>();
+
+    public void addElement(final Element candidate) {
+        updatedElements.add(candidate);
+    }
+
+    public List<Element> getUpdatedElements() {
+        return updatedElements;
+    }
+
+    public void resetUpdatedElements() {
+        updatedElements.clear();
+    }
+}
+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ActionsToolbox.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ActionsToolbox.java
@@ -88,8 +88,17 @@ public class ActionsToolbox<V extends ActionsToolboxView<?>>
         return canvasHandlerSupplier.get().getCanvas().getShape(uuid);
     }
 
+    private String lastToolBoxRendered = "";
+
     @Override
     public ActionsToolbox show() {
+
+        if (lastToolBoxRendered.equals(this.uuid)) {
+            return this;
+        }
+
+        lastToolBoxRendered = this.uuid;
+
         getView().show();
         return this;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommand.java
@@ -25,6 +25,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.ClipboardControl;
@@ -57,13 +58,23 @@ public class CopySelectionSessionCommand extends AbstractSelectionAwareSessionCo
     private ClipboardControl<Element, AbstractCanvas, ClientSession> clipboardControl;
 
     public CopySelectionSessionCommand() {
-        this(null);
+        this(null, null);
     }
 
     @Inject
-    public CopySelectionSessionCommand(final Event<CopySelectionSessionCommandExecutedEvent> commandExecutedEvent) {
+    public CopySelectionSessionCommand(final Event<CopySelectionSessionCommandExecutedEvent> commandExecutedEvent, final SessionManager sessionManager) {
         super(true);
         this.commandExecutedEvent = commandExecutedEvent;
+        SessionSingletonCommandsFactory.createOrPut(this, sessionManager);
+    }
+
+    public static CopySelectionSessionCommand getInstance(SessionManager sessionManager) {
+
+        return SessionSingletonCommandsFactory.getInstanceCopy(null, sessionManager);
+    }
+
+    public static CopySelectionSessionCommand getInstance(final Event<CopySelectionSessionCommandExecutedEvent> commandExecutedEvent, SessionManager sessionManager) {
+        return SessionSingletonCommandsFactory.getInstanceCopy(commandExecutedEvent, sessionManager);
     }
 
     @Override
@@ -94,7 +105,7 @@ public class CopySelectionSessionCommand extends AbstractSelectionAwareSessionCo
 
     @Override
     public <V> void execute(final Callback<V> callback) {
-        if (null != getSession().getSelectionControl()) {
+        if (getSession() != null && null != getSession().getSelectionControl()) {
             try {
                 //for now just copy Nodes not Edges
                 final SelectionControl<AbstractCanvasHandler, Element> selectionControl = getSession().getSelectionControl();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CutSelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CutSelectionSessionCommand.java
@@ -23,6 +23,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.ClipboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementsClearEvent;
@@ -45,7 +46,7 @@ import static org.kie.workbench.common.stunner.core.client.canvas.controls.keybo
 @Default
 public class CutSelectionSessionCommand extends AbstractSelectionAwareSessionCommand<EditorSession> {
 
-    private final CopySelectionSessionCommand copySelectionSessionCommand;
+    private CopySelectionSessionCommand copySelectionSessionCommand;
     private final DeleteSelectionSessionCommand deleteSelectionSessionCommand;
     private final Event<CutSelectionSessionCommandExecutedEvent> commandExecutedEvent;
     private static Logger LOGGER = Logger.getLogger(CopySelectionSessionCommand.class.getName());
@@ -55,29 +56,30 @@ public class CutSelectionSessionCommand extends AbstractSelectionAwareSessionCom
     protected CutSelectionSessionCommand() {
         this(null,
              null,
-             null,
              null);
     }
 
     @Inject
-    public CutSelectionSessionCommand(final CopySelectionSessionCommand copySelectionSessionCommand,
-                                      final DeleteSelectionSessionCommand deleteSelectionSessionCommand,
-                                      final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
-                                      final Event<CutSelectionSessionCommandExecutedEvent> commandExecutedEvent) {
+    public CutSelectionSessionCommand(final @Session SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                      final Event<CutSelectionSessionCommandExecutedEvent> commandExecutedEvent,
+                                      final SessionManager sessionManager) {
         super(true);
-        this.copySelectionSessionCommand = copySelectionSessionCommand;
-        this.deleteSelectionSessionCommand = deleteSelectionSessionCommand;
+        this.copySelectionSessionCommand = CopySelectionSessionCommand.getInstance(sessionManager);
+        this.deleteSelectionSessionCommand = DeleteSelectionSessionCommand.getInstance(sessionManager);
         this.sessionCommandManager = sessionCommandManager;
         this.commandExecutedEvent = commandExecutedEvent;
     }
 
     @Override
     public void bind(final EditorSession session) {
-        super.bind(session);
-        copySelectionSessionCommand.bind(session);
-        deleteSelectionSessionCommand.bind(session);
         session.getKeyboardControl().addKeyShortcutCallback(this::onKeyDownEvent);
+
+        super.bind(session);
         this.clipboardControl = session.getClipboardControl();
+    }
+
+    public void setCopySelectionSessionCommand(CopySelectionSessionCommand copySelectionSessionCommand) {
+        this.copySelectionSessionCommand = copySelectionSessionCommand;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import java.util.HashMap;
+
+import javax.enterprise.event.Event;
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+
+/**
+ * The purpose of this class is to have only one copy of Copy, Delete per Client Session.
+ * An alternate easier aproach was tried with @Produces on those classes, but the issue is that @Produces Factory from erray does not generate
+ * Decorators for @Observes extension and the result was that commands created using @Produces did not listen for Events
+ */
+@Singleton
+public class SessionSingletonCommandsFactory {
+
+    private static HashMap<ClientSession, CopySelectionSessionCommand> copySessionInstances = new HashMap<>();
+
+    private static HashMap<ClientSession, DeleteSelectionSessionCommand> deleteSessionInstances = new HashMap<>();
+
+    public static void createOrPut(AbstractSelectionAwareSessionCommand<EditorSession> command, SessionManager sessionManager) {
+
+        if (sessionManager == null) {
+            throw new IllegalStateException("Session Manager is Null");
+        }
+
+        if (command instanceof CopySelectionSessionCommand) {
+            if (copySessionInstances.containsKey(sessionManager.getCurrentSession())) { // there is one already one
+                throw new IllegalStateException("Only one instance of CopySelectionSessionCommand per Client Session can exist");
+            }
+
+            copySessionInstances.put(sessionManager.getCurrentSession(), (CopySelectionSessionCommand) command);
+        } else if (command instanceof DeleteSelectionSessionCommand) {
+            if (deleteSessionInstances.containsKey(sessionManager.getCurrentSession())) { // there is one already one
+                throw new IllegalStateException("Only one instance of DeleteSelectionSessionCommand per Client Session can exist");
+            }
+            deleteSessionInstances.put(sessionManager.getCurrentSession(), (DeleteSelectionSessionCommand) command);
+        } else {
+            throw new UnsupportedOperationException("Session Command Not Compatible Yet : " + command.getClass());
+        }
+    }
+
+    public static CopySelectionSessionCommand getInstanceCopy(
+            final Event<?> commandExecutedEvent,
+            SessionManager sessionManager) {
+
+        final ClientSession currentSession = sessionManager.getCurrentSession();
+
+        if (!copySessionInstances.containsKey(currentSession)) {
+            final CopySelectionSessionCommand copySelectionSessionCommand = new CopySelectionSessionCommand((Event<CopySelectionSessionCommandExecutedEvent>) commandExecutedEvent, sessionManager);
+
+            return copySelectionSessionCommand;
+        }
+
+        final CopySelectionSessionCommand copySelectionSessionCommand = copySessionInstances.get(currentSession);
+
+        return copySelectionSessionCommand;
+    }
+
+    public static DeleteSelectionSessionCommand getInstanceDelete(
+            final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+            final ManagedInstance<CanvasCommandFactory<AbstractCanvasHandler>> canvasCommandFactoryInstance,
+            final Event<CanvasClearSelectionEvent> clearSelectionEvent,
+            final DefinitionUtils definitionUtils,
+            final SessionManager sessionManager) {
+        final ClientSession currentSession = sessionManager.getCurrentSession();
+
+        if (!deleteSessionInstances.containsKey(currentSession)) {
+            return new DeleteSelectionSessionCommand(sessionCommandManager, canvasCommandFactoryInstance, clearSelectionEvent, definitionUtils, sessionManager);
+        }
+
+        return deleteSessionInstances.get(currentSession);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/UndoSessionCommand.java
@@ -76,6 +76,7 @@ public class UndoSessionCommand extends AbstractClientSessionCommand<EditorSessi
     @Override
     @SuppressWarnings("unchecked")
     public <V> void execute(final Callback<V> callback) {
+
         checkNotNull("callback",
                      callback);
         final SessionCommandManager<AbstractCanvasHandler> scm = getSessionCommandManager();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
@@ -15,7 +15,7 @@
  */
 package org.kie.workbench.common.stunner.core.client.canvas;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.enterprise.event.Event;
@@ -194,8 +194,7 @@ public class BaseCanvasHandlerTest {
     public void checkNotifyElementUpdatedAndListenerUpdated() {
         canvasHandler.addRegistrationListener(updateListener);
 
-        final List<Element> updatedElements = new ArrayList<>();
-        updatedElements.add(mock(Element.class));
+        final List<Element> updatedElements = Collections.singletonList(mock(Element.class));
 
         canvasHandler.doBatchUpdate(updatedElements);
         verify(updateListener, times(1)).updateBatch(any());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/BaseCanvasHandlerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.canvas;
+
+import javax.enterprise.event.Event;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.api.ClientDefinitionManager;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementAddedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementRemovedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementUpdatedEvent;
+import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementsClearEvent;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.shape.ElementShape;
+import org.kie.workbench.common.stunner.core.client.shape.MutationContext;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.processing.index.GraphIndexBuilder;
+import org.kie.workbench.common.stunner.core.graph.processing.index.MutableIndex;
+import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.rule.RuleManager;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseCanvasHandlerTest {
+
+    private BaseCanvasHandler canvasHandler;
+
+    @Mock
+    private ClientDefinitionManager clientDefinitionManager;
+
+    @Mock
+    private CanvasCommandFactory<AbstractCanvasHandler> commandFactory;
+
+    @Mock
+    private RuleManager ruleManager;
+
+    @Mock
+    private GraphUtils graphUtils;
+
+    @Mock
+    private GraphIndexBuilder<? extends MutableIndex<Node, Edge>> indexBuilder;
+
+    @Mock
+    private ShapeManager shapeManager;
+
+    @Mock
+    private TextPropertyProviderFactory textPropertyProviderFactory;
+
+    @Mock
+    private Event<CanvasElementAddedEvent> canvasElementAddedEvent;
+
+    @Mock
+    private Event<CanvasElementRemovedEvent> canvasElementRemovedEvent;
+
+    @Mock
+    private Event<CanvasElementUpdatedEvent> canvasElementUpdatedEvent;
+
+    @Mock
+    private Event<CanvasElementsClearEvent> canvasElementsClearEvent;
+
+    @Before
+    public void setup() {
+        canvasHandler = new CanvasHandlerImpl(clientDefinitionManager,
+                                              commandFactory,
+                                              ruleManager,
+                                              graphUtils,
+                                              indexBuilder,
+                                              shapeManager,
+                                              textPropertyProviderFactory,
+                                              canvasElementAddedEvent,
+                                              canvasElementRemovedEvent,
+                                              canvasElementUpdatedEvent,
+                                              canvasElementsClearEvent);
+    }
+
+    @Test
+    public void checkApplyElementMutationOnPosition() {
+        final ElementShape shape = mock(ElementShape.class);
+        final Element candidate = mock(Element.class);
+        final boolean applyPosition = true;
+        final boolean applyProperties = false;
+        final MutationContext mutationContext = mock(MutationContext.class);
+        canvasHandler.applyElementMutation(shape,
+                                           candidate,
+                                           applyPosition,
+                                           applyProperties,
+                                           mutationContext);
+
+        verify(shape, atLeastOnce()).applyPosition(any(), any());
+        verify(canvasElementUpdatedEvent, atLeastOnce()).fire(any());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
@@ -238,6 +238,30 @@ public class MapSelectionControlTest {
     }
 
     @Test
+    public void testSelectOnlyOnce() {
+        tested.init(canvasHandler);
+        tested.register(element);
+        tested.select(element.getUUID());
+        tested.select(element.getUUID());
+
+        assertEquals(1, tested.getSelectedItems().size());
+        assertEquals(ELEMENT_UUID, tested.getSelectedItems().iterator().next());
+        verify(shape, times(2)).applyState(eq(ShapeState.SELECTED));
+        verify(shape, never()).applyState(eq(ShapeState.NONE));
+        verify(shape, never()).applyState(eq(ShapeState.INVALID));
+        verify(shape, never()).applyState(eq(ShapeState.HIGHLIGHT));
+        verify(canvas, times(2)).focus();
+        final ArgumentCaptor<CanvasSelectionEvent> elementSelectedEventArgumentCaptor =
+                ArgumentCaptor.forClass(CanvasSelectionEvent.class);
+        // Verify it has only been fired once
+        verify(elementSelectedEvent,
+               times(1)).fire(elementSelectedEventArgumentCaptor.capture());
+        final CanvasSelectionEvent event = elementSelectedEventArgumentCaptor.getValue();
+        assertEquals(1, event.getIdentifiers().size());
+        assertEquals(ELEMENT_UUID, event.getIdentifiers().iterator().next());
+    }
+
+    @Test
     public void testSelectReadOnly() {
         tested.init(canvasHandler);
         tested.register(element);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/ToolboxControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/ToolboxControlTest.java
@@ -126,6 +126,21 @@ public class ToolboxControlTest {
     }
 
     @Test
+    public void testElementSelectedEventCache() {
+        final String uuid = "uuid1";
+        when(element.getUUID()).thenReturn(uuid);
+        final CanvasSelectionEvent event = new CanvasSelectionEvent(canvasHandler,
+                                                                    element.getUUID());
+        tested.onCanvasSelectionEvent(event);
+        tested.onCanvasSelectionEvent(event);
+        // Verify it has onl been selected once and called show
+        verify(delegated,
+               times(1)).show(eq(uuid));
+        verify(delegated,
+               never()).destroy();
+    }
+
+    @Test
     public void testClearSelectionEvent() {
         final CanvasClearSelectionEvent event = new CanvasClearSelectionEvent(canvasHandler);
         tested.onCanvasClearSelectionEvent(event);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/QueueGraphExecutionContextTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/command/QueueGraphExecutionContextTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.stunner.core.client.command;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.api.DefinitionManager;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.kie.workbench.common.stunner.core.rule.RuleManager;
+import org.kie.workbench.common.stunner.core.rule.RuleSet;
+import org.kie.workbench.common.stunner.core.rule.context.NodeContainmentContext;
+import org.kie.workbench.common.stunner.core.rule.context.impl.RuleEvaluationContextBuilder;
+import org.kie.workbench.common.stunner.core.rule.context.impl.StatefulGraphEvaluationState;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueGraphExecutionContextTest {
+
+    @Mock
+    private DefinitionManager definitionManager;
+
+    @Mock
+    private FactoryManager factoryManager;
+
+    @Mock
+    private RuleManager ruleManager;
+
+    @Mock
+    private StatefulGraphEvaluationState state;
+
+    @Mock
+    private Index<?, ?> graphIndex;
+
+    @Mock
+    private RuleSet ruleSet;
+
+    private QueueGraphExecutionContext tested;
+    private RuleEvaluationContextBuilder.StatefulGraphContextBuilder contextBuilder;
+
+    @Before
+    public void setUp() {
+        contextBuilder = new RuleEvaluationContextBuilder.StatefulGraphContextBuilder(state);
+        tested = new QueueGraphExecutionContext(definitionManager,
+                                                factoryManager,
+                                                ruleManager,
+                                                contextBuilder,
+                                                graphIndex,
+                                                ruleSet);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEvaluate() {
+        StatefulGraphEvaluationState.StatefulContainmentState containmentState = new StatefulGraphEvaluationState.StatefulContainmentState();
+        when(state.getContainmentState()).thenReturn(containmentState);
+        Element parent = new NodeImpl<>("parent");
+        Node child = new NodeImpl<>("child");
+        final NodeContainmentContext[] containmentContext = new NodeContainmentContext[1];
+        tested.evaluate(builder -> containmentContext[0] = builder.containment(parent, child));
+        verify(ruleManager, times(1)).evaluate(eq(ruleSet), eq(containmentContext[0]));
+        assertEquals(parent, containmentState.getParent(child));
+    }
+
+    @Test
+    public void testClear() {
+        tested.clear();
+        verify(state, times(1)).clear();
+    }
+
+    @Test
+    public void testAddElement() {
+        Element node1 = new NodeImpl<>("parent");
+        tested.addElement(node1);
+        assertEquals("Should be One Element in Updated Elements", 1, tested.getUpdatedElements().size());
+    }
+
+    @Test
+    public void testGetUpdatedElements() {
+        Element node1 = new NodeImpl<>("parent");
+        tested.addElement(node1);
+        assertEquals("node 1 should be returned from Updated Elements", node1, tested.getUpdatedElements().get(0));
+    }
+
+    @Test
+    public void testResetUpdatedElements() {
+        Element parent = new NodeImpl<>("parent");
+
+        tested.addElement(parent);
+        assertEquals("Should be One Element in Updated Elements", 1, tested.getUpdatedElements().size());
+        tested.resetUpdatedElements();
+        assertEquals("Updated Elements should be empty", 0, tested.getUpdatedElements().size());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ActionsToolboxTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/toolbox/actions/ActionsToolboxTest.java
@@ -130,6 +130,14 @@ public class ActionsToolboxTest {
     }
 
     @Test
+    public void testShowOnlyOnce() {
+        tested.show();
+        tested.show();
+        verify(view,
+               times(1)).show();
+    }
+
+    @Test
     public void testHide() {
         tested.hide();
         verify(view,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
@@ -67,9 +67,9 @@ public abstract class BaseSessionCommandKeyboardTest {
 
     @Before
     public void setup() {
-        this.command = spy(getCommand());
         when(session.getKeyboardControl()).thenReturn(keyboardControl);
         when(session.getSelectionControl()).thenReturn(selectionControl);
+        this.command = spy(getCommand());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
@@ -18,11 +18,11 @@ package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
 import java.util.Arrays;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.ClipboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.SelectionControl;
@@ -38,6 +38,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -54,6 +55,9 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
     @Mock
     private EventSourceMock<CopySelectionSessionCommandExecutedEvent> commandExecutedEvent;
 
+    @Mock
+    private SessionManager sessionManager;
+
     private ArgumentCaptor<CopySelectionSessionCommandExecutedEvent> eventArgumentCaptor;
 
     private ClipboardControl<Element, AbstractCanvas, ClientSession> clipboardControl;
@@ -68,13 +72,12 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
 
     private TestingGraphInstanceBuilder.TestGraph2 graphInstance;
 
-    @Before
-    public void setUp() throws Exception {
+    @Override
+    public void setup() {
+        super.setup();
+        when(sessionManager.getCurrentSession()).thenReturn(session);
         eventArgumentCaptor = ArgumentCaptor.forClass(CopySelectionSessionCommandExecutedEvent.class);
         clipboardControl = spy(new LocalClipboardControl());
-
-        super.setup();
-
         TestingGraphMockHandler graphMockHandler = new TestingGraphMockHandler();
         this.graphInstance = TestingGraphInstanceBuilder.newGraph2(graphMockHandler);
         this.copySelectionSessionCommand = getCommand();
@@ -191,9 +194,22 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
         assertEquals(0, clipboardControl.getEdgeMap().size());
     }
 
+    @Test
+    public void testExecuteNullSession() {
+        copySelectionSessionCommand.execute(callback);
+        // if session null, then it should never copy items
+        verify(clipboardControl, never()).set(any(), any(), any());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    @SuppressWarnings("unchecked")
+    public void testEmptyConstructor() {
+        CopySelectionSessionCommand copy = new CopySelectionSessionCommand(null, null);
+    }
+
     @Override
     protected CopySelectionSessionCommand getCommand() {
-        return new CopySelectionSessionCommand(commandExecutedEvent);
+        return CopySelectionSessionCommand.getInstance(commandExecutedEvent, sessionManager);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/CopySelectionSessionCommandTest.java
@@ -195,7 +195,13 @@ public class CopySelectionSessionCommandTest extends BaseSessionCommandKeyboardS
     }
 
     @Test
-    public void testExecuteNullSession() {
+    public void testExecuteNullSessionAndNullSelectionControl() {
+        copySelectionSessionCommand.execute(callback);
+        // if session null, then it should never copy items
+        verify(clipboardControl, never()).set(any(), any(), any());
+
+        copySelectionSessionCommand.bind(session);
+        when(session.getSelectionControl()).thenReturn(null);
         copySelectionSessionCommand.execute(callback);
         // if session null, then it should never copy items
         verify(clipboardControl, never()).set(any(), any(), any());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
@@ -35,8 +35,10 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +96,21 @@ public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboar
         deleteCommand.execute(callback);
 
         verify(selectionControl).clearSelection();
+    }
+
+    @Test
+    public void testExecuteNullSessionAndNullSelectionControl() {
+        DeleteSelectionSessionCommand deleteCommand = (DeleteSelectionSessionCommand) this.command;
+        deleteCommand.execute(callback);
+        // if session null, then it should never fire event
+
+        verify(canvasClearSelectionEventEvent, never()).fire(any());
+
+        deleteCommand.bind(session);
+        when(session.getSelectionControl()).thenReturn(null);
+        deleteCommand.execute(callback);
+        // if session null, then it should never fire event
+        verify(canvasClearSelectionEventEvent, never()).fire(any());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommandTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.TestingGraphInstanceBuilder;
 import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.CloneConnectorCommand;
@@ -155,7 +156,7 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
     private CloneConnectorCommand cloneConnectorCommand;
 
     @Mock
-    private CopySelectionSessionCommand copySelectionSessionCommand;
+    private SessionManager sessionManager;
 
     @Mock
     private org.uberfire.mvp.Command statusCallback;
@@ -200,6 +201,7 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
         when(clone2.getUUID()).thenReturn(CLONE2_UUID);
         when(session.getClipboardControl()).thenReturn(clipboardControl);
         when(sessionCommandManager.getRegistry()).thenReturn(commandRegistry);
+        when(sessionManager.getCurrentSession()).thenReturn(session);
 
         cloneMap = new HashMap() {{
             put(node, clone);
@@ -233,6 +235,8 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
         //same parent
         clipboardControl.set(graphInstance.startNode);
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(node.getUUID()));
+        CopySelectionSessionCommand.getInstance(sessionManager).bind(session);
+
         pasteSelectionSessionCommand.execute(callback);
         verify(canvasCommandFactory, times(1))
                 .cloneNode(eq(node), eq(graphInstance.parentNode.getUUID()), eq(new Point2D(X, DEFAULT_PADDING + Y + NODE_SIZE)), any());
@@ -314,6 +318,7 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
         //Executing the command
         clipboardControl.set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(graphInstance.startNode.getUUID(), graphInstance.edge1.getUUID(), graphInstance.intermNode.getUUID()));
+        CopySelectionSessionCommand.getInstance(sessionManager).bind(session);
 
         pasteSelectionSessionCommand.execute(callback);
 
@@ -392,6 +397,7 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
         //Executing the command
         clipboardControl.set(graphInstance.startNode, graphInstance.edge1, graphInstance.intermNode);
         when(selectionControl.getSelectedItems()).thenReturn(Arrays.asList(graphInstance.startNode.getUUID(), graphInstance.edge1.getUUID(), graphInstance.intermNode.getUUID()));
+        CopySelectionSessionCommand.getInstance(sessionManager).bind(session);
         pasteSelectionSessionCommand.execute(callback);
         verify(canvasCommandFactory, times(1))
                 .cloneNode(eq(graphInstance.startNode), eq(graphInstance.parentNode.getUUID()), eq(new Point2D(X, DEFAULT_PADDING + Y + NODE_SIZE)), any());
@@ -459,8 +465,8 @@ public class PasteSelectionSessionCommandTest extends BaseSessionCommandKeyboard
     @Override
     protected PasteSelectionSessionCommand getCommand() {
         return new PasteSelectionSessionCommand(sessionCommandManager, canvasCommandFactoryInstance,
-                                                selectionEvent, copySelectionSessionCommand,
-                                                definitionUtils);
+                                                selectionEvent,
+                                                definitionUtils, sessionManager);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactoryTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.session.command.impl;
+
+import javax.enterprise.event.Event;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionSingletonCommandsFactoryTest {
+
+    @Mock
+    protected EditorSession session;
+
+    @Mock
+    protected EditorSession session2;
+
+    @Mock
+    protected SessionManager sessionManager;
+
+    @Mock
+    protected SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    protected Event<CutSelectionSessionCommandExecutedEvent> commandExecutedEvent;
+
+    @Before
+    public void setUp() throws Exception {
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testOnlyOneInstancePerSessionCopy() {
+        final CopySelectionSessionCommand copySelectionSessionCommand = new CopySelectionSessionCommand(null, sessionManager);
+        final CopySelectionSessionCommand copySelectionSessionCommand2 = new CopySelectionSessionCommand(null, sessionManager);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testOnlyAllowedCommands() {
+        final CutSelectionSessionCommand cut = new CutSelectionSessionCommand(sessionCommandManager, commandExecutedEvent, sessionManager);
+        SessionSingletonCommandsFactory.createOrPut(cut, sessionManager);
+    }
+
+    @Test
+    public void testNewInstancesOndifferentSessionsCopy() {
+        final CopySelectionSessionCommand copySelectionSessionCommand = new CopySelectionSessionCommand(null, sessionManager);
+        when(sessionManager.getCurrentSession()).thenReturn(session2);
+        final CopySelectionSessionCommand copySelectionSessionCommand2 = new CopySelectionSessionCommand(null, sessionManager);
+        assertTrue(copySelectionSessionCommand.hashCode() != copySelectionSessionCommand2.hashCode());
+    }
+
+    @Test
+    public void testGetInstancesCopy() {
+        final CopySelectionSessionCommand copySelectionSessionCommand = new CopySelectionSessionCommand(null, sessionManager);
+        final CopySelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceCopy(null, sessionManager);
+
+        assertEquals(copySelectionSessionCommand, instanceCopy);
+
+        when(sessionManager.getCurrentSession()).thenReturn(session2);
+        final CopySelectionSessionCommand copySelectionSessionCommand2 = new CopySelectionSessionCommand(null, sessionManager);
+        final CopySelectionSessionCommand instanceCopy2 = SessionSingletonCommandsFactory.getInstanceCopy(null, sessionManager);
+
+        assertEquals(copySelectionSessionCommand2, instanceCopy2);
+    }
+
+    @Test
+    public void testGetInstancesOnFetchCopy() {
+        final CopySelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceCopy(null, sessionManager);
+        final CopySelectionSessionCommand instanceCopy2 = SessionSingletonCommandsFactory.getInstanceCopy(null, sessionManager);
+
+        assertEquals(instanceCopy, instanceCopy2);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGetInstancesOnFetchCopyError() {
+        final CopySelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceCopy(null, sessionManager);
+        final CopySelectionSessionCommand instanceCopy2 = new CopySelectionSessionCommand(null, sessionManager);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testOnlyOneInstancePerSessionDelete() {
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+    }
+
+    @Test
+    public void testNewInstancesOndifferentSessionsDelete() {
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        when(sessionManager.getCurrentSession()).thenReturn(session2);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        assertTrue(deleteSelectionSessionCommand.hashCode() != deleteSelectionSessionCommand2.hashCode());
+    }
+
+    @Test
+    public void testGetInstancesDelete() {
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager);
+
+        assertEquals(deleteSelectionSessionCommand, instanceCopy);
+
+        when(sessionManager.getCurrentSession()).thenReturn(session2);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand instanceCopy2 = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager);
+
+        assertEquals(deleteSelectionSessionCommand2, instanceCopy2);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGetInstancesOnFetchDelete() {
+        final DeleteSelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand instanceCopy2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -190,7 +190,6 @@ public class FormsCanvasSessionHandler {
                 final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), uuid);
 
                 Scheduler.get().scheduleDeferred(() -> render(element));
-
             } else {
                 // Select root canvas
                 final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), this.getDiagram().getMetadata().getCanvasRootUUID());
@@ -444,18 +443,10 @@ public class FormsCanvasSessionHandler {
         }
 
         @Override
-        public void updateBatch(final List<List<Element>> queue, final long numberOfItems) {
-
-            if (queue.size() == 1 && numberOfItems != 0) {
-                for (final List<Element> subQueue : queue) {
-                    if (subQueue.size() > 1) {
-                        // No point in updating lots of elements, just last one
-                        update(subQueue.get(subQueue.size() - 1));
-                    } else {
-                        // update one
-                        update(subQueue.get(0));
-                    }
-                }
+        public void updateBatch(final List<Element> queue) {
+            if (!queue.isEmpty()) {
+                // No point in updating lots of elements, just last one or if single the only one
+                update(queue.get(queue.size() - 1));
             }
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -120,7 +120,8 @@ public class FormsCanvasSessionHandler {
      * Shows properties of elements in current session.
      * See {@link SelectionControl#getSelectedItemDefinition()}
      */
-    public void show() { this.show(null);
+    public void show() {
+        this.show(null);
     }
 
     @SuppressWarnings("unchecked")
@@ -195,7 +196,6 @@ public class FormsCanvasSessionHandler {
                 // Select root canvas
                 final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), this.getDiagram().getMetadata().getCanvasRootUUID());
                 render(element);
-
             }
         }
     }
@@ -317,8 +317,6 @@ public class FormsCanvasSessionHandler {
             this.areFormsProcessing = false;
         }
 
-
-
         @Override
         public void update(final Element item) {
 
@@ -331,9 +329,8 @@ public class FormsCanvasSessionHandler {
             }
         }
 
-
         @Override
-        public void  updateBatch(final List<List<Element>> queue, final long numberOfItems) {
+        public void updateBatch(final List<List<Element>> queue, final long numberOfItems) {
 
             if (queue.size() == 1 && numberOfItems != 0) {
                 for (final List<Element> subQueue : queue) {
@@ -342,16 +339,13 @@ public class FormsCanvasSessionHandler {
                         update(subQueue.get(subQueue.size() - 1));
                     } else {
                         // update one
-                            update(subQueue.get(0));
+                        update(subQueue.get(0));
                     }
                 }
             }
-
         }
 
-
-
-            @Override
+        @Override
         public void deregister(final Element element) {
             if (null != renderer) {
                 renderer.clear(getDiagram().getGraph().getUUID(), element);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -439,7 +439,7 @@ public class FormsCanvasSessionHandler {
         @Override
         public void update(final Element item) {
 
-            if (renderer.areLastPositionsSameForElement(item)) {
+            if (!Objects.isNull(renderer) && renderer.areLastPositionsSameForElement(item)) {
                 renderer.resetCache();
             }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -25,7 +25,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.Timer;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -188,8 +188,14 @@ public class FormsCanvasSessionHandler {
             if (event.getIdentifiers().size() == 1) {
                 final String uuid = event.getIdentifiers().iterator().next();
                 final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), uuid);
+                final Timer timer = new Timer() {
+                    @Override
+                    public void run() {
+                        render(element);
+                    }
+                };
 
-                Scheduler.get().scheduleDeferred(() -> render(element));
+                timer.schedule(100);
             } else {
                 // Select root canvas
                 final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), this.getDiagram().getMetadata().getCanvasRootUUID());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
@@ -65,7 +65,6 @@ public class FormsContainer implements IsElement {
                        final Path diagramPath,
                        final FieldChangeHandler changeHandler,
                        final RenderMode renderMode) {
-
         FormDisplayer displayer = getDisplayer(graphUuid, domainObjectUUID);
 
         displayer.render(domainObjectUUID, domainObject, diagramPath, changeHandler, renderMode);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/displayer/FormDisplayer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/displayer/FormDisplayer.java
@@ -89,7 +89,6 @@ public class FormDisplayer implements FormDisplayerView.Presenter,
                           final RenderMode renderMode) {
 
         final List<String> previousExpandedCollapses = new ArrayList<>();
-
         if (renderer.isInitialized()) {
             // Collecting expanded collapses from current form to synchronize the new form collapses
             renderer.getCurrentForm().getFields()

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidgetTest.java
@@ -54,6 +54,7 @@ import org.uberfire.backend.vfs.Path;
 import org.uberfire.mvp.Command;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -70,6 +71,7 @@ public class FormPropertiesWidgetTest {
     private static final String GRAPH_UUID = "graph1";
     private static final String DIAGRAM_NAME = "diagram1";
     private static final String ROOT_UUID = "root1";
+    private static final String NODE2_UUID = "node2";
     private static final String DOMAIN_OBJECT_UUID = "domainObject1";
     private static final String DOMAIN_OBJECT_TRANSLATION_KEY = "domainObjectTranslationKey";
 
@@ -101,6 +103,8 @@ public class FormPropertiesWidgetTest {
     private Metadata metadata;
     @Mock
     private NodeImpl node;
+    @Mock
+    private NodeImpl node2;
     @Mock
     private Definition nodeContent;
     @Mock
@@ -144,6 +148,8 @@ public class FormPropertiesWidgetTest {
         when(node.getUUID()).thenReturn(ROOT_UUID);
         when(node.getContent()).thenReturn(nodeContent);
         when(nodeContent.getDefinition()).thenReturn(nodeDefObject);
+        when(node2.getUUID()).thenReturn(NODE2_UUID);
+        when(node2.getContent()).thenReturn(nodeContent);
         BindableProxyFactory.addBindableProxy(Object.class,
                                               proxyProvider);
         when(proxyProvider.getBindableProxy()).thenReturn((BindableProxy) proxy);
@@ -277,16 +283,33 @@ public class FormPropertiesWidgetTest {
         verify(formsCanvasSessionHandler).setRenderer(formRendererArgumentCaptor.capture());
         final FormsCanvasSessionHandler.FormRenderer formRenderer = formRendererArgumentCaptor.getValue();
 
-
         final Command command = mock(Command.class);
         when(formsCanvasSessionHandler.getDiagram()).thenReturn(diagram);
 
         formRenderer.render(GRAPH_UUID, node, command);
         formRenderer.render(GRAPH_UUID, node, command);
 
-
         verify(formsCanvasSessionHandler, never()).executeUpdateProperty(any(), any(), any());
         // Verify it is only rendered once, since the same item was already rendered
         verify(formsContainer, atMost(1)).render(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testAreElementsPositionSame() {
+        tested.init();
+
+        verify(formsCanvasSessionHandler).setRenderer(formRendererArgumentCaptor.capture());
+        final FormsCanvasSessionHandler.FormRenderer formRenderer = formRendererArgumentCaptor.getValue();
+
+        final Command command = mock(Command.class);
+        when(formsCanvasSessionHandler.getDiagram()).thenReturn(diagram);
+
+        formRenderer.render(GRAPH_UUID, node, command);
+
+        assertEquals("Value is not the same ", tested.areLastPositionsForSameElementSame(node), true);
+
+        formRenderer.render(GRAPH_UUID, node2, command);
+        assertEquals("Value is not the same ", tested.areLastPositionsForSameElementSame(node), false);
+        assertEquals("Value is not the same ", tested.areLastPositionsForSameElementSame(node2), true);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidgetTest.java
@@ -57,6 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -267,5 +268,25 @@ public class FormPropertiesWidgetTest {
 
         verify(formsContainer, never()).render(any(), any(), any(), any(), any(), any());
         verify(command, never()).execute();
+    }
+
+    @Test
+    public void testShowElement() {
+        tested.init();
+
+        verify(formsCanvasSessionHandler).setRenderer(formRendererArgumentCaptor.capture());
+        final FormsCanvasSessionHandler.FormRenderer formRenderer = formRendererArgumentCaptor.getValue();
+
+
+        final Command command = mock(Command.class);
+        when(formsCanvasSessionHandler.getDiagram()).thenReturn(diagram);
+
+        formRenderer.render(GRAPH_UUID, node, command);
+        formRenderer.render(GRAPH_UUID, node, command);
+
+
+        verify(formsCanvasSessionHandler, never()).executeUpdateProperty(any(), any(), any());
+        // Verify it is only rendered once, since the same item was already rendered
+        verify(formsContainer, atMost(1)).render(any(), any(), any(), any(), any(), any());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
@@ -255,6 +255,18 @@ public class FormsCanvasSessionHandlerTest {
     }
 
     @Test
+    public void testOnCanvasBatchUpdateEmpty() {
+        handler.bind(session);
+        when(formRenderer.areLastPositionsSameForElement(any())).thenReturn(true);
+
+        final List<Element> queue = new ArrayList<>();
+
+        handler.getFormsCanvasListener().updateBatch(queue);
+
+        verify(formRenderer, never()).resetCache();
+    }
+
+    @Test
     public void testOnCanvasBatchUpdateOne() {
         handler.bind(session);
         when(formRenderer.areLastPositionsSameForElement(any())).thenReturn(true);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
@@ -15,7 +15,9 @@
  */
 package org.kie.workbench.common.stunner.forms.client.widgets;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import com.google.gwt.user.client.Timer;
@@ -52,6 +54,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -231,6 +234,46 @@ public class FormsCanvasSessionHandlerTest {
         handler.onCanvasSelectionEvent(canvasSelectionEvent);
 
         verify(formRenderer, never()).render(anyString(), any(Element.class), any(Command.class));
+    }
+
+    @Test
+    public void testOnCanvasBatchUpdateMultiple() {
+        handler.bind(session);
+        when(formRenderer.areLastPositionsSameForElement(any())).thenReturn(true);
+
+        final List<List<Element>> queue = new ArrayList<>();
+        final List<Element> subQueue = new ArrayList<>();
+
+        subQueue.add(mock(Element.class));
+        subQueue.add(mock(Element.class));
+        subQueue.add(mock(Element.class));
+
+        queue.add(subQueue);
+        handler.getFormsCanvasListener().updateBatch(queue, 3);
+
+        // Will action on the very last item
+        verify(formRenderer, times(1)).resetCache();
+        // Render will be called
+    }
+
+    @Test
+    public void testOnCanvasBatchUpdateOne() {
+        handler.bind(session);
+        when(formRenderer.areLastPositionsSameForElement(any())).thenReturn(true);
+
+        final List<List<Element>> queue = new ArrayList<>();
+        final List<Element> subQueue = new ArrayList<>();
+
+        subQueue.add(mock(Element.class));
+        subQueue.add(mock(Element.class));
+        subQueue.add(mock(Element.class));
+
+        queue.add(subQueue);
+        handler.getFormsCanvasListener().updateBatch(queue, 3);
+
+        // Will action on the very last item
+        verify(formRenderer, times(1)).resetCache();
+        // Render will be calleds
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.stunner.forms.client.widgets;
 import java.util.Arrays;
 import java.util.Optional;
 
+import com.google.gwt.user.client.Timer;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +43,6 @@ import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mvp.Command;
 
 import static org.mockito.Matchers.any;
@@ -55,7 +56,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class FormsCanvasSessionHandlerTest {
 
     private static final String GRAPH_UUID = "graph-uuid";
@@ -211,10 +212,14 @@ public class FormsCanvasSessionHandlerTest {
         handler.bind(session);
 
         canvasSelectionEvent = new CanvasSelectionEvent(abstractCanvasHandler, UUID);
-
         handler.onCanvasSelectionEvent(canvasSelectionEvent);
 
-        verify(formRenderer).render(anyString(), eq(element), any(Command.class));
+        new Timer() {
+            @Override
+            public void run() {
+                verify(formRenderer).render(anyString(), eq(element), any(Command.class));
+            }
+        }.schedule(200);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandlerTest.java
@@ -241,15 +241,13 @@ public class FormsCanvasSessionHandlerTest {
         handler.bind(session);
         when(formRenderer.areLastPositionsSameForElement(any())).thenReturn(true);
 
-        final List<List<Element>> queue = new ArrayList<>();
-        final List<Element> subQueue = new ArrayList<>();
+        final List<Element> queue = new ArrayList<>();
 
-        subQueue.add(mock(Element.class));
-        subQueue.add(mock(Element.class));
-        subQueue.add(mock(Element.class));
+        queue.add(mock(Element.class));
+        queue.add(mock(Element.class));
+        queue.add(mock(Element.class));
 
-        queue.add(subQueue);
-        handler.getFormsCanvasListener().updateBatch(queue, 3);
+        handler.getFormsCanvasListener().updateBatch(queue);
 
         // Will action on the very last item
         verify(formRenderer, times(1)).resetCache();
@@ -261,15 +259,11 @@ public class FormsCanvasSessionHandlerTest {
         handler.bind(session);
         when(formRenderer.areLastPositionsSameForElement(any())).thenReturn(true);
 
-        final List<List<Element>> queue = new ArrayList<>();
-        final List<Element> subQueue = new ArrayList<>();
+        final List<Element> queue = new ArrayList<>();
 
-        subQueue.add(mock(Element.class));
-        subQueue.add(mock(Element.class));
-        subQueue.add(mock(Element.class));
+        queue.add(mock(Element.class));
 
-        queue.add(subQueue);
-        handler.getFormsCanvasListener().updateBatch(queue, 3);
+        handler.getFormsCanvasListener().updateBatch(queue);
 
         // Will action on the very last item
         verify(formRenderer, times(1)).resetCache();


### PR DESCRIPTION
JBPM 8836 : Improve Performance of Copy/Cut and Paste Operations
JBPM-8835 : Improve performance of response when user performs a click 
JBPM-8806 : Stunner - Cursor movement is not smooth
JBPM-8872 : Improve Realtime Drawing When Dragging / Moving Shapes
JBPM-8891: Improve Diagram Loading Times
JBPM-8892: Performance Degradation for Large Models
JBPM-8873 : Adding Nodes to the Canvas is Slow
JBPM-8870 : Stunner - Toolboxes seem to be destroyed and redrawn each time you select the same node
JBPM-8874 : Stunner - Prevent unnecessary instances of Copy, Delete Commands to e created by CDI.
JBPM-8877 : Improve performance of Moving Shapes with Keys
JBPM-8879 : Stunner - Performing Containment takes too long
JBPM-8881 : Stunner - Catching intermediate events are displayed slower compared to other nodes
JBPM-8181 : Stunner - Events docking is very slow when Diagram properties is opened
JBPM-8817 : Prevent Unnecesary Listeners to get added everytime a user performs a click.



