### PR TITLE
JBPM-8875 : Stunner - Re-usable subprocess doesn't show options for Called Element properties (DROOLS-3727 merge)

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProcessesDataService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProcessesDataService.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -37,7 +37,7 @@ import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestProcessD
 import org.kie.workbench.common.stunner.bpmn.project.backend.query.FindBpmnProcessIdsQuery;
 import org.uberfire.backend.vfs.Path;
 
-@ApplicationScoped
+@Dependent
 public class ProcessesDataService {
 
     private final RefactoringQueryService queryService;


### PR DESCRIPTION
@hasys @romartin Can you review this PR?
The problem was that CaseCalledElement and CalledElement depended on ProcessesDataService instance which was defined as an ApplicationScoped singleton, so CaseCalled element when setting up the query and named changed the one that CalledElement depended on