### PR TITLE
DROOLS-4735: [DMN Designer] Grid performance is dire

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -38,7 +38,6 @@ import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommand
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
-import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.kie.workbench.common.dmn.client.widgets.grid.BoundaryTransformMediator;
 import org.kie.workbench.common.dmn.client.widgets.grid.ExpressionGridCache;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.container.CellEditorControlsView;
@@ -132,10 +131,6 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         this.domainObjectSelectionEvent = domainObjectSelectionEvent;
     }
 
-    Optional<BaseExpressionGrid> getExistingEditor() {
-        return expressionContainerGrid.getExistingEditor();
-    }
-
     @Override
     public void init(final ExpressionEditorView.Presenter presenter) {
         this.presenter = presenter;
@@ -157,7 +152,6 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         final Transform transform = new Transform().scale(VP_SCALE);
         gridPanel.getElement().setId("dmn_container_" + com.google.gwt.dom.client.Document.get().createUniqueId());
         gridPanel.getViewport().setTransform(transform);
-        gridPanel.add(gridLayer);
 
         final BaseGridWidgetKeyboardHandler handler = new BaseGridWidgetKeyboardHandler(gridLayer);
         addKeyboardOperation(handler, new KeyboardOperationEditCell(gridLayer));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGrid.java
@@ -174,7 +174,8 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     public DecisionTableUIModelMapper makeUiModelMapper() {
         return new DecisionTableUIModelMapper(this::getModel,
                                               getExpression(),
-                                              listSelector);
+                                              listSelector,
+                                              getExpressionTextLineHeight(getRenderer().getTheme()));
     }
 
     @Override
@@ -246,10 +247,6 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
                                                                  getAndSetInitialWidth(index, DMNGridColumn.DEFAULT_WIDTH),
                                                                  this);
         return column;
