### PR TITLE
DROOLS-4724: [DMN Designer] Do not default to a LiteralExpression when no expression is defined

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
@@ -32,6 +32,8 @@ public class ContextEntry extends DMNModelInstrumentedBase implements HasExpress
                                                                       HasTypeRefs,
                                                                       HasVariable<InformationItem> {
 
+    public static final String DEFAULT_EXPRESSION_VALUE = "null // auto-filled by the editor to avoid missing empty expression.";
+
     private InformationItem variable;
     private Expression expression;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
@@ -57,7 +57,9 @@ public class ContextEntryPropertyConverter {
         org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
                                                                                             componentWidthsConsumer);
         if (Objects.isNull(expression)) {
-            expression = new org.kie.dmn.model.v1_2.TLiteralExpression();
+            final org.kie.dmn.model.v1_2.TLiteralExpression literalExpression = new org.kie.dmn.model.v1_2.TLiteralExpression();
+            literalExpression.setText(ContextEntry.DEFAULT_EXPRESSION_VALUE);
+            expression = literalExpression;
         }
         expression.setParent(result);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverter.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -34,11 +35,11 @@ public class ContextEntryPropertyConverter {
                                                                             hasComponentWidthsConsumer);
 
         final ContextEntry result = new ContextEntry();
-        if (variable != null) {
+        if (Objects.nonNull(variable)) {
             variable.setParent(result);
         }
         result.setVariable(variable);
-        if (expression != null) {
+        if (Objects.nonNull(expression)) {
             expression.setParent(result);
         }
         result.setExpression(expression);
@@ -50,14 +51,15 @@ public class ContextEntryPropertyConverter {
         final org.kie.dmn.model.api.ContextEntry result = new org.kie.dmn.model.v1_2.TContextEntry();
 
         final org.kie.dmn.model.api.InformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
-        if (variable != null) {
+        if (Objects.nonNull(variable)) {
             variable.setParent(result);
         }
-        final org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
-                                                                                                  componentWidthsConsumer);
-        if (expression != null) {
-            expression.setParent(result);
+        org.kie.dmn.model.api.Expression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
+                                                                                            componentWidthsConsumer);
+        if (Objects.isNull(expression)) {
+            expression = new org.kie.dmn.model.v1_2.TLiteralExpression();
         }
+        expression.setParent(result);
 
         result.setVariable(variable);
         result.setExpression(expression);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverter.java
@@ -85,11 +85,8 @@ public class ExpressionPropertyConverter {
 
     public static org.kie.dmn.model.api.Expression dmnFromWB(final Expression wb,
                                                              final Consumer<ComponentWidths> componentWidthsConsumer) {
-        // SPECIAL CASE: to represent a partially edited DMN file.
-        // reference above.
-        if (wb == null) {
-            final org.kie.dmn.model.api.LiteralExpression mockedExpression = new org.kie.dmn.model.v1_2.TLiteralExpression();
-            return mockedExpression;
+        if (Objects.isNull(wb)) {
+            return null;
         }
 
         final String uuid = wb.getId().getValue();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverterTest.java
@@ -107,4 +107,22 @@ public class ContextEntryPropertyConverterTest {
         assertThat(componentWidths.getWidths().size()).isEqualTo(literalExpression.getRequiredComponentWidthCount());
         assertThat(componentWidths.getWidths().get(0)).isEqualTo(200.0);
     }
+
+    @Test
+    public void testDMNFromWBWithNullWBExpression() {
+        final ContextEntry wb = new ContextEntry();
+        final InformationItem informationItem = new InformationItem();
+        wb.setVariable(informationItem);
+        wb.setExpression(null);
+
+        final org.kie.dmn.model.api.ContextEntry dmn = ContextEntryPropertyConverter.dmnFromWB(wb, componentWidthsConsumer);
+
+        assertThat(dmn).isNotNull();
+        assertThat(dmn.getVariable()).isNotNull();
+        assertThat(dmn.getExpression()).isNotNull();
+        assertThat(dmn.getExpression()).isInstanceOf(org.kie.dmn.model.api.LiteralExpression.class);
+
+        final org.kie.dmn.model.api.LiteralExpression literalExpression = (org.kie.dmn.model.api.LiteralExpression) dmn.getExpression();
+        assertThat(literalExpression.getText()).isNull();
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ContextEntryPropertyConverterTest.java
@@ -123,6 +123,6 @@ public class ContextEntryPropertyConverterTest {
         assertThat(dmn.getExpression()).isInstanceOf(org.kie.dmn.model.api.LiteralExpression.class);
 
         final org.kie.dmn.model.api.LiteralExpression literalExpression = (org.kie.dmn.model.api.LiteralExpression) dmn.getExpression();
-        assertThat(literalExpression.getText()).isNull();
+        assertThat(literalExpression.getText()).isEqualTo(ContextEntry.DEFAULT_EXPRESSION_VALUE);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/ExpressionPropertyConverterTest.java
@@ -227,4 +227,14 @@ public class ExpressionPropertyConverterTest {
 
         assertDMNFromWBConversion(wb, TDecisionTable.class, 100.0, 200.0);
     }
+
+    @Test
+    public void testWBFromDMN_NullConversion() {
+        assertThat(ExpressionPropertyConverter.wbFromDMN(null, hasComponentWidthsConsumer)).isNull();
+    }
+
+    @Test
+    public void testDMNFromWB_NullConversion() {
+        assertThat(ExpressionPropertyConverter.dmnFromWB(null, componentWidthsConsumer)).isNull();
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ContextEntryPropertyConverter.java
@@ -28,8 +28,11 @@ import org.kie.workbench.common.dmn.api.definition.model.InformationItem;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITContextEntry;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITExpression;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITInformationItem;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITLiteralExpression;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.kie.JSITComponentWidths;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.mapper.JsUtils;
+
+import static org.kie.workbench.common.dmn.webapp.kogito.marshaller.mapper.utils.WrapperUtils.getWrappedJSITLiteralExpression;
 
 public class ContextEntryPropertyConverter {
 
@@ -63,8 +66,12 @@ public class ContextEntryPropertyConverter {
         final JSITContextEntry result = new JSITContextEntry();
 
         final JSITInformationItem variable = InformationItemPropertyConverter.dmnFromWB(wb.getVariable());
-        final JSITExpression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
-                                                                                componentWidthsConsumer);
+        JSITExpression expression = ExpressionPropertyConverter.dmnFromWB(wb.getExpression(),
+                                                                          componentWidthsConsumer);
+        if (Objects.isNull(expression)) {
+            final JSITLiteralExpression mockLiteralExpression = new JSITLiteralExpression();
+            expression = getWrappedJSITLiteralExpression(mockLiteralExpression, "dmn", "literalExpression");
+        }
 
         result.setVariable(variable);
         result.setExpression(expression);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ContextEntryPropertyConverter.java
@@ -32,7 +32,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSIT
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.kie.JSITComponentWidths;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.mapper.JsUtils;
 
-import static org.kie.workbench.common.dmn.webapp.kogito.marshaller.mapper.utils.WrapperUtils.getWrappedJSITLiteralExpression;
+import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.utils.WrapperUtils.getWrappedJSITLiteralExpression;
 
 public class ContextEntryPropertyConverter {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ContextEntryPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ContextEntryPropertyConverter.java
@@ -70,6 +70,7 @@ public class ContextEntryPropertyConverter {
                                                                           componentWidthsConsumer);
         if (Objects.isNull(expression)) {
             final JSITLiteralExpression mockLiteralExpression = new JSITLiteralExpression();
+            mockLiteralExpression.setText(ContextEntry.DEFAULT_EXPRESSION_VALUE);
             expression = getWrappedJSITLiteralExpression(mockLiteralExpression, "dmn", "literalExpression");
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DecisionConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DecisionConverter.java
@@ -127,12 +127,9 @@ public class DecisionConverter implements NodeConverter<JSITDecision, org.kie.wo
         d.setName(source.getName().getValue());
         final JSITInformationItem variable = InformationItemPrimaryPropertyConverter.dmnFromWB(source.getVariable(), source);
         d.setVariable(variable);
-        final JSITExpression expression = ExpressionPropertyConverter.dmnFromWB(source.getExpression(),
-                                                                                componentWidthsConsumer);
+        final JSITExpression expression = ExpressionPropertyConverter.dmnFromWB(source.getExpression(), componentWidthsConsumer);
+        d.setExpression(expression);
 
-        if (Objects.nonNull(expression)) {
-            d.setExpression(expression);
-        }
         final String question = QuestionPropertyConverter.dmnFromWB(source.getQuestion());
         if (!StringUtils.isEmpty(question)) {
             d.setQuestion(question);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/ExpressionPropertyConverter.java
@@ -108,12 +108,8 @@ public class ExpressionPropertyConverter {
 
     public static JSITExpression dmnFromWB(final Expression wb,
                                            final Consumer<JSITComponentWidths> componentWidthsConsumer) {
-        // SPECIAL CASE: to represent a partially edited DMN file.
-        // reference above.
         if (Objects.isNull(wb)) {
-            final JSITLiteralExpression mockedExpression = new JSITLiteralExpression();
-            final JSITLiteralExpression wrappedMockedExpression = getWrappedJSITLiteralExpression(mockedExpression, "dmn", "literalExpression");
-            return wrappedMockedExpression;
+            return null;
         }
 
         final String uuid = wb.getId().getValue();


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4724

Unit Test for kogito marshaller will be in https://issues.jboss.org/browse/KOGITO-406

Unit Test for existing backend marshalling is included in this PR.

I've manually tested (creating, saving and re-opening) with:-
- `-webapp-standalone` (server side marshalling)
- `-webapp-kogito-testing` (client side marshalling)
- Business Central (server side marshalling)