### PR TITLE
[AF-2324] Blocking only the project explorer while it is loading

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/resources/css/StylesCss.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/resources/css/StylesCss.java
@@ -53,4 +53,6 @@ public interface StylesCss
     @ClassName("directory-name")
     String directory();
 
+    @ClassName("busy-indicator")
+    String busyIndicator();
 }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/BaseViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/BaseViewImpl.java
@@ -17,7 +17,6 @@ package org.kie.workbench.common.screens.explorer.client.widgets;
 
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.Composite;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
@@ -56,4 +55,6 @@ public abstract class BaseViewImpl extends Composite implements View {
                           final CommandWithFileNameAndCommitMessage command ) {
         copyPopUpPresenter.show( path, validator, command );
     }
+
+    public abstract void showContent(final boolean isVisible);
 }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/BaseViewPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/BaseViewPresenter.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -150,10 +151,8 @@ public abstract class BaseViewPresenter {
         }
 
         if (activeOptions.canShowTag()) {
-            baseView.showTagFilter();
             activeContextManager.refresh();
         } else {
-            baseView.hideTagFilter();
             if (activeContextItems.getActiveContent() != null) {
                 baseView.setItems(activeContextItems.getActiveContent());
             }
@@ -682,5 +681,9 @@ public abstract class BaseViewPresenter {
 
     CopyPopUpPresenter.View getCopyView() {
         return copyPopUpPresenter.getView();
+    }
+
+    public boolean canShowTags() {
+        return activeOptions.canShowTag();
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -53,6 +54,7 @@ import org.kie.workbench.common.screens.explorer.client.utils.Utils;
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewImpl;
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewPresenter;
 import org.kie.workbench.common.screens.explorer.client.widgets.View;
+import org.kie.workbench.common.screens.explorer.client.widgets.loading.BusyIndicator;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.Explorer;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorOptions;
 import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagSelector;
@@ -60,11 +62,9 @@ import org.kie.workbench.common.screens.explorer.model.FolderItem;
 import org.kie.workbench.common.screens.explorer.model.FolderItemType;
 import org.kie.workbench.common.screens.explorer.model.FolderListing;
 import org.kie.workbench.common.screens.explorer.utils.Sorters;
-import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.type.AnyResourceType;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.ext.widgets.common.client.accordion.TriggerWidget;
-import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 
 /**
  * Business View implementation
@@ -92,6 +92,8 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
         showItemLastUpdater(false);
     }};
     @UiField
+    BusyIndicator busyIndicator;
+    @UiField
     Explorer explorer;
     @UiField
     PanelGroup itemsContainer;
@@ -100,8 +102,6 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
     TagSelector tagSelector;
     @Inject
     Classifier classifier;
-    @Inject
-    PlaceManager placeManager;
     @Inject
     User user;
     private Map<String, PanelCollapse> collapses = new HashMap<>();
@@ -301,11 +301,26 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
 
     @Override
     public void showBusyIndicator(final String message) {
-        BusyPopup.showMessage(message);
+        showContent(false);
+        busyIndicator.showBusyIndicator(message);
+
     }
 
     @Override
     public void hideBusyIndicator() {
-        BusyPopup.close();
+        showContent(true);
+        busyIndicator.hideBusyIndicator();
+    }
+
+    @Override
+    public void showContent(final boolean isVisible) {
+        if (isVisible && presenter.canShowTags()) {
+            tagSelector.show();
+        } else {
+            tagSelector.hide();
+        }
+
+        explorer.setVisible(isVisible);
+        itemsContainer.setVisible(isVisible);
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.ui.xml
@@ -18,7 +18,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:navigator="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.navigator"
              xmlns:tagselector="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.tagSelector"
-             xmlns:branches="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.branches"
+             xmlns:loading="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.loading"
              xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
              xmlns:bootstrap="urn:import:org.gwtbootstrap3.client.ui">
 
@@ -27,6 +27,7 @@
 
     <gwt:HTMLPanel visible="true">
         <div class="{resources.CSS.viewContainer}">
+            <loading:BusyIndicator ui:field="busyIndicator"/>
             <tagselector:TagSelector ui:field="tagSelector"/>
             <navigator:Explorer ui:field="explorer"/>
             <bootstrap:PanelGroup ui:field="itemsContainer"/>

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/loading/BusyIndicator.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/loading/BusyIndicator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.explorer.client.widgets.loading;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.gwtbootstrap3.client.ui.html.Span;
+import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
+
+public class BusyIndicator extends Composite implements HasBusyIndicator {
+
+    interface BusyIndicatorBinder extends UiBinder<Widget, BusyIndicator> {
+
+    }
+
+    private static BusyIndicatorBinder uiBinder = GWT.create(BusyIndicatorBinder.class);
+
+    @UiField
+    Span message;
+
+    @UiField
+    HTMLPanel container;
+
+    public BusyIndicator() {
+        initWidget(uiBinder.createAndBindUi(this));
+        hideBusyIndicator();
+    }
+
+    @Override
+    public void showBusyIndicator(final String messageText) {
+        container.setVisible(true);
+        message.setText(messageText);
+    }
+
+    @Override
+    public void hideBusyIndicator() {
+        container.setVisible(false);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/loading/BusyIndicator.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/loading/BusyIndicator.ui.xml
@@ -1,0 +1,33 @@
+<!--
+~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~       http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+             xmlns:g="urn:import:com.google.gwt.user.client.ui"
+             xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+             xmlns:h="urn:import:org.gwtbootstrap3.client.ui.html">
+
+  <ui:with field="resources"
+           type="org.kie.workbench.common.screens.explorer.client.resources.ProjectExplorerResources"/>
+
+  <g:HTMLPanel ui:field="container" styleName="{resources.CSS.busyIndicator}">
+      <b:Well>
+          <h:Div addStyleNames="spinner spinner-lg" pull="LEFT"/>
+          <h:Span ui:field="message"/>
+      </b:Well>
+  </g:HTMLPanel>
+
+</ui:UiBinder>

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/tagSelector/TagSelectorViewImpl.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/tagSelector/TagSelectorViewImpl.ui.xml
@@ -27,7 +27,7 @@
     }
   </ui:style>
 
-  <gwt:HTMLPanel>
+  <gwt:HTMLPanel visible="false">
     <b:Form type="INLINE">
       <b:FormLabel addStyleNames="{style.tagLabel}"><ui:text from="{i18n.filterByTag}"/></b:FormLabel>
       <b:ButtonGroup>

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.screens.explorer.client.widgets.technical;
 
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
@@ -30,14 +31,13 @@ import org.guvnor.common.services.project.model.Module;
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewImpl;
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewPresenter;
 import org.kie.workbench.common.screens.explorer.client.widgets.View;
+import org.kie.workbench.common.screens.explorer.client.widgets.loading.BusyIndicator;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.Explorer;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorOptions;
 import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagChangedEvent;
 import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagSelector;
 import org.kie.workbench.common.screens.explorer.model.FolderItem;
 import org.kie.workbench.common.screens.explorer.model.FolderListing;
-import org.uberfire.client.mvp.PlaceManager;
-import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 
 /**
  * Technical View implementation
@@ -64,12 +64,12 @@ public class TechnicalViewWidget
         showItemLastUpdater(false);
     }};
     @UiField
+    BusyIndicator busyIndicator;
+    @UiField
     Explorer explorer;
     @UiField(provided = true)
     @Inject
     TagSelector tagSelector;
-    @Inject
-    PlaceManager placeManager;
     private BaseViewPresenter presenter;
 
     @PostConstruct
@@ -147,12 +147,25 @@ public class TechnicalViewWidget
 
     @Override
     public void showBusyIndicator(final String message) {
-        BusyPopup.showMessage(message);
+        showContent(false);
+        busyIndicator.showBusyIndicator(message);
     }
 
     @Override
     public void hideBusyIndicator() {
-        BusyPopup.close();
+        showContent(true);
+        busyIndicator.hideBusyIndicator();
+    }
+
+    @Override
+    public void showContent(final boolean isVisible) {
+        if (isVisible && presenter.canShowTags()) {
+            tagSelector.show();
+        } else {
+            tagSelector.hide();
+        }
+
+        explorer.setVisible(isVisible);
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.ui.xml
@@ -18,17 +18,18 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
              xmlns:navigator="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.navigator"
-             xmlns:selector="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.branches"
+             xmlns:loading="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.loading"
              xmlns:tagSelector="urn:import:org.kie.workbench.common.screens.explorer.client.widgets.tagSelector">
 
     <ui:with field="resources" type="org.kie.workbench.common.screens.explorer.client.resources.ProjectExplorerResources"/>
     <ui:with field="i18n" type="org.kie.workbench.common.screens.explorer.client.resources.i18n.ProjectExplorerConstants"/>
 
   <gwt:HTMLPanel visible="false">
-        <div ui:field="technicalView">
-            <tagSelector:TagSelector ui:field="tagSelector"/>
-          <navigator:Explorer ui:field="explorer"/>
-        </div>
+    <div ui:field="technicalView" class="{resources.CSS.viewContainer}">
+        <loading:BusyIndicator ui:field="busyIndicator"/>
+        <tagSelector:TagSelector ui:field="tagSelector"/>
+        <navigator:Explorer ui:field="explorer"/>
+    </div>
   </gwt:HTMLPanel>
 
 </ui:UiBinder>

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/resources/org/kie/workbench/common/screens/explorer/client/resources/css/Styles.css
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/resources/org/kie/workbench/common/screens/explorer/client/resources/css/Styles.css
@@ -112,3 +112,19 @@
 .navigator-icon-container i:hover {
     cursor: pointer;
 }
+
+.busy-indicator {
+    width: 300px;
+    margin: auto;
+}
+
+.busy-indicator span {
+    padding-left: 15px;
+    vertical-align: text-top;
+}
+
+@external .spinner;
+
+.busy-indicator .spinner {
+    margin-top: -3px;
+}

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/widgets/BaseViewPresenterUpdateTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/widgets/BaseViewPresenterUpdateTest.java
@@ -188,25 +188,6 @@ public class BaseViewPresenterUpdateTest {
     }
 
     @Test
-    public void showTag() throws Exception {
-        when(activeContextOptions.canShowTag()).thenReturn(true);
-        presenter.update();
-
-        verify(view).showTagFilter();
-        verify(activeContextManager).refresh();
-    }
-
-    @Test
-    public void hideTag() throws Exception {
-        when(activeContextOptions.canShowTag()).thenReturn(false);
-        presenter.update();
-
-        verify(view).hideTagFilter();
-        verify(activeContextManager,
-               never()).refresh();
-    }
-
-    @Test
     public void hideTagWhenActiveContentDoesNotExist() throws Exception {
         when(activeContextOptions.canShowTag()).thenReturn(false);
         presenter.update();

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidgetTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidgetTest.java
@@ -18,20 +18,40 @@ package org.kie.workbench.common.screens.explorer.client.widgets.business;
 
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.PanelGroup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewPresenter;
+import org.kie.workbench.common.screens.explorer.client.widgets.loading.BusyIndicator;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.Explorer;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorOptions;
+import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagSelector;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class BusinessViewWidgetTest {
 
     @GwtMock
     Explorer explorer;
+
+    @GwtMock
+    TagSelector tagSelector;
+
+    @GwtMock
+    PanelGroup itemsContainer;
+
+    @GwtMock
+    BusyIndicator busyIndicator;
+
+    @GwtMock
+    BaseViewPresenter presenter;
 
     private BusinessViewWidget businessViewWidget;
 
@@ -40,8 +60,13 @@ public class BusinessViewWidgetTest {
         businessViewWidget = new BusinessViewWidget() {
             {
                 explorer = BusinessViewWidgetTest.this.explorer;
+                tagSelector = BusinessViewWidgetTest.this.tagSelector;
+                itemsContainer = BusinessViewWidgetTest.this.itemsContainer;
+                busyIndicator = BusinessViewWidgetTest.this.busyIndicator;
             }
         };
+
+        businessViewWidget.init(presenter);
     }
 
     @Test
@@ -70,5 +95,41 @@ public class BusinessViewWidgetTest {
         verify(explorer).hideHeaderNavigator();
         verify(explorer,
                never()).showHeaderNavigator();
+    }
+
+    @Test
+    public void hideContentTest() {
+        final String msg = "Loading";
+
+        businessViewWidget.showBusyIndicator(msg);
+
+        verify(busyIndicator).showBusyIndicator(msg);
+        verify(explorer).setVisible(false);
+        verify(itemsContainer).setVisible(false);
+        verify(tagSelector).hide();
+    }
+
+    @Test
+    public void showContentNoTagsTest() {
+        doReturn(false).when(presenter).canShowTags();
+
+        businessViewWidget.hideBusyIndicator();
+
+        verify(busyIndicator).hideBusyIndicator();
+        verify(tagSelector).hide();
+        verify(explorer).setVisible(true);
+        verify(itemsContainer).setVisible(true);
+    }
+
+    @Test
+    public void showContentWithTagsTest() {
+        doReturn(true).when(presenter).canShowTags();
+
+        businessViewWidget.hideBusyIndicator();
+
+        verify(busyIndicator).hideBusyIndicator();
+        verify(tagSelector).show();
+        verify(explorer).setVisible(true);
+        verify(itemsContainer).setVisible(true);
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidgetTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidgetTest.java
@@ -22,16 +22,32 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewPresenter;
+import org.kie.workbench.common.screens.explorer.client.widgets.loading.BusyIndicator;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.Explorer;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorOptions;
+import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagSelector;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class TechnicalViewWidgetTest {
 
     @GwtMock
     Explorer explorer;
+
+    @GwtMock
+    TagSelector tagSelector;
+
+    @GwtMock
+    BusyIndicator busyIndicator;
+
+    @GwtMock
+    BaseViewPresenter presenter;
 
     private TechnicalViewWidget technicalViewWidget;
 
@@ -40,8 +56,12 @@ public class TechnicalViewWidgetTest {
         technicalViewWidget = new TechnicalViewWidget() {
             {
                 explorer = TechnicalViewWidgetTest.this.explorer;
+                tagSelector = TechnicalViewWidgetTest.this.tagSelector;
+                busyIndicator = TechnicalViewWidgetTest.this.busyIndicator;
             }
         };
+
+        technicalViewWidget.init(presenter);
     }
 
     @Test
@@ -71,5 +91,38 @@ public class TechnicalViewWidgetTest {
         verify(explorer).hideHeaderNavigator();
         verify(explorer,
                never()).showHeaderNavigator();
+    }
+
+    @Test
+    public void hideContentTest() {
+        final String msg = "Loading";
+
+        technicalViewWidget.showBusyIndicator(msg);
+
+        verify(busyIndicator).showBusyIndicator(msg);
+        verify(explorer).setVisible(false);
+        verify(tagSelector).hide();
+    }
+
+    @Test
+    public void showContentNoTagsTest() {
+        doReturn(false).when(presenter).canShowTags();
+
+        technicalViewWidget.hideBusyIndicator();
+
+        verify(busyIndicator).hideBusyIndicator();
+        verify(tagSelector).hide();
+        verify(explorer).setVisible(true);
+    }
+
+    @Test
+    public void showContentWithTagsTest() {
+        doReturn(true).when(presenter).canShowTags();
+
+        technicalViewWidget.hideBusyIndicator();
+
+        verify(busyIndicator).hideBusyIndicator();
+        verify(tagSelector).show();
+        verify(explorer).setVisible(true);
     }
 }


### PR DESCRIPTION
Task: [AF-2324](https://issues.jboss.org/browse/AF-2324)

As requested, only the project explorer will be blocked while it is loading, not the entire workbench.
Currently, users must wait until the loading finishes to continue using the editor when the project explorer is opened. Here's a demo showing this behavior:

![2_Master](https://user-images.githubusercontent.com/638737/68231034-06e27000-ffd9-11e9-98e5-b9c4719591a2.gif)

After this PR, users can interact with the editor while the project explorer is being loaded.
Here's a demo showing this behavior:

![3_LoadingChanged_v1](https://user-images.githubusercontent.com/638737/68231042-0b0e8d80-ffd9-11e9-93b4-27d60d87b90f.gif)
One downside is that users might notice a UI hang while the project explorer is being loaded.
This can be seen when the "select/unselect" flow stops for a while.
For more details, check [RHPAM-2359](https://issues.jboss.org/browse/RHPAM-2359).