### PR TITLE
KOGITO-526: [DMN Designer] Constraint Enumeration widget overlaps when re-opened 

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumeration.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumeration.java
@@ -27,6 +27,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.Scheduler;
 import elemental2.dom.Element;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
@@ -157,11 +158,17 @@ public class DataTypeConstraintEnumeration implements DataTypeConstraintComponen
     }
 
     public void render() {
-        view.clear();
-        getEnumerationItems()
-                .stream()
-                .sorted(Comparator.comparingInt(DataTypeConstraintEnumerationItem::getOrder))
-                .forEach(enumerationItem -> view.addItem(enumerationItem.getElement()));
+        scheduleRender(() -> {
+            view.clear();
+            getEnumerationItems()
+                    .stream()
+                    .sorted(Comparator.comparingInt(DataTypeConstraintEnumerationItem::getOrder))
+                    .forEach(enumerationItem -> view.addItem(enumerationItem.getElement()));
+        });
+    }
+
+    void scheduleRender(final Scheduler.ScheduledCommand command) {
+        Scheduler.get().scheduleDeferred(command);
     }
 
     void addEnumerationItem() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumerationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/enumeration/DataTypeConstraintEnumerationTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.types.listview.constraint.en
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
@@ -31,6 +32,8 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.com
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.enumeration.item.DataTypeConstraintEnumerationItem;
 import org.kie.workbench.common.dmn.client.service.DMNClientServicesProxy;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -69,6 +72,9 @@ public class DataTypeConstraintEnumerationTest {
     @Mock
     private ManagedInstance<DataTypeConstraintEnumerationItem> enumerationItemInstances;
 
+    @Captor
+    private ArgumentCaptor<ScheduledCommand> scheduledCommandArgumentCaptor;
+
     private DataTypeConstraintEnumeration constraintEnumeration;
 
     @Before
@@ -78,6 +84,8 @@ public class DataTypeConstraintEnumerationTest {
                                                                       scrollHelper,
                                                                       parserWarningEvent,
                                                                       enumerationItemInstances));
+
+        doNothing().when(constraintEnumeration).scheduleRender(any(ScheduledCommand.class));
     }
 
     @Test
@@ -217,6 +225,9 @@ public class DataTypeConstraintEnumerationTest {
         doReturn(asList(item1, item2)).when(constraintEnumeration).getEnumerationItems();
 
         constraintEnumeration.render();
+
+        verify(constraintEnumeration).scheduleRender(scheduledCommandArgumentCaptor.capture());
+        scheduledCommandArgumentCaptor.getValue().execute();
 
         verify(view).clear();
         inorder.verify(view).addItem(element2);


### PR DESCRIPTION
See https://issues.jboss.org/browse/KOGITO-526