### PR TITLE
AF-2333: removing dependency mina-core as only one class is used

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-build-maven/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-build-maven/pom.xml
@@ -144,10 +144,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.mina</groupId>
-      <artifactId>mina-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <type>jar</type>

--- a/kie-wb-common-ala/kie-wb-common-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/executor/gwt/GWTCodeServerPortLeaserImpl.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-build-maven/src/main/java/org/guvnor/ala/build/maven/executor/gwt/GWTCodeServerPortLeaserImpl.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.enterprise.context.ApplicationScoped;
 
-import org.apache.mina.util.ConcurrentHashSet;
 import org.guvnor.ala.config.gwt.CodeServerPortHandle;
 
 @ApplicationScoped
@@ -28,7 +27,7 @@ public class GWTCodeServerPortLeaserImpl implements GWTCodeServerPortLeaser {
 
     protected static final int CODE_SERVER_LOWEST_PORT = 5000;
     protected static final int CODE_SERVER_HIGHEST_PORT = 5010;
-    protected final Set<Integer> leasedCodeServerPorts = new ConcurrentHashSet<Integer>();
+    protected final Set<Integer> leasedCodeServerPorts = new ConcurrentHashMap<Integer, Integer>().keySet();
     protected Map<String, Integer> codeServerByProject = new ConcurrentHashMap<>();
 
     @Override


### PR DESCRIPTION
parent PR is kiegroup/droolsjbpm-build-bootstrap/pull/1102