### PR TITLE
DROOLS-3677: [DMN Designer] Change tabs order

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImpl.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.HTMLElement;
@@ -87,5 +88,9 @@ public class NameAndDataTypePopoverImpl implements NameAndDataTypePopoverView.Pr
     @Override
     public void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback) {
         view.setOnClosedByKeyboardCallback(callback);
+    }
+
+    public void onDataTypePageNavTabActiveEvent(final @Observes DataTypePageTabActiveEvent event) {
+        hide();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImpl.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.dom.client.BrowserEvents;
@@ -416,9 +415,5 @@ public class NameAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl impl
 
     boolean isEnter(final KeyDownEvent event) {
         return Objects.equals(event.getNativeKeyCode(), KeyCodes.KEY_ENTER);
-    }
-
-    public void onDataTypePageNavTabActiveEvent(final @Observes DataTypePageTabActiveEvent event) {
-        hide();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverImplTest.java
@@ -30,6 +30,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +51,7 @@ public class NameAndDataTypePopoverImplTest {
     @Mock
     private QName typeRef;
 
-    private NameAndDataTypePopoverView.Presenter editor;
+    private NameAndDataTypePopoverImpl editor;
 
     @Before
     public void setup() {
@@ -116,11 +117,27 @@ public class NameAndDataTypePopoverImplTest {
     }
 
     @Test
-    public void testSetOnClosedByKeyboardCallback(){
+    public void testSetOnClosedByKeyboardCallback() {
         final Consumer callback = mock(Consumer.class);
 
         editor.setOnClosedByKeyboardCallback(callback);
 
         verify(view).setOnClosedByKeyboardCallback(callback);
+    }
+
+    @Test
+    public void testOnDataTypePageNavTabActiveEvent_WhenBound() {
+        editor.bind(bound, 0, 0);
+
+        editor.onDataTypePageNavTabActiveEvent(mock(DataTypePageTabActiveEvent.class));
+
+        verify(view).hide();
+    }
+
+    @Test
+    public void testOnDataTypePageNavTabActiveEvent_WhenNotBound() {
+        editor.onDataTypePageNavTabActiveEvent(mock(DataTypePageTabActiveEvent.class));
+
+        verify(view, never()).hide();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/NameAndDataTypePopoverViewImplTest.java
@@ -574,15 +574,6 @@ public class NameAndDataTypePopoverViewImplTest {
     }
 
     @Test
-    public void testOnDataTypePageNavTabActiveEvent() {
-        doNothing().when(view).hide(true);
-
-        view.onDataTypePageNavTabActiveEvent(mock(DataTypePageTabActiveEvent.class));
-
-        verify(view).hide();
-    }
-
-    @Test
     public void testOnClosedByKeyboard() {
         final Consumer consumer = mock(Consumer.class);
         final Optional opt = Optional.of(consumer);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
+import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -112,8 +113,8 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
 
     public static final String EDITOR_ID = "DMNDiagramEditor";
 
-    //Editor tabs: [0] Main editor, [1] Overview, [2] Documentation, [3] Data-Types, [4] Imported Models
-    protected static final int DATA_TYPES_PAGE_INDEX = 3;
+    //Editor tabs: [0] Main editor, [1] Documentation, [2] Data-Types, [3] Imported Models, [4] Overview
+    protected static final int DATA_TYPES_PAGE_INDEX = 2;
 
     private final SessionManager sessionManager;
     private final SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
@@ -259,7 +260,30 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         kieView.getMultiPage().addPage(dataTypesPage);
         kieView.getMultiPage().addPage(includedModelsPage);
 
+        kieView.addOverviewPage(overviewWidget,
+                                () -> overviewWidget.refresh(versionRecordManager.getVersion()));
+
         setupSearchComponent();
+    }
+
+    void superInitialiseKieEditorForSession(final ProjectDiagram diagram) {
+        super.initialiseKieEditorForSession(diagram);
+    }
+
+    @Override
+    protected void resetEditorPages(final Overview overview) {
+        overviewWidget.setContent(overview,
+                                  versionRecordManager.getPathToLatest());
+
+        resetMetadata(overview);
+
+        kieView.clear();
+        kieView.addMainEditorPage(baseView);
+    }
+
+    @Override
+    protected void resetEditorPagesOnLoadError(final Overview overview) {
+        super.resetEditorPages(overview);
     }
 
     @Override
@@ -316,10 +340,6 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
 
     public void onDataTypePageNavTabActiveEvent(final @Observes DataTypePageTabActiveEvent event) {
         kieView.getMultiPage().selectPage(DATA_TYPES_PAGE_INDEX);
-    }
-
-    void superInitialiseKieEditorForSession(final ProjectDiagram diagram) {
-        super.initialiseKieEditorForSession(diagram);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import javax.enterprise.event.Event;
 
+import com.google.gwt.user.client.Command;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import elemental2.dom.HTMLElement;
@@ -58,6 +59,7 @@ import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHand
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.documentation.DocumentationPage;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.kie.workbench.common.stunner.kogito.client.editor.AbstractDiagramEditorMenuSessionItems;
 import org.kie.workbench.common.stunner.project.client.editor.AbstractProjectDiagramEditor;
@@ -435,7 +437,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     public void testOnDataTypePageNavTabActiveEvent() {
         diagramEditor.onDataTypePageNavTabActiveEvent(mock(DataTypePageTabActiveEvent.class));
 
-        verify(multiPage).selectPage(3);
+        verify(multiPage).selectPage(DATA_TYPES_PAGE_INDEX);
     }
 
     @Test
@@ -546,5 +548,22 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     public void testOnRefreshFormPropertiesEvent() {
         diagramEditor.onRefreshFormPropertiesEvent(mock(RefreshFormPropertiesEvent.class));
         verify(searchBarComponent).disableSearch();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testTabContentOrdering() {
+        when(documentationView.isEnabled()).thenReturn(Boolean.TRUE);
+        when(documentationView.initialize(diagram)).thenReturn(documentationView);
+        when(kieView.getMultiPage()).thenReturn(multiPage);
+
+        open();
+
+        final InOrder inOrder = inOrder(kieView, multiPage);
+        inOrder.verify(kieView).addMainEditorPage(view);
+        inOrder.verify(kieView).addPage(any(DocumentationPage.class));
+        inOrder.verify(multiPage).addPage(dataTypesPage);
+        inOrder.verify(multiPage).addPage(includedModelsPage);
+        inOrder.verify(kieView).addOverviewPage(eq(overviewWidget), any(Command.class));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -222,7 +222,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
 
                 setOriginalHash(xml.hashCode());
                 updateTitle(metadata.getTitle());
-                resetEditorPages(((ProjectMetadata) metadata).getOverview());
+                resetEditorPagesOnLoadError(((ProjectMetadata) metadata).getOverview());
                 menuSessionItems.setEnabled(false);
 
                 getXMLEditorView().setReadOnly(isReadOnly);

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieEditor.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieEditor.java
@@ -286,7 +286,11 @@ public abstract class KieEditor<T>
                                 () -> overviewWidget.refresh(versionRecordManager.getVersion()));
     }
 
-    private void resetMetadata(final Overview overview) {
+    protected void resetEditorPagesOnLoadError(final Overview overview) {
+        resetEditorPages(overview);
+    }
+
+    protected void resetMetadata(final Overview overview) {
 
         this.metadata = overview.getMetadata();
 
@@ -477,14 +481,14 @@ public abstract class KieEditor<T>
             save(commitMessage);
             concurrentUpdateSessionInfo = null;
         };
-        
+
         if (saveWithComments) {
             savePopUpPresenter.show(versionRecordManager.getCurrentPath(),
                                     command);
         } else {
             command.execute("");
         }
-       
+
         concurrentUpdateSessionInfo = null;
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3677

This PR also fixes an issue navigating to the Data Types tab on a "fresh" diagram where the "Name and Data-Type" popover had not been previously displayed. The `DataTypePageTabActiveEvent` event (raised when clicking on the _manage_ link) was being handled in the _view_ and led to a NPE if it had not been bound to a _presenter_. I've moved handling to the _presenter_.