### PR TITLE
RHPAM-1560 Preferences breadcrumbs are not links

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/admin/DefaultAdminPageHelper.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/admin/DefaultAdminPageHelper.java
@@ -399,7 +399,8 @@ public class DefaultAdminPageHelper {
         breadcrumbs.clearBreadcrumbs(perspective);
         breadcrumbs.addBreadCrumb(perspective,
                                   constants.Admin(),
-                                  new DefaultPlaceRequest(ADMIN));
+                                  new DefaultPlaceRequest(ADMIN),
+                                  () -> placeManager.goTo(PerspectiveIds.ADMIN));
         breadcrumbs.addBreadCrumb(perspective,
                                   label,
                                   accessCommand);


### PR DESCRIPTION
Added command link to Admin breadcrumb
Test for related method already implemented in uppformer 
https://github.com/kiegroup/appformer/blob/master/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbsTest.java#L287
