### PR TITLE
DROOLS-4689/DROOLS-4690/DROOLS-4691/DROOLS-4692: [DMN Designer] Code Completion - Enable code completion for Literal Expressions

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/DMNClientEntryPoint.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/DMNClientEntryPoint.java
@@ -28,5 +28,6 @@ public class DMNClientEntryPoint {
     @PostConstruct
     public void init() {
         PatternFlyBootstrapper.ensureMomentIsAvailable();
+        PatternFlyBootstrapper.ensureMonacoEditorLoaderIsAvailable();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumn.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumn.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.NameAndDataTypeDOMElementColumnRenderer;
-import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.AutocompleteTextAreaDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNSimpleGridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -31,10 +31,10 @@ import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDO
 
 public class LiteralExpressionColumn extends DMNSimpleGridColumn<LiteralExpressionGrid, String> implements HasSingletonDOMElementResource {
 
-    private final TextAreaSingletonDOMElementFactory factory;
+    private final AutocompleteTextAreaDOMElementFactory factory;
 
     public LiteralExpressionColumn(final List<HeaderMetaData> headerMetaData,
-                                   final TextAreaSingletonDOMElementFactory factory,
+                                   final AutocompleteTextAreaDOMElementFactory factory,
                                    final double width,
                                    final LiteralExpressionGrid gridWidget) {
         super(headerMetaData,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -40,7 +40,6 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelect
 import org.kie.workbench.common.dmn.client.widgets.grid.handlers.DelegatingGridWidgetCellSelectorMouseEventHandler;
 import org.kie.workbench.common.dmn.client.widgets.grid.handlers.DelegatingGridWidgetEditCellMouseEventHandler;
 import org.kie.workbench.common.dmn.client.widgets.grid.handlers.EditableHeaderGridWidgetEditCellMouseEventHandler;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorChanged;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
@@ -62,6 +61,8 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedM
 import static org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils.getExpressionTextLineHeight;
 
 public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralExpression, DMNGridData, LiteralExpressionUIModelMapper> implements HasListSelectorControl {
+
+    static final double LITERAL_EXPRESSION_DEFAULT_WIDTH = 300.0;
 
     private final NameAndDataTypePopoverView.Presenter headerEditor;
 
@@ -158,8 +159,8 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
         }
 
         final GridColumn literalExpressionColumn = new LiteralExpressionColumn(headerMetaData,
-                                                                               getBodyTextAreaFactory(),
-                                                                               getAndSetInitialWidth(0, DMNGridColumn.DEFAULT_WIDTH),
+                                                                               getAutocompleteTextareaFactory(),
+                                                                               getAndSetInitialWidth(0, LITERAL_EXPRESSION_DEFAULT_WIDTH),
                                                                                this);
 
         model.appendColumn(literalExpressionColumn);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoFEELInitializer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoFEELInitializer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.codecompletion;
+
+import java.util.function.Consumer;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.uberfire.client.views.pfly.monaco.MonacoEditorInitializer;
+import org.uberfire.client.views.pfly.monaco.jsinterop.Monaco;
+
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer.MonacoFEELInitializationStatus.INITIALIZED;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer.MonacoFEELInitializationStatus.INITIALIZING;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer.MonacoFEELInitializationStatus.NOT_INITIALIZED;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory.FEEL_LANGUAGE_ID;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory.FEEL_THEME_ID;
+
+@ApplicationScoped
+public class MonacoFEELInitializer {
+
+    private MonacoFEELInitializationStatus initializationStatus = NOT_INITIALIZED;
+
+    public void initializeFEELEditor() {
+
+        if (isFEELInitialized()) {
+            return;
+        }
+
+        setFEELAsInitializing();
+        makeMonacoEditorInitializer().require(onMonacoLoaded());
+    }
+
+    Consumer<Monaco> onMonacoLoaded() {
+        final MonacoPropertiesFactory properties = makeMonacoPropertiesFactory();
+        return monaco -> {
+            monaco.languages.register(properties.getLanguage());
+            monaco.languages.setMonarchTokensProvider(FEEL_LANGUAGE_ID, properties.getLanguageDefinition());
+            monaco.languages.registerCompletionItemProvider(FEEL_LANGUAGE_ID, properties.getCompletionItemProvider());
+            monaco.editor.defineTheme(FEEL_THEME_ID, properties.getThemeData());
+            setFEELAsInitialized();
+        };
+    }
+
+    MonacoEditorInitializer makeMonacoEditorInitializer() {
+        return new MonacoEditorInitializer();
+    }
+
+    MonacoPropertiesFactory makeMonacoPropertiesFactory() {
+        return new MonacoPropertiesFactory();
+    }
+
+    void setFEELAsInitialized() {
+        initializationStatus = INITIALIZED;
+    }
+
+    void setFEELAsInitializing() {
+        initializationStatus = INITIALIZING;
+    }
+
+    boolean isFEELInitialized() {
+        return INITIALIZED == getInitializationStatus() || INITIALIZING == getInitializationStatus();
+    }
+
+    public MonacoFEELInitializationStatus getInitializationStatus() {
+        return initializationStatus;
+    }
+
+    enum MonacoFEELInitializationStatus {
+        NOT_INITIALIZED,
+        INITIALIZING,
+        INITIALIZED
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoPropertiesFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoPropertiesFactory.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.codecompletion;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONBoolean;
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+import com.google.gwt.json.client.JSONValue;
+import elemental2.core.RegExp;
+import jsinterop.base.Js;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoLanguages.ProvideCompletionItemsFunction;
+
+public class MonacoPropertiesFactory {
+
+    public static final String FEEL_LANGUAGE_ID = "feel-language";
+
+    public static final String FEEL_THEME_ID = "feel-theme";
+
+    /*
+     * This method returns a JavaScript object with properties specified here:
+     * https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html
+     */
+    public JavaScriptObject getConstructionOptions() {
+
+        final JSONObject options = makeJSONObject();
+        final JSONObject scrollbar = makeJSONObject();
+        final JSONObject miniMap = makeJSONObject();
+
+        options.put("language", makeJSONString(FEEL_LANGUAGE_ID));
+        options.put("theme", makeJSONString(FEEL_THEME_ID));
+
+        options.put("renderLineHighlight", makeJSONString("none"));
+        options.put("lineNumbers", makeJSONString("off"));
+
+        options.put("fontSize", makeJSONNumber(12));
+        options.put("lineNumbersMinChars", makeJSONNumber(1));
+        options.put("lineDecorationsWidth", makeJSONNumber(1));
+
+        options.put("overviewRulerBorder", makeJSONBoolean(false));
+        options.put("scrollBeyondLastLine", makeJSONBoolean(false));
+        options.put("snippetSuggestions", makeJSONBoolean(false));
+        options.put("useTabStops", makeJSONBoolean(false));
+        options.put("contextmenu", makeJSONBoolean(false));
+        options.put("folding", makeJSONBoolean(false));
+        miniMap.put("enabled", makeJSONBoolean(false));
+        scrollbar.put("useShadows", makeJSONBoolean(false));
+
+        options.put("automaticLayout", makeJSONBoolean(true));
+        options.put("renderWhitespace", makeJSONBoolean(true));
+        options.put("hideCursorInOverviewRuler", makeJSONBoolean(true));
+
+        options.put("scrollbar", scrollbar);
+        options.put("minimap", miniMap);
+
+        return options.getJavaScriptObject();
+    }
+
+    /*
+     * This method returns a JavaScript object with properties specified here:
+     * https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonethemedata.html
+     */
+    public JavaScriptObject getThemeData() {
+
+        final JSONObject themeDefinition = makeJSONObject();
+        final JSONObject colors = makeJSONObject();
+        final JSONString colorHEXCode = makeJSONString("#000000");
+        final JSONString base = makeJSONString("vs");
+        final JSONBoolean inherit = makeJSONBoolean(false);
+        final JSONArray rules = getRules();
+
+        colors.put("editorLineNumber.foreground", colorHEXCode);
+        themeDefinition.put("base", base);
+        themeDefinition.put("inherit", inherit);
+        themeDefinition.put("rules", rules);
+        themeDefinition.put("colors", colors);
+
+        return themeDefinition.getJavaScriptObject();
+    }
+
+    public JSONArray getRules() {
+
+        final JSONObject rule1 = makeJSONObject();
+        final JSONObject rule2 = makeJSONObject();
+        final JSONObject rule3 = makeJSONObject();
+        final JSONObject rule4 = makeJSONObject();
+        final JSONObject rule5 = makeJSONObject();
+        final JSONArray rules = makeJSONArray();
+
+        rule1.put("token", makeJSONString("feel-keyword"));
+        rule1.put("foreground", makeJSONString("26268C"));
+        rule1.put("fontStyle", makeJSONString("bold"));
+
+        rule2.put("token", makeJSONString("feel-numeric"));
+        rule2.put("foreground", makeJSONString("3232E7"));
+
+        rule3.put("token", makeJSONString("feel-boolean"));
+        rule3.put("foreground", makeJSONString("26268D"));
+        rule3.put("fontStyle", makeJSONString("bold"));
+
+        rule4.put("token", makeJSONString("feel-string"));
+        rule4.put("foreground", makeJSONString("2A9343"));
+        rule4.put("fontStyle", makeJSONString("bold"));
+
+        rule5.put("token", makeJSONString("feel-function"));
+        rule5.put("foreground", makeJSONString("3232E8"));
+
+        push(rules, rule1);
+        push(rules, rule2);
+        push(rules, rule3);
+        push(rules, rule4);
+        push(rules, rule5);
+
+        return rules;
+    }
+
+    /*
+     * This method returns a JavaScript object with properties specified here:
+     * https://microsoft.github.io/monaco-editor/api/interfaces/monaco.languages.completionitemprovider.html
+     */
+    public JavaScriptObject getCompletionItemProvider() {
+        return makeJavaScriptObject("provideCompletionItems", makeJSONObject(getProvideCompletionItemsFunction()));
+    }
+
+    /*
+     * This method returns a JavaScript object with properties specified here:
+     * https://microsoft.github.io/monaco-editor/api/interfaces/monaco.languages.completionlist.html
+     */
+    ProvideCompletionItemsFunction getProvideCompletionItemsFunction() {
+        return () -> {
+            final JSONObject suggestions = makeJSONObject();
+            suggestions.put("suggestions", getSuggestions());
+            return suggestions.getJavaScriptObject();
+        };
+    }
+
+    /*
+     * This method returns a JavaScript object with properties specified here:
+     * https://microsoft.github.io/monaco-editor/api/interfaces/monaco.languages.imonarchlanguage.html
+     */
+    public JavaScriptObject getLanguageDefinition() {
+        return makeJavaScriptObject("tokenizer", getTokenizer());
+    }
+
+    public JSONValue getTokenizer() {
+        final JSONObject tokenizer = makeJSONObject();
+        tokenizer.put("root", getRoot());
+        return tokenizer;
+    }
+
+    /*
+     * This methods returns a collection of IShortMonarchLanguageRule1[RegExp, IMonarchLanguageAction]
+     * https://microsoft.github.io/monaco-editor/api/modules/monaco.languages.html#ishortmonarchlanguagerule1
+     * Each item from the 'root' array represents a rule:
+     * - 1st rule     - occurrences of booleans' are marked as "feel-boolean"
+     * - 2nd rule     - occurrences of numbers are marked as "feel-numeric"
+     * - 3rd rule     - occurrences of strings are marked as "feel-string"
+     * - 4th rule     - occurrences of FEEL functions calls are marked as "feel-function"
+     * - 5th/6th rule - occurrences of FEEL keywords(if, then, else, for, in, return) are marked as "feel-keyword"
+     */
+    public JSONArray getRoot() {
+        final JSONArray root = makeJSONArray();
+        push(root, row("(?:(\\btrue\\b)|(\\bfalse\\b))", "feel-boolean"));
+        push(root, row("[0-9]+", "feel-numeric"));
+        push(root, row("(?:\\\"(?:.*?)\\\")", "feel-string"));
+        push(root, row("(?:(?:[a-z ]+\\()|(?:\\()|(?:\\)))", "feel-function"));
+        push(root, row("(?:(\\bif\\b)|(\\bthen\\b)|(\\belse\\b))", "feel-keyword"));
+        push(root, row("(?:(\\bfor\\b)|(\\bin\\b)|(\\breturn\\b))", "feel-keyword"));
+        return root;
+    }
+
+    public JSONArray getSuggestions() {
+
+        final JSONArray suggestionTypes = makeJSONArray();
+
+        push(suggestionTypes, getFunctionSuggestion("abs(duration)", "abs($1)"));
+        push(suggestionTypes, getFunctionSuggestion("abs(number)", "abs($1)"));
+        push(suggestionTypes, getFunctionSuggestion("after(range, value)", "after($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("after(range1, range2)", "after($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("after(value, range)", "after($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("after(value1, value2)", "after($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("all(b)", "all($1)"));
+        push(suggestionTypes, getFunctionSuggestion("all(list)", "all($1)"));
+        push(suggestionTypes, getFunctionSuggestion("any(b)", "any($1)"));
+        push(suggestionTypes, getFunctionSuggestion("any(list)", "any($1)"));
+        push(suggestionTypes, getFunctionSuggestion("append(list, item)", "append($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("before(range, value)", "before($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("before(range1, range2)", "before($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("before(value, range)", "before($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("before(value1, value2)", "before($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("ceiling(n)", "ceiling($1)"));
+        push(suggestionTypes, getFunctionSuggestion("code(value)", "code($1)"));
+        push(suggestionTypes, getFunctionSuggestion("coincides(range1, range2)", "coincides($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("coincides(value1, value2)", "coincides($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("concatenate(list)", "concatenate($1)"));
+        push(suggestionTypes, getFunctionSuggestion("contains(string, match)", "contains($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("count(c)", "count($1)"));
+        push(suggestionTypes, getFunctionSuggestion("count(list)", "count($1)"));
+        push(suggestionTypes, getFunctionSuggestion("date and time(date, time)", "date and time($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("date and time(from)", "date and time($1)"));
+        push(suggestionTypes, getFunctionSuggestion("date and time(year, month, day, hour, minute, second)", "date and time($1, $2, $3, $4, $5, $6)"));
+        push(suggestionTypes, getFunctionSuggestion("date and time(year, month, day, hour, minute, second, hour offset)", "date and time($1, $2, $3, $4, $5, $6, $7)"));
+        push(suggestionTypes, getFunctionSuggestion("date and time(year, month, day, hour, minute, second, timezone)", "date and time($1, $2, $3, $4, $5, $6, $7)"));
+        push(suggestionTypes, getFunctionSuggestion("date(from)", "date($1)"));
+        push(suggestionTypes, getFunctionSuggestion("date(year, month, day)", "date($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("day of week(date)", "day of week($1)"));
+        push(suggestionTypes, getFunctionSuggestion("day of year(date)", "day of year($1)"));
+        push(suggestionTypes, getFunctionSuggestion("decimal(n, scale)", "decimal($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("decision table(ctx, outputs, input expression list, input values list, output values, rule list, hit policy, default output value)", "decision table($1, $2, $3, $4, $5, $6, $7, $8)"));
+        push(suggestionTypes, getFunctionSuggestion("distinct values(list)", "distinct values($1)"));
+        push(suggestionTypes, getFunctionSuggestion("duration(from)", "duration($1)"));
+        push(suggestionTypes, getFunctionSuggestion("during(range1, range2)", "during($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("during(value, range)", "during($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("ends with(string, match)", "ends with($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("even(number)", "even($1)"));
+        push(suggestionTypes, getFunctionSuggestion("exp(number)", "exp($1)"));
+        push(suggestionTypes, getFunctionSuggestion("finished by(range, value)", "finished by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("finished by(range1, range2)", "finished by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("finishes(range1, range2)", "finishes($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("finishes(value, range)", "finishes($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("flatten(list)", "flatten($1)"));
+        push(suggestionTypes, getFunctionSuggestion("floor(n)", "floor($1)"));
+        push(suggestionTypes, getFunctionSuggestion("get entries(m)", "get entries($1)"));
+        push(suggestionTypes, getFunctionSuggestion("get value(m, key)", "get value($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("includes(range, value)", "includes($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("includes(range1, range2)", "includes($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("index of(list, match)", "index of($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("insert before(list, position, newItem)", "insert before($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("invoke(ctx, namespace, model name, decision name, parameters)", "invoke($1, $2, $3, $4, $5)"));
+        push(suggestionTypes, getFunctionSuggestion("list contains(list, element)", "list contains($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("log(number)", "log($1)"));
+        push(suggestionTypes, getFunctionSuggestion("lower case(string)", "lower case($1)"));
+        push(suggestionTypes, getFunctionSuggestion("matches(input, pattern)", "matches($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("matches(input, pattern, flags)", "matches($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("max(c)", "max($1)"));
+        push(suggestionTypes, getFunctionSuggestion("max(list)", "max($1)"));
+        push(suggestionTypes, getFunctionSuggestion("mean(list)", "mean($1)"));
+        push(suggestionTypes, getFunctionSuggestion("mean(n)", "mean($1)"));
+        push(suggestionTypes, getFunctionSuggestion("median(list)", "median($1)"));
+        push(suggestionTypes, getFunctionSuggestion("median(n)", "median($1)"));
+        push(suggestionTypes, getFunctionSuggestion("meets(range1, range2)", "meets($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("met by(range1, range2)", "met by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("min(c)", "min($1)"));
+        push(suggestionTypes, getFunctionSuggestion("min(list)", "min($1)"));
+        push(suggestionTypes, getFunctionSuggestion("mode(list)", "mode($1)"));
+        push(suggestionTypes, getFunctionSuggestion("mode(n)", "mode($1)"));
+        push(suggestionTypes, getFunctionSuggestion("modulo(dividend, divisor)", "modulo($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("month of year(date)", "month of year($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn all(b)", "nn all($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn all(list)", "nn all($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn any(b)", "nn any($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn any(list)", "nn any($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn count(c)", "nn count($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn count(list)", "nn count($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn max(c)", "nn max($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn max(list)", "nn max($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn mean(list)", "nn mean($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn mean(n)", "nn mean($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn median(list)", "nn median($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn median(n)", "nn median($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn min(c)", "nn min($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn min(list)", "nn min($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn mode(list)", "nn mode($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn mode(n)", "nn mode($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn stddev(list)", "nn stddev($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn stddev(n)", "nn stddev($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn sum(list)", "nn sum($1)"));
+        push(suggestionTypes, getFunctionSuggestion("nn sum(n)", "nn sum($1)"));
+        push(suggestionTypes, getFunctionSuggestion("not(negand)", "not($1)"));
+        push(suggestionTypes, getFunctionSuggestion("now()", "now()"));
+        push(suggestionTypes, getFunctionSuggestion("number(from, grouping separator, decimal separator)", "number($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("odd(number)", "odd($1)"));
+        push(suggestionTypes, getFunctionSuggestion("overlapped after by(range1, range2)", "overlapped after by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("overlapped before by(range1, range2)", "overlapped before by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("overlapped by(range1, range2)", "overlapped by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("overlaps after(range1, range2)", "overlaps after($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("overlaps before(range1, range2)", "overlaps before($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("overlaps(range1, range2)", "overlaps($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("product(list)", "product($1)"));
+        push(suggestionTypes, getFunctionSuggestion("product(n)", "product($1)"));
+        push(suggestionTypes, getFunctionSuggestion("remove(list, position)", "remove($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("replace(input, pattern, replacement)", "replace($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("replace(input, pattern, replacement, flags)", "replace($1, $2, $3, $4)"));
+        push(suggestionTypes, getFunctionSuggestion("reverse(list)", "reverse($1)"));
+        push(suggestionTypes, getFunctionSuggestion("sort()", "sort()"));
+        push(suggestionTypes, getFunctionSuggestion("sort(ctx, list, precedes)", "sort($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("sort(list)", "sort($1)"));
+        push(suggestionTypes, getFunctionSuggestion("split(string, delimiter)", "split($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("split(string, delimiter, flags)", "split($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("sqrt(number)", "sqrt($1)"));
+        push(suggestionTypes, getFunctionSuggestion("started by(range, value)", "started by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("started by(range1, range2)", "started by($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("starts with(string, match)", "starts with($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("starts(range1, range2)", "starts($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("starts(value, range)", "starts($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("stddev(list)", "stddev($1)"));
+        push(suggestionTypes, getFunctionSuggestion("stddev(n)", "stddev($1)"));
+        push(suggestionTypes, getFunctionSuggestion("string length(string)", "string length($1)"));
+        push(suggestionTypes, getFunctionSuggestion("string(from)", "string($1)"));
+        push(suggestionTypes, getFunctionSuggestion("string(mask, p)", "string($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("sublist(list, start position)", "sublist($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("sublist(list, start position, length)", "sublist($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("substring after(string, match)", "substring after($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("substring before(string, match)", "substring before($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("substring(string, start position)", "substring($1, $2)"));
+        push(suggestionTypes, getFunctionSuggestion("substring(string, start position, length)", "substring($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("sum(list)", "sum($1)"));
+        push(suggestionTypes, getFunctionSuggestion("sum(n)", "sum($1)"));
+        push(suggestionTypes, getFunctionSuggestion("time(from)", "time($1)"));
+        push(suggestionTypes, getFunctionSuggestion("time(hour, minute, second)", "time($1, $2, $3)"));
+        push(suggestionTypes, getFunctionSuggestion("time(hour, minute, second, offset)", "time($1, $2, $3, $4)"));
+        push(suggestionTypes, getFunctionSuggestion("today()", "today()"));
+        push(suggestionTypes, getFunctionSuggestion("union(list)", "union($1)"));
+        push(suggestionTypes, getFunctionSuggestion("upper case(string)", "upper case($1)"));
+        push(suggestionTypes, getFunctionSuggestion("week of year(date)", "week of year($1)"));
+        push(suggestionTypes, getFunctionSuggestion("years and months duration(from, to)", "years and months duration($1, $2)"));
+
+        return suggestionTypes;
+    }
+
+    JSONValue getFunctionSuggestion(final String label,
+                                    final String insertText) {
+
+        final JSONObject suggestion = makeJSONObject();
+        final int completionItemKindFunction = 1;
+        final int completionItemInsertTextRuleInsertAsSnippet = 4;
+
+        suggestion.put("kind", makeJSONNumber(completionItemKindFunction));
+        suggestion.put("insertTextRules", makeJSONNumber(completionItemInsertTextRuleInsertAsSnippet));
+        suggestion.put("label", makeJSONString(label));
+        suggestion.put("insertText", makeJSONString(insertText));
+
+        return suggestion;
+    }
+
+    public JSONArray row(final String pattern,
+                         final String name) {
+        final JSONArray row = makeJSONArray();
+        row.set(0, makeJSONObject(makeRegExp(pattern)));
+        row.set(1, makeJSONString(name));
+        return row;
+    }
+
+    /*
+     * This method returns a JavaScript object with properties specified here:
+     * https://microsoft.github.io/monaco-editor/api/interfaces/monaco.languages.ilanguageextensionpoint.html
+     */
+    public JavaScriptObject getLanguage() {
+        return makeJavaScriptObject("id", makeJSONString(FEEL_LANGUAGE_ID));
+    }
+
+    JavaScriptObject makeJavaScriptObject(final String property,
+                                          final JSONValue value) {
+        final JSONObject jsonObject = makeJSONObject();
+        jsonObject.put(property, value);
+        return jsonObject.getJavaScriptObject();
+    }
+
+    RegExp makeRegExp(final String pattern) {
+        return new RegExp(pattern);
+    }
+
+    JSONArray makeJSONArray() {
+        return new JSONArray();
+    }
+
+    JSONBoolean makeJSONBoolean(final boolean value) {
+        return JSONBoolean.getInstance(value);
+    }
+
+    JSONString makeJSONString(final String value) {
+        return new JSONString(value);
+    }
+
+    JSONValue makeJSONNumber(final int value) {
+        return new JSONNumber(value);
+    }
+
+    JSONObject makeJSONObject(final Object obj) {
+        return new JSONObject(Js.uncheckedCast(obj));
+    }
+
+    JSONObject makeJSONObject() {
+        return new JSONObject();
+    }
+
+    void push(final JSONArray jsonArray,
+              final JSONValue jsonValue) {
+        jsonArray.set(jsonArray.size(), jsonValue);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/BaseExpressionGrid.java
@@ -47,6 +47,7 @@ import org.kie.workbench.common.dmn.client.commands.general.SetHeaderValueComman
 import org.kie.workbench.common.dmn.client.commands.general.SetTypeRefCommand;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.EditableHeaderMetaData;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.AutocompleteTextAreaDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.ListBoxSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextBoxSingletonDOMElementFactory;
@@ -250,6 +251,16 @@ public abstract class BaseExpressionGrid<E extends Expression, D extends GridDat
                                                       sessionCommandManager,
                                                       newCellHasNoValueCommand(),
                                                       newCellHasValueCommand());
+    }
+
+    public AutocompleteTextAreaDOMElementFactory getAutocompleteTextareaFactory() {
+        return new AutocompleteTextAreaDOMElementFactory(gridPanel,
+                                                         gridLayer,
+                                                         this,
+                                                         sessionManager,
+                                                         sessionCommandManager,
+                                                         newCellHasNoValueCommand(),
+                                                         newCellHasValueCommand());
     }
 
     public ListBoxSingletonDOMElementFactory getBodyListBoxFactory() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/AutocompleteTextAreaDOMElementFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/AutocompleteTextAreaDOMElementFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.columns.factory;
+
+import java.util.function.Function;
+
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.MonacoEditorDOMElement;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.MonacoEditorWidget;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.single.impl.BaseSingletonDOMElementFactory;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.keyboard.KeyDownHandlerCommon;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+public class AutocompleteTextAreaDOMElementFactory extends BaseSingletonDOMElementFactory<String, MonacoEditorWidget, MonacoEditorDOMElement> {
+
+    private final SessionManager sessionManager;
+    private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+    private final Function<GridCellTuple, Command> hasNoValueCommand;
+    private final Function<GridCellValueTuple, Command> hasValueCommand;
+
+    public AutocompleteTextAreaDOMElementFactory(final DMNGridPanel gridPanel,
+                                                 final GridLayer gridLayer,
+                                                 final GridWidget gridWidget,
+                                                 final SessionManager sessionManager,
+                                                 final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                                 final Function<GridCellTuple, Command> hasNoValueCommand,
+                                                 final Function<GridCellValueTuple, Command> hasValueCommand) {
+        super(gridPanel,
+              gridLayer,
+              gridWidget);
+        this.sessionManager = sessionManager;
+        this.sessionCommandManager = sessionCommandManager;
+        this.hasNoValueCommand = hasNoValueCommand;
+        this.hasValueCommand = hasValueCommand;
+    }
+
+    public Function<GridCellTuple, Command> getHasNoValueCommand() {
+        return hasNoValueCommand;
+    }
+
+    public Function<GridCellValueTuple, Command> getHasValueCommand() {
+        return hasValueCommand;
+    }
+
+    @Override
+    public MonacoEditorWidget createWidget() {
+        return new MonacoEditorWidget();
+    }
+
+    @Override
+    protected String getValue() {
+        if (widget != null) {
+            return widget.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    protected KeyDownHandlerCommon destroyOrFlushKeyDownHandler() {
+        return new KeyDownHandlerCommon(gridPanel, gridLayer, gridWidget, this, true, false, true);
+    }
+
+    @Override
+    protected MonacoEditorDOMElement createDomElementInternal(final MonacoEditorWidget widget,
+                                                              final GridLayer gridLayer,
+                                                              final GridWidget gridWidget) {
+
+        final MonacoEditorDOMElement domElement = makeMonacoEditorDOMElement(widget, gridLayer, gridWidget);
+        domElement.setupElements();
+        return domElement;
+    }
+
+    protected MonacoEditorDOMElement makeMonacoEditorDOMElement(final MonacoEditorWidget widget,
+                                                                final GridLayer gridLayer,
+                                                                final GridWidget gridWidget) {
+        return new MonacoEditorDOMElement(widget,
+                                          gridLayer,
+                                          gridWidget,
+                                          sessionManager,
+                                          sessionCommandManager,
+                                          hasNoValueCommand,
+                                          hasValueCommand);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorDOMElement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorDOMElement.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.TakesValue;
+import com.google.gwt.user.client.ui.Focusable;
+import com.google.gwt.user.client.ui.SimplePanel;
+import elemental2.dom.Element;
+import jsinterop.base.Js;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
+import org.uberfire.client.views.pfly.monaco.MonacoEditorInitializer;
+import org.uberfire.client.views.pfly.monaco.jsinterop.Monaco;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoStandaloneCodeEditor;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static com.google.gwt.dom.client.Style.Unit.PCT;
+import static com.google.gwt.dom.client.Style.Unit.PX;
+
+public class MonacoEditorDOMElement extends BaseDOMElement<String, MonacoEditorWidget> implements TakesValue<String>,
+                                                                                                  Focusable {
+
+    private final SessionManager sessionManager;
+    private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+    private final Function<GridCellTuple, Command> hasNoValueCommand;
+    private final Function<GridCellValueTuple, Command> hasValueCommand;
+
+    private String originalValue;
+
+    public MonacoEditorDOMElement(final MonacoEditorWidget widget,
+                                  final GridLayer gridLayer,
+                                  final GridWidget gridWidget,
+                                  final SessionManager sessionManager,
+                                  final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                  final Function<GridCellTuple, Command> hasNoValueCommand,
+                                  final Function<GridCellValueTuple, Command> hasValueCommand) {
+        super(widget,
+              gridLayer,
+              gridWidget);
+        this.sessionManager = sessionManager;
+        this.sessionCommandManager = sessionCommandManager;
+        this.hasNoValueCommand = hasNoValueCommand;
+        this.hasValueCommand = hasValueCommand;
+    }
+
+    public void setupElements() {
+        setupContainerComponent();
+        setupInternalComponent();
+    }
+
+    void setupContainerComponent() {
+
+        final SimplePanel container = getContainer();
+        final Style style = container.getElement().getStyle();
+
+        style.setPadding(5, PX);
+
+        container.setWidget(widget);
+    }
+
+    void setupInternalComponent() {
+
+        final Style style = widget.getElement().getStyle();
+
+        style.setWidth(100, PCT);
+        style.setHeight(100, PCT);
+
+        makeMonacoEditorInitializer().require(onMonacoLoaded());
+    }
+
+    Consumer<Monaco> onMonacoLoaded() {
+        final MonacoPropertiesFactory properties = makeMonacoPropertiesFactory();
+        return monaco -> {
+            final MonacoStandaloneCodeEditor codeEditor = monaco.editor.create(uncheckedCast(widget.getElement()), properties.getConstructionOptions());
+
+            codeEditor.onKeyDown(getOnKeyDown(codeEditor));
+
+            widget.setCodeEditor(codeEditor);
+            widget.setFocus(true);
+        };
+    }
+
+    MonacoStandaloneCodeEditor.CallbackFunction getOnKeyDown(final MonacoStandaloneCodeEditor codeEditor) {
+        return event -> {
+            boolean isSuggestWidgetVisible = codeEditor.isSuggestWidgetVisible();
+            final boolean isEsc = event.getKeyCode() == 9;
+            if (isSuggestWidgetVisible && isEsc) {
+                codeEditor.trigger("keyboard", "cursorHome");
+                codeEditor.trigger("keyboard", "cursorEnd");
+
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        };
+    }
+
+    @Override
+    public void initialise(final GridBodyCellRenderContext context) {
+        transform(context);
+    }
+
+    @Override
+    public void setValue(final String value) {
+        getWidget().setValue(value);
+        this.originalValue = value;
+    }
+
+    @Override
+    public String getValue() {
+        return getWidget().getValue();
+    }
+
+    @Override
+    public int getTabIndex() {
+        return getWidget().getTabIndex();
+    }
+
+    @Override
+    public void setAccessKey(final char key) {
+        getWidget().setAccessKey(key);
+    }
+
+    @Override
+    public void setFocus(final boolean focused) {
+        getWidget().setFocus(focused);
+    }
+
+    @Override
+    public void setTabIndex(final int index) {
+        getWidget().setTabIndex(index);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void flush(final String value) {
+
+        widget.getCodeEditor().ifPresent(c -> c.dispose());
+
+        if (Objects.equals(value, originalValue)) {
+            return;
+        }
+
+        final int rowIndex = context.getRowIndex();
+        final int columnIndex = context.getColumnIndex();
+
+        if (StringUtils.isEmpty(value)) {
+            sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
+                                          hasNoValueCommand.apply(new GridCellTuple(rowIndex,
+                                                                                    columnIndex,
+                                                                                    gridWidget)));
+        } else {
+            sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
+                                          hasValueCommand.apply(new GridCellValueTuple<>(rowIndex,
+                                                                                         columnIndex,
+                                                                                         gridWidget,
+                                                                                         new BaseGridCellValue<>(value))));
+        }
+    }
+
+    Element uncheckedCast(final com.google.gwt.user.client.Element element) {
+        return Js.uncheckedCast(element);
+    }
+
+    MonacoPropertiesFactory makeMonacoPropertiesFactory() {
+        return new MonacoPropertiesFactory();
+    }
+
+    MonacoEditorInitializer makeMonacoEditorInitializer() {
+        return new MonacoEditorInitializer();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorWidget.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom;
+
+import java.util.Optional;
+
+import com.google.gwt.user.client.DOM;
+import org.gwtbootstrap3.client.ui.base.TextBoxBase;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoStandaloneCodeEditor;
+
+public class MonacoEditorWidget extends TextBoxBase {
+
+    private MonacoStandaloneCodeEditor codeEditor;
+
+    public MonacoEditorWidget() {
+        super(DOM.createDiv());
+    }
+
+    public void setCodeEditor(final MonacoStandaloneCodeEditor codeEditor) {
+        this.codeEditor = codeEditor;
+    }
+
+    public void setValue(final String value) {
+        getCodeEditor().ifPresent(c -> c.setValue(value));
+    }
+
+    @Override
+    public String getValue() {
+        return getCodeEditor()
+                .map(editor -> editor.getValue())
+                .orElse("");
+    }
+
+    @Override
+    public void setFocus(final boolean focused) {
+        getCodeEditor().ifPresent(c -> {
+            if (focused) {
+                c.focus();
+            }
+            // IStandaloneCodeEditor(codeEditor) supports focus, but does not support blur.
+            // https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonecodeeditor.html
+        });
+    }
+
+    public Optional<MonacoStandaloneCodeEditor> getCodeEditor() {
+        return Optional.ofNullable(codeEditor);
+    }
+
+    @Override
+    public void setTabIndex(final int index) {
+        // IStandaloneCodeEditor(codeEditor) does not support tab index.
+        // https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonecodeeditor.html
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionContainerGridTest.java
@@ -53,6 +53,7 @@ import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCacheImpl;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.AutocompleteTextAreaDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl;
@@ -194,6 +195,9 @@ public class ExpressionContainerGridTest {
 
     @Mock
     private TextAreaSingletonDOMElementFactory textAreaSingletonDOMElementFactory;
+
+    @Mock
+    private AutocompleteTextAreaDOMElementFactory autocompleteTextareaDOMElementFactory;
 
     @Captor
     private ArgumentCaptor<Optional<HasName>> hasNameCaptor;
@@ -396,7 +400,7 @@ public class ExpressionContainerGridTest {
     public void testResizeContainerCorrectlyResizesExpressionComponentWidth() {
         final BaseGridData literalExpressionModel = new BaseGridData();
         final DMNGridColumn literalExpressionEditorColumn = new LiteralExpressionColumn(Collections.emptyList(),
-                                                                                        textAreaSingletonDOMElementFactory,
+                                                                                        autocompleteTextareaDOMElementFactory,
                                                                                         DMNGridColumn.DEFAULT_WIDTH,
                                                                                         literalExpressionEditor);
         literalExpressionModel.appendColumn(literalExpressionEditorColumn);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/BaseLiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/BaseLiteralExpressionGridTest.java
@@ -300,7 +300,7 @@ public abstract class BaseLiteralExpressionGridTest<G extends BaseDelegatingExpr
     public void testInitialColumnWidthsFromDefinition() {
         setupGrid(0);
 
-        assertComponentWidths(DMNGridColumn.DEFAULT_WIDTH);
+        assertComponentWidths(getDefaultWidth());
     }
 
     @Test
@@ -421,6 +421,10 @@ public abstract class BaseLiteralExpressionGridTest<G extends BaseDelegatingExpr
         grid.onItemSelected(listSelectorItem);
 
         verify(command).execute();
+    }
+
+    protected double getDefaultWidth() {
+        return DMNGridColumn.DEFAULT_WIDTH;
     }
 }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumnTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionColumnTest.java
@@ -24,32 +24,32 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.expressions.mocks.MockHasDOMElementResourcesHeaderMetaData;
 import org.kie.workbench.common.dmn.client.widgets.grid.columns.BaseDOMElementSingletonColumnTest;
-import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.TextAreaSingletonDOMElementFactory;
-import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.TextAreaDOMElement;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.AutocompleteTextAreaDOMElementFactory;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.MonacoEditorDOMElement;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class LiteralExpressionColumnTest extends BaseDOMElementSingletonColumnTest<TextAreaSingletonDOMElementFactory, TextAreaDOMElement, TextArea, LiteralExpressionColumn, LiteralExpressionGrid> {
+public class LiteralExpressionColumnTest extends BaseDOMElementSingletonColumnTest<AutocompleteTextAreaDOMElementFactory, MonacoEditorDOMElement, TextArea, LiteralExpressionColumn, LiteralExpressionGrid> {
 
     @Mock
-    private TextAreaSingletonDOMElementFactory factory;
+    private AutocompleteTextAreaDOMElementFactory factory;
 
     @Mock
-    private TextAreaDOMElement domElement;
+    private MonacoEditorDOMElement domElement;
 
     @Mock
     private TextArea widget;
 
     @Override
-    protected TextAreaSingletonDOMElementFactory getFactory() {
+    protected AutocompleteTextAreaDOMElementFactory getFactory() {
         return factory;
     }
 
     @Override
-    protected TextAreaDOMElement getDomElement() {
+    protected MonacoEditorDOMElement getDomElement() {
         return domElement;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGridTest.java
@@ -44,6 +44,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.NodeMouseEventHandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionGrid.LITERAL_EXPRESSION_DEFAULT_WIDTH;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
@@ -236,6 +237,11 @@ public class LiteralExpressionGridTest extends BaseLiteralExpressionGridTest<Lit
         setupGrid(0);
 
         assertThat(extractHeaderMetaData().asDMNModelInstrumentedBase()).isInstanceOf(hasExpression.getVariable().getClass());
+    }
+
+    @Override
+    protected double getDefaultWidth() {
+        return LITERAL_EXPRESSION_DEFAULT_WIDTH;
     }
 }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoFEELInitializerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoFEELInitializerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.codecompletion;
+
+import java.util.function.Consumer;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.core.client.JavaScriptObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.client.views.pfly.monaco.MonacoEditorInitializer;
+import org.uberfire.client.views.pfly.monaco.jsinterop.Monaco;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoEditor;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoLanguages;
+
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer.MonacoFEELInitializationStatus.INITIALIZED;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer.MonacoFEELInitializationStatus.INITIALIZING;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer.MonacoFEELInitializationStatus.NOT_INITIALIZED;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory.FEEL_LANGUAGE_ID;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory.FEEL_THEME_ID;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class MonacoFEELInitializerTest {
+
+    private MonacoFEELInitializer initializer;
+
+    @Before
+    public void setup() {
+        initializer = spy(new MonacoFEELInitializer());
+    }
+
+    @Test
+    public void testInitializeFEELEditorWhenEditorIsNotInitialized() {
+
+        final MonacoEditorInitializer monacoEditorInitializer = mock(MonacoEditorInitializer.class);
+        final Consumer<Monaco> onMonacoLoaded = m -> {/* Nothing. */};
+
+        doReturn(onMonacoLoaded).when(initializer).onMonacoLoaded();
+        doReturn(monacoEditorInitializer).when(initializer).makeMonacoEditorInitializer();
+        doReturn(NOT_INITIALIZED).when(initializer).getInitializationStatus();
+
+        initializer.initializeFEELEditor();
+
+        verify(monacoEditorInitializer).require(onMonacoLoaded);
+    }
+
+    @Test
+    public void testInitializeFEELEditorWhenEditorIsInitializing() {
+
+        final MonacoEditorInitializer monacoEditorInitializer = mock(MonacoEditorInitializer.class);
+
+        doReturn(monacoEditorInitializer).when(initializer).makeMonacoEditorInitializer();
+        doReturn(INITIALIZING).when(initializer).getInitializationStatus();
+
+        initializer.initializeFEELEditor();
+
+        verify(monacoEditorInitializer, never()).require(any());
+    }
+
+    @Test
+    public void testInitializeFEELEditorWhenEditorIsInitialized() {
+
+        final MonacoEditorInitializer monacoEditorInitializer = mock(MonacoEditorInitializer.class);
+
+        doReturn(monacoEditorInitializer).when(initializer).makeMonacoEditorInitializer();
+        doReturn(INITIALIZED).when(initializer).getInitializationStatus();
+
+        initializer.initializeFEELEditor();
+
+        verify(monacoEditorInitializer, never()).require(any());
+    }
+
+    @Test
+    public void testOnMonacoLoaded() {
+
+        final MonacoPropertiesFactory properties = mock(MonacoPropertiesFactory.class);
+        final MonacoLanguages languages = mock(MonacoLanguages.class);
+        final JavaScriptObject language = mock(JavaScriptObject.class);
+        final JavaScriptObject languageDefinition = mock(JavaScriptObject.class);
+        final JavaScriptObject completionItemProvider = mock(JavaScriptObject.class);
+        final JavaScriptObject themeData = mock(JavaScriptObject.class);
+        final JavaScriptObject constructionOptions = mock(JavaScriptObject.class);
+        final MonacoEditor editor = mock(MonacoEditor.class);
+        final Monaco monaco = mock(Monaco.class);
+
+        monaco.languages = languages;
+        monaco.editor = editor;
+
+        when(properties.getLanguage()).thenReturn(language);
+        when(properties.getLanguageDefinition()).thenReturn(languageDefinition);
+        when(properties.getCompletionItemProvider()).thenReturn(completionItemProvider);
+        when(properties.getThemeData()).thenReturn(themeData);
+        when(properties.getConstructionOptions()).thenReturn(constructionOptions);
+        when(properties.getConstructionOptions()).thenReturn(constructionOptions);
+        doReturn(properties).when(initializer).makeMonacoPropertiesFactory();
+
+        initializer.onMonacoLoaded().accept(monaco);
+
+        verify(languages).register(language);
+        verify(languages).setMonarchTokensProvider(FEEL_LANGUAGE_ID, languageDefinition);
+        verify(languages).registerCompletionItemProvider(FEEL_LANGUAGE_ID, completionItemProvider);
+        verify(languages).register(language);
+        verify(editor).defineTheme(FEEL_THEME_ID, themeData);
+        verify(initializer).setFEELAsInitialized();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoPropertiesFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/codecompletion/MonacoPropertiesFactoryTest.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.codecompletion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONBoolean;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+import com.google.gwt.json.client.JSONValue;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.core.RegExp;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoLanguages.ProvideCompletionItemsFunction;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory.FEEL_LANGUAGE_ID;
+import static org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory.FEEL_THEME_ID;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class MonacoPropertiesFactoryTest {
+
+    private MonacoPropertiesFactory factory;
+
+    @Before
+    public void setup() {
+        factory = spy(new MonacoPropertiesFactory());
+    }
+
+    @Test
+    public void testGetConstructionOptions() {
+
+        final JSONObject options = mock(JSONObject.class);
+        final JSONObject scrollbar = mock(JSONObject.class);
+        final JSONObject miniMap = mock(JSONObject.class);
+        final JSONString language = mock(JSONString.class);
+        final JSONString theme = mock(JSONString.class);
+        final JSONString renderLineHighlight = mock(JSONString.class);
+        final JSONString lineNumbers = mock(JSONString.class);
+        final JSONBoolean overviewRulerBorder = mock(JSONBoolean.class);
+        final JSONBoolean scrollBeyondLastLine = mock(JSONBoolean.class);
+        final JSONBoolean snippetSuggestions = mock(JSONBoolean.class);
+        final JSONBoolean useTabStops = mock(JSONBoolean.class);
+        final JSONBoolean contextmenu = mock(JSONBoolean.class);
+        final JSONBoolean folding = mock(JSONBoolean.class);
+        final JSONBoolean enabled = mock(JSONBoolean.class);
+        final JSONBoolean useShadows = mock(JSONBoolean.class);
+        final JSONValue fontSize = mock(JSONValue.class);
+        final JSONValue lineNumbersMinChars = mock(JSONValue.class);
+        final JSONValue lineDecorationsWidth = mock(JSONValue.class);
+        final JSONBoolean automaticLayout = mock(JSONBoolean.class);
+        final JSONBoolean renderWhitespace = mock(JSONBoolean.class);
+        final JSONBoolean hideCursorInOverviewRuler = mock(JSONBoolean.class);
+        final JavaScriptObject expectedOptions = mock(JavaScriptObject.class);
+
+        doReturn(language).when(factory).makeJSONString(FEEL_LANGUAGE_ID);
+        doReturn(theme).when(factory).makeJSONString(FEEL_THEME_ID);
+        doReturn(renderLineHighlight).when(factory).makeJSONString("none");
+        doReturn(lineNumbers).when(factory).makeJSONString("off");
+        doReturn(fontSize).when(factory).makeJSONNumber(12);
+
+        when(options.getJavaScriptObject()).thenReturn(expectedOptions);
+
+        // mocking spy with when(...).thenReturn(...) because the many calls are being mocked.
+        when(factory.makeJSONObject()).thenReturn(options, scrollbar, miniMap);
+        when(factory.makeJSONNumber(1)).thenReturn(lineNumbersMinChars, lineDecorationsWidth);
+        when(factory.makeJSONBoolean(false)).thenReturn(overviewRulerBorder, scrollBeyondLastLine, snippetSuggestions, useTabStops, contextmenu, folding, enabled, useShadows);
+        when(factory.makeJSONBoolean(true)).thenReturn(automaticLayout, renderWhitespace, hideCursorInOverviewRuler);
+
+        final JavaScriptObject actualOptions = factory.getConstructionOptions();
+
+        verify(options).put("language", language);
+        verify(options).put("theme", theme);
+        verify(options).put("renderLineHighlight", renderLineHighlight);
+        verify(options).put("fontSize", fontSize);
+        verify(options).put("lineNumbersMinChars", lineNumbersMinChars);
+        verify(options).put("lineDecorationsWidth", lineDecorationsWidth);
+        verify(options).put("overviewRulerBorder", overviewRulerBorder);
+        verify(options).put("scrollBeyondLastLine", scrollBeyondLastLine);
+        verify(options).put("snippetSuggestions", snippetSuggestions);
+        verify(options).put("useTabStops", useTabStops);
+        verify(options).put("contextmenu", contextmenu);
+        verify(options).put("folding", folding);
+        verify(miniMap).put("enabled", enabled);
+        verify(scrollbar).put("useShadows", useShadows);
+        verify(options).put("automaticLayout", automaticLayout);
+        verify(options).put("renderWhitespace", renderWhitespace);
+        verify(options).put("hideCursorInOverviewRuler", hideCursorInOverviewRuler);
+
+        assertEquals(expectedOptions, actualOptions);
+    }
+
+    @Test
+    public void testGetThemeData() {
+
+        final JSONObject themeDefinition = mock(JSONObject.class);
+        final JSONObject colors = mock(JSONObject.class);
+        final JSONString colorHEXCode = mock(JSONString.class);
+        final JSONString base = mock(JSONString.class);
+        final JSONBoolean inherit = mock(JSONBoolean.class);
+        final JSONArray rules = mock(JSONArray.class);
+        final JavaScriptObject expectedEditorThemeData = mock(JavaScriptObject.class);
+
+        doReturn(colorHEXCode).when(factory).makeJSONString("#000000");
+        doReturn(base).when(factory).makeJSONString("vs");
+        doReturn(inherit).when(factory).makeJSONBoolean(false);
+        doReturn(rules).when(factory).getRules();
+
+        when(themeDefinition.getJavaScriptObject()).thenReturn(expectedEditorThemeData);
+
+        // mocking spy with when(...).thenReturn(...) because the many calls are being mocked.
+        when(factory.makeJSONObject()).thenReturn(themeDefinition, colors);
+
+        final JavaScriptObject actualEditorThemeData = factory.getThemeData();
+
+        verify(colors).put("editorLineNumber.foreground", colorHEXCode);
+        verify(themeDefinition).put("base", base);
+        verify(themeDefinition).put("inherit", inherit);
+        verify(themeDefinition).put("rules", rules);
+        verify(themeDefinition).put("colors", colors);
+
+        assertEquals(expectedEditorThemeData, actualEditorThemeData);
+    }
+
+    @Test
+    public void testGetRules() {
+
+        final JSONObject rule1 = mock(JSONObject.class);
+        final JSONObject rule2 = mock(JSONObject.class);
+        final JSONObject rule3 = mock(JSONObject.class);
+        final JSONObject rule4 = mock(JSONObject.class);
+        final JSONObject rule5 = mock(JSONObject.class);
+        final JSONString token1 = mock(JSONString.class);
+        final JSONString foreground1 = mock(JSONString.class);
+        final JSONString token2 = mock(JSONString.class);
+        final JSONString foreground2 = mock(JSONString.class);
+        final JSONString token3 = mock(JSONString.class);
+        final JSONString foreground3 = mock(JSONString.class);
+        final JSONString token4 = mock(JSONString.class);
+        final JSONString foreground4 = mock(JSONString.class);
+        final JSONString token5 = mock(JSONString.class);
+        final JSONString foreground5 = mock(JSONString.class);
+        final JSONArray expectedRules = mock(JSONArray.class);
+        final JSONString bold = mock(JSONString.class);
+
+        doReturn(token1).when(factory).makeJSONString("feel-keyword");
+        doReturn(token2).when(factory).makeJSONString("feel-numeric");
+        doReturn(token3).when(factory).makeJSONString("feel-boolean");
+        doReturn(token4).when(factory).makeJSONString("feel-string");
+        doReturn(token5).when(factory).makeJSONString("feel-function");
+
+        doReturn(foreground1).when(factory).makeJSONString("26268C");
+        doReturn(foreground2).when(factory).makeJSONString("3232E7");
+        doReturn(foreground3).when(factory).makeJSONString("26268D");
+        doReturn(foreground4).when(factory).makeJSONString("2A9343");
+        doReturn(foreground5).when(factory).makeJSONString("3232E8");
+
+        doReturn(expectedRules).when(factory).makeJSONArray();
+        doReturn(bold).when(factory).makeJSONString("bold");
+
+        // mocking spy with when(...).thenReturn(...) because the many calls are being mocked.
+        when(factory.makeJSONObject()).thenReturn(rule1, rule2, rule3, rule4, rule5);
+
+        final JSONArray actualRules = factory.getRules();
+
+        verify(rule1).put("token", token1);
+        verify(rule2).put("token", token2);
+        verify(rule3).put("token", token3);
+        verify(rule4).put("token", token4);
+        verify(rule5).put("token", token5);
+
+        verify(rule1).put("foreground", foreground1);
+        verify(rule2).put("foreground", foreground2);
+        verify(rule3).put("foreground", foreground3);
+        verify(rule4).put("foreground", foreground4);
+        verify(rule5).put("foreground", foreground5);
+
+        verify(rule1).put("fontStyle", bold);
+        verify(rule4).put("fontStyle", bold);
+        verify(rule3).put("fontStyle", bold);
+
+        verify(factory).push(expectedRules, rule1);
+        verify(factory).push(expectedRules, rule2);
+        verify(factory).push(expectedRules, rule3);
+        verify(factory).push(expectedRules, rule4);
+        verify(factory).push(expectedRules, rule5);
+
+        assertEquals(expectedRules, actualRules);
+    }
+
+    @Test
+    public void testGetSuggestions() {
+
+        final JSONArray expectedSuggestions = mock(JSONArray.class);
+        final List<JSONValue> functions = new ArrayList<>();
+        final List<List<String>> suggestions = asList(
+                asList("abs(duration)", "abs($1)"),
+                asList("abs(number)", "abs($1)"),
+                asList("after(range, value)", "after($1, $2)"),
+                asList("after(range1, range2)", "after($1, $2)"),
+                asList("after(value, range)", "after($1, $2)"),
+                asList("after(value1, value2)", "after($1, $2)"),
+                asList("all(b)", "all($1)"),
+                asList("all(list)", "all($1)"),
+                asList("any(b)", "any($1)"),
+                asList("any(list)", "any($1)"),
+                asList("append(list, item)", "append($1, $2)"),
+                asList("before(range, value)", "before($1, $2)"),
+                asList("before(range1, range2)", "before($1, $2)"),
+                asList("before(value, range)", "before($1, $2)"),
+                asList("before(value1, value2)", "before($1, $2)"),
+                asList("ceiling(n)", "ceiling($1)"),
+                asList("code(value)", "code($1)"),
+                asList("coincides(range1, range2)", "coincides($1, $2)"),
+                asList("coincides(value1, value2)", "coincides($1, $2)"),
+                asList("concatenate(list)", "concatenate($1)"),
+                asList("contains(string, match)", "contains($1, $2)"),
+                asList("count(c)", "count($1)"),
+                asList("count(list)", "count($1)"),
+                asList("date and time(date, time)", "date and time($1, $2)"),
+                asList("date and time(from)", "date and time($1)"),
+                asList("date and time(year, month, day, hour, minute, second)", "date and time($1, $2, $3, $4, $5, $6)"),
+                asList("date and time(year, month, day, hour, minute, second, hour offset)", "date and time($1, $2, $3, $4, $5, $6, $7)"),
+                asList("date and time(year, month, day, hour, minute, second, timezone)", "date and time($1, $2, $3, $4, $5, $6, $7)"),
+                asList("date(from)", "date($1)"),
+                asList("date(year, month, day)", "date($1, $2, $3)"),
+                asList("day of week(date)", "day of week($1)"),
+                asList("day of year(date)", "day of year($1)"),
+                asList("decimal(n, scale)", "decimal($1, $2)"),
+                asList("decision table(ctx, outputs, input expression list, input values list, output values, rule list, hit policy, default output value)", "decision table($1, $2, $3, $4, $5, $6, $7, $8)"),
+                asList("distinct values(list)", "distinct values($1)"),
+                asList("duration(from)", "duration($1)"),
+                asList("during(range1, range2)", "during($1, $2)"),
+                asList("during(value, range)", "during($1, $2)"),
+                asList("ends with(string, match)", "ends with($1, $2)"),
+                asList("even(number)", "even($1)"),
+                asList("exp(number)", "exp($1)"),
+                asList("finished by(range, value)", "finished by($1, $2)"),
+                asList("finished by(range1, range2)", "finished by($1, $2)"),
+                asList("finishes(range1, range2)", "finishes($1, $2)"),
+                asList("finishes(value, range)", "finishes($1, $2)"),
+                asList("flatten(list)", "flatten($1)"),
+                asList("floor(n)", "floor($1)"),
+                asList("get entries(m)", "get entries($1)"),
+                asList("get value(m, key)", "get value($1, $2)"),
+                asList("includes(range, value)", "includes($1, $2)"),
+                asList("includes(range1, range2)", "includes($1, $2)"),
+                asList("index of(list, match)", "index of($1, $2)"),
+                asList("insert before(list, position, newItem)", "insert before($1, $2, $3)"),
+                asList("invoke(ctx, namespace, model name, decision name, parameters)", "invoke($1, $2, $3, $4, $5)"),
+                asList("list contains(list, element)", "list contains($1, $2)"),
+                asList("log(number)", "log($1)"),
+                asList("lower case(string)", "lower case($1)"),
+                asList("matches(input, pattern)", "matches($1, $2)"),
+                asList("matches(input, pattern, flags)", "matches($1, $2, $3)"),
+                asList("max(c)", "max($1)"),
+                asList("max(list)", "max($1)"),
+                asList("mean(list)", "mean($1)"),
+                asList("mean(n)", "mean($1)"),
+                asList("median(list)", "median($1)"),
+                asList("median(n)", "median($1)"),
+                asList("meets(range1, range2)", "meets($1, $2)"),
+                asList("met by(range1, range2)", "met by($1, $2)"),
+                asList("min(c)", "min($1)"),
+                asList("min(list)", "min($1)"),
+                asList("mode(list)", "mode($1)"),
+                asList("mode(n)", "mode($1)"),
+                asList("modulo(dividend, divisor)", "modulo($1, $2)"),
+                asList("month of year(date)", "month of year($1)"),
+                asList("nn all(b)", "nn all($1)"),
+                asList("nn all(list)", "nn all($1)"),
+                asList("nn any(b)", "nn any($1)"),
+                asList("nn any(list)", "nn any($1)"),
+                asList("nn count(c)", "nn count($1)"),
+                asList("nn count(list)", "nn count($1)"),
+                asList("nn max(c)", "nn max($1)"),
+                asList("nn max(list)", "nn max($1)"),
+                asList("nn mean(list)", "nn mean($1)"),
+                asList("nn mean(n)", "nn mean($1)"),
+                asList("nn median(list)", "nn median($1)"),
+                asList("nn median(n)", "nn median($1)"),
+                asList("nn min(c)", "nn min($1)"),
+                asList("nn min(list)", "nn min($1)"),
+                asList("nn mode(list)", "nn mode($1)"),
+                asList("nn mode(n)", "nn mode($1)"),
+                asList("nn stddev(list)", "nn stddev($1)"),
+                asList("nn stddev(n)", "nn stddev($1)"),
+                asList("nn sum(list)", "nn sum($1)"),
+                asList("nn sum(n)", "nn sum($1)"),
+                asList("not(negand)", "not($1)"),
+                asList("now()", "now()"),
+                asList("number(from, grouping separator, decimal separator)", "number($1, $2, $3)"),
+                asList("odd(number)", "odd($1)"),
+                asList("overlapped after by(range1, range2)", "overlapped after by($1, $2)"),
+                asList("overlapped before by(range1, range2)", "overlapped before by($1, $2)"),
+                asList("overlapped by(range1, range2)", "overlapped by($1, $2)"),
+                asList("overlaps after(range1, range2)", "overlaps after($1, $2)"),
+                asList("overlaps before(range1, range2)", "overlaps before($1, $2)"),
+                asList("overlaps(range1, range2)", "overlaps($1, $2)"),
+                asList("product(list)", "product($1)"),
+                asList("product(n)", "product($1)"),
+                asList("remove(list, position)", "remove($1, $2)"),
+                asList("replace(input, pattern, replacement)", "replace($1, $2, $3)"),
+                asList("replace(input, pattern, replacement, flags)", "replace($1, $2, $3, $4)"),
+                asList("reverse(list)", "reverse($1)"),
+                asList("sort()", "sort()"),
+                asList("sort(ctx, list, precedes)", "sort($1, $2, $3)"),
+                asList("sort(list)", "sort($1)"),
+                asList("split(string, delimiter)", "split($1, $2)"),
+                asList("split(string, delimiter, flags)", "split($1, $2, $3)"),
+                asList("sqrt(number)", "sqrt($1)"),
+                asList("started by(range, value)", "started by($1, $2)"),
+                asList("started by(range1, range2)", "started by($1, $2)"),
+                asList("starts with(string, match)", "starts with($1, $2)"),
+                asList("starts(range1, range2)", "starts($1, $2)"),
+                asList("starts(value, range)", "starts($1, $2)"),
+                asList("stddev(list)", "stddev($1)"),
+                asList("stddev(n)", "stddev($1)"),
+                asList("string length(string)", "string length($1)"),
+                asList("string(from)", "string($1)"),
+                asList("string(mask, p)", "string($1, $2)"),
+                asList("sublist(list, start position)", "sublist($1, $2)"),
+                asList("sublist(list, start position, length)", "sublist($1, $2, $3)"),
+                asList("substring after(string, match)", "substring after($1, $2)"),
+                asList("substring before(string, match)", "substring before($1, $2)"),
+                asList("substring(string, start position)", "substring($1, $2)"),
+                asList("substring(string, start position, length)", "substring($1, $2, $3)"),
+                asList("sum(list)", "sum($1)"),
+                asList("sum(n)", "sum($1)"),
+                asList("time(from)", "time($1)"),
+                asList("time(hour, minute, second)", "time($1, $2, $3)"),
+                asList("time(hour, minute, second, offset)", "time($1, $2, $3, $4)"),
+                asList("today()", "today()"),
+                asList("union(list)", "union($1)"),
+                asList("upper case(string)", "upper case($1)"),
+                asList("week of year(date)", "week of year($1)"),
+                asList("years and months duration(from, to)", "years and months duration($1, $2)"));
+
+        suggestions.forEach(suggestion -> {
+            final JSONValue function = mock(JSONValue.class);
+            functions.add(function);
+            doReturn(function).when(factory).getFunctionSuggestion(suggestion.get(0), suggestion.get(1));
+        });
+
+        doReturn(expectedSuggestions).when(factory).makeJSONArray();
+
+        final JSONArray actualSuggestions = factory.getSuggestions();
+
+        functions.forEach(function -> {
+            verify(factory).push(expectedSuggestions, function);
+        });
+        assertEquals(expectedSuggestions, actualSuggestions);
+    }
+
+    @Test
+    public void testGetFunctionSuggestion() {
+
+        final String label = "label";
+        final String insertText = "insertText";
+        final JSONValue kind = mock(JSONValue.class);
+        final JSONValue insertTextRules = mock(JSONValue.class);
+        final JSONObject expectedSuggestion = mock(JSONObject.class);
+        final JSONString labelString = mock(JSONString.class);
+        final JSONString insertTextString = mock(JSONString.class);
+
+        doReturn(expectedSuggestion).when(factory).makeJSONObject();
+        doReturn(kind).when(factory).makeJSONNumber(1);
+        doReturn(insertTextRules).when(factory).makeJSONNumber(4);
+        doReturn(labelString).when(factory).makeJSONString(label);
+        doReturn(insertTextString).when(factory).makeJSONString(insertText);
+
+        final JSONValue actualSuggestion = factory.getFunctionSuggestion(label, insertText);
+
+        verify(expectedSuggestion).put("kind", kind);
+        verify(expectedSuggestion).put("insertTextRules", insertTextRules);
+        verify(expectedSuggestion).put("label", labelString);
+        verify(expectedSuggestion).put("insertText", insertTextString);
+        assertEquals(expectedSuggestion, actualSuggestion);
+    }
+
+    @Test
+    public void testRow() {
+
+        final String pattern = "pattern";
+        final String name = "name";
+        final RegExp regExp = mock(RegExp.class);
+        final JSONObject jsonRegExp = mock(JSONObject.class);
+        final JSONString jsonName = mock(JSONString.class);
+        final JSONArray expectedRow = mock(JSONArray.class);
+
+        doReturn(regExp).when(factory).makeRegExp(pattern);
+        doReturn(jsonRegExp).when(factory).makeJSONObject(regExp);
+        doReturn(jsonName).when(factory).makeJSONString(name);
+        doReturn(expectedRow).when(factory).makeJSONArray();
+
+        final JSONValue actualRow = factory.row(pattern, name);
+
+        verify(expectedRow).set(0, jsonRegExp);
+        verify(expectedRow).set(1, jsonName);
+        assertEquals(expectedRow, actualRow);
+    }
+
+    @Test
+    public void testGetLanguage() {
+
+        final JSONString languageId = mock(JSONString.class);
+        final JavaScriptObject expectedLanguage = mock(JavaScriptObject.class);
+
+        doReturn(languageId).when(factory).makeJSONString(FEEL_LANGUAGE_ID);
+        doReturn(expectedLanguage).when(factory).makeJavaScriptObject("id", languageId);
+
+        final JavaScriptObject actualLanguage = factory.getLanguage();
+
+        assertEquals(expectedLanguage, actualLanguage);
+    }
+
+    @Test
+    public void testGetCompletionItemProvider() {
+
+        final ProvideCompletionItemsFunction provideCompletionItemsFunction = mock(ProvideCompletionItemsFunction.class);
+        final JSONObject functionObject = mock(JSONObject.class);
+        final JavaScriptObject expectedCompletionItemProvider = mock(JavaScriptObject.class);
+
+        doReturn(provideCompletionItemsFunction).when(factory).getProvideCompletionItemsFunction();
+        doReturn(functionObject).when(factory).makeJSONObject(provideCompletionItemsFunction);
+        doReturn(expectedCompletionItemProvider).when(factory).makeJavaScriptObject("provideCompletionItems", functionObject);
+
+        final JavaScriptObject actualCompletionItemProvider = factory.getCompletionItemProvider();
+
+        assertEquals(expectedCompletionItemProvider, actualCompletionItemProvider);
+    }
+
+    @Test
+    public void testGetProvideCompletionItemsFunction() {
+
+        final JavaScriptObject expectedSuggestions = mock(JavaScriptObject.class);
+        final JSONObject expectedJSONObjectSuggestions = mock(JSONObject.class);
+        final JSONArray suggestions = mock(JSONArray.class);
+
+        doReturn(expectedJSONObjectSuggestions).when(factory).makeJSONObject();
+        doReturn(suggestions).when(factory).getSuggestions();
+        when(expectedJSONObjectSuggestions.getJavaScriptObject()).thenReturn(expectedSuggestions);
+
+        final JavaScriptObject actualSuggestions = factory.getProvideCompletionItemsFunction().call();
+
+        verify(expectedJSONObjectSuggestions).put("suggestions", suggestions);
+        assertEquals(expectedSuggestions, actualSuggestions);
+    }
+
+    @Test
+    public void testGetLanguageDefinition() {
+
+        final JSONValue tokenizer = mock(JSONValue.class);
+        final JavaScriptObject expectedLanguageDefinition = mock(JavaScriptObject.class);
+
+        doReturn(expectedLanguageDefinition).when(factory).makeJavaScriptObject("tokenizer", tokenizer);
+        doReturn(tokenizer).when(factory).getTokenizer();
+
+        final JavaScriptObject actualLanguageDefinition = factory.getLanguageDefinition();
+
+        assertEquals(expectedLanguageDefinition, actualLanguageDefinition);
+    }
+
+    @Test
+    public void testGetTokenizer() {
+
+        final JSONObject expectedTokenizer = mock(JSONObject.class);
+        final JSONArray root = mock(JSONArray.class);
+
+        doReturn(expectedTokenizer).when(factory).makeJSONObject();
+        doReturn(root).when(factory).getRoot();
+
+        final JSONValue actualTokenizer = factory.getTokenizer();
+
+        verify(expectedTokenizer).put("root", root);
+        assertEquals(expectedTokenizer, actualTokenizer);
+    }
+
+    @Test
+    public void testGetRoot() {
+
+        final JSONArray expectedRoot = mock(JSONArray.class);
+        final JSONArray row1 = mock(JSONArray.class);
+        final JSONArray row2 = mock(JSONArray.class);
+        final JSONArray row3 = mock(JSONArray.class);
+        final JSONArray row4 = mock(JSONArray.class);
+        final JSONArray row5 = mock(JSONArray.class);
+        final JSONArray row6 = mock(JSONArray.class);
+
+        doReturn(expectedRoot).when(factory).makeJSONArray();
+        doReturn(row1).when(factory).row("(?:(\\btrue\\b)|(\\bfalse\\b))", "feel-boolean");
+        doReturn(row2).when(factory).row("[0-9]+", "feel-numeric");
+        doReturn(row3).when(factory).row("(?:\\\"(?:.*?)\\\")", "feel-string");
+        doReturn(row4).when(factory).row("(?:(?:[a-z ]+\\()|(?:\\()|(?:\\)))", "feel-function");
+        doReturn(row5).when(factory).row("(?:(\\bif\\b)|(\\bthen\\b)|(\\belse\\b))", "feel-keyword");
+        doReturn(row6).when(factory).row("(?:(\\bfor\\b)|(\\bin\\b)|(\\breturn\\b))", "feel-keyword");
+
+        final JSONArray actualRoot = factory.getRoot();
+
+        verify(factory).push(expectedRoot, row1);
+        verify(factory).push(expectedRoot, row2);
+        verify(factory).push(expectedRoot, row3);
+        verify(factory).push(expectedRoot, row4);
+        verify(factory).push(expectedRoot, row5);
+        verify(factory).push(expectedRoot, row6);
+        assertEquals(expectedRoot, actualRoot);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/AutocompleteTextAreaDOMElementFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/AutocompleteTextAreaDOMElementFactoryTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.columns.factory;
+
+import java.util.function.Function;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.commands.general.DeleteCellValueCommand;
+import org.kie.workbench.common.dmn.client.commands.general.SetCellValueCommand;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.MonacoEditorDOMElement;
+import org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom.MonacoEditorWidget;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
+import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.keyboard.KeyDownHandlerCommon;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class AutocompleteTextAreaDOMElementFactoryTest extends BaseSingletonDOMElementFactoryTest<AutocompleteTextAreaDOMElementFactory, MonacoEditorDOMElement> {
+
+    @Mock
+    private KeyDownEvent event;
+
+    @Override
+    protected AutocompleteTextAreaDOMElementFactory getFactoryForAttachDomElementTest() {
+        return new AutocompleteTextAreaDOMElementFactoryFake(gridPanel,
+                                                             gridLayer,
+                                                             gridWidget,
+                                                             sessionManager,
+                                                             sessionCommandManager,
+                                                             (gc) -> new DeleteCellValueCommand(gc,
+                                                                                                () -> uiModelMapper,
+                                                                                                gridLayer::batch),
+                                                             (gcv) -> new SetCellValueCommand(gcv,
+                                                                                              () -> uiModelMapper,
+                                                                                              gridLayer::batch)) {
+        };
+    }
+
+    @Override
+    protected AutocompleteTextAreaDOMElementFactory getFactoryForFlushTest() {
+        return new AutocompleteTextAreaDOMElementFactoryFake(gridPanel,
+                                                             gridLayer,
+                                                             gridWidget,
+                                                             sessionManager,
+                                                             sessionCommandManager,
+                                                             (gc) -> new DeleteCellValueCommand(gc,
+                                                                                                () -> uiModelMapper,
+                                                                                                gridLayer::batch),
+                                                             (gcv) -> new SetCellValueCommand(gcv,
+                                                                                              () -> uiModelMapper,
+                                                                                              gridLayer::batch));
+    }
+
+    @Test
+    public void testKeyDownHandlerCommon_KEY_TAB() {
+        final AutocompleteTextAreaDOMElementFactory factory = spy(getFactoryForAttachDomElementTest());
+        final KeyDownHandlerCommon keyDownHandlerCommon = factory.destroyOrFlushKeyDownHandler();
+
+        when(event.getNativeKeyCode()).thenReturn(KeyCodes.KEY_TAB);
+
+        keyDownHandlerCommon.onKeyDown(event);
+
+        verify(factory).flush();
+    }
+
+    @Test
+    public void testKeyDownHandlerCommon_KEY_ENTER() {
+        final AutocompleteTextAreaDOMElementFactory factory = spy(getFactoryForAttachDomElementTest());
+        final KeyDownHandlerCommon keyDownHandlerCommon = factory.destroyOrFlushKeyDownHandler();
+
+        when(event.getNativeKeyCode()).thenReturn(KeyCodes.KEY_ENTER);
+
+        keyDownHandlerCommon.onKeyDown(event);
+
+        verify(factory, never()).flush();
+    }
+
+    @Test
+    public void testKeyDownHandlerCommon_KEY_ESCAPE() {
+        final AutocompleteTextAreaDOMElementFactory factory = spy(getFactoryForAttachDomElementTest());
+        final KeyDownHandlerCommon keyDownHandlerCommon = factory.destroyOrFlushKeyDownHandler();
+
+        when(event.getNativeKeyCode()).thenReturn(KeyCodes.KEY_ESCAPE);
+
+        keyDownHandlerCommon.onKeyDown(event);
+
+        verify(factory, never()).flush();
+    }
+
+    @Test
+    public void testCreateDomElementInternal() {
+
+        final MonacoEditorWidget widget = mock(MonacoEditorWidget.class);
+        final MonacoEditorDOMElement domElement = getFactoryForAttachDomElementTest().createDomElementInternal(widget, gridLayer, gridWidget);
+
+        verify(domElement).setupElements();
+    }
+
+    static class AutocompleteTextAreaDOMElementFactoryFake extends AutocompleteTextAreaDOMElementFactory {
+
+        AutocompleteTextAreaDOMElementFactoryFake(final DMNGridPanel gridPanel,
+                                                  final GridLayer gridLayer,
+                                                  final GridWidget gridWidget,
+                                                  final SessionManager sessionManager,
+                                                  final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                                  final Function<GridCellTuple, Command> hasNoValueCommand,
+                                                  final Function<GridCellValueTuple, Command> hasValueCommand) {
+            super(gridPanel, gridLayer, gridWidget, sessionManager, sessionCommandManager, hasNoValueCommand, hasValueCommand);
+        }
+
+        @Override
+        protected MonacoEditorDOMElement makeMonacoEditorDOMElement(final MonacoEditorWidget widget,
+                                                                    final GridLayer gridLayer,
+                                                                    final GridWidget gridWidget) {
+            final MonacoEditorDOMElement domElement = spy(super.makeMonacoEditorDOMElement(widget, gridLayer, gridWidget));
+            doNothing().when(domElement).setupElements();
+            return domElement;
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorDOMElementTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorDOMElementTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.SimplePanel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.commands.general.DeleteCellValueCommand;
+import org.kie.workbench.common.dmn.client.commands.general.SetCellValueCommand;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoPropertiesFactory;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellTuple;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.GridCellValueTuple;
+import org.kie.workbench.common.stunner.core.client.api.SessionManager;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.command.Command;
+import org.mockito.Mock;
+import org.uberfire.client.views.pfly.monaco.MonacoEditorInitializer;
+import org.uberfire.client.views.pfly.monaco.jsinterop.Monaco;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoEditor;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoStandaloneCodeEditor;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoStandaloneCodeEditor.CallbackFunction;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static com.google.gwt.dom.client.Style.Unit.PCT;
+import static com.google.gwt.dom.client.Style.Unit.PX;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class MonacoEditorDOMElementTest extends BaseDOMElementTest<MonacoEditorWidget, MonacoEditorDOMElementTest.MonacoEditorDOMElementFake> {
+
+    @Mock
+    private MonacoEditorWidget monacoEditorWidget;
+
+    @Override
+    protected MonacoEditorWidget getWidget() {
+        when(monacoEditorWidget.getCodeEditor()).thenReturn(Optional.empty());
+        return monacoEditorWidget;
+    }
+
+    @Override
+    protected MonacoEditorDOMElementFake getDomElement() {
+        return spy(new MonacoEditorDOMElementFake(widget,
+                                                  gridLayer,
+                                                  gridWidget,
+                                                  sessionManager,
+                                                  sessionCommandManager,
+                                                  (gc) -> new DeleteCellValueCommand(gc,
+                                                                                     () -> uiModelMapper,
+                                                                                     gridLayer::batch),
+                                                  (gcv) -> new SetCellValueCommand(gcv,
+                                                                                   () -> uiModelMapper,
+                                                                                   gridLayer::batch)));
+    }
+
+    @Test
+    public void testSetValue() {
+        domElement.setValue(VALUE);
+        verify(widget).setValue(VALUE);
+    }
+
+    @Test
+    public void testGetValue() {
+        domElement.getValue();
+        verify(widget).getValue();
+    }
+
+    @Test
+    public void testSetupElements() {
+
+        doNothing().when(domElement).setupContainerComponent();
+        doNothing().when(domElement).setupInternalComponent();
+
+        domElement.setupElements();
+
+        verify(domElement).setupContainerComponent();
+        verify(domElement).setupInternalComponent();
+    }
+
+    @Test
+    public void testSetupContainerComponent() {
+
+        final SimplePanel container = mock(SimplePanel.class);
+        final Element element = mock(Element.class);
+        final Style style = mock(Style.class);
+
+        doReturn(container).when(domElement).getContainer();
+        when(container.getElement()).thenReturn(element);
+        when(element.getStyle()).thenReturn(style);
+
+        domElement.setupContainerComponent();
+
+        verify(style).setPadding(5, PX);
+        verify(container).setWidget(widget);
+    }
+
+    @Test
+    public void testSetupInternalComponent() {
+
+        final MonacoEditorInitializer editorInitializer = mock(MonacoEditorInitializer.class);
+        final Element element = mock(Element.class);
+        final Style style = mock(Style.class);
+        final Consumer<Monaco> onMonacoLoaded = m -> {/* Nothing. */};
+
+        doReturn(editorInitializer).when(domElement).makeMonacoEditorInitializer();
+        doReturn(onMonacoLoaded).when(domElement).onMonacoLoaded();
+        when(widget.getElement()).thenReturn(element);
+        when(element.getStyle()).thenReturn(style);
+
+        domElement.setupInternalComponent();
+
+        verify(style).setWidth(100, PCT);
+        verify(style).setHeight(100, PCT);
+        verify(editorInitializer).require(onMonacoLoaded);
+    }
+
+    @Test
+    public void testOnMonacoLoaded() {
+
+        final MonacoPropertiesFactory properties = mock(MonacoPropertiesFactory.class);
+        final JavaScriptObject constructionOptions = mock(JavaScriptObject.class);
+        final Monaco monaco = mock(Monaco.class);
+        final MonacoEditor editor = mock(MonacoEditor.class);
+        final MonacoStandaloneCodeEditor standaloneCodeEditor = mock(MonacoStandaloneCodeEditor.class);
+        final com.google.gwt.user.client.Element element = mock(com.google.gwt.user.client.Element.class);
+        final elemental2.dom.Element elemental2Element = mock(elemental2.dom.Element.class);
+        final CallbackFunction onKeyDown = mock(CallbackFunction.class);
+
+        monaco.editor = editor;
+
+        when(widget.getElement()).thenReturn(element);
+        when(properties.getConstructionOptions()).thenReturn(constructionOptions);
+        doReturn(onKeyDown).when(domElement).getOnKeyDown(standaloneCodeEditor);
+        doReturn(properties).when(domElement).makeMonacoPropertiesFactory();
+        doReturn(elemental2Element).when(domElement).uncheckedCast(element);
+        doReturn(standaloneCodeEditor).when(editor).create(elemental2Element, constructionOptions);
+
+        domElement.onMonacoLoaded().accept(monaco);
+
+        verify(standaloneCodeEditor).onKeyDown(onKeyDown);
+        verify(widget).setCodeEditor(standaloneCodeEditor);
+        verify(widget).setFocus(true);
+    }
+
+    @Test
+    public void testGetOnKeyDownWhenSuggestWidgetIsVisibleAndKeyCodeIsEsc() {
+
+        final MonacoStandaloneCodeEditor codeEditor = mock(MonacoStandaloneCodeEditor.class);
+        final NativeEvent event = mock(NativeEvent.class);
+
+        when(event.getKeyCode()).thenReturn(9);
+        when(codeEditor.isSuggestWidgetVisible()).thenReturn(true);
+
+        domElement.getOnKeyDown(codeEditor).call(event);
+
+        verify(codeEditor).trigger("keyboard", "cursorHome");
+        verify(codeEditor).trigger("keyboard", "cursorEnd");
+        verify(event).stopPropagation();
+        verify(event).preventDefault();
+    }
+
+    @Test
+    public void testGetOnKeyDownWhenSuggestWidgetIsVisibleAndKeyCodeIsNotEsc() {
+
+        final MonacoStandaloneCodeEditor codeEditor = mock(MonacoStandaloneCodeEditor.class);
+        final NativeEvent event = mock(NativeEvent.class);
+
+        when(event.getKeyCode()).thenReturn(10);
+        when(codeEditor.isSuggestWidgetVisible()).thenReturn(true);
+
+        domElement.getOnKeyDown(codeEditor).call(event);
+
+        verify(codeEditor, never()).trigger("keyboard", "cursorHome");
+        verify(codeEditor, never()).trigger("keyboard", "cursorEnd");
+        verify(event, never()).stopPropagation();
+        verify(event, never()).preventDefault();
+    }
+
+    @Test
+    public void testGetOnKeyDownWhenSuggestWidgetIsNotVisibleAndKeyCodeIsEsc() {
+
+        final MonacoStandaloneCodeEditor codeEditor = mock(MonacoStandaloneCodeEditor.class);
+        final NativeEvent event = mock(NativeEvent.class);
+
+        when(event.getKeyCode()).thenReturn(9);
+        when(codeEditor.isSuggestWidgetVisible()).thenReturn(false);
+
+        domElement.getOnKeyDown(codeEditor).call(event);
+
+        verify(codeEditor, never()).trigger("keyboard", "cursorHome");
+        verify(codeEditor, never()).trigger("keyboard", "cursorEnd");
+        verify(event, never()).stopPropagation();
+        verify(event, never()).preventDefault();
+    }
+
+    @Test
+    public void testGetOnKeyDownWhenSuggestWidgetIsNotVisibleAndKeyCodeIsNotEsc() {
+
+        final MonacoStandaloneCodeEditor codeEditor = mock(MonacoStandaloneCodeEditor.class);
+        final NativeEvent event = mock(NativeEvent.class);
+
+        when(event.getKeyCode()).thenReturn(10);
+        when(codeEditor.isSuggestWidgetVisible()).thenReturn(false);
+
+        domElement.getOnKeyDown(codeEditor).call(event);
+
+        verify(codeEditor, never()).trigger("keyboard", "cursorHome");
+        verify(codeEditor, never()).trigger("keyboard", "cursorEnd");
+        verify(event, never()).stopPropagation();
+        verify(event, never()).preventDefault();
+    }
+
+    @Test
+    public void testInitialise() {
+        final GridBodyCellRenderContext context = mock(GridBodyCellRenderContext.class);
+        domElement.initialise(context);
+        verify(domElement).transform(context);
+    }
+
+    static class MonacoEditorDOMElementFake extends MonacoEditorDOMElement {
+
+        MonacoEditorDOMElementFake(final MonacoEditorWidget widget,
+                                   final GridLayer gridLayer,
+                                   final GridWidget gridWidget,
+                                   final SessionManager sessionManager,
+                                   final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager,
+                                   final Function<GridCellTuple, Command> hasNoValueCommand,
+                                   final Function<GridCellValueTuple, Command> hasValueCommand) {
+            super(widget, gridLayer, gridWidget, sessionManager, sessionCommandManager, hasNoValueCommand, hasValueCommand);
+        }
+
+        @Override
+        protected SimplePanel getContainer() {
+            return super.getContainer();
+        }
+
+        @Override
+        protected void transform(final GridBodyCellRenderContext context) {
+            // empty
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/columns/factory/dom/MonacoEditorWidgetTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.columns.factory.dom;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoStandaloneCodeEditor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class MonacoEditorWidgetTest {
+
+    @Mock
+    private MonacoStandaloneCodeEditor codeEditor;
+
+    private MonacoEditorWidget widget;
+
+    @Before
+    public void setup() {
+        widget = spy(new MonacoEditorWidget());
+        widget.setCodeEditor(codeEditor);
+    }
+
+    @Test
+    public void testSetValueWhenCodeEditorIsPresent() {
+
+        final String value = "value";
+
+        widget.setValue(value);
+
+        verify(codeEditor).setValue(value);
+    }
+
+    @Test
+    public void testSetValueWhenCodeEditorIsNotPresent() {
+
+        final String value = "value";
+
+        widget.setCodeEditor(null);
+        widget.setValue(value);
+
+        verifyNoMoreInteractions(codeEditor);
+    }
+
+    @Test
+    public void testGetValueWhenCodeEditorIsPresent() {
+
+        final String expectedValue = "value";
+
+        when(codeEditor.getValue()).thenReturn(expectedValue);
+
+        final String actualValue = widget.getValue();
+
+        assertEquals(expectedValue, actualValue);
+    }
+
+    @Test
+    public void testGetValueWhenCodeEditorIsNotPresent() {
+
+        final String expectedValue = "";
+
+        widget.setCodeEditor(null);
+        when(widget.getValue()).thenReturn(expectedValue);
+
+        final String actualValue = widget.getValue();
+
+        assertEquals(expectedValue, actualValue);
+    }
+
+    @Test
+    public void testSetFocusWhenFocusIsEnabled() {
+        widget.setFocus(true);
+        verify(codeEditor).focus();
+    }
+
+    @Test
+    public void testSetFocusWhenFocusIsNotEnabled() {
+        widget.setFocus(false);
+        verify(codeEditor, never()).focus();
+    }
+
+    @Test
+    public void testSetFocusWhenCodeEditorIsNotPresent() {
+        widget.setCodeEditor(null);
+        widget.setFocus(true);
+        verify(codeEditor, never()).focus();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -47,6 +47,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.project.client.resources.i18n.DMNProjectClientConstants;
 import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
@@ -129,6 +130,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
     private final IncludedModelsPageStateProviderImpl importsPageProvider;
     private final DMNEditorSearchIndex editorSearchIndex;
     private final SearchBarComponent<DMNSearchableElement> searchBarComponent;
+    private final MonacoFEELInitializer feelInitializer;
 
     @Inject
     public DMNDiagramEditor(final View view,
@@ -157,7 +159,8 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final IncludedModelsPage includedModelsPage,
                             final IncludedModelsPageStateProviderImpl importsPageProvider,
                             final DMNEditorSearchIndex editorSearchIndex,
-                            final SearchBarComponent<DMNSearchableElement> searchBarComponent) {
+                            final SearchBarComponent<DMNSearchableElement> searchBarComponent,
+                            final MonacoFEELInitializer feelInitializer) {
         super(view,
               xmlEditorView,
               editorSessionPresenterInstances,
@@ -185,6 +188,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         this.importsPageProvider = importsPageProvider;
         this.editorSearchIndex = editorSearchIndex;
         this.searchBarComponent = searchBarComponent;
+        this.feelInitializer = feelInitializer;
     }
 
     @Override
@@ -194,6 +198,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         getMenuSessionItems().setErrorConsumer(e -> hideLoadingViews());
         editorSearchIndex.setCurrentAssetHashcodeSupplier(getGetCurrentContentHashSupplier());
         editorSearchIndex.setIsDataTypesTabActiveSupplier(getIsDataTypesTabActiveSupplier());
+        feelInitializer.initializeFEELEditor();
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.project.client.resources.i18n.DMNProjectClientConstants;
 import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
@@ -177,6 +178,9 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     private HTMLElement searchBarComponentViewElement;
 
     @Mock
+    private MonacoFEELInitializer feelInitializer;
+
+    @Mock
     private ElementWrapperWidget searchBarComponentWidget;
 
     @Captor
@@ -236,7 +240,8 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                  includedModelsPage,
                                                  importsPageProvider,
                                                  editorSearchIndex,
-                                                 searchBarComponent) {
+                                                 searchBarComponent,
+                                                 feelInitializer) {
             {
                 docks = DMNDiagramEditorTest.this.docks;
                 fileMenuBuilder = DMNDiagramEditorTest.this.fileMenuBuilder;
@@ -307,6 +312,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
 
         //DMNProjectEditorMenuSessionItems.setErrorConsumer(..) is called several times so just check the last invocation
         verify(dmnProjectMenuSessionItems, atLeast(1)).setErrorConsumer(errorConsumerCaptor.capture());
+        verify(feelInitializer, atLeast(1)).initializeFEELEditor();
 
         errorConsumerCaptor.getValue().accept("ERROR");
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.webapp.common.client.docks.preview.PreviewDiagramDock;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
@@ -111,6 +112,7 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
     protected final SearchBarComponent<DMNSearchableElement> searchBarComponent;
 
     protected final KogitoClientDiagramService diagramServices;
+    protected final MonacoFEELInitializer feelInitializer;
 
     public AbstractDMNDiagramEditor(final View view,
                                     final FileMenuBuilder fileMenuBuilder,
@@ -138,7 +140,8 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
                                     final LayoutHelper layoutHelper,
                                     final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                                     final DataTypesPage dataTypesPage,
-                                    final KogitoClientDiagramService diagramServices) {
+                                    final KogitoClientDiagramService diagramServices,
+                                    final MonacoFEELInitializer feelInitializer) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -171,6 +174,7 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
         this.searchBarComponent = searchBarComponent;
 
         this.diagramServices = diagramServices;
+        this.feelInitializer = feelInitializer;
     }
 
     @OnStartup
@@ -181,6 +185,8 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
         decisionNavigatorDock.init(PERSPECTIVE_ID);
         diagramPropertiesDock.init(PERSPECTIVE_ID);
         diagramPreviewAndExplorerDock.init(PERSPECTIVE_ID);
+
+        feelInitializer.initializeFEELEditor();
     }
 
     void superDoStartUp(final PlaceRequest place) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.webapp.common.client.docks.preview.PreviewDiagramDock;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
@@ -227,6 +228,9 @@ public abstract class AbstractDMNDiagramEditorTest {
     @Mock
     protected ClientRuntimeError clientRuntimeError;
 
+    @Mock
+    protected MonacoFEELInitializer feelInitializer;
+
     @Captor
     protected ArgumentCaptor<KogitoDiagramResourceImpl> kogitoDiagramResourceArgumentCaptor;
 
@@ -292,6 +296,7 @@ public abstract class AbstractDMNDiagramEditorTest {
         verify(fileMenuBuilder).build();
 
         verify(multiPageEditorContainerView).init(eq(editor));
+        verify(feelInitializer).initializeFEELEditor();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.webapp.common.client.docks.preview.PreviewDiagramDock;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditor;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.DMNEditorMenuSessionItems;
@@ -100,7 +101,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final LayoutHelper layoutHelper,
                             final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                             final DataTypesPage dataTypesPage,
-                            final KogitoClientDiagramService diagramServices) {
+                            final KogitoClientDiagramService diagramServices,
+                            final MonacoFEELInitializer feelInitializer) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -127,7 +129,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               layoutHelper,
               openDiagramLayoutExecutor,
               dataTypesPage,
-              diagramServices);
+              diagramServices,
+              feelInitializer);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -66,7 +66,8 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                                     layoutHelper,
                                     layoutExecutor,
                                     dataTypesPage,
-                                    clientDiagramService) {
+                                    clientDiagramService,
+                                    feelInitializer) {
             @Override
             protected ElementWrapperWidget<?> getWidget(final HTMLElement element) {
                 return searchBarComponentWidget;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.showcase.client.navigator.DMNVFSService;
 import org.kie.workbench.common.dmn.webapp.common.client.docks.preview.PreviewDiagramDock;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditor;
@@ -124,7 +125,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final DataTypesPage dataTypesPage,
                             final KogitoClientDiagramService diagramServices,
                             final DMNVFSService vfsService,
-                            final Promises promises) {
+                            final Promises promises,
+                            final MonacoFEELInitializer feelInitializer) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -151,7 +153,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               layoutHelper,
               openDiagramLayoutExecutor,
               dataTypesPage,
-              diagramServices);
+              diagramServices,
+              feelInitializer);
         this.notificationEvent = notificationEvent;
         this.vfsService = vfsService;
         this.promises = promises;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -142,7 +142,8 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                                     dataTypesPage,
                                     clientDiagramService,
                                     vfsService,
-                                    promises) {
+                                    promises,
+                                    feelInitializer) {
 
             @Override
             protected PlaceRequest getPlaceRequest() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNEditorToolbar;
 import org.kie.workbench.common.dmn.showcase.client.perspectives.AuthoringPerspective;
 import org.kie.workbench.common.dmn.showcase.client.services.DMNShowcaseDiagramService;
@@ -141,6 +142,7 @@ public class DMNDiagramEditor implements KieEditorWrapperView.KieEditorWrapperPr
     private final ScreenPanelView screenPanelView;
     private final ScreenErrorView screenErrorView;
     private final KieEditorWrapperView kieView;
+    private final MonacoFEELInitializer feelInitializer;
 
     private PlaceRequest placeRequest;
     private String title = "Authoring Screen";
@@ -170,7 +172,8 @@ public class DMNDiagramEditor implements KieEditorWrapperView.KieEditorWrapperPr
                             final MenuDevCommandsBuilder menuDevCommandsBuilder,
                             final ScreenPanelView screenPanelView,
                             final ScreenErrorView screenErrorView,
-                            final KieEditorWrapperView kieView) {
+                            final KieEditorWrapperView kieView,
+                            final MonacoFEELInitializer feelInitializer) {
         this.sessionManager = sessionManager;
         this.sessionCommandManager = sessionCommandManager;
         this.presenter = presenter;
@@ -199,6 +202,7 @@ public class DMNDiagramEditor implements KieEditorWrapperView.KieEditorWrapperPr
         this.screenPanelView = screenPanelView;
         this.screenErrorView = screenErrorView;
         this.kieView = kieView;
+        this.feelInitializer = feelInitializer;
     }
 
     @PostConstruct
@@ -213,6 +217,7 @@ public class DMNDiagramEditor implements KieEditorWrapperView.KieEditorWrapperPr
         kieView.getMultiPage().addPage(getDocumentationPage());
         kieView.getMultiPage().addPage(dataTypesPage);
         kieView.getMultiPage().addPage(includedModelsPage);
+        feelInitializer.initializeFEELEditor();
 
         setupEditorSearchIndex();
         setupSearchComponent();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
+import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.showcase.client.perspectives.AuthoringPerspective;
 import org.kie.workbench.common.dmn.webapp.common.client.docks.preview.PreviewDiagramDock;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
@@ -147,6 +148,9 @@ public class DMNDiagramEditorTest {
     private HTMLElement searchBarComponentViewElement;
 
     @Mock
+    private MonacoFEELInitializer feelInitializer;
+
+    @Mock
     private ElementWrapperWidget searchBarComponentWidget;
     private DMNDiagramEditor editor;
 
@@ -195,7 +199,8 @@ public class DMNDiagramEditorTest {
                                           null,
                                           screenPanelView,
                                           null,
-                                          kieView));
+                                          kieView,
+                                          feelInitializer));
 
         doReturn(searchBarComponentWidget).when(editor).getWidget(searchBarComponentViewElement);
     }
@@ -225,6 +230,7 @@ public class DMNDiagramEditorTest {
         verify(kieView).addMainEditorPage(screenPanelWidget);
         verify(multiPageEditor).addPage(dataTypesPage);
         verify(multiPageEditor).addPage(includedModelsPage);
+        verify(feelInitializer).initializeFEELEditor();
         verify(multiPageEditor).addPage(documentationPage);
         verify(editorSearchIndex).setIsDataTypesTabActiveSupplier(isDataTypesTabActiveSupplier);
         verify(editorSearchIndex).setCurrentAssetHashcodeSupplier(hashcodeSupplier);


### PR DESCRIPTION
See:
- [DROOLS-4689](https://issues.jboss.org/browse/DROOLS-4689): [DMN Designer] Code Completion - Setup Monaco (loader)
- [DROOLS-4690](https://issues.jboss.org/browse/DROOLS-4690): [DMN Designer] Code Completion - Add Monaco support for 'TextAreaSingletonDOMElementFactory'
- [DROOLS-4691](https://issues.jboss.org/browse/DROOLS-4691): [DMN Designer] Code Completion - Enable code completion for only Literal Expressions
- [DROOLS-4692](https://issues.jboss.org/browse/DROOLS-4692): [DMN Designer] Code Completion - UI adjusts for Monaco component into DMN Boxed Expression component

---

![2019-11-07 14 31 45](https://user-images.githubusercontent.com/1079279/68412704-74bea100-016b-11ea-80b8-c421d9c337c7.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/836
- https://github.com/kiegroup/kie-wb-common/pull/3000