-    }
-
-    private GridRow makeDecisionTableRow() {
-        return new LiteralExpressionGridRow(getExpressionTextLineHeight(getRenderer().getTheme()));
     }
 
     private Supplier<List<GridColumn.HeaderMetaData>> outputClauseHeaderMetaData(final OutputClause oc) {
@@ -392,7 +389,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
     @Override
     public void initialiseUiRows() {
         getExpression().get().ifPresent(e -> {
-            e.getRule().forEach(r -> model.appendRow(makeDecisionTableRow()));
+            e.getRule().forEach(r -> model.appendRow(new LiteralExpressionGridRow()));
         });
     }
 
@@ -654,7 +651,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
 
     void addDecisionRule(final int index) {
         getExpression().get().ifPresent(dtable -> {
-            final GridRow decisionTableRow = makeDecisionTableRow();
+            final GridRow decisionTableRow = new LiteralExpressionGridRow();
             final DecisionRule decisionRule = DecisionRuleFactory.makeDecisionRule(dtable);
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new AddDecisionRuleCommand(dtable,
@@ -679,7 +676,7 @@ public class DecisionTableGrid extends BaseExpressionGrid<DecisionTable, Decisio
 
     void duplicateDecisionRule(final int index) {
         getExpression().get().ifPresent(dtable -> {
-            final GridRow decisionTableRow = makeDecisionTableRow();
+            final GridRow decisionTableRow = new LiteralExpressionGridRow();
             final DecisionRule decisionRule = DecisionRuleFactory.duplicateDecisionRule(index, dtable);
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new AddDecisionRuleCommand(dtable,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCell.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCell.java
@@ -19,16 +19,17 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridCell;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 
-public class DecisionTableGridCell<T> extends DMNGridCell<T> {
+public class DecisionTableGridCell<T> extends BaseHasDynamicHeightCell<T> {
 
     private final ListSelectorView.Presenter listSelector;
 
     public DecisionTableGridCell(final GridCellValue<T> value,
-                                 final ListSelectorView.Presenter listSelector) {
-        super(value);
+                                 final ListSelectorView.Presenter listSelector,
+                                 final double lineHeight) {
+        super(value, lineHeight);
         this.listSelector = listSelector;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapper.java
@@ -32,13 +32,16 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowS
 public class DecisionTableUIModelMapper extends BaseUIModelMapper<DecisionTable> {
 
     private final ListSelectorView.Presenter listSelector;
+    private final double lineHeight;
 
     public DecisionTableUIModelMapper(final Supplier<GridData> uiModel,
                                       final Supplier<Optional<DecisionTable>> dmnModel,
-                                      final ListSelectorView.Presenter listSelector) {
+                                      final ListSelectorView.Presenter listSelector,
+                                      final double lineHeight) {
         super(uiModel,
               dmnModel);
         this.listSelector = listSelector;
+        this.lineHeight = lineHeight;
     }
 
     @Override
@@ -52,7 +55,8 @@ public class DecisionTableUIModelMapper extends BaseUIModelMapper<DecisionTable>
                     uiModel.get().setCell(rowIndex,
                                           columnIndex,
                                           () -> new DecisionTableGridCell<>(new BaseGridCellValue<>(rowIndex + 1),
-                                                                            listSelector));
+                                                                            listSelector,
+                                                                            lineHeight));
                     uiModel.get().getCell(rowIndex,
                                           columnIndex).setSelectionStrategy(RowSelectionStrategy.INSTANCE);
                     break;
@@ -61,20 +65,23 @@ public class DecisionTableUIModelMapper extends BaseUIModelMapper<DecisionTable>
                     uiModel.get().setCell(rowIndex,
                                           columnIndex,
                                           () -> new DecisionTableGridCell<>(new BaseGridCellValue<>(rule.getInputEntry().get(iei).getText().getValue()),
-                                                                            listSelector));
+                                                                            listSelector,
+                                                                            lineHeight));
                     break;
                 case OUTPUT_CLAUSES:
                     final int oei = DecisionTableUIModelMapperHelper.getOutputEntryIndex(dtable, columnIndex);
                     uiModel.get().setCell(rowIndex,
                                           columnIndex,
                                           () -> new DecisionTableGridCell<>(new BaseGridCellValue<>(rule.getOutputEntry().get(oei).getText().getValue()),
-                                                                            listSelector));
+                                                                            listSelector,
+                                                                            lineHeight));
                     break;
                 case DESCRIPTION:
                     uiModel.get().setCell(rowIndex,
                                           columnIndex,
                                           () -> new DecisionTableGridCell<>(new BaseGridCellValue<>(rule.getDescription().getValue()),
-                                                                            listSelector));
+                                                                            listSelector,
+                                                                            lineHeight));
                     break;
             }
         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLGrid.java
@@ -58,6 +58,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.NodeMouseEventHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 
+import static org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils.getExpressionTextLineHeight;
+
 public abstract class LiteralExpressionPMMLGrid extends LiteralExpressionGrid {
 
     public LiteralExpressionPMMLGrid(final GridCellTuple parent,
@@ -116,6 +118,7 @@ public abstract class LiteralExpressionPMMLGrid extends LiteralExpressionGrid {
         return new LiteralExpressionPMMLUIModelMapper(this::getModel,
                                                       getExpression(),
                                                       listSelector,
+                                                      getExpressionTextLineHeight(getRenderer().getTheme()),
                                                       getPlaceHolder());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLUIModelMapper.java
@@ -33,10 +33,12 @@ public class LiteralExpressionPMMLUIModelMapper extends LiteralExpressionUIModel
     public LiteralExpressionPMMLUIModelMapper(final Supplier<GridData> uiModel,
                                               final Supplier<Optional<LiteralExpression>> dmnModel,
                                               final ListSelectorView.Presenter listSelector,
+                                              final double lineHeight,
                                               final String placeHolder) {
         super(uiModel,
               dmnModel,
-              listSelector);
+              listSelector,
+              lineHeight);
         this.placeHolder = placeHolder;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCell.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCell.java
@@ -19,16 +19,17 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.literal;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridCell;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 
-public class LiteralExpressionCell<T> extends DMNGridCell<T> {
+public class LiteralExpressionCell<T> extends BaseHasDynamicHeightCell<T> {
 
     private final ListSelectorView.Presenter listSelector;
 
     public LiteralExpressionCell(final GridCellValue<T> value,
-                                 final ListSelectorView.Presenter listSelector) {
-        super(value);
+                                 final ListSelectorView.Presenter listSelector,
+                                 final double lineHeight) {
+        super(value, lineHeight);
         this.listSelector = listSelector;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionGrid.java
@@ -139,7 +139,8 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
     public LiteralExpressionUIModelMapper makeUiModelMapper() {
         return new LiteralExpressionUIModelMapper(this::getModel,
                                                   getExpression(),
-                                                  listSelector);
+                                                  listSelector,
+                                                  getExpressionTextLineHeight(getRenderer().getTheme()));
     }
 
     @Override
@@ -166,7 +167,7 @@ public class LiteralExpressionGrid extends BaseDelegatingExpressionGrid<LiteralE
 
     @Override
     public void initialiseUiRows() {
-        getExpression().get().ifPresent(e -> model.appendRow(new LiteralExpressionGridRow(getExpressionTextLineHeight(getRenderer().getTheme()))));
+        getExpression().get().ifPresent(e -> model.appendRow(new LiteralExpressionGridRow()));
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapper.java
@@ -29,13 +29,16 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 public class LiteralExpressionUIModelMapper extends BaseUIModelMapper<LiteralExpression> {
 
     private final ListSelectorView.Presenter listSelector;
+    private final double lineHeight;
 
     public LiteralExpressionUIModelMapper(final Supplier<GridData> uiModel,
                                           final Supplier<Optional<LiteralExpression>> dmnModel,
-                                          final ListSelectorView.Presenter listSelector) {
+                                          final ListSelectorView.Presenter listSelector,
+                                          final double lineHeight) {
         super(uiModel,
               dmnModel);
         this.listSelector = listSelector;
+        this.lineHeight = lineHeight;
     }
 
     @Override
@@ -45,7 +48,8 @@ public class LiteralExpressionUIModelMapper extends BaseUIModelMapper<LiteralExp
             uiModel.get().setCell(rowIndex,
                                   columnIndex,
                                   () -> new LiteralExpressionCell<>(new BaseGridCellValue<>(literalExpression.getText().getValue()),
-                                                                    listSelector));
+                                                                    listSelector,
+                                                                    lineHeight));
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGrid.java
@@ -130,7 +130,8 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
     public RelationUIModelMapper makeUiModelMapper() {
         return new RelationUIModelMapper(this::getModel,
                                          getExpression(),
-                                         listSelector);
+                                         listSelector,
+                                         getExpressionTextLineHeight(getRenderer().getTheme()));
     }
 
     @Override
@@ -169,14 +170,10 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
         return relationColumn;
     }
 
-    private GridRow makeRelationRow() {
-        return new LiteralExpressionGridRow(getExpressionTextLineHeight(getRenderer().getTheme()));
-    }
-
     @Override
     public void initialiseUiRows() {
         getExpression().get().ifPresent(e -> {
-            e.getRow().forEach(r -> model.appendRow(makeRelationRow()));
+            e.getRow().forEach(r -> model.appendRow(new LiteralExpressionGridRow()));
         });
     }
 
@@ -303,7 +300,7 @@ public class RelationGrid extends BaseExpressionGrid<Relation, RelationGridData,
 
     void addRow(final int index) {
         getExpression().get().ifPresent(relation -> {
-            final GridRow relationRow = makeRelationRow();
+            final GridRow relationRow = new LiteralExpressionGridRow();
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new AddRelationRowCommand(relation,
                                                                     new List(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCell.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCell.java
@@ -19,16 +19,17 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.relation;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridCell;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 
-public class RelationGridCell<T> extends DMNGridCell<T> {
+public class RelationGridCell<T> extends BaseHasDynamicHeightCell<T> {
 
     private final ListSelectorView.Presenter listSelector;
 
     public RelationGridCell(final GridCellValue<T> value,
-                            final ListSelectorView.Presenter listSelector) {
-        super(value);
+                            final ListSelectorView.Presenter listSelector,
+                            final double lineHeight) {
+        super(value, lineHeight);
         this.listSelector = listSelector;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapper.java
@@ -32,13 +32,16 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowS
 public class RelationUIModelMapper extends BaseUIModelMapper<Relation> {
 
     private final ListSelectorView.Presenter listSelector;
+    private final double lineHeight;
 
     public RelationUIModelMapper(final Supplier<GridData> uiModel,
                                  final Supplier<Optional<Relation>> dmnModel,
-                                 final ListSelectorView.Presenter listSelector) {
+                                 final ListSelectorView.Presenter listSelector,
+                                 final double lineHeight) {
         super(uiModel,
               dmnModel);
         this.listSelector = listSelector;
+        this.lineHeight = lineHeight;
     }
 
     @Override
@@ -51,7 +54,8 @@ public class RelationUIModelMapper extends BaseUIModelMapper<Relation> {
                     uiModel.get().setCell(rowIndex,
                                           columnIndex,
                                           () -> new RelationGridCell<>(new BaseGridCellValue<>(rowIndex + 1),
-                                                                       listSelector));
+                                                                       listSelector,
+                                                                       lineHeight));
                     uiModel.get().getCell(rowIndex,
                                           columnIndex).setSelectionStrategy(RowSelectionStrategy.INSTANCE);
                     break;
@@ -69,7 +73,8 @@ public class RelationUIModelMapper extends BaseUIModelMapper<Relation> {
                         uiModel.get().setCell(rowIndex,
                                               columnIndex,
                                               () -> new RelationGridCell<>(new BaseGridCellValue<>(le.getText().getValue()),
-                                                                           listSelector));
+                                                                           listSelector,
+                                                                           lineHeight));
                     });
             }
         });

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/dnd/DelegatingGridWidgetDndMouseMoveHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/dnd/DelegatingGridWidgetDndMouseMoveHandler.java
@@ -20,6 +20,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.model.HasRowDragRestrict
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDMouseMoveHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
 public class DelegatingGridWidgetDndMouseMoveHandler extends GridWidgetDnDMouseMoveHandler {
@@ -32,9 +33,11 @@ public class DelegatingGridWidgetDndMouseMoveHandler extends GridWidgetDnDMouseM
 
     @Override
     protected void findMovableRows(final GridWidget view,
+                                   final BaseGridRendererHelper.RenderingInformation renderingInformation,
                                    final double cx,
                                    final double cy) {
         super.findMovableRows(view,
+                              renderingInformation,
                               cx,
                               cy);
         if (view instanceof HasRowDragRestrictions) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCell.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCell.java
@@ -24,6 +24,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 
 public abstract class BaseHasDynamicHeightCell<T> extends DMNGridCell<T> implements HasDynamicHeight {
 
+    public static final double DEFAULT_HEIGHT = 48.0;
+
     protected final double lineHeight;
 
     private double height;
@@ -57,5 +59,26 @@ public abstract class BaseHasDynamicHeightCell<T> extends DMNGridCell<T> impleme
 
         final int expressionLineCount = asText.split("\\r?\\n", -1).length;
         return expressionLineCount * lineHeight + (RendererUtils.EXPRESSION_TEXT_PADDING * 3);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BaseHasDynamicHeightCell)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final BaseHasDynamicHeightCell<?> that = (BaseHasDynamicHeightCell<?>) o;
+        return Double.compare(that.lineHeight, lineHeight) == 0 &&
+                Double.compare(that.height, height) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lineHeight, height);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCell.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCell.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.model;
+
+import java.util.Objects;
+
+import org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+
+public abstract class BaseHasDynamicHeightCell<T> extends DMNGridCell<T> implements HasDynamicHeight {
+
+    protected final double lineHeight;
+
+    private double height;
+
+    public BaseHasDynamicHeightCell(final GridCellValue<T> value,
+                                    final double lineHeight) {
+        super(value);
+        this.lineHeight = lineHeight;
+        this.height = getExpressionTextHeight();
+    }
+
+    @Override
+    protected void setValue(final GridCellValue<T> value) {
+        super.setValue(value);
+        this.height = getExpressionTextHeight();
+    }
+
+    @Override
+    public double getHeight() {
+        return height;
+    }
+
+    protected double getExpressionTextHeight() {
+        if (Objects.isNull(value) || Objects.isNull(value.getValue())) {
+            return DEFAULT_HEIGHT;
+        }
+        final int expressionLineCount = getExpressionLineCount();
+        return expressionLineCount * lineHeight + (RendererUtils.EXPRESSION_TEXT_PADDING * 3);
+    }
+
+    protected int getExpressionLineCount() {
+        final String asText = getValue().getValue().toString();
+        return asText.split("\\r?\\n", -1).length;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCell.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCell.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.widgets.grid.model;
 import java.util.Objects;
 
 import org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 
 public abstract class BaseHasDynamicHeightCell<T> extends DMNGridCell<T> implements HasDynamicHeight {
@@ -49,12 +50,12 @@ public abstract class BaseHasDynamicHeightCell<T> extends DMNGridCell<T> impleme
         if (Objects.isNull(value) || Objects.isNull(value.getValue())) {
             return DEFAULT_HEIGHT;
         }
-        final int expressionLineCount = getExpressionLineCount();
-        return expressionLineCount * lineHeight + (RendererUtils.EXPRESSION_TEXT_PADDING * 3);
-    }
-
-    protected int getExpressionLineCount() {
         final String asText = getValue().getValue().toString();
-        return asText.split("\\r?\\n", -1).length;
+        if (StringUtils.isEmpty(asText)) {
+            return DEFAULT_HEIGHT;
+        }
+
+        final int expressionLineCount = asText.split("\\r?\\n", -1).length;
+        return expressionLineCount * lineHeight + (RendererUtils.EXPRESSION_TEXT_PADDING * 3);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRow.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRow.java
@@ -42,8 +42,11 @@ public class ExpressionEditorGridRow extends BaseGridRow {
 
     @Override
     public double getHeight() {
-        long currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- ExpressionEditorGridRow.getHeight()");
+        long currentTimeMillis = 0;
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- ExpressionEditorGridRow.getHeight()");
+        }
 
         final double height = this.getCells()
                 .values()
@@ -58,7 +61,9 @@ public class ExpressionEditorGridRow extends BaseGridRow {
                 .reduce(Double::max)
                 .orElse(defaultHeight);
 
-        LOGGER.log(Level.FINEST, " - Post- ExpressionEditorGridRow.getHeight() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- ExpressionEditorGridRow.getHeight() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
         return height;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRow.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRow.java
@@ -16,12 +16,13 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
+
+import static org.uberfire.ext.wires.core.grids.client.util.Logging.log;
 
 public class ExpressionEditorGridRow extends BaseGridRow {
 
@@ -42,11 +43,7 @@ public class ExpressionEditorGridRow extends BaseGridRow {
 
     @Override
     public double getHeight() {
-        long currentTimeMillis = 0;
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- ExpressionEditorGridRow.getHeight()");
-        }
+        long currentTimeMillis = log(LOGGER, " - Pre- ExpressionEditorGridRow.getHeight()");
 
         final double height = this.getCells()
                 .values()
@@ -61,9 +58,8 @@ public class ExpressionEditorGridRow extends BaseGridRow {
                 .reduce(Double::max)
                 .orElse(defaultHeight);
 
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- ExpressionEditorGridRow.getHeight() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(LOGGER, " - Post- ExpressionEditorGridRow.getHeight()", currentTimeMillis);
+
         return height;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRow.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRow.java
@@ -16,11 +16,16 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 
 public class ExpressionEditorGridRow extends BaseGridRow {
+
+    private static final Logger LOGGER = Logger.getLogger(ExpressionEditorGridRow.class.getName());
 
     public static final double DEFAULT_HEIGHT = 48.0;
 
@@ -37,7 +42,10 @@ public class ExpressionEditorGridRow extends BaseGridRow {
 
     @Override
     public double getHeight() {
-        return this.getCells()
+        long currentTimeMillis = System.currentTimeMillis();
+        LOGGER.log(Level.FINEST, " - Pre- ExpressionEditorGridRow.getHeight()");
+
+        final double height = this.getCells()
                 .values()
                 .stream()
                 .filter(cell -> cell != null && cell.getValue() != null)
@@ -49,5 +57,8 @@ public class ExpressionEditorGridRow extends BaseGridRow {
                 .map(editor -> editor.getHeight() + editor.getPadding() * 2)
                 .reduce(Double::max)
                 .orElse(defaultHeight);
+
+        LOGGER.log(Level.FINEST, " - Post- ExpressionEditorGridRow.getHeight() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        return height;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/HasDynamicHeight.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/HasDynamicHeight.java
@@ -18,7 +18,5 @@ package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
 public interface HasDynamicHeight {
 
-    double DEFAULT_HEIGHT = 48.0;
-
     double getHeight();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/HasDynamicHeight.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/HasDynamicHeight.java
@@ -13,25 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
-import org.uberfire.ext.wires.core.grids.client.model.GridCell;
-import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
+public interface HasDynamicHeight {
 
-public class LiteralExpressionGridRow extends BaseGridRow {
+    double DEFAULT_HEIGHT = 48.0;
 
-    public LiteralExpressionGridRow() {
-        super(HasDynamicHeight.DEFAULT_HEIGHT);
-    }
-
-    @Override
-    public double getHeight() {
-        double height = HasDynamicHeight.DEFAULT_HEIGHT;
-        for (GridCell<?> cell : this.getCells().values()) {
-            if (cell instanceof HasDynamicHeight) {
-                height = Math.max(((HasDynamicHeight) cell).getHeight(), height);
-            }
-        }
-        return height;
-    }
+    double getHeight();
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/LiteralExpressionGridRow.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/model/LiteralExpressionGridRow.java
@@ -18,15 +18,17 @@ package org.kie.workbench.common.dmn.client.widgets.grid.model;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
+
 public class LiteralExpressionGridRow extends BaseGridRow {
 
     public LiteralExpressionGridRow() {
-        super(HasDynamicHeight.DEFAULT_HEIGHT);
+        super(DEFAULT_HEIGHT);
     }
 
     @Override
     public double getHeight() {
-        double height = HasDynamicHeight.DEFAULT_HEIGHT;
+        double height = DEFAULT_HEIGHT;
         for (GridCell<?> cell : this.getCells().values()) {
             if (cell instanceof HasDynamicHeight) {
                 height = Math.max(((HasDynamicHeight) cell).getHeight(), height);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -46,6 +46,13 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMe
 
 public class DMNGridLayer extends DefaultGridLayer {
 
+    private final GridLayerRedrawManager.PrioritizedCommand BATCH = new GridLayerRedrawManager.PrioritizedCommand(Integer.MIN_VALUE) {
+        @Override
+        public void execute() {
+            doBatch();
+        }
+    };
+
     private TransformMediator defaultTransformMediator;
 
     private Optional<GridWidget> selectedGridWidget = Optional.empty();
@@ -64,12 +71,7 @@ public class DMNGridLayer extends DefaultGridLayer {
 
     @Override
     public Layer batch() {
-        return batch(new GridLayerRedrawManager.PrioritizedCommand(Integer.MIN_VALUE) {
-            @Override
-            public void execute() {
-                doBatch();
-            }
-        });
+        return batch(BATCH);
     }
 
     Layer doBatch() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayer.java
@@ -46,7 +46,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMe
 
 public class DMNGridLayer extends DefaultGridLayer {
 
-    private final GridLayerRedrawManager.PrioritizedCommand BATCH = new GridLayerRedrawManager.PrioritizedCommand(Integer.MIN_VALUE) {
+    private final GridLayerRedrawManager.PrioritizedCommand batch = new GridLayerRedrawManager.PrioritizedCommand(Integer.MIN_VALUE) {
         @Override
         public void execute() {
             doBatch();
@@ -71,7 +71,7 @@ public class DMNGridLayer extends DefaultGridLayer {
 
     @Override
     public Layer batch() {
-        return batch(BATCH);
+        return batch(batch);
     }
 
     Layer doBatch() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanel.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanel.java
@@ -34,15 +34,14 @@ public class DMNGridPanel extends GridLienzoPanel {
 
     public static final int LIENZO_PANEL_HEIGHT = 450;
 
-    private DMNGridLayer gridLayer;
     private RestrictedMousePanMediator mousePanMediator;
 
     public DMNGridPanel(final DMNGridLayer gridLayer,
                         final RestrictedMousePanMediator mousePanMediator,
                         final ContextMenuHandler contextMenuHandler) {
         super(LIENZO_PANEL_WIDTH,
-              LIENZO_PANEL_HEIGHT);
-        this.gridLayer = gridLayer;
+              LIENZO_PANEL_HEIGHT,
+              gridLayer);
         this.mousePanMediator = mousePanMediator;
 
         getDomElementContainer().addDomHandler(destroyDOMElements(),
@@ -52,7 +51,7 @@ public class DMNGridPanel extends GridLienzoPanel {
     }
 
     private MouseWheelHandler destroyDOMElements() {
-        return (event) -> gridLayer
+        return (event) -> getDefaultGridLayer()
                 .getGridWidgets()
                 .forEach(gridWidget -> gridWidget
                         .getModel()
@@ -70,10 +69,10 @@ public class DMNGridPanel extends GridLienzoPanel {
             refreshScrollPosition();
 
             final TransformMediator restriction = mousePanMediator.getTransformMediator();
-            final Transform transform = restriction.adjust(gridLayer.getViewport().getTransform(),
-                                                           gridLayer.getVisibleBounds());
-            gridLayer.getViewport().setTransform(transform);
-            gridLayer.batch();
+            final Transform transform = restriction.adjust(getDefaultGridLayer().getViewport().getTransform(),
+                                                           getDefaultGridLayer().getVisibleBounds());
+            getDefaultGridLayer().getViewport().setTransform(transform);
+            getDefaultGridLayer().batch();
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
@@ -33,7 +33,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -50,6 +49,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -103,7 +103,7 @@ public class AddDecisionRuleCommandTest {
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
                                                             listSelector,
-                                                            HasDynamicHeight.DEFAULT_HEIGHT);
+                                                            DEFAULT_HEIGHT);
 
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiInputClauseColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddDecisionRuleCommandTest.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -101,7 +102,8 @@ public class AddDecisionRuleCommandTest {
         this.uiModelRow = new BaseGridRow();
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
-                                                            listSelector);
+                                                            listSelector,
+                                                            HasDynamicHeight.DEFAULT_HEIGHT);
 
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiInputClauseColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Deci
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.InputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -51,6 +50,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -99,7 +99,7 @@ public class AddInputClauseCommandTest {
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
                                                             listSelector,
-                                                            HasDynamicHeight.DEFAULT_HEIGHT);
+                                                            DEFAULT_HEIGHT);
 
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiInputClauseColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddInputClauseCommandTest.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Deci
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.InputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -97,7 +98,8 @@ public class AddInputClauseCommandTest {
         this.inputClause = new InputClause();
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
-                                                            listSelector);
+                                                            listSelector,
+                                                            HasDynamicHeight.DEFAULT_HEIGHT);
 
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiInputClauseColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -37,7 +37,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -53,6 +52,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -112,7 +112,7 @@ public class AddOutputClauseCommandTest {
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
                                                             listSelector,
-                                                            HasDynamicHeight.DEFAULT_HEIGHT);
+                                                            DEFAULT_HEIGHT);
 
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiOutputClauseColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.OutputClauseColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -110,7 +111,8 @@ public class AddOutputClauseCommandTest {
         this.outputClause = new OutputClause();
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
-                                                            listSelector);
+                                                            listSelector,
+                                                            HasDynamicHeight.DEFAULT_HEIGHT);
 
         doReturn(0).when(uiRowNumberColumn).getIndex();
         doReturn(1).when(uiOutputClauseColumn).getIndex();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -103,7 +104,8 @@ public class DeleteInputClauseCommandTest {
 
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
-                                                            listSelector);
+                                                            listSelector,
+                                                            HasDynamicHeight.DEFAULT_HEIGHT);
 
         makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteInputClauseCommandTest.java
@@ -32,7 +32,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Inpu
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -47,6 +46,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -105,7 +105,7 @@ public class DeleteInputClauseCommandTest {
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
                                                             listSelector,
-                                                            HasDynamicHeight.DEFAULT_HEIGHT);
+                                                            DEFAULT_HEIGHT);
 
         makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
@@ -32,7 +32,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Outp
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -47,6 +46,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -105,7 +105,7 @@ public class DeleteOutputClauseCommandTest {
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
                                                             listSelector,
-                                                            HasDynamicHeight.DEFAULT_HEIGHT);
+                                                            DEFAULT_HEIGHT);
 
         makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT + dtable.getInput().size());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/DeleteOutputClauseCommandTest.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.Outp
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridData;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -103,7 +104,8 @@ public class DeleteOutputClauseCommandTest {
 
         this.uiModelMapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                             () -> Optional.of(dtable),
-                                                            listSelector);
+                                                            listSelector,
+                                                            HasDynamicHeight.DEFAULT_HEIGHT);
 
         makeCommand(DecisionTableUIModelMapperHelper.ROW_INDEX_COLUMN_COUNT + dtable.getInput().size());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.Re
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationDefaultValueUtilities;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -99,7 +100,8 @@ public class AddRelationColumnCommandTest {
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
-                                                       listSelector);
+                                                       listSelector,
+                                                       HasDynamicHeight.DEFAULT_HEIGHT);
 
         makeCommand(1);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationColumnCommandTest.java
@@ -30,7 +30,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.Re
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationDefaultValueUtilities;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -49,6 +48,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -101,7 +101,7 @@ public class AddRelationColumnCommandTest {
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
                                                        listSelector,
-                                                       HasDynamicHeight.DEFAULT_HEIGHT);
+                                                       DEFAULT_HEIGHT);
 
         makeCommand(1);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
@@ -28,7 +28,6 @@ import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -47,6 +46,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberCol
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -98,7 +98,7 @@ public class AddRelationRowCommandTest {
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
                                                        listSelector,
-                                                       HasDynamicHeight.DEFAULT_HEIGHT);
+                                                       DEFAULT_HEIGHT);
 
         makeCommand(0);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/AddRelationRowCommandTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -96,7 +97,8 @@ public class AddRelationRowCommandTest {
         this.uiModel.appendColumn(uiRowNumberColumn);
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
-                                                       listSelector);
+                                                       listSelector,
+                                                       HasDynamicHeight.DEFAULT_HEIGHT);
 
         makeCommand(0);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.Re
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -46,6 +45,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -108,7 +108,7 @@ public class DeleteRelationColumnCommandTest {
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
                                                        listSelector,
-                                                       HasDynamicHeight.DEFAULT_HEIGHT);
+                                                       DEFAULT_HEIGHT);
     }
 
     private void makeCommand(final int uiColumnIndex) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationColumnCommandTest.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.Re
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridColumn;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -106,7 +107,8 @@ public class DeleteRelationColumnCommandTest {
 
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
-                                                       listSelector);
+                                                       listSelector,
+                                                       HasDynamicHeight.DEFAULT_HEIGHT);
     }
 
     private void makeCommand(final int uiColumnIndex) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationRowCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationRowCommandTest.java
@@ -28,7 +28,6 @@ import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -46,6 +45,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
 
 import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -96,7 +96,7 @@ public class DeleteRelationRowCommandTest {
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
                                                        listSelector,
-                                                       HasDynamicHeight.DEFAULT_HEIGHT);
+                                                       DEFAULT_HEIGHT);
 
         makeCommand(0);
         doReturn(ruleManager).when(handler).getRuleManager();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationRowCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/relation/DeleteRelationRowCommandTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationColumn;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.relation.RelationUIModelMapper;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
@@ -94,7 +95,8 @@ public class DeleteRelationRowCommandTest {
 
         this.uiModelMapper = new RelationUIModelMapper(() -> uiModel,
                                                        () -> Optional.of(relation),
-                                                       listSelector);
+                                                       listSelector,
+                                                       HasDynamicHeight.DEFAULT_HEIGHT);
 
         makeCommand(0);
         doReturn(ruleManager).when(handler).getRuleManager();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -289,7 +289,6 @@ public class ExpressionEditorViewImplTest {
                      0.0);
 
         verify(gridPanel).addKeyDownHandler(any(BaseGridWidgetKeyboardHandler.class));
-        verify(gridPanel).add(gridLayer);
         verify(gridPanelContainer).clear();
         verify(gridPanelContainer).setWidget(gridPanel);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCellTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -40,7 +41,8 @@ public class DecisionTableGridCellTest {
     @Before
     public void setup() {
         this.cell = new DecisionTableGridCell<>(value,
-                                                listSelector);
+                                                listSelector,
+                                                HasDynamicHeight.DEFAULT_HEIGHT);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCellTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCellTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -28,7 +28,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DecisionTableGridCellTest {
+public class DecisionTableGridCellTest extends BaseHasDynamicHeightCellTest<DecisionTableGridCell> {
 
     @Mock
     private GridCellValue<String> value;
@@ -36,13 +36,16 @@ public class DecisionTableGridCellTest {
     @Mock
     private ListSelectorView.Presenter listSelector;
 
-    private DecisionTableGridCell cell;
+    @Override
+    public DecisionTableGridCell makeCell() {
+        return new DecisionTableGridCell<>(value,
+                                           listSelector,
+                                           LINE_HEIGHT);
+    }
 
-    @Before
-    public void setup() {
-        this.cell = new DecisionTableGridCell<>(value,
-                                                listSelector,
-                                                HasDynamicHeight.DEFAULT_HEIGHT);
+    @Test
+    public void testIsAHasDynamicHeightSubclass() {
+        assertThat(cell).isInstanceOf(HasDynamicHeight.class);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableGridCellTest.java
@@ -38,9 +38,14 @@ public class DecisionTableGridCellTest extends BaseHasDynamicHeightCellTest<Deci
 
     @Override
     public DecisionTableGridCell makeCell() {
+        return makeCell(LINE_HEIGHT);
+    }
+
+    @Override
+    protected DecisionTableGridCell makeCell(final double lineHeight) {
         return new DecisionTableGridCell<>(value,
                                            listSelector,
-                                           LINE_HEIGHT);
+                                           lineHeight);
     }
 
     @Test
@@ -49,6 +54,7 @@ public class DecisionTableGridCellTest extends BaseHasDynamicHeightCellTest<Deci
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetEditor() {
         assertThat(cell.getEditor()).isNotEmpty();
         assertThat(cell.getEditor().get()).isSameAs(listSelector);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapperTest.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.dmn.api.definition.model.OutputClause;
 import org.kie.workbench.common.dmn.api.definition.model.UnaryTests;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -111,7 +112,8 @@ public class DecisionTableUIModelMapperTest {
 
         this.mapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                      () -> Optional.of(dtable),
-                                                     listSelector);
+                                                     listSelector,
+                                                     HasDynamicHeight.DEFAULT_HEIGHT);
         this.cellValueSupplier = Optional::empty;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapperTest.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.dmn.api.definition.model.OutputClause;
 import org.kie.workbench.common.dmn.api.definition.model.UnaryTests;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
@@ -39,6 +38,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowS
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -109,7 +109,7 @@ public class DecisionTableUIModelMapperTest {
         this.mapper = new DecisionTableUIModelMapper(() -> uiModel,
                                                      () -> Optional.of(dtable),
                                                      listSelector,
-                                                     HasDynamicHeight.DEFAULT_HEIGHT);
+                                                     DEFAULT_HEIGHT);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableUIModelMapperTest.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +32,6 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelect
 import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
@@ -64,8 +62,6 @@ public class DecisionTableUIModelMapperTest {
     private BaseGridData uiModel;
 
     private DecisionTable dtable;
-
-    private Supplier<Optional<GridCellValue<?>>> cellValueSupplier;
 
     private DecisionTableUIModelMapper mapper;
 
@@ -114,7 +110,6 @@ public class DecisionTableUIModelMapperTest {
                                                      () -> Optional.of(dtable),
                                                      listSelector,
                                                      HasDynamicHeight.DEFAULT_HEIGHT);
-        this.cellValueSupplier = Optional::empty;
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLUIModelMapperTest.java
@@ -22,9 +22,9 @@ import org.junit.Test;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionUIModelMapper;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionUIModelMapperTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridCell;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 
 public class LiteralExpressionPMMLUIModelMapperTest extends LiteralExpressionUIModelMapperTest {
 
@@ -33,7 +33,7 @@ public class LiteralExpressionPMMLUIModelMapperTest extends LiteralExpressionUIM
         return new LiteralExpressionPMMLUIModelMapper(() -> uiModel,
                                                       () -> Optional.of(literalExpression),
                                                       listSelector,
-                                                      HasDynamicHeight.DEFAULT_HEIGHT,
+                                                      DEFAULT_HEIGHT,
                                                       "placeholder");
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/supplementary/pmml/LiteralExpressionPMMLUIModelMapperTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionUIModelMapper;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.literal.LiteralExpressionUIModelMapperTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.DMNGridCell;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 
 import static org.junit.Assert.assertTrue;
 
@@ -32,6 +33,7 @@ public class LiteralExpressionPMMLUIModelMapperTest extends LiteralExpressionUIM
         return new LiteralExpressionPMMLUIModelMapper(() -> uiModel,
                                                       () -> Optional.of(literalExpression),
                                                       listSelector,
+                                                      HasDynamicHeight.DEFAULT_HEIGHT,
                                                       "placeholder");
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCellTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -40,7 +41,8 @@ public class LiteralExpressionCellTest {
     @Before
     public void setup() {
         this.cell = new LiteralExpressionCell<>(value,
-                                                listSelector);
+                                                listSelector,
+                                                HasDynamicHeight.DEFAULT_HEIGHT);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCellTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.literal;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCellTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -28,7 +28,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LiteralExpressionCellTest {
+public class LiteralExpressionCellTest extends BaseHasDynamicHeightCellTest<LiteralExpressionCell> {
 
     @Mock
     private GridCellValue<String> value;
@@ -36,13 +36,16 @@ public class LiteralExpressionCellTest {
     @Mock
     private ListSelectorView.Presenter listSelector;
 
-    private LiteralExpressionCell cell;
+    @Override
+    public LiteralExpressionCell makeCell() {
+        return new LiteralExpressionCell<>(value,
+                                           listSelector,
+                                           LINE_HEIGHT);
+    }
 
-    @Before
-    public void setup() {
-        this.cell = new LiteralExpressionCell<>(value,
-                                                listSelector,
-                                                HasDynamicHeight.DEFAULT_HEIGHT);
+    @Test
+    public void testIsAHasDynamicHeightSubclass() {
+        assertThat(cell).isInstanceOf(HasDynamicHeight.class);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionCellTest.java
@@ -38,9 +38,14 @@ public class LiteralExpressionCellTest extends BaseHasDynamicHeightCellTest<Lite
 
     @Override
     public LiteralExpressionCell makeCell() {
+        return makeCell(LINE_HEIGHT);
+    }
+
+    @Override
+    protected LiteralExpressionCell makeCell(final double lineHeight) {
         return new LiteralExpressionCell<>(value,
                                            listSelector,
-                                           LINE_HEIGHT);
+                                           lineHeight);
     }
 
     @Test
@@ -49,6 +54,7 @@ public class LiteralExpressionCellTest extends BaseHasDynamicHeightCellTest<Lite
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetEditor() {
         assertThat(cell.getEditor()).isNotEmpty();
         assertThat(cell.getEditor().get()).isSameAs(listSelector);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
@@ -32,6 +31,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -66,7 +66,7 @@ public class LiteralExpressionUIModelMapperTest {
         return new LiteralExpressionUIModelMapper(() -> uiModel,
                                                   () -> Optional.of(literalExpression),
                                                   listSelector,
-                                                  HasDynamicHeight.DEFAULT_HEIGHT);
+                                                  DEFAULT_HEIGHT);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/literal/LiteralExpressionUIModelMapperTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
@@ -64,7 +65,8 @@ public class LiteralExpressionUIModelMapperTest {
     protected LiteralExpressionUIModelMapper getMapper() {
         return new LiteralExpressionUIModelMapper(() -> uiModel,
                                                   () -> Optional.of(literalExpression),
-                                                  listSelector);
+                                                  listSelector,
+                                                  HasDynamicHeight.DEFAULT_HEIGHT);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCellTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.relation;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCellTest;
 import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -28,7 +28,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RelationGridCellTest {
+public class RelationGridCellTest extends BaseHasDynamicHeightCellTest<RelationGridCell> {
 
     @Mock
     private GridCellValue<String> value;
@@ -36,13 +36,16 @@ public class RelationGridCellTest {
     @Mock
     private ListSelectorView.Presenter listSelector;
 
-    private RelationGridCell cell;
+    @Override
+    public RelationGridCell makeCell() {
+        return new RelationGridCell<>(value,
+                                      listSelector,
+                                      LINE_HEIGHT);
+    }
 
-    @Before
-    public void setup() {
-        this.cell = new RelationGridCell<>(value,
-                                           listSelector,
-                                           HasDynamicHeight.DEFAULT_HEIGHT);
+    @Test
+    public void testIsAHasDynamicHeightSubclass() {
+        assertThat(cell).isInstanceOf(HasDynamicHeight.class);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCellTest.java
@@ -38,9 +38,14 @@ public class RelationGridCellTest extends BaseHasDynamicHeightCellTest<RelationG
 
     @Override
     public RelationGridCell makeCell() {
+        return makeCell(LINE_HEIGHT);
+    }
+
+    @Override
+    protected RelationGridCell makeCell(final double lineHeight) {
         return new RelationGridCell<>(value,
                                       listSelector,
-                                      LINE_HEIGHT);
+                                      lineHeight);
     }
 
     @Test
@@ -49,6 +54,7 @@ public class RelationGridCellTest extends BaseHasDynamicHeightCellTest<RelationG
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetEditor() {
         assertThat(cell.getEditor()).isNotEmpty();
         assertThat(cell.getEditor().get()).isSameAs(listSelector);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationGridCellTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -40,7 +41,8 @@ public class RelationGridCellTest {
     @Before
     public void setup() {
         this.cell = new RelationGridCell<>(value,
-                                           listSelector);
+                                           listSelector,
+                                           HasDynamicHeight.DEFAULT_HEIGHT);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
@@ -28,7 +28,6 @@ import org.kie.workbench.common.dmn.api.definition.model.List;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
-import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -41,6 +40,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowS
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -101,7 +101,7 @@ public class RelationUIModelMapperTest {
         this.mapper = new RelationUIModelMapper(() -> uiModel,
                                                 () -> Optional.of(relation),
                                                 listSelector,
-                                                HasDynamicHeight.DEFAULT_HEIGHT);
+                                                DEFAULT_HEIGHT);
         this.cellValueSupplier = Optional::empty;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/relation/RelationUIModelMapperTest.java
@@ -28,6 +28,7 @@ import org.kie.workbench.common.dmn.api.definition.model.List;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.ListSelectorView;
+import org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
@@ -99,7 +100,8 @@ public class RelationUIModelMapperTest {
 
         this.mapper = new RelationUIModelMapper(() -> uiModel,
                                                 () -> Optional.of(relation),
-                                                listSelector);
+                                                listSelector,
+                                                HasDynamicHeight.DEFAULT_HEIGHT);
         this.cellValueSupplier = Optional::empty;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/dnd/DelegatingGridWidgetDndMouseMoveHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/dnd/DelegatingGridWidgetDndMouseMoveHandlerTest.java
@@ -70,7 +70,7 @@ public class DelegatingGridWidgetDndMouseMoveHandlerTest {
         final GridWidget view = mock(GridWidget.class);
         doReturn(rendererHelper).when(view).getRendererHelper();
 
-        handler.findMovableRows(view, 0, 0);
+        handler.findMovableRows(view, rendererHelper.getRenderingInformation(), 0, 0);
 
         verify(state, never()).reset();
     }
@@ -81,7 +81,7 @@ public class DelegatingGridWidgetDndMouseMoveHandlerTest {
         doReturn(rendererHelper).when(view).getRendererHelper();
         doReturn(true).when(view).isRowDragPermitted(eq(state));
 
-        handler.findMovableRows(view, 0, 0);
+        handler.findMovableRows(view, rendererHelper.getRenderingInformation(), 0, 0);
 
         verify(state, never()).reset();
     }
@@ -96,7 +96,7 @@ public class DelegatingGridWidgetDndMouseMoveHandlerTest {
         doReturn(element).when(viewport).getElement();
         doReturn(style).when(element).getStyle();
 
-        handler.findMovableRows(view, 0, 0);
+        handler.findMovableRows(view, rendererHelper.getRenderingInformation(), 0, 0);
 
         verify(state).reset();
         verify(style).setCursor(eq(Style.Cursor.DEFAULT));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCellTest.java
@@ -28,7 +28,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import static com.ibm.icu.impl.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils.EXPRESSION_TEXT_PADDING;
-import static org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight.DEFAULT_HEIGHT;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 
 public abstract class BaseHasDynamicHeightCellTest<CELL extends BaseGridCell & HasDynamicHeight> {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCellTest.java
@@ -38,6 +38,8 @@ public abstract class BaseHasDynamicHeightCellTest<CELL extends BaseGridCell & H
 
     protected abstract CELL makeCell();
 
+    protected abstract CELL makeCell(final double lineHeight);
+
     @Before
     public void setup() {
         this.cell = makeCell();
@@ -96,9 +98,46 @@ public abstract class BaseHasDynamicHeightCellTest<CELL extends BaseGridCell & H
         assertThat(cell.getHeight()).isEqualTo(4 * LINE_HEIGHT + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
     }
 
+    @Test
+    public void testEquals() {
+        final CELL sameCell = makeCell();
+
+        assertThat(cell).isEqualTo(sameCell);
+        assertThat(cell.hashCode()).isEqualTo(sameCell.hashCode());
+    }
+
+    @Test
+    public void testEqualsIdentity() {
+        assertThat(cell).isEqualTo(cell);
+        assertThat(cell.hashCode()).isEqualTo(cell.hashCode());
+    }
+
+    @Test
+    public void testEqualsDifferentHeight() {
+        final CELL differentCell = makeCell();
+        final GridCellValue<String> differentValue = new BaseGridCellValue<>("Hello\nWorld!");
+        setValue(differentCell, differentValue);
+
+        assertThat(cell).isNotEqualTo(differentCell);
+        assertThat(cell.hashCode()).isNotEqualTo(differentCell.hashCode());
+    }
+
+    @Test
+    public void testEqualsDifferentLineHeight() {
+        final CELL differentCell = makeCell(LINE_HEIGHT + 1);
+
+        assertThat(cell).isNotEqualTo(differentCell);
+        assertThat(cell.hashCode()).isNotEqualTo(differentCell.hashCode());
+    }
+
+    protected void setValue(final GridCellValue value) {
+        setValue(cell, value);
+    }
+
     @SuppressWarnings("unchecked")
     //It's not nice invoking the _setValue_ through reflection however I really don't want it public.
-    protected void setValue(final GridCellValue value) {
+    protected void setValue(final CELL cell,
+                            final GridCellValue value) {
         try {
             final Method m = BaseGridCell.class.getDeclaredMethod("setValue", GridCellValue.class);
             m.setAccessible(true);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCellTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/BaseHasDynamicHeightCellTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.widgets.grid.model;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
+
+import static com.ibm.icu.impl.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils.EXPRESSION_TEXT_PADDING;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight.DEFAULT_HEIGHT;
+
+public abstract class BaseHasDynamicHeightCellTest<CELL extends BaseGridCell & HasDynamicHeight> {
+
+    public static final double LINE_HEIGHT = 16.0;
+
+    protected CELL cell;
+
+    protected abstract CELL makeCell();
+
+    @Before
+    public void setup() {
+        this.cell = makeCell();
+    }
+
+    @Test
+    public void testNullValue() {
+        setValue(null);
+
+        assertThat(cell.getHeight()).isEqualTo(DEFAULT_HEIGHT);
+    }
+
+    @Test
+    public void testEmptyValue() {
+        setValue(new BaseGridCellValue<>(""));
+
+        assertThat(cell.getHeight()).isEqualTo(DEFAULT_HEIGHT);
+    }
+
+    @Test
+    public void testSingleLineValue() {
+        setValue(new BaseGridCellValue<>("cheese"));
+
+        assertThat(cell.getHeight()).isEqualTo(LINE_HEIGHT + EXPRESSION_TEXT_PADDING * 3);
+    }
+
+    @Test
+    public void testMultipleLineValue() {
+        //Lines [1,2,3,4]
+        setValue(new BaseGridCellValue<>("1\n2\n3\n4"));
+
+        assertThat(cell.getHeight()).isEqualTo(4 * LINE_HEIGHT + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
+    }
+
+    @Test
+    public void testMulitpleLineValueWithEmptyLines() {
+        //Lines [1,2,<empty>,<empty>,3,4]
+        setValue(new BaseGridCellValue<>("1\n2\n\n\n3\n4"));
+
+        assertThat(cell.getHeight()).isEqualTo(6 * LINE_HEIGHT + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
+    }
+
+    @Test
+    public void testMulitpleLineValueWithDifferentEndOfLines() {
+        //Lines [1,2, ,3,4 ,<empty>]
+        setValue(new BaseGridCellValue<>("1\n2\r\n \n3\n4 \r\n"));
+
+        assertThat(cell.getHeight()).isEqualTo(6 * LINE_HEIGHT + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
+    }
+
+    @Test
+    public void testMultipleLineValueWithEndingWithEmptyLine() {
+        //Lines [1,2,3,<empty>]
+        setValue(new BaseGridCellValue<>("1\n2\r\n3\n"));
+
+        assertThat(cell.getHeight()).isEqualTo(4 * LINE_HEIGHT + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
+    }
+
+    @SuppressWarnings("unchecked")
+    //It's not nice invoking the _setValue_ through reflection however I really don't want it public.
+    protected void setValue(final GridCellValue value) {
+        try {
+            final Method m = BaseGridCell.class.getDeclaredMethod("setValue", GridCellValue.class);
+            m.setAccessible(true);
+            m.invoke(cell, value);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            fail(e);
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRowTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/ExpressionEditorGridRowTest.java
@@ -16,23 +16,24 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.model;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Maps;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.context.ExpressionCellValue;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorGridRow.DEFAULT_HEIGHT;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class ExpressionEditorGridRowTest {
@@ -41,32 +42,66 @@ public class ExpressionEditorGridRowTest {
     private BaseExpressionGrid view;
 
     @Test
-    public void testEmptyRow() throws Exception {
+    public void testEmptyRow() {
         final GridRow row = new ExpressionEditorGridRow();
-        Assertions.assertThat(row.getHeight()).isEqualTo(DEFAULT_HEIGHT);
+        assertThat(row.getHeight()).isEqualTo(DEFAULT_HEIGHT);
     }
 
     @Test
-    public void testRowNoHigherThanDefault() throws Exception {
-        final GridRow row = Mockito.spy(ExpressionEditorGridRow.class);
-        final Map<Integer, GridCell> cells = new HashMap<Integer, GridCell>() {{
-            Mockito.doReturn(DEFAULT_HEIGHT - 1).when(view).getHeight();
-            put(0, new BaseGridCell<>(new ExpressionCellValue(Optional.of(view))));
-        }};
+    @SuppressWarnings("unchecked")
+    public void testRowLowerThanDefault() {
+        when(view.getHeight()).thenReturn(DEFAULT_HEIGHT - 1);
 
-        Mockito.doReturn(cells).when(row).getCells();
-        Assertions.assertThat(row.getHeight()).isBetween(0D, DEFAULT_HEIGHT);
+        final GridRow row = spy(ExpressionEditorGridRow.class);
+        final Map<Integer, GridCell<?>> cells = new Maps.Builder<Integer, GridCell<?>>()
+                .put(0, new BaseGridCell<>(new ExpressionCellValue(Optional.of(view))))
+                .build();
+
+        when(row.getCells()).thenReturn(cells);
+        assertThat(row.getHeight()).isBetween(0D, DEFAULT_HEIGHT);
     }
 
     @Test
-    public void testRowHigherThanDefault() throws Exception {
-        final GridRow row = Mockito.spy(ExpressionEditorGridRow.class);
-        final Map<Integer, GridCell> cells = new HashMap<Integer, GridCell>() {{
-            Mockito.doReturn(DEFAULT_HEIGHT + 1).when(view).getHeight();
-            put(0, new BaseGridCell<>(new ExpressionCellValue(Optional.of(view))));
-        }};
+    @SuppressWarnings("unchecked")
+    public void testRowHigherThanDefault() {
+        when(view.getHeight()).thenReturn(DEFAULT_HEIGHT + 1);
 
-        Mockito.doReturn(cells).when(row).getCells();
-        Assertions.assertThat(row.getHeight()).isGreaterThan(DEFAULT_HEIGHT);
+        final GridRow row = spy(ExpressionEditorGridRow.class);
+        final Map<Integer, GridCell<?>> cells = new Maps.Builder<Integer, GridCell<?>>()
+                .put(0, new BaseGridCell<>(new ExpressionCellValue(Optional.of(view))))
+                .build();
+
+        when(row.getCells()).thenReturn(cells);
+        assertThat(row.getHeight()).isGreaterThan(DEFAULT_HEIGHT);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRowHigherThanDefaultWithNullCell() {
+        when(view.getHeight()).thenReturn(DEFAULT_HEIGHT + 1);
+
+        final GridRow row = spy(ExpressionEditorGridRow.class);
+        final Map<Integer, GridCell<?>> cells = new Maps.Builder<Integer, GridCell<?>>()
+                .put(0, new BaseGridCell<>(new ExpressionCellValue(Optional.of(view))))
+                .put(1, null)
+                .build();
+
+        when(row.getCells()).thenReturn(cells);
+        assertThat(row.getHeight()).isGreaterThan(DEFAULT_HEIGHT);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRowHigherThanDefaultWithNullCellValue() {
+        when(view.getHeight()).thenReturn(DEFAULT_HEIGHT + 1);
+
+        final GridRow row = spy(ExpressionEditorGridRow.class);
+        final Map<Integer, GridCell<?>> cells = new Maps.Builder<Integer, GridCell<?>>()
+                .put(0, new BaseGridCell<>(new ExpressionCellValue(Optional.of(view))))
+                .put(1, new BaseGridCell<>(null))
+                .build();
+
+        when(row.getCells()).thenReturn(cells);
+        assertThat(row.getHeight()).isGreaterThan(DEFAULT_HEIGHT);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/LiteralExpressionGridRowTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/LiteralExpressionGridRowTest.java
@@ -19,73 +19,59 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
-import org.kie.workbench.common.dmn.client.editors.expressions.util.RendererUtils;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kie.workbench.common.dmn.client.widgets.grid.model.ExpressionEditorGridRow.DEFAULT_HEIGHT;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 public class LiteralExpressionGridRowTest {
 
-    private static final double TEXT_LINE_HEIGHT = 10.0;
+    private static final double CELL_HEIGHT = DEFAULT_HEIGHT * 2;
+
+    private static class MockHasDynamicHeightCell<T> extends BaseGridCell<T> implements HasDynamicHeight {
+
+        private MockHasDynamicHeightCell(final GridCellValue<T> value) {
+            super(value);
+        }
+
+        @Override
+        public double getHeight() {
+            return CELL_HEIGHT;
+        }
+    }
 
     @Test
-    public void testEmptyRow() throws Exception {
-        final GridRow row = new LiteralExpressionGridRow(TEXT_LINE_HEIGHT);
+    public void testEmptyRow() {
+        final GridRow row = new LiteralExpressionGridRow();
         assertThat(row.getHeight()).isEqualTo(DEFAULT_HEIGHT);
     }
 
     @Test
-    public void testGetHeightWithEmptyExpressionText() {
-        assertRowHeight("",
-                        LiteralExpressionGridRow.DEFAULT_HEIGHT);
-    }
-
-    private void assertRowHeight(final String value,
-                                 final double expectedHeight) {
-        final GridRow row = spy(new LiteralExpressionGridRow(TEXT_LINE_HEIGHT));
+    public void testGetHeightWithHasDynamicHeightCell() {
+        final GridRow row = spy(new LiteralExpressionGridRow());
         final Map<Integer, GridCell> cells = new HashMap<Integer, GridCell>() {{
-            put(0, new BaseGridCell<>(new BaseGridCellValue<>(value)));
+            put(0, new MockHasDynamicHeightCell<>(new BaseGridCellValue<>("cheese")));
+            put(1, new BaseGridCell<>(new BaseGridCellValue<>("cheese")));
         }};
 
         doReturn(cells).when(row).getCells();
-        assertThat(row.getHeight()).isEqualTo(expectedHeight);
+        assertThat(row.getHeight()).isEqualTo(CELL_HEIGHT);
     }
 
     @Test
-    public void testGetHeightWithMultiLineExpressionText() {
-        //Lines [1,2,3,4]
-        assertRowHeight("1\n2\n3\n4",
-                        4 * TEXT_LINE_HEIGHT
-                                + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
-    }
+    public void testGetHeightWithoutHasDynamicHeightCell() {
+        final GridRow row = spy(new LiteralExpressionGridRow());
+        final Map<Integer, GridCell> cells = new HashMap<Integer, GridCell>() {{
+            put(0, new BaseGridCell<>(new BaseGridCellValue<>("cheese")));
+        }};
 
-    @Test
-    public void testGetHeightWithEmptyLinesExpressionText() {
-        //Lines [1,2,<empty>,<empty>,3,4]
-        assertRowHeight("1\n2\n\n\n3\n4",
-                        6 * TEXT_LINE_HEIGHT
-                                + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
-    }
-
-    @Test
-    public void testGetHeightWithDifferentEndOfLinesExpressionText() {
-        //Lines [1,2, ,3,4 ,<empty>]
-        assertRowHeight("1\n2\r\n \n3\n4 \r\n",
-                        6 * TEXT_LINE_HEIGHT
-                                + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
-    }
-
-    @Test
-    public void testGetHeightEndingWithEmptyLineExpressionText() {
-        //Lines [1,2,3,<empty>]
-        assertRowHeight("1\n2\r\n3\n",
-                        4 * TEXT_LINE_HEIGHT
-                                + (RendererUtils.EXPRESSION_TEXT_PADDING * 3));
+        doReturn(cells).when(row).getCells();
+        assertThat(row.getHeight()).isEqualTo(DEFAULT_HEIGHT);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/LiteralExpressionGridRowTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/model/LiteralExpressionGridRowTest.java
@@ -26,7 +26,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kie.workbench.common.dmn.client.widgets.grid.model.HasDynamicHeight.DEFAULT_HEIGHT;
+import static org.kie.workbench.common.dmn.client.widgets.grid.model.BaseHasDynamicHeightCell.DEFAULT_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/layer/DMNGridLayerTest.java
@@ -148,6 +148,8 @@ public class DMNGridLayerTest {
 
     @Test
     public void testBatchDelegatesToDoBatch() {
+        when(gridLayer.doBatch()).thenCallRealMethod();
+
         gridLayer.batch();
 
         verify(gridLayer).batch(drawCommand.capture());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelControlImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/panel/DMNGridPanelControlImplTest.java
@@ -16,7 +16,13 @@
 
 package org.kie.workbench.common.dmn.client.widgets.panel;
 
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.INativeContext2D;
+import com.ait.lienzo.client.core.shape.Node;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.CanvasElement;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Style;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +46,24 @@ public class DMNGridPanelControlImplTest {
     private DMNGridLayer gridLayer;
 
     @Mock
+    private DivElement gridLayerDivElement;
+
+    @Mock
+    private Style gridLayerDivElementStyle;
+
+    @Mock
+    private CanvasElement gridLayerCanvasElement;
+
+    @Mock
+    private Node gridLayerNode;
+
+    @Mock
+    private Context2D context2D;
+
+    @Mock
+    private INativeContext2D nativeContext2D;
+
+    @Mock
     private CellEditorControlsView.Presenter cellEditorControls;
 
     @Mock
@@ -48,12 +72,20 @@ public class DMNGridPanelControlImplTest {
     private DMNGridPanelControlImpl control;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() {
         this.control = new DMNGridPanelControlImpl();
 
         when(session.getGridLayer()).thenReturn(gridLayer);
         when(session.getCellEditorControls()).thenReturn(cellEditorControls);
         when(session.getMousePanMediator()).thenReturn(mousePanMediator);
+
+        when(gridLayer.getElement()).thenReturn(gridLayerDivElement);
+        when(gridLayerDivElement.getStyle()).thenReturn(gridLayerDivElementStyle);
+        when(gridLayer.getCanvasElement()).thenReturn(gridLayerCanvasElement);
+        when(gridLayer.getContext()).thenReturn(context2D);
+        when(gridLayer.asNode()).thenReturn(gridLayerNode);
+        when(context2D.getNativeContext()).thenReturn(nativeContext2D);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
-    <gwt.helper.includes>Marshaller</gwt.helper.includes>
+    <gwt.helper.includes>DMNClient,Marshaller</gwt.helper.includes>
     <gwt.helper.rootDirectories>${project.parent.basedir}/</gwt.helper.rootDirectories>
   </properties>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/DMNKogitoTestingEntryPoint.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/DMNKogitoTestingEntryPoint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.showcase.client;
+
+import javax.annotation.PostConstruct;
+
+import org.jboss.errai.common.client.logging.formatters.ErraiSimpleFormatter;
+import org.jboss.errai.ioc.client.api.EntryPoint;
+
+@EntryPoint
+public class DMNKogitoTestingEntryPoint {
+
+    @PostConstruct
+    public void init() {
+        ErraiSimpleFormatter.setSimpleFormatString("%1$tH:%1$tM:%1$tS:%1$tL %4$s [%3$s] %5$s");
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/resources/org/kie/workbench/common/dmn/showcase/DMNKogitoTestingWebapp.gwt.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/resources/org/kie/workbench/common/dmn/showcase/DMNKogitoTestingWebapp.gwt.xml
@@ -18,6 +18,7 @@
 
 <module>
 
+  <inherits name="com.google.gwt.logging.Logging"/>
   <inherits name="org.uberfire.UberfireWorkbenchBackend"/>
   <inherits name="org.kie.workbench.common.dmn.webapp.kogito.common.DMNWebappKogitoCommon"/>
 
@@ -26,7 +27,7 @@
   <set-property name="user.agent" value="gecko1_8,safari"/>
 
   <!-- To change the default logLevel -->
-  <set-property name="gwt.logging.logLevel" value="SEVERE"/>
+  <set-property name="gwt.logging.logLevel" value="FINEST"/>
 
   <!-- To enable logging -->
   <set-property name="gwt.logging.enabled" value="TRUE"/>


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4735

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/843
- https://github.com/kiegroup/kie-wb-common/pull/3004
- https://github.com/kiegroup/drools-wb/pull/1264

This PR moves calculation of a row's height from "on demand" calculation of cells' heights to "on value set" i.e. the height of a cell is now calculated when it's value is set hence moving much of the expensive calculation to a far less frequently invoked point in the codebase.

This PR also ensures DMN's `GridLayer` is not instantiated (by Stunner) multiple times and subsequent event handlers attached to each instance (thus leading to multiple re-handling of events that slowed things down).