### PR TITLE
JBPM-8826: Forms memory leaks fixes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -110,6 +110,12 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-api</artifactId>
     </dependency>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/DocumentationLinksFieldRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/DocumentationLinksFieldRenderer.java
@@ -20,7 +20,9 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
+import org.kie.workbench.common.dmn.api.property.dmn.DocumentationLinksFieldType;
 import org.kie.workbench.common.dmn.client.editors.documentation.DocumentationLinksWidget;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
@@ -28,6 +30,7 @@ import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContex
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 
 @Dependent
+@Renderer(type = DocumentationLinksFieldType.class)
 public class DocumentationLinksFieldRenderer extends FieldRenderer<DocumentationLinksFieldDefinition, DefaultFormGroup> {
 
     private DocumentationLinksWidget widget;
@@ -75,11 +78,6 @@ public class DocumentationLinksFieldRenderer extends FieldRenderer<Documentation
 
     @Override
     public String getName() {
-        return DocumentationLinksFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return DocumentationLinksFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRenderer.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRenderer.java
@@ -23,7 +23,9 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBase;
+import org.kie.workbench.common.dmn.api.property.dmn.QNameFieldType;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePickerWidget;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
@@ -31,6 +33,7 @@ import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContex
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 
 @Dependent
+@Renderer(type = QNameFieldType.class)
 public class QNameFieldRenderer extends FieldRenderer<QNameFieldDefinition, DefaultFormGroup> {
 
     private DataTypePickerWidget typePicker;
@@ -82,11 +85,6 @@ public class QNameFieldRenderer extends FieldRenderer<QNameFieldDefinition, Defa
         formGroup.render(typePicker, field);
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return QNameFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/property/dmn/DocumentationLinksFieldRendererTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/property/dmn/DocumentationLinksFieldRendererTest.java
@@ -111,10 +111,4 @@ public class DocumentationLinksFieldRendererTest {
         assertEquals(DocumentationLinksFieldDefinition.FIELD_TYPE.getTypeName(),
                      renderer.getName());
     }
-
-    @Test
-    public void testGetSupportedCode() {
-        assertEquals(DocumentationLinksFieldDefinition.FIELD_TYPE.getTypeName(),
-                     renderer.getSupportedCode());
-    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRendererTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/property/dmn/QNameFieldRendererTest.java
@@ -130,12 +130,6 @@ public class QNameFieldRendererTest {
     }
 
     @Test
-    public void testGetSupportedCode() {
-        assertEquals(QNameFieldDefinition.FIELD_TYPE.getTypeName(),
-                     renderer.getSupportedCode());
-    }
-
-    @Test
     public void testSetReadOnly() {
         renderer.setReadOnly(false);
         verify(typePicker).setEnabled(true);

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/pom.xml
@@ -137,6 +137,12 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-api</artifactId>
     </dependency>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicFormRendererViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicFormRendererViewImpl.java
@@ -43,6 +43,9 @@ public class DynamicFormRendererViewImpl extends Composite implements DynamicFor
     @DataField
     private FlowPanel formContent;
 
+    @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     private HTMLElement layoutContent;
 
     private DynamicFormRenderer presenter;
@@ -58,7 +61,7 @@ public class DynamicFormRendererViewImpl extends Composite implements DynamicFor
 
         if (context != null) {
             layoutContent = layoutGenerator.buildLayout(context);
-            formContent.add(FormsElementWrapperWidgetUtil.getWidget(this, layoutContent));
+            formContent.add(wrapperWidgetUtil.getWidget(this, layoutContent));
         }
     }
 
@@ -76,8 +79,8 @@ public class DynamicFormRendererViewImpl extends Composite implements DynamicFor
 
     @Override
     public void clear() {
-        if(layoutContent != null) {
-            FormsElementWrapperWidgetUtil.clear(this);
+        if (layoutContent != null) {
+            wrapperWidgetUtil.clear(this);
             layoutContent = null;
         }
         formContent.clear();

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicFormRendererViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicFormRendererViewImpl.java
@@ -22,12 +22,12 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Widget;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldLayoutComponent;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FormLayoutGenerator;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
@@ -43,6 +43,8 @@ public class DynamicFormRendererViewImpl extends Composite implements DynamicFor
     @DataField
     private FlowPanel formContent;
 
+    private HTMLElement layoutContent;
+
     private DynamicFormRenderer presenter;
 
     @Override
@@ -52,12 +54,11 @@ public class DynamicFormRendererViewImpl extends Composite implements DynamicFor
 
     @Override
     public void render(FormRenderingContext context) {
-        layoutGenerator.clear();
-        formContent.clear();
+        clear();
 
         if (context != null) {
-            Widget layout = ElementWrapperWidget.getWidget(layoutGenerator.buildLayout(context));
-            formContent.add(layout);
+            layoutContent = layoutGenerator.buildLayout(context);
+            formContent.add(FormsElementWrapperWidgetUtil.getWidget(this, layoutContent));
         }
     }
 
@@ -75,6 +76,11 @@ public class DynamicFormRendererViewImpl extends Composite implements DynamicFor
 
     @Override
     public void clear() {
+        if(layoutContent != null) {
+            FormsElementWrapperWidgetUtil.clear(this);
+            layoutContent = null;
+        }
         formContent.clear();
+        layoutGenerator.clear();
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicRendererEntryPoint.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicRendererEntryPoint.java
@@ -16,11 +16,40 @@
 
 package org.kie.workbench.common.forms.dynamic.client;
 
+import java.util.Collection;
+
+import javax.annotation.PostConstruct;
+
 import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ioc.client.container.IOC;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
+import org.kie.workbench.common.forms.adf.rendering.FieldRendererTypesProvider;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRendererTypeRegistry;
 
 @EntryPoint
 @Bundle("resources/i18n/FormRenderingConstants.properties")
 public class DynamicRendererEntryPoint {
 
+    @PostConstruct
+    public void init() {
+        pouplateFieldRenderersRegistry();
+    }
+
+    private void pouplateFieldRenderersRegistry() {
+
+        final SyncBeanManager beanManager = IOC.getBeanManager();
+
+        Collection<SyncBeanDef<FieldRendererTypesProvider>> providers = beanManager.lookupBeans(FieldRendererTypesProvider.class);
+
+        providers.forEach(providerDef -> {
+            FieldRendererTypesProvider provider = providerDef.newInstance();
+
+            FieldRendererTypeRegistry.load(provider);
+
+            beanManager.destroyBean(provider);
+        });
+
+    }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicRendererEntryPoint.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/DynamicRendererEntryPoint.java
@@ -19,9 +19,9 @@ package org.kie.workbench.common.forms.dynamic.client;
 import java.util.Collection;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.EntryPoint;
-import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
@@ -32,14 +32,19 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRendererType
 @Bundle("resources/i18n/FormRenderingConstants.properties")
 public class DynamicRendererEntryPoint {
 
-    @PostConstruct
-    public void init() {
-        pouplateFieldRenderersRegistry();
+    private SyncBeanManager beanManager;
+
+    @Inject
+    public DynamicRendererEntryPoint(SyncBeanManager beanManager) {
+        this.beanManager = beanManager;
     }
 
-    private void pouplateFieldRenderersRegistry() {
+    @PostConstruct
+    public void init() {
+        populateFieldRenderersRegistry();
+    }
 
-        final SyncBeanManager beanManager = IOC.getBeanManager();
+    private void populateFieldRenderersRegistry() {
 
         Collection<SyncBeanDef<FieldRendererTypesProvider>> providers = beanManager.lookupBeans(FieldRendererTypesProvider.class);
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldLayoutComponent.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldLayoutComponent.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.forms.dynamic.client.rendering;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -38,10 +39,8 @@ public class FieldLayoutComponent implements FormLayoutComponent,
 
     protected FlowPanel content = new FlowPanel();
 
-    @Inject
     protected FieldRendererManager fieldRendererManager;
 
-    @Inject
     protected TranslationService translationService;
 
     protected FieldDefinition field;
@@ -49,6 +48,12 @@ public class FieldLayoutComponent implements FormLayoutComponent,
     protected FieldRenderer fieldRenderer;
 
     protected FormRenderingContext renderingContext;
+
+    @Inject
+    public FieldLayoutComponent(FieldRendererManager fieldRendererManager, TranslationService translationService) {
+        this.fieldRendererManager = fieldRendererManager;
+        this.translationService = translationService;
+    }
 
     public void init(FormRenderingContext renderingContext,
                      FieldDefinition field) {
@@ -106,7 +111,6 @@ public class FieldLayoutComponent implements FormLayoutComponent,
         return content;
     }
 
-
     protected void renderContent() {
         content.clear();
         content.add(fieldRenderer.renderWidget());
@@ -132,5 +136,10 @@ public class FieldLayoutComponent implements FormLayoutComponent,
 
     public FieldDefinition getField() {
         return field;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        content.clear();
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldLayoutComponent.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldLayoutComponent.java
@@ -67,8 +67,7 @@ public class FieldLayoutComponent implements FormLayoutComponent,
     protected void initComponent() {
         fieldRenderer = fieldRendererManager.getRendererForField(field);
         if (fieldRenderer != null) {
-            fieldRenderer.init(renderingContext,
-                               field);
+            fieldRenderer.init(renderingContext, field);
         }
     }
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRenderer.java
@@ -40,7 +40,7 @@ import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeListener;
 import org.kie.workbench.common.forms.processing.engine.handling.FormField;
 
-public abstract class FieldRenderer<F extends FieldDefinition, FORM_GROUP extends FormGroup> {
+public abstract class FieldRenderer<F extends FieldDefinition, G extends FormGroup> {
 
     protected FormRenderingContext renderingContext;
     protected String fieldNS;
@@ -51,10 +51,13 @@ public abstract class FieldRenderer<F extends FieldDefinition, FORM_GROUP extend
     private Map<String, IsWidget> partsWidgets = new HashMap<>();
 
     @Inject
-    protected ManagedInstance<FORM_GROUP> formGroupsInstance;
+    protected ManagedInstance<G> formGroupsInstance;
 
     @Inject
-    private ConfigErrorDisplayer errorDisplayer;
+    protected ConfigErrorDisplayer errorDisplayer;
+
+    @Inject
+    protected FormsElementWrapperWidgetUtil wrapperWidgetUtil;
 
     public void init(FormRenderingContext renderingContext, F field) {
         this.renderingContext = renderingContext;
@@ -114,7 +117,7 @@ public abstract class FieldRenderer<F extends FieldDefinition, FORM_GROUP extend
 
             registerCustomFieldValidators(formField);
 
-            return FormsElementWrapperWidgetUtil.getWidget(this, formGroup.getElement());
+            return wrapperWidgetUtil.getWidget(this, formGroup.getElement());
         }
     }
 
@@ -180,10 +183,7 @@ public abstract class FieldRenderer<F extends FieldDefinition, FORM_GROUP extend
 
     @PreDestroy
     public void preDestroy() {
-        // checking if formGroup is not null, it might be null inside of the form editor
-        if(formGroup != null) {
-            FormsElementWrapperWidgetUtil.clear(this);
-        }
+        wrapperWidgetUtil.clear(this);
         partsWidgets.values().forEach(part -> part.asWidget().removeFromParent());
         partsWidgets.clear();
         formGroupsInstance.destroyAll();

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererManagerImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererManagerImpl.java
@@ -16,19 +16,11 @@
 
 package org.kie.workbench.common.forms.dynamic.client.rendering;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.jboss.errai.ioc.client.container.IOC;
-import org.jboss.errai.ioc.client.container.SyncBeanDef;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
 @Dependent
@@ -36,49 +28,15 @@ public class FieldRendererManagerImpl implements FieldRendererManager {
 
     private ManagedInstance<FieldRenderer> renderers;
 
-    protected static boolean initialized = false;
-
-    protected static Map<String, Class<? extends FieldRenderer>> availableRenderers = new HashMap<>();
-
-    protected static Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> fieldDefinitionRemderers = new HashMap<>();
-
     @Inject
     public FieldRendererManagerImpl(ManagedInstance<FieldRenderer> renderers) {
         this.renderers = renderers;
     }
 
-    @PostConstruct
-    public void init() {
-        if (!initialized) {
-            registerRenderers(IOC.getBeanManager().lookupBeans(FieldRenderer.class));
-            initialized = true;
-        }
-    }
-
-    protected void registerRenderers(Collection<SyncBeanDef<FieldRenderer>> renderers) {
-        PortablePreconditions.checkNotNull("renderers",
-                                           renderers);
-        renderers.forEach(rendererDef -> {
-            FieldRenderer renderer = rendererDef.getInstance();
-            if (renderer != null) {
-                if (renderer instanceof FieldDefinitionFieldRenderer) {
-                    fieldDefinitionRemderers.put(((FieldDefinitionFieldRenderer) renderer).getSupportedFieldDefinition(),
-                                                 (Class<? extends FieldRenderer>) rendererDef.getBeanClass());
-                } else {
-                    availableRenderers.put(renderer.getSupportedCode(),
-                                           (Class<? extends FieldRenderer>) rendererDef.getBeanClass());
-                }
-            }
-        });
-    }
-
     @Override
     public FieldRenderer getRendererForField(FieldDefinition fieldDefinition) {
-        Class<? extends FieldRenderer> rendererClass = fieldDefinitionRemderers.get(fieldDefinition.getClass());
 
-        if (rendererClass == null) {
-            rendererClass = availableRenderers.get(fieldDefinition.getFieldType().getTypeName());
-        }
+        Class<? extends FieldRenderer> rendererClass = FieldRendererTypeRegistry.getFieldRenderer(fieldDefinition);
 
         if (rendererClass != null) {
             return renderers.select(rendererClass).get();

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererTypeRegistry.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererTypeRegistry.java
@@ -33,10 +33,10 @@ public class FieldRendererTypeRegistry {
     }
 
     public static void load(FieldRendererTypesProvider provider) {
-        if(!provider.getFieldTypeRenderers().isEmpty()) {
+        if (!provider.getFieldTypeRenderers().isEmpty()) {
             fieldTypeRenderers.putAll(provider.getFieldTypeRenderers());
         }
-        if(!provider.getFieldDefinitionRenderers().isEmpty()) {
+        if (!provider.getFieldDefinitionRenderers().isEmpty()) {
             fieldDefinitionRemderers.putAll(provider.getFieldDefinitionRenderers());
         }
     }
@@ -44,7 +44,7 @@ public class FieldRendererTypeRegistry {
     public static Class<? extends FieldRenderer> getFieldRenderer(FieldDefinition fieldDefinition) {
         Class<? extends FieldRenderer> rendererClass = fieldDefinitionRemderers.get(fieldDefinition.getClass());
 
-        if(rendererClass == null) {
+        if (rendererClass == null) {
             rendererClass = fieldTypeRenderers.get(fieldDefinition.getFieldType().getClass());
         }
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererTypeRegistry.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererTypeRegistry.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.workbench.common.forms.adf.rendering.FieldRendererTypesProvider;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.FieldType;
+
+public class FieldRendererTypeRegistry {
+
+    private static Map<Class<? extends FieldType>, Class<? extends FieldRenderer>> fieldTypeRenderers = new HashMap<>();
+
+    private static Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> fieldDefinitionRemderers = new HashMap<>();
+
+    private FieldRendererTypeRegistry() {
+    }
+
+    public static void load(FieldRendererTypesProvider provider) {
+        if(!provider.getFieldTypeRenderers().isEmpty()) {
+            fieldTypeRenderers.putAll(provider.getFieldTypeRenderers());
+        }
+        if(!provider.getFieldDefinitionRenderers().isEmpty()) {
+            fieldDefinitionRemderers.putAll(provider.getFieldDefinitionRenderers());
+        }
+    }
+
+    public static Class<? extends FieldRenderer> getFieldRenderer(FieldDefinition fieldDefinition) {
+        Class<? extends FieldRenderer> rendererClass = fieldDefinitionRemderers.get(fieldDefinition.getClass());
+
+        if(rendererClass == null) {
+            rendererClass = fieldTypeRenderers.get(fieldDefinition.getFieldType().getClass());
+        }
+
+        return rendererClass;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FormGeneratorDriver.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/FormGeneratorDriver.java
@@ -28,9 +28,8 @@ import javax.inject.Inject;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.constants.ColumnSize;
-import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.Document;
 import org.jboss.errai.common.client.dom.HTMLElement;
-import org.jboss.errai.common.client.dom.Window;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
@@ -48,17 +47,24 @@ import org.uberfire.ext.layout.editor.client.infra.ColumnSizeBuilder;
 @Dependent
 public class FormGeneratorDriver implements LayoutGeneratorDriver {
 
+    static final String CONTAINER_TAG = "div";
+    static final String ROW_CLASS = "row";
+
     private SyncBeanManager beanManager;
     private ManagedInstance<LayoutDragComponent> instance;
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+    private Document document;
+
     private List<FieldLayoutComponent> layoutComponents = new ArrayList<>();
-    private List<HTMLElement> layoutElements = new ArrayList<>();
     private Map<String, Class<? extends LayoutDragComponent>> componentsCache = new HashMap<>();
     private FormRenderingContext renderingContext;
 
     @Inject
-    public FormGeneratorDriver(SyncBeanManager beanManager, ManagedInstance<LayoutDragComponent> instance) {
+    public FormGeneratorDriver(SyncBeanManager beanManager, ManagedInstance<LayoutDragComponent> instance, FormsElementWrapperWidgetUtil wrapperWidgetUtil, Document document) {
         this.beanManager = beanManager;
         this.instance = instance;
+        this.wrapperWidgetUtil = wrapperWidgetUtil;
+        this.document = document;
     }
 
     public FormRenderingContext getRenderingContext() {
@@ -71,24 +77,24 @@ public class FormGeneratorDriver implements LayoutGeneratorDriver {
 
     @Override
     public HTMLElement createContainer() {
-        Div column = (Div) Window.getDocument().createElement("div");
-        column.setClassName(ColumnSize.MD_12.getCssName());
-        return column;
+        HTMLElement container = document.createElement(CONTAINER_TAG);
+        container.setClassName(ColumnSize.MD_12.getCssName());
+        return container;
     }
 
     @Override
     public HTMLElement createRow(LayoutRow layoutRow) {
-        Div div = (Div) Window.getDocument().createElement("div");
-        div.setClassName("row");
-        return div;
+        HTMLElement row = document.createElement(CONTAINER_TAG);
+        row.setClassName(ROW_CLASS);
+        return row;
     }
 
     @Override
     public HTMLElement createColumn(LayoutColumn layoutColumn) {
-        Div div = (Div) Window.getDocument().createElement("div");
+        HTMLElement column = document.createElement(CONTAINER_TAG);
         String colSize = ColumnSizeBuilder.buildColumnSize(new Integer(layoutColumn.getSpan()));
-        div.setClassName(colSize);
-        return div;
+        column.setClassName(colSize);
+        return column;
     }
 
     @Override
@@ -101,7 +107,7 @@ public class FormGeneratorDriver implements LayoutGeneratorDriver {
         }
         return null;
     }
-    
+
     @Override
     public Optional<IsWidget> getComponentPart(HTMLElement column, LayoutComponent layoutComponent, String partId) {
         FieldDefinition field = getFieldForLayoutComponent(layoutComponent);
@@ -114,7 +120,7 @@ public class FormGeneratorDriver implements LayoutGeneratorDriver {
         return Optional.empty();
     }
 
-    protected LayoutDragComponent lookupComponent(LayoutComponent layoutComponent) {
+    private LayoutDragComponent lookupComponent(LayoutComponent layoutComponent) {
         Class<? extends LayoutDragComponent> clazz = componentsCache.get(layoutComponent.getDragTypeName());
         if (clazz == null) {
             SyncBeanDef dragTypeDef = beanManager.lookupBeans(layoutComponent.getDragTypeName()).iterator().next();
@@ -130,8 +136,8 @@ public class FormGeneratorDriver implements LayoutGeneratorDriver {
             FieldLayoutComponent fieldComponent = (FieldLayoutComponent) dragComponent;
 
             FieldDefinition field = getFieldForLayoutComponent(layoutComponent);
-            fieldComponent.init(renderingContext,
-                                field);
+
+            fieldComponent.init(renderingContext, field);
 
             layoutComponents.add(fieldComponent);
         }
@@ -153,20 +159,18 @@ public class FormGeneratorDriver implements LayoutGeneratorDriver {
     }
 
     private Widget getWidget(HTMLElement element) {
-        layoutElements.add(element);
-        return FormsElementWrapperWidgetUtil.getWidget(this, element);
+        return wrapperWidgetUtil.getWidget(this, element);
     }
 
     public void clear() {
         layoutComponents.clear();
         instance.destroyAll();
-        FormsElementWrapperWidgetUtil.clear(this);
-        layoutElements.clear();
+        wrapperWidgetUtil.clear(this);
         componentsCache.clear();
         renderingContext = null;
     }
-    
-    private FieldDefinition getFieldForLayoutComponent(LayoutComponent layoutComponent) {
+
+    FieldDefinition getFieldForLayoutComponent(LayoutComponent layoutComponent) {
         FieldDefinition field = renderingContext.getRootForm().getFieldById(layoutComponent.getProperties().get(
                 FieldLayoutComponent.FIELD_ID));
         return field;

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/checkbox/CheckBoxFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/checkbox/CheckBoxFormGroupViewImpl.java
@@ -19,16 +19,17 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.HTMLElement;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.labels.label.FieldLabel;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
 @Templated
@@ -50,7 +51,7 @@ public class CheckBoxFormGroupViewImpl implements IsElement,
 
         fieldLabel.renderForInput(widget,
                                   field);
-        viewPartsWidget.put("Check Box Label", ElementWrapperWidget.getWidget(fieldLabel.getElement()));
+        viewPartsWidget.put("Check Box Label", FormsElementWrapperWidgetUtil.getWidget(this, fieldLabel.getElement()));
     }
 
     @Override
@@ -61,5 +62,10 @@ public class CheckBoxFormGroupViewImpl implements IsElement,
     @Override
     public Map<String, Widget> getViewPartsWidgets() {
         return viewPartsWidget;
+    }
+
+    @PreDestroy
+    public void clear() {
+        FormsElementWrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/checkbox/CheckBoxFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/checkbox/CheckBoxFormGroupViewImpl.java
@@ -44,6 +44,9 @@ public class CheckBoxFormGroupViewImpl implements IsElement,
     @DataField
     protected Div helpBlock;
 
+    @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     private Map<String, Widget> viewPartsWidget = new HashMap<>();
 
     public void render(Widget widget,
@@ -51,7 +54,7 @@ public class CheckBoxFormGroupViewImpl implements IsElement,
 
         fieldLabel.renderForInput(widget,
                                   field);
-        viewPartsWidget.put("Check Box Label", FormsElementWrapperWidgetUtil.getWidget(this, fieldLabel.getElement()));
+        viewPartsWidget.put("Check Box Label", wrapperWidgetUtil.getWidget(this, fieldLabel.getElement()));
     }
 
     @Override
@@ -66,6 +69,6 @@ public class CheckBoxFormGroupViewImpl implements IsElement,
 
     @PreDestroy
     public void clear() {
-        FormsElementWrapperWidgetUtil.clear(this);
+        wrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/def/DefaultFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/def/DefaultFormGroupViewImpl.java
@@ -19,17 +19,18 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.HTMLElement;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.labels.label.FieldLabel;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
 @Templated
@@ -72,7 +73,7 @@ public class DefaultFormGroupViewImpl implements IsElement,
         fieldContainer.clear();
         fieldContainer.add(widget);
         
-        Widget labelWidget = ElementWrapperWidget.getWidget(fieldLabel.getElement());
+        Widget labelWidget = FormsElementWrapperWidgetUtil.getWidget(this, fieldLabel.getElement());
         partsWidgets.put(PART_LABEL, labelWidget);
     }
 
@@ -84,5 +85,10 @@ public class DefaultFormGroupViewImpl implements IsElement,
     @Override
     public Map<String, Widget> getViewPartsWidgets() {
         return partsWidgets;
+    }
+
+    @PreDestroy
+    public void clear() {
+        FormsElementWrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/def/DefaultFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/def/DefaultFormGroupViewImpl.java
@@ -53,6 +53,9 @@ public class DefaultFormGroupViewImpl implements IsElement,
     @DataField
     protected Div helpBlock;
 
+    @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     @Override
     public void render(Widget widget,
                        FieldDefinition fieldDefinition) {
@@ -73,7 +76,7 @@ public class DefaultFormGroupViewImpl implements IsElement,
         fieldContainer.clear();
         fieldContainer.add(widget);
         
-        Widget labelWidget = FormsElementWrapperWidgetUtil.getWidget(this, fieldLabel.getElement());
+        Widget labelWidget = wrapperWidgetUtil.getWidget(this, fieldLabel.getElement());
         partsWidgets.put(PART_LABEL, labelWidget);
     }
 
@@ -89,6 +92,6 @@ public class DefaultFormGroupViewImpl implements IsElement,
 
     @PreDestroy
     public void clear() {
-        FormsElementWrapperWidgetUtil.clear(this);
+        wrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/collapse/CollapsibleFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/collapse/CollapsibleFormGroupViewImpl.java
@@ -74,6 +74,9 @@ public class CollapsibleFormGroupViewImpl implements IsElement,
     @DataField
     private Div helpBlock;
 
+    @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     private Presenter presenter;
 
     private Map<String, Widget> partsWidget = new HashMap<>();
@@ -107,7 +110,7 @@ public class CollapsibleFormGroupViewImpl implements IsElement,
 
         container.add(widget);
 
-        partsWidget.put(PART_ANCHOR_TEXT, FormsElementWrapperWidgetUtil.getWidget(this, anchorText));
+        partsWidget.put(PART_ANCHOR_TEXT, wrapperWidgetUtil.getWidget(this, anchorText));
     }
 
     @Override
@@ -144,6 +147,6 @@ public class CollapsibleFormGroupViewImpl implements IsElement,
     @PreDestroy
     public void destroy() {
         container.clear();
-        FormsElementWrapperWidgetUtil.clear(this);
+        wrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/collapse/CollapsibleFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/collapse/CollapsibleFormGroupViewImpl.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import com.google.gwt.dom.client.Document;
@@ -29,13 +30,13 @@ import org.jboss.errai.common.client.dom.Anchor;
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.Span;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.labels.help.FieldHelp;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.labels.required.FieldRequired;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
 @Templated
@@ -105,8 +106,8 @@ public class CollapsibleFormGroupViewImpl implements IsElement,
         container.clear();
 
         container.add(widget);
-        
-        partsWidget.put(PART_ANCHOR_TEXT, ElementWrapperWidget.getWidget(anchorText));
+
+        partsWidget.put(PART_ANCHOR_TEXT, FormsElementWrapperWidgetUtil.getWidget(this, anchorText));
     }
 
     @Override
@@ -134,9 +135,15 @@ public class CollapsibleFormGroupViewImpl implements IsElement,
     public void onClick(ClickEvent clickEvent) {
         presenter.notifyClick();
     }
-    
+
     @Override
     public Map<String, Widget> getViewPartsWidgets() {
         return partsWidget;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        container.clear();
+        FormsElementWrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/fieldSet/FieldSetFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/fieldSet/FieldSetFormGroupViewImpl.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -29,12 +30,12 @@ import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.Span;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.labels.help.FieldHelp;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.labels.required.FieldRequired;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
 @Templated
@@ -92,11 +93,16 @@ public class FieldSetFormGroupViewImpl implements IsElement,
 
         fieldContainer.add(widget);
         
-        partsWidgets.put(PART_LEGEND_TEXT, ElementWrapperWidget.getWidget(legendText));
+        partsWidgets.put(PART_LEGEND_TEXT, FormsElementWrapperWidgetUtil.getWidget(this, legendText));
     }
     
     @Override
     public Map<String, Widget> getViewPartsWidgets() {
         return partsWidgets;
+    }
+
+    @PreDestroy
+    public void clear() {
+        FormsElementWrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/fieldSet/FieldSetFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/nestedForm/fieldSet/FieldSetFormGroupViewImpl.java
@@ -70,6 +70,9 @@ public class FieldSetFormGroupViewImpl implements IsElement,
     @DataField
     protected Div helpBlock;
 
+    @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     private Map<String, Widget> partsWidgets = new HashMap<>();
 
     @Override
@@ -93,7 +96,7 @@ public class FieldSetFormGroupViewImpl implements IsElement,
 
         fieldContainer.add(widget);
         
-        partsWidgets.put(PART_LEGEND_TEXT, FormsElementWrapperWidgetUtil.getWidget(this, legendText));
+        partsWidgets.put(PART_LEGEND_TEXT, wrapperWidgetUtil.getWidget(this, legendText));
     }
     
     @Override
@@ -103,6 +106,6 @@ public class FieldSetFormGroupViewImpl implements IsElement,
 
     @PreDestroy
     public void clear() {
-        FormsElementWrapperWidgetUtil.clear(this);
+        wrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/slider/SliderFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/slider/SliderFormGroupViewImpl.java
@@ -49,6 +49,9 @@ public class SliderFormGroupViewImpl implements SliderFormGroupView {
     @DataField
     protected Div helpBlock;
 
+    @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     private Map<String, Widget> viewPartsWidgets = new HashMap<>();
 
     @Override
@@ -58,7 +61,7 @@ public class SliderFormGroupViewImpl implements SliderFormGroupView {
         render("", widget, fieldDefinition);
         
         viewPartsWidgets.put(PART_SLIDER_LABEL,
-                             FormsElementWrapperWidgetUtil.getWidget(this, fieldLabel.getElement()));
+                             wrapperWidgetUtil.getWidget(this, fieldLabel.getElement()));
     }
 
     public void render(String inputId, Widget widget, FieldDefinition fieldDefinition) {
@@ -81,6 +84,6 @@ public class SliderFormGroupViewImpl implements SliderFormGroupView {
 
     @PreDestroy
     public void clear() {
-        FormsElementWrapperWidgetUtil.clear(this);
+        wrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/slider/SliderFormGroupViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/formGroups/impl/slider/SliderFormGroupViewImpl.java
@@ -19,16 +19,17 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.HTMLElement;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.labels.label.FieldLabel;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
 @Templated
@@ -56,8 +57,8 @@ public class SliderFormGroupViewImpl implements SliderFormGroupView {
 
         render("", widget, fieldDefinition);
         
-        viewPartsWidgets.put(PART_SLIDER_LABEL, 
-                             ElementWrapperWidget.getWidget(fieldLabel.getElement()));
+        viewPartsWidgets.put(PART_SLIDER_LABEL,
+                             FormsElementWrapperWidgetUtil.getWidget(this, fieldLabel.getElement()));
     }
 
     public void render(String inputId, Widget widget, FieldDefinition fieldDefinition) {
@@ -76,5 +77,10 @@ public class SliderFormGroupViewImpl implements SliderFormGroupView {
     @Override
     public Map<String, Widget> getViewPartsWidgets() {
         return viewPartsWidgets;
+    }
+
+    @PreDestroy
+    public void clear() {
+        FormsElementWrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/CheckBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/CheckBoxFieldRenderer.java
@@ -19,13 +19,16 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
 import javax.enterprise.context.Dependent;
 
 import org.gwtbootstrap3.client.ui.SimpleCheckBox;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.checkbox.CheckBoxFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.definition.CheckBoxFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.type.CheckBoxFieldType;
 
 @Dependent
+@Renderer(type = CheckBoxFieldType.class)
 public class CheckBoxFieldRenderer extends FieldRenderer<CheckBoxFieldDefinition, CheckBoxFormGroup> {
 
     private SimpleCheckBox checkbox;
@@ -43,17 +46,11 @@ public class CheckBoxFieldRenderer extends FieldRenderer<CheckBoxFieldDefinition
 
         CheckBoxFormGroup formGroup = formGroupsInstance.get();
 
-        formGroup.render(checkbox,
-                         field);
+        formGroup.render(checkbox, field);
         
         registerFieldRendererPart(checkbox);
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return CheckBoxFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/CheckBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/CheckBoxFieldRenderer.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.ui.SimpleCheckBox;
 import org.kie.workbench.common.forms.adf.rendering.Renderer;
@@ -31,6 +32,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.ty
 @Renderer(type = CheckBoxFieldType.class)
 public class CheckBoxFieldRenderer extends FieldRenderer<CheckBoxFieldDefinition, CheckBoxFormGroup> {
 
+    @Inject
     private SimpleCheckBox checkbox;
 
     @Override
@@ -40,7 +42,7 @@ public class CheckBoxFieldRenderer extends FieldRenderer<CheckBoxFieldDefinition
 
     @Override
     protected FormGroup getFormGroup(RenderMode renderMode) {
-        checkbox = new SimpleCheckBox();
+        checkbox.setId(generateUniqueId());
         checkbox.setName(fieldNS);
         checkbox.setEnabled(!field.getReadOnly() && renderingContext.getRenderMode().equals(RenderMode.EDIT_MODE));
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/DecimalBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/DecimalBoxFieldRenderer.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.HTML;
 import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.ValueConvertersFactory;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.decimalBox.DecimalBox;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
@@ -28,8 +29,10 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGr
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.definition.DecimalBoxFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.type.DecimalBoxFieldType;
 
 @Dependent
+@Renderer(type = DecimalBoxFieldType.class)
 public class DecimalBoxFieldRenderer extends FieldRenderer<DecimalBoxFieldDefinition, DefaultFormGroup>
         implements RequiresValueConverter {
 
@@ -65,11 +68,6 @@ public class DecimalBoxFieldRenderer extends FieldRenderer<DecimalBoxFieldDefini
         }
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return DecimalBoxFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/IntegerBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/IntegerBoxFieldRenderer.java
@@ -69,9 +69,7 @@ public class IntegerBoxFieldRenderer extends FieldRenderer<IntegerBoxFieldDefini
 
         DefaultFormGroup formGroup = formGroupsInstance.get();
 
-        formGroup.render(inputId,
-                         widget,
-                         field);
+        formGroup.render(inputId, widget, field);
         registerFieldRendererPart(widget);
 
         return formGroup;

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/IntegerBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/IntegerBoxFieldRenderer.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.ValueConvertersFactory;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.integerBox.IntegerBox;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
@@ -29,8 +30,10 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGr
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.definition.IntegerBoxFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.type.IntegerBoxFieldType;
 
 @Dependent
+@Renderer(type = IntegerBoxFieldType.class)
 public class IntegerBoxFieldRenderer extends FieldRenderer<IntegerBoxFieldDefinition, DefaultFormGroup>
         implements RequiresValueConverter {
 
@@ -72,11 +75,6 @@ public class IntegerBoxFieldRenderer extends FieldRenderer<IntegerBoxFieldDefini
         registerFieldRendererPart(widget);
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return IntegerBoxFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/SliderFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/SliderFieldRenderer.java
@@ -20,6 +20,7 @@ import javax.enterprise.context.Dependent;
 
 import com.google.gwt.i18n.client.NumberFormat;
 import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.slider.Slider;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.slider.converters.IntegerToDoubleConverter;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
@@ -27,8 +28,10 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGr
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.slider.SliderFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition.SliderBaseDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.type.SliderFieldType;
 
 @Dependent
+@Renderer(type = SliderFieldType.class)
 public class SliderFieldRenderer extends FieldRenderer<SliderBaseDefinition, SliderFormGroup>
         implements RequiresValueConverter {
 
@@ -73,11 +76,6 @@ public class SliderFieldRenderer extends FieldRenderer<SliderBaseDefinition, Sli
             }
         }
         return NumberFormat.getFormat(pattern);
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return SliderBaseDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRenderer.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.HTML;
 import org.gwtbootstrap3.client.ui.TextArea;
@@ -34,12 +35,13 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.ty
 @Renderer(type = TextAreaFieldType.class)
 public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition, DefaultFormGroup> implements RequiresValueConverter {
 
+    @Inject
+    private TextArea textArea;
+
     @Override
     public String getName() {
         return "TextArea";
     }
-
-    private TextArea textArea;
 
     @Override
     protected FormGroup getFormGroup(RenderMode renderMode) {
@@ -51,16 +53,14 @@ public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition
         } else {
             String inputId = generateUniqueId();
 
-            textArea = new TextArea();
             textArea.setId(inputId);
             textArea.setName(fieldNS);
             textArea.setPlaceholder(field.getPlaceHolder());
             textArea.setVisibleLines(field.getRows());
             textArea.setEnabled(!field.getReadOnly());
-            textArea.setVisibleLines(field.getRows());
 
             formGroup.render(inputId, textArea, field);
-            
+
             registerFieldRendererPart(textArea);
         }
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRenderer.java
@@ -21,14 +21,17 @@ import javax.enterprise.context.Dependent;
 import com.google.gwt.user.client.ui.HTML;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.ObjectToStringConverter;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
 
 @Dependent
+@Renderer(type = TextAreaFieldType.class)
 public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition, DefaultFormGroup> implements RequiresValueConverter {
 
     @Override
@@ -44,9 +47,7 @@ public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition
         DefaultFormGroup formGroup = formGroupsInstance.get();
 
         if (renderMode.equals(RenderMode.PRETTY_MODE)) {
-            HTML html = new HTML();
-            formGroup.render(html,
-                             field);
+            formGroup.render(new HTML(), field);
         } else {
             String inputId = generateUniqueId();
 
@@ -64,11 +65,6 @@ public class TextAreaFieldRenderer extends FieldRenderer<TextAreaFieldDefinition
         }
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return TextAreaFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextBoxFieldRenderer.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.HTML;
 import org.gwtbootstrap3.client.ui.TextBox;
@@ -34,7 +35,8 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.typ
 @Renderer(type = TextBoxFieldType.class)
 public class TextBoxFieldRenderer extends FieldRenderer<TextBoxBaseDefinition, DefaultFormGroup> implements RequiresValueConverter {
 
-    private TextBox textBox;
+    @Inject
+    protected TextBox textBox;
 
     @Override
     public String getName() {
@@ -52,7 +54,6 @@ public class TextBoxFieldRenderer extends FieldRenderer<TextBoxBaseDefinition, D
                              field);
         } else {
             String inputId = generateUniqueId();
-            textBox = new TextBox();
             textBox.setName(fieldNS);
             textBox.setId(inputId);
             textBox.setPlaceholder(field.getPlaceHolder());

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextBoxFieldRenderer.java
@@ -21,17 +21,20 @@ import javax.enterprise.context.Dependent;
 import com.google.gwt.user.client.ui.HTML;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.ValueConvertersFactory;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxBaseDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.type.TextBoxFieldType;
 
 @Dependent
+@Renderer(type = TextBoxFieldType.class)
 public class TextBoxFieldRenderer extends FieldRenderer<TextBoxBaseDefinition, DefaultFormGroup> implements RequiresValueConverter {
 
-    private TextBox textBox = new TextBox();
+    private TextBox textBox;
 
     @Override
     public String getName() {
@@ -62,11 +65,6 @@ public class TextBoxFieldRenderer extends FieldRenderer<TextBoxBaseDefinition, D
         }
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return TextBoxBaseDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/date/DatePickerFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/date/DatePickerFieldRenderer.java
@@ -19,14 +19,17 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date.input.DatePickerWrapper;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.type.DatePickerFieldType;
 
 @Dependent
+@Renderer(type = DatePickerFieldType.class)
 public class DatePickerFieldRenderer extends FieldRenderer<DatePickerFieldDefinition, DefaultFormGroup> {
 
     protected WidgetHandler handler;
@@ -63,11 +66,6 @@ public class DatePickerFieldRenderer extends FieldRenderer<DatePickerFieldDefini
                          field);
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return DatePickerFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/creator/MultipleInputFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/creator/MultipleInputFieldRenderer.java
@@ -20,6 +20,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
@@ -31,6 +32,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.input
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.input.MultipleInputFieldType;
 
 @Dependent
+@Renderer(type = MultipleInputFieldType.class)
 public class MultipleInputFieldRenderer extends FieldRenderer<AbstractMultipleInputFieldDefinition, DefaultFormGroup> implements RequiresValueConverter {
 
     private MultipleInput input;
@@ -58,11 +60,6 @@ public class MultipleInputFieldRenderer extends FieldRenderer<AbstractMultipleIn
 
     @Override
     public String getName() {
-        return MultipleInputFieldType.NAME;
-    }
-
-    @Override
-    public String getSupportedCode() {
         return MultipleInputFieldType.NAME;
     }
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/selector/MultipleSelectorFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/selector/MultipleSelectorFieldRenderer.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import org.jboss.errai.databinding.client.api.Converter;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
@@ -40,6 +41,7 @@ import org.uberfire.ext.widgets.common.client.dropdown.LiveSearchService;
 import org.uberfire.ext.widgets.common.client.dropdown.MultipleLiveSearchSelectionHandler;
 
 @Dependent
+@Renderer(type = MultipleSelectorFieldType.class)
 public class MultipleSelectorFieldRenderer<TYPE> extends FieldRenderer<AbstractMultipleSelectorFieldDefinition, DefaultFormGroup> implements RequiresValueConverter {
 
     private MultipleSelectorInput<TYPE> selector;
@@ -127,11 +129,6 @@ public class MultipleSelectorFieldRenderer<TYPE> extends FieldRenderer<AbstractM
 
     @Override
     public String getName() {
-        return MultipleSelectorFieldType.NAME;
-    }
-
-    @Override
-    public String getSupportedCode() {
         return MultipleSelectorFieldType.NAME;
     }
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/picture/PictureFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/picture/PictureFieldRenderer.java
@@ -19,14 +19,17 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.pictur
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.picture.PictureInput;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.image.definition.PictureFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.image.type.PictureFieldType;
 
 @Dependent
+@Renderer(type = PictureFieldType.class)
 public class PictureFieldRenderer extends FieldRenderer<PictureFieldDefinition, DefaultFormGroup> {
 
     private PictureInput pictureInput;
@@ -53,11 +56,6 @@ public class PictureFieldRenderer extends FieldRenderer<PictureFieldDefinition, 
 
     @Override
     public String getName() {
-        return PictureFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return PictureFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/multipleSubform/MultipleSubFormFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/multipleSubform/MultipleSubFormFieldRenderer.java
@@ -21,14 +21,17 @@ import java.util.List;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.nestedForm.fieldSet.FieldSetFormGroup;
 import org.kie.workbench.common.forms.dynamic.client.resources.i18n.FormRenderingConstants;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.definition.MultipleSubFormFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.type.MultipleSubFormFieldType;
 
 @Dependent
+@Renderer(type = MultipleSubFormFieldType.class)
 public class MultipleSubFormFieldRenderer extends FieldRenderer<MultipleSubFormFieldDefinition, FieldSetFormGroup> {
 
     @Inject
@@ -69,11 +72,6 @@ public class MultipleSubFormFieldRenderer extends FieldRenderer<MultipleSubFormF
             configErrors.add(FormRenderingConstants.MultipleSubformWongEditionForm);
         }
         return configErrors;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return MultipleSubFormFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/multipleSubform/MultipleSubFormFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/multipleSubform/MultipleSubFormFieldRenderer.java
@@ -34,12 +34,14 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipl
 @Renderer(type = MultipleSubFormFieldType.class)
 public class MultipleSubFormFieldRenderer extends FieldRenderer<MultipleSubFormFieldDefinition, FieldSetFormGroup> {
 
+    static String RENDERER_NAME = "Multiple SubForm";
+
     @Inject
     private MultipleSubFormWidget multipleSubFormWidget;
 
     @Override
     public String getName() {
-        return "Multiple SubForm";
+        return RENDERER_NAME;
     }
 
     @Override
@@ -58,7 +60,7 @@ public class MultipleSubFormFieldRenderer extends FieldRenderer<MultipleSubFormF
     protected List<String> getConfigErrors() {
         List<String> configErrors = new ArrayList<>();
 
-        if (field.getColumnMetas() == null || field.getColumnMetas().size() == 0) {
+        if (field.getColumnMetas() == null || field.getColumnMetas().isEmpty()) {
             configErrors.add(FormRenderingConstants.MultipleSubformNoColumns);
         }
         if (field.getCreationForm() == null || field.getCreationForm().isEmpty()) {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/subform/SubFormFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/subform/SubFormFieldRenderer.java
@@ -53,6 +53,7 @@ public class SubFormFieldRenderer extends FieldRenderer<SubFormFieldDefinition, 
         if (field.getReadOnly()) {
             nestedContext.setRenderMode(RenderMode.READ_ONLY_MODE);
         }
+
         subFormWidget.render(nestedContext);
 
         AbstractNestedFormFormGroup formGroup;

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/subform/SubFormFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/subform/SubFormFieldRenderer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.nestedForm.AbstractNestedFormFormGroup;
@@ -33,8 +34,10 @@ import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContex
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.Container;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.definition.SubFormFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.type.SubFormFieldType;
 
 @Dependent
+@Renderer(type = SubFormFieldType.class)
 public class SubFormFieldRenderer extends FieldRenderer<SubFormFieldDefinition, AbstractNestedFormFormGroup> {
 
     @Inject
@@ -85,11 +88,6 @@ public class SubFormFieldRenderer extends FieldRenderer<SubFormFieldDefinition, 
     @Override
     public String getName() {
         return "SubForm";
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return SubFormFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/SelectorFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/SelectorFieldRenderer.java
@@ -27,7 +27,6 @@ import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.databinding.client.BindableListWrapper;
 import org.kie.workbench.common.forms.dynamic.client.config.ClientSelectorDataProviderManager;
-import org.kie.workbench.common.forms.dynamic.client.rendering.FieldDefinitionFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
@@ -38,7 +37,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.S
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorOption;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeListener;
 
-public abstract class SelectorFieldRenderer<FIELD extends SelectorFieldBaseDefinition<OPTION, TYPE>, OPTION extends SelectorOption<TYPE>, TYPE> extends FieldRenderer<FIELD, DefaultFormGroup> implements FieldDefinitionFieldRenderer<FIELD> {
+public abstract class SelectorFieldRenderer<FIELD extends SelectorFieldBaseDefinition<OPTION, TYPE>, OPTION extends SelectorOption<TYPE>, TYPE> extends FieldRenderer<FIELD, DefaultFormGroup> {
 
     @Inject
     protected SelectorDataProviderManager clientProviderManager;

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/AbstractListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/AbstractListBoxFieldRenderer.java
@@ -116,11 +116,6 @@ public abstract class AbstractListBoxFieldRenderer<FIELD extends ListBoxBaseDefi
     public abstract TYPE getEmptyValue();
 
     @Override
-    public String getSupportedCode() {
-        return ListBoxBaseDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
     protected void setReadOnly(boolean readOnly) {
         widgetList.setEnabled(!readOnly);
     }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/CharacterListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/CharacterListBoxFieldRenderer.java
@@ -21,21 +21,18 @@ import javax.inject.Inject;
 
 import org.jboss.errai.databinding.client.api.Converter;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.CharacterSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.CharacterListBoxFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = CharacterListBoxFieldDefinition.class)
 public class CharacterListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<CharacterListBoxFieldDefinition, CharacterSelectorOption, Character> {
 
     @Inject
     public CharacterListBoxFieldRenderer(TranslationService translationService) {
         super(translationService);
-    }
-
-    @Override
-    public Class<CharacterListBoxFieldDefinition> getSupportedFieldDefinition() {
-        return CharacterListBoxFieldDefinition.class;
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/DecimalListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/DecimalListBoxFieldRenderer.java
@@ -20,21 +20,18 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.DecimalSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.DecimalListBoxFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = DecimalListBoxFieldDefinition.class)
 public class DecimalListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<DecimalListBoxFieldDefinition, DecimalSelectorOption, Double> {
 
     @Inject
     public DecimalListBoxFieldRenderer(TranslationService translationService) {
         super(translationService);
-    }
-
-    @Override
-    public Class<DecimalListBoxFieldDefinition> getSupportedFieldDefinition() {
-        return DecimalListBoxFieldDefinition.class;
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/EnumListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/EnumListBoxFieldRenderer.java
@@ -20,21 +20,18 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.EnumSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.EnumListBoxFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = EnumListBoxFieldDefinition.class)
 public class EnumListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<EnumListBoxFieldDefinition, EnumSelectorOption, Enum> {
 
     @Inject
     public EnumListBoxFieldRenderer(TranslationService translationService) {
         super(translationService);
-    }
-
-    @Override
-    public Class<EnumListBoxFieldDefinition> getSupportedFieldDefinition() {
-        return EnumListBoxFieldDefinition.class;
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/IntegerListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/IntegerListBoxFieldRenderer.java
@@ -20,21 +20,18 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.IntegerSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.IntegerListBoxFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = IntegerListBoxFieldDefinition.class)
 public class IntegerListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<IntegerListBoxFieldDefinition, IntegerSelectorOption, Long> {
 
     @Inject
     public IntegerListBoxFieldRenderer(TranslationService translationService) {
         super(translationService);
-    }
-
-    @Override
-    public Class<IntegerListBoxFieldDefinition> getSupportedFieldDefinition() {
-        return IntegerListBoxFieldDefinition.class;
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/StringListBoxFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/listBox/StringListBoxFieldRenderer.java
@@ -20,21 +20,18 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.StringListBoxFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = StringListBoxFieldDefinition.class)
 public class StringListBoxFieldRenderer
         extends AbstractListBoxFieldRenderer<StringListBoxFieldDefinition, StringSelectorOption, String> {
 
     @Inject
     public StringListBoxFieldRenderer(TranslationService translationService) {
         super(translationService);
-    }
-
-    @Override
-    public Class<StringListBoxFieldDefinition> getSupportedFieldDefinition() {
-        return StringListBoxFieldDefinition.class;
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/CharacterRadioGroupFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/CharacterRadioGroupFieldRenderer.java
@@ -19,19 +19,16 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.select
 import javax.enterprise.context.Dependent;
 
 import org.jboss.errai.databinding.client.api.Converter;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.CharacterRadioGroup;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.RadioGroupBase;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.CharacterSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.CharacterRadioGroupFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = CharacterRadioGroupFieldDefinition.class)
 public class CharacterRadioGroupFieldRenderer
         extends RadioGroupFieldRendererBase<CharacterRadioGroupFieldDefinition, CharacterSelectorOption, Character> {
-
-    @Override
-    public Class<CharacterRadioGroupFieldDefinition> getSupportedFieldDefinition() {
-        return CharacterRadioGroupFieldDefinition.class;
-    }
 
     @Override
     protected RadioGroupBase<Character> getRadioGroup() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/DecimalRadioGroupFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/DecimalRadioGroupFieldRenderer.java
@@ -18,19 +18,16 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.select
 
 import javax.enterprise.context.Dependent;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.DecimalRadioGroup;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.RadioGroupBase;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.DecimalSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.DecimalRadioGroupFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = DecimalRadioGroupFieldDefinition.class)
 public class DecimalRadioGroupFieldRenderer
         extends RadioGroupFieldRendererBase<DecimalRadioGroupFieldDefinition, DecimalSelectorOption, Double> {
-
-    @Override
-    public Class<DecimalRadioGroupFieldDefinition> getSupportedFieldDefinition() {
-        return DecimalRadioGroupFieldDefinition.class;
-    }
 
     @Override
     protected RadioGroupBase<Double> getRadioGroup() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/IntegerRadioGroupFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/IntegerRadioGroupFieldRenderer.java
@@ -18,19 +18,16 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.select
 
 import javax.enterprise.context.Dependent;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.IntegerRadioGroup;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.RadioGroupBase;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.IntegerSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.IntegerRadioGroupFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = IntegerRadioGroupFieldDefinition.class)
 public class IntegerRadioGroupFieldRenderer
         extends RadioGroupFieldRendererBase<IntegerRadioGroupFieldDefinition, IntegerSelectorOption, Long> {
-
-    @Override
-    public Class<IntegerRadioGroupFieldDefinition> getSupportedFieldDefinition() {
-        return IntegerRadioGroupFieldDefinition.class;
-    }
 
     @Override
     protected RadioGroupBase<Long> getRadioGroup() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/RadioGroupFieldRendererBase.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/RadioGroupFieldRendererBase.java
@@ -33,7 +33,6 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selecto
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.SelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.RadioGroupBaseDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.StringRadioGroupFieldDefinition;
 
 public abstract class RadioGroupFieldRendererBase<FIELD extends RadioGroupBaseDefinition<OPTION, TYPE>, OPTION extends SelectorOption<TYPE>, TYPE>
         extends SelectorFieldRenderer<FIELD, OPTION, TYPE>
@@ -96,11 +95,6 @@ public abstract class RadioGroupFieldRendererBase<FIELD extends RadioGroupBaseDe
         }
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return StringRadioGroupFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/StringRadioGroupFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/selectors/radioGroup/StringRadioGroupFieldRenderer.java
@@ -18,19 +18,16 @@ package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.select
 
 import javax.enterprise.context.Dependent;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.RadioGroupBase;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.selectors.radiogroup.StringRadioGroup;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.StringRadioGroupFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = StringRadioGroupFieldDefinition.class)
 public class StringRadioGroupFieldRenderer
         extends RadioGroupFieldRendererBase<StringRadioGroupFieldDefinition, StringSelectorOption, String> {
-
-    @Override
-    public Class<StringRadioGroupFieldDefinition> getSupportedFieldDefinition() {
-        return StringRadioGroupFieldDefinition.class;
-    }
 
     @Override
     protected RadioGroupBase<String> getRadioGroup() {

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/util/FormsElementWrapperWidgetUtil.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/util/FormsElementWrapperWidgetUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.gwt.user.client.ui.Widget;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+
+public class FormsElementWrapperWidgetUtil {
+
+    private static Map<Object, List<ElementWrapperWidget<?>>> mappedWidgets = new HashMap<>();
+
+    private FormsElementWrapperWidgetUtil() {
+    }
+
+    public static Widget getWidget(Object source, HTMLElement element) {
+        return getWidget(source, element, ElementWrapperWidget::getWidget);
+    }
+
+    public static Widget getWidget(Object source, elemental2.dom.HTMLElement element) {
+        return getWidget(source, element, ElementWrapperWidget::getWidget);
+    }
+
+    private static <T> Widget getWidget(Object source, T element, Function<T, ElementWrapperWidget> function) {
+        ElementWrapperWidget<?> widget = function.apply(element);
+
+        mappedWidgets.computeIfAbsent(source, key -> new ArrayList<>())
+                .add(widget);
+        return widget;
+    }
+
+    public static void clear(Object source) {
+        mappedWidgets.computeIfPresent(source, (o, wrapperWidgets) -> {
+            wrapperWidgets.forEach(widget -> {
+                ElementWrapperWidget.removeWidget(widget);
+                widget.removeFromParent();
+            });
+            return null;
+        });
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/util/FormsElementWrapperWidgetUtil.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/util/FormsElementWrapperWidgetUtil.java
@@ -16,46 +16,36 @@
 
 package org.kie.workbench.common.forms.dynamic.client.rendering.util;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 
-public class FormsElementWrapperWidgetUtil {
+/**
+ * Utility class that helps to handle the lifecycle of the generated {@link ElementWrapperWidget} on forms views.
+ */
+public interface FormsElementWrapperWidgetUtil {
 
-    private static Map<Object, List<ElementWrapperWidget<?>>> mappedWidgets = new HashMap<>();
+    /**
+     * Generates a {@link Widget} ({@link ElementWrapperWidget}) for a specific {@link HTMLElement} and keeps a reference
+     * to the view (source) that is using it.
+     * @param source The view object that requires the {@link Widget} to be generated
+     * @param element The {@link HTMLElement} that needs to be converted into a {@link Widget}
+     * @return a {@link Widget} wrapping the given {@link HTMLElement}
+     */
+    Widget getWidget(Object source, HTMLElement element);
 
-    private FormsElementWrapperWidgetUtil() {
-    }
+    /**
+     * Generates a {@link Widget} ({@link ElementWrapperWidget}) for a specific {@link elemental2.dom.HTMLElement} and keeps a reference
+     * to the view (source) that is using it.
+     * @param source The view object that requires the {@link Widget} to be generated
+     * @param element The {@link elemental2.dom.HTMLElement} that needs to be converted into a {@link Widget}
+     * @return a {@link Widget} wrapping the given {@link elemental2.dom.HTMLElement}
+     */
+    Widget getWidget(Object source, elemental2.dom.HTMLElement element);
 
-    public static Widget getWidget(Object source, HTMLElement element) {
-        return getWidget(source, element, ElementWrapperWidget::getWidget);
-    }
-
-    public static Widget getWidget(Object source, elemental2.dom.HTMLElement element) {
-        return getWidget(source, element, ElementWrapperWidget::getWidget);
-    }
-
-    private static <T> Widget getWidget(Object source, T element, Function<T, ElementWrapperWidget> function) {
-        ElementWrapperWidget<?> widget = function.apply(element);
-
-        mappedWidgets.computeIfAbsent(source, key -> new ArrayList<>())
-                .add(widget);
-        return widget;
-    }
-
-    public static void clear(Object source) {
-        mappedWidgets.computeIfPresent(source, (o, wrapperWidgets) -> {
-            wrapperWidgets.forEach(widget -> {
-                ElementWrapperWidget.removeWidget(widget);
-                widget.removeFromParent();
-            });
-            return null;
-        });
-    }
+    /**
+     * Clears and detaches all the {@link ElementWrapperWidget} generated for a given view (source).
+     * @param source The view that has been generating the {@link ElementWrapperWidget}
+     */
+    void clear(Object source);
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/util/impl/FormsElementWrapperWidgetUtilImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/main/java/org/kie/workbench/common/forms/dynamic/client/rendering/util/impl/FormsElementWrapperWidgetUtilImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.util.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+import com.google.gwt.user.client.ui.Widget;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
+
+@ApplicationScoped
+public class FormsElementWrapperWidgetUtilImpl implements FormsElementWrapperWidgetUtil {
+
+    private Map<Object, List<ElementWrapperWidget<?>>> mappedWidgets = new HashMap<>();
+
+    public Widget getWidget(Object source, HTMLElement element) {
+        return getWidget(source, element, ElementWrapperWidget::getWidget);
+    }
+
+    public Widget getWidget(Object source, elemental2.dom.HTMLElement element) {
+        return getWidget(source, element, ElementWrapperWidget::getWidget);
+    }
+
+    private <T> Widget getWidget(Object source, T element, Function<T, ElementWrapperWidget<?>> function) {
+        ElementWrapperWidget<?> widget = function.apply(element);
+
+        mappedWidgets.computeIfAbsent(source, key -> new ArrayList<>())
+                .add(widget);
+        return widget;
+    }
+
+    public void clear(Object source) {
+        mappedWidgets.computeIfPresent(source, (o, wrapperWidgets) -> {
+            wrapperWidgets.forEach(this::removeWidget);
+            return null;
+        });
+    }
+
+    private void removeWidget(ElementWrapperWidget<?> widget) {
+        ElementWrapperWidget.removeWidget(widget);
+        widget.removeFromParent();
+    }
+
+    @PreDestroy
+    public void clear() {
+        mappedWidgets.values()
+                .forEach(wrapperWidgets -> wrapperWidgets.forEach(this::removeWidget));
+        mappedWidgets.clear();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/DynamicRendererEntryPointTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/DynamicRendererEntryPointTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.adf.rendering.FieldRendererTypesProvider;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DynamicRendererEntryPointTest {
+
+    @Mock
+    private SyncBeanManager beanManager;
+
+    private DynamicRendererEntryPoint entryPoint;
+
+    private List<FieldRendererTypesProvider> rendererTypesProviders = new ArrayList<>();
+
+    @Before
+    public void init() {
+
+        prepareFieldRendererProviders();
+
+        entryPoint = new DynamicRendererEntryPoint(beanManager);
+
+        entryPoint.init();
+    }
+
+    @Test
+    public void testPopulateFieldRendererProviders() {
+        verify(beanManager).lookupBeans(eq(FieldRendererTypesProvider.class));
+
+        rendererTypesProviders.forEach(provider -> {
+            verify(provider).getFieldTypeRenderers();
+            verify(provider).getFieldDefinitionRenderers();
+            verify(beanManager).destroyBean(provider);
+        });
+    }
+
+    private void prepareFieldRendererProviders() {
+        List<SyncBeanDef<FieldRendererTypesProvider>> beanDefs = new ArrayList<>();
+
+        beanDefs.add(newProvider());
+        beanDefs.add(newProvider());
+        beanDefs.add(newProvider());
+
+        when(beanManager.lookupBeans(eq(FieldRendererTypesProvider.class))).thenReturn(beanDefs);
+    }
+
+    private SyncBeanDef<FieldRendererTypesProvider> newProvider() {
+        FieldRendererTypesProvider provider = mock(FieldRendererTypesProvider.class);
+
+        rendererTypesProviders.add(provider);
+
+        when(provider.getFieldTypeRenderers()).thenReturn(new HashMap<>());
+        when(provider.getFieldDefinitionRenderers()).thenReturn(new HashMap<>());
+
+
+        SyncBeanDef<FieldRendererTypesProvider> beanDef = mock(SyncBeanDef.class);
+        when(beanDef.newInstance()).thenReturn(provider);
+
+        return beanDef;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/AbstractFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/AbstractFieldRendererTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.configError.ConfigErrorDisplayer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
+import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractFieldRendererTest<R extends FieldRenderer, F extends FieldDefinition, G extends FormGroup> {
+
+    protected static final String NAMESPACE = "ns";
+
+    @Mock
+    protected ManagedInstance<G> managedInstance;
+
+    @Mock
+    protected ManagedInstance<G> formGroupsInstance;
+
+    @Mock
+    protected ConfigErrorDisplayer errorDisplayer;
+
+    @Mock
+    protected FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
+    @Mock
+    protected FormRenderingContext context;
+
+    protected F fieldDefinition;
+    protected R renderer;
+
+    @Before
+    public void init() {
+        when(context.getRenderMode()).thenReturn(RenderMode.EDIT_MODE);
+        when(context.getNamespace()).thenReturn(NAMESPACE);
+
+        renderer = getRendererInstance();
+        fieldDefinition = spy(getFieldDefinition());
+
+        renderer.init(context, fieldDefinition);
+    }
+
+    @Test
+    public void testRender() {
+        renderer.renderWidget();
+
+        verify(errorDisplayer, never()).render(anyList());
+        verify(wrapperWidgetUtil).getWidget(eq(renderer), any(HTMLElement.class));
+    }
+
+    @Test
+    public void testGetName() {
+        checkName(renderer.getName());
+    }
+
+    protected void checkName(String name) {
+        assertEquals(fieldDefinition.getFieldType().getTypeName(), name);
+    }
+
+    protected void testRenderWithConfigErrors(String expectedError) {
+        renderer.renderWidget();
+
+        ArgumentCaptor<List> errorCaptor = ArgumentCaptor.forClass(List.class);
+        verify(errorDisplayer).render((java.util.List<String>) errorCaptor.capture());
+
+        Assertions.assertThat(errorCaptor.getValue())
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(expectedError);
+
+        verify(wrapperWidgetUtil, never()).getWidget(eq(renderer), any(HTMLElement.class));
+    }
+
+    @Test
+    public void testDestroy() {
+        renderer.preDestroy();
+
+        verify(wrapperWidgetUtil).clear(eq(renderer));
+        verify(formGroupsInstance).destroyAll();
+    }
+
+    protected abstract R getRendererInstance();
+
+    protected abstract F getFieldDefinition();
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldLayoutComponentTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldLayoutComponentTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.assertj.core.api.Assertions;
+import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.TextBoxFieldRenderer;
+import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition;
+import org.kie.workbench.common.forms.model.FormDefinition;
+import org.mockito.Mock;
+import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
+import org.uberfire.ext.layout.editor.client.api.RenderingContext;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class FieldLayoutComponentTest {
+
+    private static String NAME = "textBox";
+
+    private static String PART_1 = "part1";
+    private static String PART_2 = "part2";
+    private static String PART_3 = "part3";
+
+    private static String UNEXISTING_PART = "unexisting_part";
+
+    @GwtMock
+    private FlowPanel content;
+
+    @Mock
+    private FieldRendererManager fieldRendererManager;
+
+    @Mock
+    private TranslationService translationService;
+
+    @Mock
+    private FormDefinition formDefinition;
+
+    @Mock
+    private FormRenderingContext context;
+
+    @Mock
+    private TextBoxFieldRenderer renderer;
+
+    private Set<String> parts = new TreeSet<>();
+
+    private TextBoxFieldDefinition field;
+
+    private FieldLayoutComponent component;
+
+    @Before
+    public void init() {
+
+        when(context.getRootForm()).thenReturn(formDefinition);
+        when(fieldRendererManager.getRendererForField(any())).thenReturn(renderer);
+
+        parts.add(PART_1);
+        parts.add(PART_2);
+        parts.add(PART_3);
+
+        when(renderer.renderWidget()).thenReturn(mock(IsWidget.class));
+        when(renderer.getFieldParts()).thenReturn(parts);
+        when(renderer.getFieldPartWidget(anyString())).thenAnswer(invocation -> {
+            String partId = invocation.getArguments()[0].toString();
+
+            if (parts.contains(partId)) {
+                return mock(Widget.class);
+            }
+
+            return null;
+        });
+
+        component = new FieldLayoutComponent(fieldRendererManager, translationService) {
+            {
+                this.content = FieldLayoutComponentTest.this.content;
+            }
+        };
+
+        field = spy(new TextBoxFieldDefinition());
+
+        field.setName(NAME);
+        field.setBinding(NAME);
+        field.setPlaceHolder(NAME);
+
+        component.init(context, field);
+
+        verify(fieldRendererManager).getRendererForField(eq(field));
+        verify(renderer).init(eq(context), eq(field));
+    }
+
+    @Test
+    public void testBasicChecks() {
+        component.getFieldId();
+        verify(field).getId();
+
+        assertSame(field, component.getField());
+
+        component.getFormId();
+        verify(context).getRootForm();
+        verify(formDefinition).getId();
+
+        assertSame(renderer, component.getFieldRenderer());
+
+        component.destroy();
+
+        verify(content).clear();
+    }
+
+    @Test
+    public void testGetDragComponentTitle() {
+
+        String result = component.getDragComponentTitle();
+
+        verify(renderer, never()).getName();
+        verify(translationService, never()).getTranslation(anyString());
+
+        Assertions.assertThat(result)
+                .isEqualTo(NAME);
+    }
+
+    @Test
+    public void testUnBoundGetDragComponentTitleWithTranslation() {
+
+        field.setBinding(null);
+
+        component.getDragComponentTitle();
+
+        verify(renderer, times(2)).getName();
+        verify(translationService).getTranslation(anyString());
+    }
+
+    @Test
+    public void testUnBoundGetDragComponentTitleWithoutTranslation() {
+
+        when(translationService.getTranslation(anyString())).thenReturn(NAME);
+        field.setBinding(null);
+
+        component.getDragComponentTitle();
+
+        verify(renderer).getName();
+        verify(translationService).getTranslation(anyString());
+    }
+
+    @Test
+    public void testGetPreviewWidget() {
+
+        component.getPreviewWidget(mock(RenderingContext.class));
+
+        verify(renderer).renderWidget();
+        verify(content).clear();
+        verify(content).add(any(IsWidget.class));
+    }
+
+    @Test
+    public void testGetShowWidget() {
+
+        component.getShowWidget(mock(RenderingContext.class));
+
+        verify(renderer).renderWidget();
+        verify(content).clear();
+        verify(content).add(any(IsWidget.class));
+    }
+
+    @Test
+    public void testAddExistingComponentPart() {
+        LayoutComponent layoutComponent = new LayoutComponent();
+
+        component.addComponentParts(layoutComponent);
+
+        Assertions.assertThat(layoutComponent.getParts())
+                .isNotEmpty()
+                .hasSize(parts.size())
+                .anyMatch(part -> part.getPartId().equals(PART_1))
+                .anyMatch(part -> part.getPartId().equals(PART_2))
+                .anyMatch(part -> part.getPartId().equals(PART_3));
+    }
+
+    @Test
+    public void testGetContentPart() {
+        RenderingContext renderingContext = mock(RenderingContext.class);
+
+        Assertions.assertThat(component.getContentPart(PART_1, renderingContext))
+                .isNotNull()
+                .isPresent();
+
+        Assertions.assertThat(component.getContentPart(PART_2, renderingContext))
+                .isNotNull()
+                .isPresent();
+
+        Assertions.assertThat(component.getContentPart(PART_3, renderingContext))
+                .isNotNull()
+                .isPresent();
+
+        Assertions.assertThat(component.getContentPart(UNEXISTING_PART, renderingContext))
+                .isNotNull()
+                .isNotPresent();
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererManagerImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/FieldRendererManagerImplTest.java
@@ -15,14 +15,7 @@
  */
 package org.kie.workbench.common.forms.dynamic.client.rendering;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.jboss.errai.ioc.client.container.SyncBeanDef;
-import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,43 +27,42 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.SliderF
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.TextAreaFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.TextBoxFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date.DatePickerFieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.picture.PictureFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.relations.multipleSubform.MultipleSubFormFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.relations.subform.SubFormFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.EnumListBoxFieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.IntegerListBoxFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.StringListBoxFieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.radioGroup.IntegerRadioGroupFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.radioGroup.StringRadioGroupFieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.test.TestFieldRendererTypesProvider;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.definition.CheckBoxFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.type.CheckBoxFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.type.DatePickerFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.definition.DecimalBoxFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.type.DecimalBoxFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.image.definition.PictureFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.definition.IntegerBoxFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.type.IntegerBoxFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.EnumListBoxFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.IntegerListBoxFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.StringListBoxFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.type.ListBoxFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.IntegerRadioGroupFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.StringRadioGroupFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.type.RadioGroupFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition.DoubleSliderDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition.IntegerSliderDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.type.SliderFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.CharacterBoxFieldDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.type.TextBoxFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.definition.MultipleSubFormFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.type.MultipleSubFormFieldType;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.definition.SubFormFieldDefinition;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.type.SubFormFieldType;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,118 +70,64 @@ import static org.mockito.Mockito.when;
 public class FieldRendererManagerImplTest {
 
     @Mock
-    SyncBeanManager beanManager;
-
-    @Mock
     ManagedInstance<FieldRenderer> managedInstance;
-
-    Map<Class, FieldRenderer> renderersMap = new HashMap<>();
 
     FieldRendererManagerImpl fieldRendererManager;
 
     @Before
     public void init() {
+        FieldRendererTypeRegistry.load(new TestFieldRendererTypesProvider());
 
-        registerRenderer(CheckBoxFieldRenderer.class,
-                         CheckBoxFieldType.NAME,
-                         null);
-        registerRenderer(DatePickerFieldRenderer.class,
-                         DatePickerFieldType.NAME,
-                         null);
-        registerRenderer(EnumListBoxFieldRenderer.class,
-                         ListBoxFieldType.NAME,
-                         EnumListBoxFieldDefinition.class);
-        registerRenderer(StringListBoxFieldRenderer.class,
-                         ListBoxFieldType.NAME,
-                         StringListBoxFieldDefinition.class);
-        registerRenderer(StringRadioGroupFieldRenderer.class,
-                         RadioGroupFieldType.NAME,
-                         StringRadioGroupFieldDefinition.class);
-        registerRenderer(TextAreaFieldRenderer.class,
-                         TextAreaFieldType.NAME,
-                         null);
-        registerRenderer(SliderFieldRenderer.class,
-                         SliderFieldType.NAME,
-                         null);
-        registerRenderer(MultipleSubFormFieldRenderer.class,
-                         MultipleSubFormFieldType.NAME,
-                         null);
-        registerRenderer(SubFormFieldRenderer.class,
-                         SubFormFieldType.NAME,
-                         null);
-        registerRenderer(TextBoxFieldRenderer.class,
-                         TextBoxFieldType.NAME,
-                         null);
-        registerRenderer(DecimalBoxFieldRenderer.class,
-                         DecimalBoxFieldType.NAME,
-                         null);
-        registerRenderer(IntegerBoxFieldRenderer.class,
-                         IntegerBoxFieldType.NAME,
-                         null);
-
-        Collection<SyncBeanDef<FieldRenderer>> renderers = new ArrayList<>();
-
-        renderersMap.forEach((fieldRendererClass, fieldRenderer) -> {
-            SyncBeanDef<FieldRenderer> def = mock(SyncBeanDef.class);
-            when(def.getInstance()).thenReturn(fieldRenderer);
-            when(def.newInstance()).thenReturn(fieldRenderer);
-            when(def.getBeanClass()).thenReturn(fieldRendererClass);
-            renderers.add(def);
-        });
-
-        when(beanManager.lookupBeans(FieldRenderer.class)).thenReturn(renderers);
+        fieldRendererManager = new FieldRendererManagerImpl(managedInstance);
 
         when(managedInstance.select(any(Class.class))).thenAnswer(invocationOnMock -> {
             ManagedInstance<FieldRenderer> newInstance = mock(ManagedInstance.class);
-            when(newInstance.get()).thenReturn(renderersMap.get(invocationOnMock.getArguments()[0]));
+            when(newInstance.get()).thenReturn(mock((Class<FieldRenderer>)invocationOnMock.getArguments()[0]));
             return newInstance;
         });
-
-        fieldRendererManager = new FieldRendererManagerImpl(managedInstance) {
-            {
-                registerRenderers(renderers);
-            }
-        };
     }
 
     @Test
     public void testFunctionallity() {
-        testRendererFor(new CheckBoxFieldDefinition());
-        testRendererFor(new DatePickerFieldDefinition());
-        testRendererFor(new EnumListBoxFieldDefinition());
-        testRendererFor(new StringListBoxFieldDefinition());
-        testRendererFor(new StringRadioGroupFieldDefinition());
-        testRendererFor(new TextAreaFieldDefinition());
-        testRendererFor(new IntegerSliderDefinition());
-        testRendererFor(new DoubleSliderDefinition());
-        testRendererFor(new MultipleSubFormFieldDefinition());
-        testRendererFor(new SubFormFieldDefinition());
-        testRendererFor(new TextBoxFieldDefinition());
-        testRendererFor(new DecimalBoxFieldDefinition());
-        testRendererFor(new IntegerBoxFieldDefinition());
+        testRendererFor(new CheckBoxFieldDefinition(), CheckBoxFieldRenderer.class, 1);
+        testRendererFor(new DatePickerFieldDefinition(), DatePickerFieldRenderer.class, 1);
+        testRendererFor(new EnumListBoxFieldDefinition(), EnumListBoxFieldRenderer.class, 1);
+        testRendererFor(new StringListBoxFieldDefinition(), StringListBoxFieldRenderer.class, 1);
+        testRendererFor(new IntegerListBoxFieldDefinition(), IntegerListBoxFieldRenderer.class, 1);
+        testRendererFor(new StringRadioGroupFieldDefinition(), StringRadioGroupFieldRenderer.class, 1);
+        testRendererFor(new IntegerRadioGroupFieldDefinition(), IntegerRadioGroupFieldRenderer.class, 1);
+        testRendererFor(new TextAreaFieldDefinition(), TextAreaFieldRenderer.class, 1);
+        testRendererFor(new IntegerSliderDefinition(), SliderFieldRenderer.class, 1);
+        testRendererFor(new DoubleSliderDefinition(), SliderFieldRenderer.class, 2);
+        testRendererFor(new MultipleSubFormFieldDefinition(), MultipleSubFormFieldRenderer.class, 1);
+        testRendererFor(new SubFormFieldDefinition(), SubFormFieldRenderer.class, 1);
+        testRendererFor(new TextBoxFieldDefinition(), TextBoxFieldRenderer.class, 1);
+        testRendererFor(new CharacterBoxFieldDefinition(), TextBoxFieldRenderer.class, 2);
+        testRendererFor(new DecimalBoxFieldDefinition(), DecimalBoxFieldRenderer.class, 1);
+        testRendererFor(new IntegerBoxFieldDefinition(), IntegerBoxFieldRenderer.class, 1);
+
+        testUnexistingRenderer(new PictureFieldDefinition());
     }
 
-    protected void testRendererFor(FieldDefinition field) {
+    private void testRendererFor(FieldDefinition field, Class<? extends FieldRenderer> expectedRenderer, int count) {
         FieldRenderer renderer = fieldRendererManager.getRendererForField(field);
+
         assertNotNull(renderer);
-        assertTrue(renderersMap.containsValue(renderer));
+
+        verify(managedInstance, times(count)).select(expectedRenderer);
+    }
+
+    private void testUnexistingRenderer(FieldDefinition field) {
+        FieldRenderer renderer = fieldRendererManager.getRendererForField(field);
+
+        assertNull(renderer);
+
+        verify(managedInstance, never()).select(PictureFieldRenderer.class);
     }
 
     @After
     public void destroy() {
         fieldRendererManager.destroy();
         verify(managedInstance).destroyAll();
-    }
-
-    protected void registerRenderer(Class<? extends FieldRenderer> rendererClass,
-                                    String fieldType,
-                                    Class<? extends FieldDefinition> relatedFieldType) {
-        FieldRenderer renderer = mock(rendererClass);
-        when(renderer.getSupportedCode()).thenReturn(fieldType);
-        if (renderer instanceof FieldDefinitionFieldRenderer) {
-            when(((FieldDefinitionFieldRenderer) renderer).getSupportedFieldDefinition()).thenReturn(relatedFieldType);
-        }
-        renderersMap.put(rendererClass,
-                         renderer);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/FormGeneratorDriverTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/FormGeneratorDriverTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.assertj.core.api.Assertions;
+import org.gwtbootstrap3.client.ui.constants.ColumnSize;
+import org.jboss.errai.common.client.dom.Document;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
+import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.layout.editor.api.editor.LayoutColumn;
+import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
+import org.uberfire.ext.layout.editor.api.editor.LayoutRow;
+import org.uberfire.ext.layout.editor.client.api.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.infra.ColumnSizeBuilder;
+
+import static org.kie.workbench.common.forms.dynamic.client.rendering.FormGeneratorDriver.CONTAINER_TAG;
+import static org.kie.workbench.common.forms.dynamic.client.rendering.FormGeneratorDriver.ROW_CLASS;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FormGeneratorDriverTest {
+
+    @Mock
+    private SyncBeanManager beanManager;
+
+    @Mock
+    private ManagedInstance<LayoutDragComponent> instance;
+
+    @Mock
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
+    @Mock
+    private Document document;
+
+    @Mock
+    private FormRenderingContext context;
+
+    private FormGeneratorDriver driver;
+
+    @Before
+    public void init() {
+        when(beanManager.lookupBeans(anyString())).thenAnswer(invocationOnMock -> {
+            SyncBeanDef beanDef = mock(SyncBeanDef.class);
+            when(beanDef.getBeanClass()).thenReturn(FieldLayoutComponent.class);
+            return Collections.singletonList(beanDef);
+        });
+
+        when(instance.select(any(Class.class))).thenAnswer(invocationOnMock -> {
+            ManagedInstance<FieldLayoutComponent> nestedInstance = mock(ManagedInstance.class);
+            FieldLayoutComponent component = mock(FieldLayoutComponent.class);
+            when(component.getContentPart(any(), any())).thenReturn(Optional.of(mock(IsWidget.class)));
+            when(nestedInstance.get()).thenReturn(component);
+            return nestedInstance;
+        });
+
+        when(document.createElement(anyString())).thenAnswer(invocationOnMock -> mock(HTMLElement.class));
+
+        driver = new FormGeneratorDriver(beanManager, instance, wrapperWidgetUtil, document) {
+            @Override
+            FieldDefinition getFieldForLayoutComponent(LayoutComponent layoutComponent) {
+                return new TextBoxFieldDefinition();
+            }
+
+            @Override
+            public FieldLayoutComponent getFieldLayoutComponentForField(FieldDefinition field) {
+                return driver.getLayoutFields().get(0);
+            }
+        };
+
+        driver.setRenderingContext(context);
+    }
+
+    @Test
+    public void testCreateContainers() {
+        HTMLElement container = driver.createContainer();
+
+        verify(document).createElement(eq(CONTAINER_TAG));
+        Assert.assertNotNull(container);
+        verify(container).setClassName(ColumnSize.MD_12.getCssName());
+
+        HTMLElement row = driver.createRow(new LayoutRow());
+        verify(document, times(2)).createElement(eq(CONTAINER_TAG));
+        Assert.assertNotNull(row);
+        verify(row).setClassName(eq(ROW_CLASS));
+
+        LayoutColumn layoutColumn = new LayoutColumn("12");
+        HTMLElement column = driver.createColumn(layoutColumn);
+        Assert.assertNotNull(column);
+        verify(column).setClassName(ColumnSizeBuilder.buildColumnSize(12));
+    }
+
+    @Test
+    public void testCreateComponent() {
+        HTMLElement column = mock(HTMLElement.class);
+
+        LayoutComponent layoutComponent = new LayoutComponent(FieldLayoutComponent.class.getName());
+
+        driver.createComponent(column, layoutComponent);
+
+        verify(beanManager).lookupBeans(anyString());
+        verify(instance).select(eq(FieldLayoutComponent.class));
+        verify(wrapperWidgetUtil).getWidget(same(driver), any(HTMLElement.class));
+
+        Assertions.assertThat(driver.getLayoutFields())
+                .hasSize(1);
+
+        FieldLayoutComponent fieldLayoutComponent = driver.getLayoutFields().get(0);
+
+        verify(fieldLayoutComponent).init(eq(context), any());
+        verify(fieldLayoutComponent).getShowWidget(any());
+
+        // checking a second try
+        layoutComponent = new LayoutComponent(FieldLayoutComponent.class.getName());
+
+        driver.createComponent(column, layoutComponent);
+
+        verify(beanManager, times(1)).lookupBeans(anyString());
+        verify(instance, times(2)).select(eq(FieldLayoutComponent.class));
+        verify(wrapperWidgetUtil, times(2)).getWidget(same(driver), any(HTMLElement.class));
+
+        Assertions.assertThat(driver.getLayoutFields())
+                .hasSize(2);
+
+        fieldLayoutComponent = driver.getLayoutFields().get(1);
+
+        verify(fieldLayoutComponent).init(eq(context), any());
+        verify(fieldLayoutComponent).getShowWidget(any());
+    }
+
+    @Test
+    public void testGetComponentPart() {
+        testCreateComponent();
+
+        HTMLElement column = mock(HTMLElement.class);
+
+        LayoutComponent layoutComponent = new LayoutComponent(FieldLayoutComponent.class.getName());
+
+        Optional<IsWidget> result = driver.getComponentPart(column, layoutComponent, "");
+
+        Assert.assertTrue(result.isPresent());
+        verify(wrapperWidgetUtil, times(3)).getWidget(same(driver), any(HTMLElement.class));
+
+        FieldLayoutComponent fieldLayoutComponent = driver.getLayoutFields().get(0);
+
+        verify(fieldLayoutComponent).getContentPart(eq(""), any());
+    }
+
+    @Test
+    public void testClear() {
+        driver.clear();
+
+        verify(instance).destroyAll();
+        verify(wrapperWidgetUtil).clear(same(driver));
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/CheckBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/CheckBoxFieldRendererTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.SimpleCheckBox;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.checkbox.CheckBoxFormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.definition.CheckBoxFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class CheckBoxFieldRendererTest extends AbstractFieldRendererTest<CheckBoxFieldRenderer, CheckBoxFieldDefinition, CheckBoxFormGroup> {
+
+    private static String NAME = "checkbox";
+
+    @Mock
+    private SimpleCheckBox checkBox;
+
+    @Mock
+    private CheckBoxFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private CheckBoxFieldRenderer checkBoxFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        verify(checkBox).setId(any());
+        verify(checkBox).setName(anyString());
+        verify(checkBox).setEnabled(eq(!fieldDefinition.getReadOnly()));
+
+        verify(formGroup).render(eq(checkBox), eq(fieldDefinition));
+    }
+
+    @Override
+    protected CheckBoxFieldRenderer getRendererInstance() {
+        return checkBoxFieldRenderer;
+    }
+
+    @Override
+    protected CheckBoxFieldDefinition getFieldDefinition() {
+        CheckBoxFieldDefinition checkBoxFieldDefinition = new CheckBoxFieldDefinition();
+
+        checkBoxFieldDefinition.setName(NAME);
+        checkBoxFieldDefinition.setBinding(NAME);
+
+        return checkBoxFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/DecimalBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/DecimalBoxFieldRendererTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
+
+import java.math.BigDecimal;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.BigDecimalToDoubleConverter;
+import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.FloatToDoubleConverter;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.decimalBox.DecimalBox;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.definition.DecimalBoxFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DecimalBoxFieldRendererTest extends AbstractFieldRendererTest<DecimalBoxFieldRenderer, DecimalBoxFieldDefinition, DefaultFormGroup> {
+
+    private static String NAME = "decimalBox";
+
+    @Mock
+    private DecimalBox decimalBox;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private DecimalBoxFieldRenderer decimalBoxFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        verify(decimalBox).setId(any());
+        verify(decimalBox).setPlaceholder(eq(fieldDefinition.getPlaceHolder()));
+        verify(decimalBox).setMaxLength(eq(fieldDefinition.getMaxLength()));
+        verify(decimalBox).setEnabled(eq(!fieldDefinition.getReadOnly()));
+
+        verify(decimalBox).asWidget();
+
+        verify(formGroup).render(anyString(), any(), eq(fieldDefinition));
+    }
+
+    @Test
+    public void testGetConverter() {
+        checkConverter(Float.class.getName(), FloatToDoubleConverter.class);
+        checkConverter(float.class.getName(), FloatToDoubleConverter.class);
+        checkConverter(BigDecimal.class.getName(), BigDecimalToDoubleConverter.class);
+    }
+
+    private void checkConverter(String className, Class expectedType) {
+        when(fieldDefinition.getStandaloneClassName()).thenReturn(className);
+        Assertions.assertThat(renderer.getConverter())
+                .isNotNull()
+                .isInstanceOf(expectedType);
+    }
+
+    @Override
+    protected DecimalBoxFieldRenderer getRendererInstance() {
+        return decimalBoxFieldRenderer;
+    }
+
+    @Override
+    protected DecimalBoxFieldDefinition getFieldDefinition() {
+        DecimalBoxFieldDefinition decimalBoxFieldDefinition = new DecimalBoxFieldDefinition();
+
+        decimalBoxFieldDefinition.setName(NAME);
+        decimalBoxFieldDefinition.setBinding(NAME);
+        decimalBoxFieldDefinition.setPlaceHolder(NAME);
+
+        return decimalBoxFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/IntegerBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/IntegerBoxFieldRendererTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
+
+import java.math.BigInteger;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.BigIntegerToLongConverter;
+import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.ByteToLongConverter;
+import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.IntegerToLongConverter;
+import org.kie.workbench.common.forms.common.rendering.client.util.valueConverters.ShortToLongConverter;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.integerBox.IntegerBox;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.definition.IntegerBoxFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class IntegerBoxFieldRendererTest extends AbstractFieldRendererTest<IntegerBoxFieldRenderer, IntegerBoxFieldDefinition, DefaultFormGroup> {
+
+    private static String NAME = "integerBox";
+
+    @Mock
+    private IntegerBox integerBox;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private IntegerBoxFieldRenderer integerBoxFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        verify(integerBox).setId(any());
+        verify(integerBox).setPlaceholder(eq(fieldDefinition.getPlaceHolder()));
+        verify(integerBox).setMaxLength(eq(fieldDefinition.getMaxLength()));
+        verify(integerBox).setEnabled(eq(!fieldDefinition.getReadOnly()));
+
+        verify(integerBox).asWidget();
+
+        verify(formGroup).render(anyString(), any(), eq(fieldDefinition));
+    }
+
+    @Test
+    public void testGetConverter() {
+        checkConverter(BigInteger.class.getName(), BigIntegerToLongConverter.class);
+        checkConverter(Byte.class.getName(), ByteToLongConverter.class);
+        checkConverter(byte.class.getName(), ByteToLongConverter.class);
+        checkConverter(Integer.class.getName(), IntegerToLongConverter.class);
+        checkConverter(int.class.getName(), IntegerToLongConverter.class);
+        checkConverter(Short.class.getName(), ShortToLongConverter.class);
+        checkConverter(short.class.getName(), ShortToLongConverter.class);
+    }
+
+    private void checkConverter(String className, Class expectedType) {
+        when(fieldDefinition.getStandaloneClassName()).thenReturn(className);
+        Assertions.assertThat(renderer.getConverter())
+                .isNotNull()
+                .isInstanceOf(expectedType);
+    }
+
+    @Override
+    protected IntegerBoxFieldRenderer getRendererInstance() {
+        return integerBoxFieldRenderer;
+    }
+
+    @Override
+    protected IntegerBoxFieldDefinition getFieldDefinition() {
+        IntegerBoxFieldDefinition integerBoxFieldDefinition = new IntegerBoxFieldDefinition();
+
+        integerBoxFieldDefinition.setName(NAME);
+        integerBoxFieldDefinition.setBinding(NAME);
+        integerBoxFieldDefinition.setPlaceHolder(NAME);
+
+        return integerBoxFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/SliderFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/SliderFieldRendererTest.java
@@ -69,13 +69,6 @@ public class SliderFieldRendererTest {
     }
 
     @Test
-    public void testGetSupportedCode() {
-        String name = fieldRenderer.getSupportedCode();
-        assertEquals(SliderBaseDefinition.FIELD_TYPE.getTypeName(),
-                     name);
-    }
-
-    @Test
     public void testGetConverterInteger() {
         when(fieldMock.getStandaloneClassName()).thenReturn(Integer.class.getName());
         Converter converter = fieldRenderer.getConverter();

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/SliderFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/SliderFieldRendererTest.java
@@ -17,60 +17,52 @@
 package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
 
 import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.databinding.client.api.Converter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.slider.Slider;
 import org.kie.workbench.common.forms.common.rendering.client.widgets.slider.converters.IntegerToDoubleConverter;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.slider.SliderFormGroup;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition.DoubleSliderDefinition;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.definition.SliderBaseDefinition;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Spy;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SliderFieldRendererTest {
+@RunWith(GwtMockitoTestRunner.class)
+public class SliderFieldRendererTest extends AbstractFieldRendererTest<SliderFieldRenderer, SliderBaseDefinition, SliderFormGroup> {
 
-    private SliderFieldRenderer fieldRenderer;
+    private static String NAME = "slider";
 
     @Mock
-    private SliderBaseDefinition fieldMock;
+    private SliderFormGroup formGroup;
 
     @GwtMock
     private Slider sliderMock;
 
+    @Spy
+    @InjectMocks
+    private SliderFieldRenderer fieldRenderer;
+
     @Before
     public void init() {
+        super.init();
 
-        when(fieldMock.getMin()).thenReturn(0d);
-        when(fieldMock.getMax()).thenReturn(100d);
-        when(fieldMock.getStep()).thenReturn(1d);
-        when(fieldMock.getPrecision()).thenReturn(.1d);
-
-        fieldRenderer = spy(new SliderFieldRenderer() {
-            {
-                field = fieldMock;
-            }
-        });
-    }
-
-    @Test
-    public void testGetName() {
-        String name = fieldRenderer.getName();
-        assertEquals(SliderBaseDefinition.FIELD_TYPE.getTypeName(),
-                     name);
+        when(formGroupsInstance.get()).thenReturn(formGroup);
     }
 
     @Test
     public void testGetConverterInteger() {
-        when(fieldMock.getStandaloneClassName()).thenReturn(Integer.class.getName());
+        when(fieldDefinition.getStandaloneClassName()).thenReturn(Integer.class.getName());
         Converter converter = fieldRenderer.getConverter();
         assertNotNull(converter);
         assertThat(converter,
@@ -79,7 +71,7 @@ public class SliderFieldRendererTest {
 
     @Test
     public void testGetConverterInt() {
-        when(fieldMock.getStandaloneClassName()).thenReturn("int");
+        when(fieldDefinition.getStandaloneClassName()).thenReturn("int");
         Converter converter = fieldRenderer.getConverter();
         assertNotNull(converter);
         assertThat(converter,
@@ -88,8 +80,25 @@ public class SliderFieldRendererTest {
 
     @Test
     public void testGetConverterNotInt() {
-        when(fieldMock.getStandaloneClassName()).thenReturn(Double.class.getName());
+        when(fieldDefinition.getStandaloneClassName()).thenReturn(Double.class.getName());
         Converter converter = fieldRenderer.getConverter();
         assertNull(converter);
+    }
+
+    @Override
+    protected SliderFieldRenderer getRendererInstance() {
+        return fieldRenderer;
+    }
+
+    @Override
+    protected SliderBaseDefinition getFieldDefinition() {
+        DoubleSliderDefinition doubleSliderDefinition = new DoubleSliderDefinition();
+        doubleSliderDefinition.setName(NAME);
+        doubleSliderDefinition.setBinding(NAME);
+        doubleSliderDefinition.setMin(0d);
+        doubleSliderDefinition.setMax(100d);
+        doubleSliderDefinition.setStep(1d);
+        doubleSliderDefinition.setPrecision(.1d);
+        return doubleSliderDefinition;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextAreaFieldRendererTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.TextArea;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class TextAreaFieldRendererTest extends AbstractFieldRendererTest<TextAreaFieldRenderer, TextAreaFieldDefinition, DefaultFormGroup> {
+
+    private static String NAME = "textArea";
+
+    @Mock
+    private TextArea textArea;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private TextAreaFieldRenderer textAreaFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        verify(textArea).setId(any());
+        verify(textArea).setName(anyString());
+        verify(textArea).setPlaceholder(eq(fieldDefinition.getPlaceHolder()));
+        verify(textArea).setVisibleLines(eq(fieldDefinition.getRows()));
+        verify(textArea).setEnabled(eq(!fieldDefinition.getReadOnly()));
+
+        verify(formGroup).render(anyString(), eq(textArea), eq(fieldDefinition));
+    }
+
+    @Override
+    protected TextAreaFieldRenderer getRendererInstance() {
+        return textAreaFieldRenderer;
+    }
+
+    @Override
+    protected TextAreaFieldDefinition getFieldDefinition() {
+        TextAreaFieldDefinition textAreaFieldDefinition = new TextAreaFieldDefinition();
+
+        textAreaFieldDefinition.setName(NAME);
+        textAreaFieldDefinition.setBinding(NAME);
+        textAreaFieldDefinition.setPlaceHolder(NAME);
+
+        return textAreaFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextBoxFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/TextBoxFieldRendererTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class TextBoxFieldRendererTest extends AbstractFieldRendererTest<TextBoxFieldRenderer, TextBoxFieldDefinition, DefaultFormGroup> {
+
+    private static String NAME = "textBox";
+
+    @Mock
+    private TextBox textBox;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private TextBoxFieldRenderer textBoxFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        verify(textBox).setId(any());
+        verify(textBox).setName(anyString());
+        verify(textBox).setPlaceholder(eq(fieldDefinition.getPlaceHolder()));
+        verify(textBox).setMaxLength(eq(fieldDefinition.getMaxLength()));
+        verify(textBox).setEnabled(eq(!fieldDefinition.getReadOnly()));
+
+        verify(formGroup).render(anyString(), eq(textBox), eq(fieldDefinition));
+    }
+
+    @Override
+    protected TextBoxFieldRenderer getRendererInstance() {
+        return textBoxFieldRenderer;
+    }
+
+    @Override
+    protected TextBoxFieldDefinition getFieldDefinition() {
+        TextBoxFieldDefinition textBoxFieldDefinition = new TextBoxFieldDefinition();
+
+        textBoxFieldDefinition.setName(NAME);
+        textBoxFieldDefinition.setBinding(NAME);
+        textBoxFieldDefinition.setPlaceHolder(NAME);
+
+        return textBoxFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/date/DatePickerFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/date/DatePickerFieldRendererTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date.input.DatePickerWrapper;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DatePickerFieldRendererTest extends AbstractFieldRendererTest<org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date.DatePickerFieldRenderer, DatePickerFieldDefinition, DefaultFormGroup> {
+
+    private static String NAME = "datePicker";
+
+    @Mock
+    private DatePickerWrapper datePicker;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private DatePickerFieldRenderer datePickerFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroupShortDate() {
+        testGetFormGroup(false);
+    }
+
+    @Test
+    public void testGetFormGroupTimestamp() {
+        testGetFormGroup(true);
+    }
+
+    private void testGetFormGroup(boolean showTime) {
+        when(fieldDefinition.getShowTime()).thenReturn(showTime);
+
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        verify(datePicker).setDatePickerWidget(eq(showTime));
+        verify(datePicker).setId(any());
+        verify(datePicker).setPlaceholder(eq(fieldDefinition.getPlaceHolder()));
+        verify(datePicker).setEnabled(eq(!fieldDefinition.getReadOnly()));
+
+        verify(datePicker).asWidget();
+
+        verify(formGroup).render(anyString(), any(), eq(fieldDefinition));
+    }
+
+    @Override
+    protected DatePickerFieldRenderer getRendererInstance() {
+        return datePickerFieldRenderer;
+    }
+
+    @Override
+    protected DatePickerFieldDefinition getFieldDefinition() {
+        DatePickerFieldDefinition datePickerFieldDefinition = new DatePickerFieldDefinition();
+
+        datePickerFieldDefinition.setName(NAME);
+        datePickerFieldDefinition.setBinding(NAME);
+        datePickerFieldDefinition.setPlaceHolder(NAME);
+
+        return datePickerFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/creator/MultipleInputFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/creator/MultipleInputFieldRendererTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.lov.creator;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.lov.creator.input.MultipleInput;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.input.AbstractMultipleInputFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.input.impl.StringMultipleInputFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class MultipleInputFieldRendererTest extends AbstractFieldRendererTest<MultipleInputFieldRenderer, AbstractMultipleInputFieldDefinition, DefaultFormGroup> {
+
+    private static String NAME = "multipleInput";
+
+    @Mock
+    private MultipleInput multipleInput;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private MultipleInputFieldRenderer multipleInputFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        testGetFormGroup(false);
+    }
+
+    @Test
+    public void testGetFormGroupReadOnly() {
+        fieldDefinition.setReadOnly(true);
+        testGetFormGroup(true);
+    }
+
+    private void testGetFormGroup(boolean readOnly) {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        verify(multipleInput).setPageSize(eq(fieldDefinition.getPageSize()));
+        verify(multipleInput).init(eq(fieldDefinition.getStandaloneClassName()));
+        verify(multipleInput, readOnly ? times(1) : never()).setReadOnly(eq(true));
+        verify(multipleInput).asWidget();
+
+        verify(formGroup).render(any(), eq(fieldDefinition));
+    }
+
+    @Override
+    protected MultipleInputFieldRenderer getRendererInstance() {
+        return multipleInputFieldRenderer;
+    }
+
+    @Override
+    protected AbstractMultipleInputFieldDefinition getFieldDefinition() {
+        StringMultipleInputFieldDefinition multipleInputFieldDefinition = new StringMultipleInputFieldDefinition();
+
+        multipleInputFieldDefinition.setName(NAME);
+        multipleInputFieldDefinition.setBinding(NAME);
+
+        return multipleInputFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/selector/MultipleSelectorFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/lov/selector/MultipleSelectorFieldRendererTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.lov.selector;
+
+import java.util.Arrays;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.lov.selector.input.MultipleSelectorInput;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.selector.AbstractMultipleSelectorFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.selector.impl.StringMultipleSelectorFieldDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class MultipleSelectorFieldRendererTest extends AbstractFieldRendererTest<MultipleSelectorFieldRenderer, AbstractMultipleSelectorFieldDefinition, DefaultFormGroup> {
+
+    private static String NAME = "textBox";
+
+    @Mock
+    private MultipleSelectorInput<?> selector;
+
+    @Mock
+    private TranslationService translationService;
+
+    @Mock
+    private DefaultFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private MultipleSelectorFieldRenderer multipleSelectorFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+        selector.init(any(), any());
+
+        verify(selector).setMaxItems(fieldDefinition.getMaxDropdownElements());
+        verify(selector).setEnabled(true);
+        verify(selector).setFilterEnabled(fieldDefinition.getAllowFilter());
+        verify(selector).setClearSelectionEnabled(fieldDefinition.getAllowClearSelection());
+
+        verify(formGroup).render(any(), eq(fieldDefinition));
+    }
+
+    @Override
+    protected MultipleSelectorFieldRenderer getRendererInstance() {
+        return multipleSelectorFieldRenderer;
+    }
+
+    @Override
+    protected AbstractMultipleSelectorFieldDefinition getFieldDefinition() {
+        StringMultipleSelectorFieldDefinition stringMultipleInputFieldDefinition = new StringMultipleSelectorFieldDefinition();
+
+        stringMultipleInputFieldDefinition.setName(NAME);
+        stringMultipleInputFieldDefinition.setBinding(NAME);
+
+        stringMultipleInputFieldDefinition.setListOfValues(Arrays.asList("a", "b", "c"));
+
+        return stringMultipleInputFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/multipleSubform/MultipleSubFormFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/multipleSubform/MultipleSubFormFieldRendererTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.relations.multipleSubform;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.nestedForm.fieldSet.FieldSetFormGroup;
+import org.kie.workbench.common.forms.dynamic.client.resources.i18n.FormRenderingConstants;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.TableColumnMeta;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.definition.MultipleSubFormFieldDefinition;
+import org.kie.workbench.common.forms.model.FormDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class MultipleSubFormFieldRendererTest extends AbstractFieldRendererTest<MultipleSubFormFieldRenderer, MultipleSubFormFieldDefinition, FieldSetFormGroup> {
+
+    private static String CREATION_FORM = "creation_form";
+    private static String EDITION_FORM = "edition_form";
+
+    private static String NAME = "multipleSubForm";
+
+    private Map<String, FormDefinition> availableForms = new HashMap<>();
+
+    @Mock
+    private MultipleSubFormWidget multipleSubFormWidget;
+
+    @Mock
+    private FieldSetFormGroup formGroup;
+
+    @InjectMocks
+    @Spy
+    private MultipleSubFormFieldRenderer multipleSubFormFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        availableForms.put(CREATION_FORM, mock(FormDefinition.class));
+        availableForms.put(EDITION_FORM, mock(FormDefinition.class));
+
+        when(context.getAvailableForms()).thenReturn(availableForms);
+        when(formGroupsInstance.get()).thenReturn(formGroup);
+    }
+
+    @Test
+    public void testGetFormGroup() {
+        renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        verify(formGroupsInstance).get();
+
+        multipleSubFormWidget.config(any(), any());
+
+        verify(formGroup).render(any(), any());
+    }
+
+    @Override
+    protected void checkName(String name) {
+        assertEquals(renderer.RENDERER_NAME, name);
+    }
+
+    @Test
+    public void testRenderWithConfigErrorsNoColumnMetas() {
+        fieldDefinition.getColumnMetas().clear();
+        testRenderWithConfigErrors(FormRenderingConstants.MultipleSubformNoColumns);
+    }
+
+    @Test
+    public void testRenderWithConfigErrorsMissingCreationForm() {
+        availableForms.remove(CREATION_FORM);
+        testRenderWithConfigErrors(FormRenderingConstants.MultipleSubformWrongCreationForm);
+    }
+
+    @Test
+    public void testRenderWithConfigErrorsEmptyCreationForm() {
+        fieldDefinition.setCreationForm(null);
+        testRenderWithConfigErrors(FormRenderingConstants.MultipleSubformNoCreationForm);
+    }
+
+    @Test
+    public void testRenderWithConfigErrorsMissingEditionForm() {
+        availableForms.remove(EDITION_FORM);
+        testRenderWithConfigErrors(FormRenderingConstants.MultipleSubformWongEditionForm);
+    }
+
+    @Test
+    public void testRenderWithConfigErrorsEmptyEditionForm() {
+        fieldDefinition.setEditionForm(null);
+        testRenderWithConfigErrors(FormRenderingConstants.MultipleSubformNoEditionForm);
+    }
+
+    @Override
+    protected MultipleSubFormFieldRenderer getRendererInstance() {
+        return multipleSubFormFieldRenderer;
+    }
+
+    @Override
+    protected MultipleSubFormFieldDefinition getFieldDefinition() {
+        MultipleSubFormFieldDefinition multipleSubFormFieldDefinition = new MultipleSubFormFieldDefinition();
+
+        multipleSubFormFieldDefinition.setName(NAME);
+        multipleSubFormFieldDefinition.setBinding(NAME);
+
+        multipleSubFormFieldDefinition.getColumnMetas().add(new TableColumnMeta("a", "b"));
+        multipleSubFormFieldDefinition.setCreationForm(CREATION_FORM);
+        multipleSubFormFieldDefinition.setEditionForm(EDITION_FORM);
+
+        return multipleSubFormFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/subform/SubFormFieldRendererTest.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/rendering/renderers/relations/subform/SubFormFieldRendererTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.rendering.renderers.relations.subform;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.assertj.core.api.Assertions;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.client.rendering.AbstractFieldRendererTest;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.nestedForm.AbstractNestedFormFormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.nestedForm.collapse.CollapsibleFormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.nestedForm.fieldSet.FieldSetFormGroup;
+import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.relations.subform.widget.SubFormWidget;
+import org.kie.workbench.common.forms.dynamic.client.resources.i18n.FormRenderingConstants;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.Container;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.definition.SubFormFieldDefinition;
+import org.kie.workbench.common.forms.model.FormDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class SubFormFieldRendererTest extends AbstractFieldRendererTest<SubFormFieldRenderer, SubFormFieldDefinition, FieldSetFormGroup> {
+
+    private static String NESTED_FORM = "nested_form";
+
+    private static String NAME = "subForm";
+
+    private Map<String, FormDefinition> availableForms = new HashMap<>();
+
+    @Mock
+    private SubFormWidget subFormWidget;
+
+    @Mock
+    private FieldSetFormGroup fieldSetFormGroup;
+
+    @Mock
+    private ManagedInstance<CollapsibleFormGroup> collapsibleFormGroupManagedInstance;
+
+    @Mock
+    private CollapsibleFormGroup collapsibleFormGroup;
+
+    @InjectMocks
+    @Spy
+    private SubFormFieldRenderer subFormFieldRenderer;
+
+    @Before
+    public void init() {
+        super.init();
+
+        availableForms.put(NESTED_FORM, mock(FormDefinition.class));
+
+        when(context.getAvailableForms()).thenReturn(availableForms);
+        when(context.getCopyFor(anyString(), any(), any())).thenReturn(context);
+
+        when(collapsibleFormGroupManagedInstance.get()).thenReturn(collapsibleFormGroup);
+
+        when(formGroupsInstance.select(any(Class.class))).thenReturn(formGroupsInstance);
+
+        when(formGroupsInstance.get()).thenAnswer(invocation -> {
+            if (Container.COLLAPSIBLE.equals(fieldDefinition.getContainer())) {
+                return collapsibleFormGroup;
+            }
+            return fieldSetFormGroup;
+        });
+    }
+
+    @Test
+    public void testGetCollapsibleFormGroup() {
+        fieldDefinition.setContainer(Container.COLLAPSIBLE);
+        testGetFormGroup(CollapsibleFormGroup.class);
+    }
+
+    @Test
+    public void testGetFieldSetFormGroup() {
+        fieldDefinition.setContainer(Container.FIELD_SET);
+        testGetFormGroup(FieldSetFormGroup.class);
+    }
+
+    private void testGetFormGroup(Class<? extends AbstractNestedFormFormGroup> expectedGroupType) {
+        AbstractNestedFormFormGroup group = (AbstractNestedFormFormGroup) renderer.getFormGroup(RenderMode.EDIT_MODE);
+
+        Assertions.assertThat(group)
+                .isNotNull()
+                .isInstanceOf(expectedGroupType);
+
+        verify(context).getCopyFor(anyString(), any(), any());
+
+        verify(formGroupsInstance).get();
+
+        subFormWidget.render(eq(context));
+
+        verify(group).render(any(), any());
+    }
+
+    @Test
+    public void testRenderWithConfigErrorsMissingNestedForm() {
+        availableForms.remove(NESTED_FORM);
+        testRenderWithConfigErrors(FormRenderingConstants.SubFormWrongForm);
+    }
+
+    @Test
+    public void testRenderWithConfigErrorsEmptyNestedForm() {
+        fieldDefinition.setNestedForm(null);
+        testRenderWithConfigErrors(FormRenderingConstants.SubFormNoForm);
+    }
+
+    @Override
+    protected SubFormFieldRenderer getRendererInstance() {
+        return subFormFieldRenderer;
+    }
+
+    @Override
+    protected SubFormFieldDefinition getFieldDefinition() {
+        SubFormFieldDefinition subFormFieldDefinition = new SubFormFieldDefinition();
+
+        subFormFieldDefinition.setName(NAME);
+        subFormFieldDefinition.setBinding(NAME);
+        subFormFieldDefinition.setNestedForm(NESTED_FORM);
+
+        return subFormFieldDefinition;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/test/TestFieldRendererTypesProvider.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/src/test/java/org/kie/workbench/common/forms/dynamic/client/test/TestFieldRendererTypesProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.dynamic.client.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.workbench.common.forms.adf.rendering.FieldRendererTypesProvider;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.FieldType;
+
+public class TestFieldRendererTypesProvider implements FieldRendererTypesProvider<FieldRenderer> {
+
+    private Map<Class<? extends FieldType>, Class<? extends FieldRenderer>> fieldTypeRenderers = new HashMap<>();
+    private Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> fieldDefinitionRenderers = new HashMap<>();
+
+    public TestFieldRendererTypesProvider() {
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.integerBox.type.IntegerBoxFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.IntegerBoxFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.selector.MultipleSelectorFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.lov.selector.MultipleSelectorFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.multipleSubform.type.MultipleSubFormFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.relations.multipleSubform.MultipleSubFormFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.type.TextBoxFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.TextBoxFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.input.MultipleInputFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.lov.creator.MultipleInputFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.type.DatePickerFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.date.DatePickerFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.slider.type.SliderFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.SliderFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.TextAreaFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.type.CheckBoxFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.CheckBoxFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.subForm.type.SubFormFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.relations.subform.SubFormFieldRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.decimalBox.type.DecimalBoxFieldType.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.DecimalBoxFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.IntegerListBoxFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.IntegerListBoxFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.DecimalRadioGroupFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.radioGroup.DecimalRadioGroupFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.StringListBoxFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.StringListBoxFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.IntegerRadioGroupFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.radioGroup.IntegerRadioGroupFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.CharacterRadioGroupFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.radioGroup.CharacterRadioGroupFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.DecimalListBoxFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.DecimalListBoxFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.radioGroup.definition.StringRadioGroupFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.radioGroup.StringRadioGroupFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.EnumListBoxFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.EnumListBoxFieldRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.listBox.definition.CharacterListBoxFieldDefinition.class, org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.listBox.CharacterListBoxFieldRenderer.class);
+    }
+
+    @Override
+    public Map<Class<? extends FieldType>, Class<? extends FieldRenderer>> getFieldTypeRenderers() {
+        return fieldTypeRenderers;
+    }
+
+    @Override
+    public Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> getFieldDefinitionRenderers() {
+        return fieldDefinitionRenderers;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/src/main/java/org/kie/workbench/common/forms/adf/rendering/FieldRendererTypesProvider.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/src/main/java/org/kie/workbench/common/forms/adf/rendering/FieldRendererTypesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.forms.dynamic.client.rendering;
+package org.kie.workbench.common.forms.adf.rendering;
+
+import java.util.Map;
 
 import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.FieldType;
 
-public interface FieldDefinitionFieldRenderer<FIELD extends FieldDefinition> {
+public interface FieldRendererTypesProvider<R> {
 
-    Class<FIELD> getSupportedFieldDefinition();
+    Map<Class<? extends FieldType>, Class<? extends R>> getFieldTypeRenderers();
+
+    Map<Class<? extends FieldDefinition>, Class<? extends R>> getFieldDefinitionRenderers();
+
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/src/main/java/org/kie/workbench/common/forms/adf/rendering/Renderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/src/main/java/org/kie/workbench/common/forms/adf/rendering/Renderer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.rendering;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.FieldType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Renderer {
+
+    Class<? extends FieldType> type() default FieldType.class;
+
+    Class<? extends FieldDefinition> fieldDefinition() default FieldDefinition.class;
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/src/main/resources/org/kie/workbench/common/forms/adf/AnnotationDrivenFormsBase.gwt.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/src/main/resources/org/kie/workbench/common/forms/adf/AnnotationDrivenFormsBase.gwt.xml
@@ -23,5 +23,6 @@
   <inherits name="org.kie.workbench.common.forms.FormsAPI"/>
 
   <source path="definitions"/>
+  <source path="rendering"/>
   <source path="service"/>
 </module>

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/src/main/java/org/kie/workbench/common/forms/adf/engine/client/formGeneration/ClientFormGenerator.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/src/main/java/org/kie/workbench/common/forms/adf/engine/client/formGeneration/ClientFormGenerator.java
@@ -51,17 +51,21 @@ public class ClientFormGenerator extends AbstractFormGenerator {
 
         Collection<SyncBeanDef<FormElementProcessor>> processors = beanManager.lookupBeans(FormElementProcessor.class);
 
-        processors.forEach(processorDef -> {
-            registerProcessor(processorDef.getInstance());
-        });
+        processors.stream()
+                .map(SyncBeanDef::getInstance)
+                .forEach(processor -> {
+                    registerProcessor(processor);
+                    beanManager.destroyBean(processor);
+                });
 
         Collection<SyncBeanDef<FormGenerationResourcesProvider>> builderDefs = beanManager.lookupBeans(FormGenerationResourcesProvider.class);
 
-        builderDefs.forEach(builderDef -> {
-            FormGenerationResourcesProvider instance = builderDef.getInstance();
-            registerResources(instance);
-            beanManager.destroyBean(instance);
-        });
+        builderDefs.stream()
+                .map(SyncBeanDef::getInstance)
+                .forEach(provider -> {
+                    registerResources(provider);
+                    beanManager.destroyBean(provider);
+                });
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/pom.xml
@@ -60,6 +60,12 @@
       <artifactId>kie-wb-common-forms-adf-processors</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-dynamic-forms-client</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/java/org/kie/workbench/common/forms/adf/processors/FieldRendererProcessorTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/java/org/kie/workbench/common/forms/adf/processors/FieldRendererProcessorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.processors;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+
+import org.junit.Test;
+import org.uberfire.annotations.processors.AbstractErrorAbsorbingProcessor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class FieldRendererProcessorTest extends AbstractProcessorTest {
+
+    private static final String RENDERER_1 = "org/kie/workbench/common/forms/adf/processors/renderers/TextAreaFieldTypeRenderer";
+    private static final String RENDERER_2 = "org/kie/workbench/common/forms/adf/processors/renderers/TextBoxFieldTypeRenderer";
+    private static final String RENDERER_3 = "org/kie/workbench/common/forms/adf/processors/renderers/TextAreaFieldDefinitionRenderer";
+    private static final String RENDERER_4 = "org/kie/workbench/common/forms/adf/processors/renderers/TextBoxFieldDefinitionRenderer";
+
+    private static final String RESULT = "org/kie/workbench/common/forms/adf/processors/renderers/ModuleFieldRendererTypesProvider.expected";
+
+    private Result generated = new Result();
+
+    @Test
+    public void testProcessing() throws FileNotFoundException {
+        generated.setExpectedCode(getExpectedSourceCode(RESULT));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(getProcessorUnderTest(), RENDERER_1, RENDERER_2, RENDERER_3, RENDERER_4);
+
+        assertSuccessfulCompilation(diagnostics);
+
+        assertNotNull(generated.getActualCode());
+        assertNotNull(generated.getExpectedCode());
+        assertEquals(generated.getExpectedCode(), generated.getActualCode());
+    }
+
+    @Override
+    protected AbstractErrorAbsorbingProcessor getProcessorUnderTest() {
+        return new FieldRendererProcessor(code -> generated.setActualCode(code));
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/ModuleFieldRendererTypesProvider.expected
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/ModuleFieldRendererTypesProvider.expected
@@ -1,0 +1,52 @@
+/*
+* Copyright 2019 Red Hat, Inc. and/or its affiliates.
+*  
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*  
+*    http://www.apache.org/licenses/LICENSE-2.0
+*  
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.kie.workbench.common.forms.adf.processors.renderers;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.kie.workbench.common.forms.adf.rendering.FieldRendererTypesProvider;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.FieldType;
+
+@Generated("org.kie.workbench.common.forms.adf.processors.FieldRendererProcessor")
+@ApplicationScoped
+public class ModuleFieldRendererTypesProvider implements FieldRendererTypesProvider<FieldRenderer> {
+
+    private Map<Class<? extends FieldType>, Class<? extends FieldRenderer>> fieldTypeRenderers = new HashMap<>();
+    private Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> fieldDefinitionRenderers = new HashMap<>();
+
+    public ModuleFieldRendererTypesProvider() {
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType.class, org.kie.workbench.common.forms.adf.processors.renderers.TextAreaFieldTypeRenderer.class);
+        fieldTypeRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.type.TextBoxFieldType.class, org.kie.workbench.common.forms.adf.processors.renderers.TextBoxFieldTypeRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition.class, org.kie.workbench.common.forms.adf.processors.renderers.TextAreaFieldDefinitionRenderer.class);
+        fieldDefinitionRenderers.put(org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition.class, org.kie.workbench.common.forms.adf.processors.renderers.TextBoxFieldDefinitionRenderer.class);
+    }
+
+    @Override
+    public Map<Class<? extends FieldType>, Class<? extends FieldRenderer>> getFieldTypeRenderers() {
+        return fieldTypeRenderers;
+    }
+
+    @Override
+    public Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> getFieldDefinitionRenderers() {
+        return fieldDefinitionRenderers;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextAreaFieldDefinitionRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextAreaFieldDefinitionRenderer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.processors.renderers;
+
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.definition.TextAreaFieldDefinition;
+
+@Renderer(fieldDefinition = TextAreaFieldDefinition.class)
+public class TextAreaFieldDefinitionRenderer extends FieldRenderer {
+
+    @Override
+    protected FormGroup getFormGroup(RenderMode renderMode) {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    protected void setReadOnly(boolean readOnly) {
+
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextAreaFieldTypeRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextAreaFieldTypeRenderer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.processors.renderers;
+
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
+
+@Renderer(type = TextAreaFieldType.class)
+public class TextAreaFieldTypeRenderer extends FieldRenderer {
+
+    @Override
+    protected FormGroup getFormGroup(RenderMode renderMode) {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    protected void setReadOnly(boolean readOnly) {
+
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextBoxFieldDefinitionRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextBoxFieldDefinitionRenderer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.processors.renderers;
+
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition;
+
+@Renderer(fieldDefinition = TextBoxFieldDefinition.class)
+public class TextBoxFieldDefinitionRenderer extends FieldRenderer {
+
+    @Override
+    protected FormGroup getFormGroup(RenderMode renderMode) {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    protected void setReadOnly(boolean readOnly) {
+
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextBoxFieldTypeRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/src/test/resources/org/kie/workbench/common/forms/adf/processors/renderers/TextBoxFieldTypeRenderer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.processors.renderers;
+
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
+import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.type.TextBoxFieldType;
+
+@Renderer(type = TextBoxFieldType.class)
+public class TextBoxFieldTypeRenderer extends FieldRenderer {
+
+    @Override
+    protected FormGroup getFormGroup(RenderMode renderMode) {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    protected void setReadOnly(boolean readOnly) {
+
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/java/org/kie/workbench/common/forms/adf/processors/FieldRendererProcessor.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/java/org/kie/workbench/common/forms/adf/processors/FieldRendererProcessor.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.processors;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.MirroredTypeException;
+import javax.tools.Diagnostic;
+
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.annotations.processors.AbstractErrorAbsorbingProcessor;
+import org.uberfire.annotations.processors.GenerationCompleteCallback;
+
+@SupportedAnnotationTypes(FieldRendererProcessor.FIELD_RENDERER_ANNOTATION)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class FieldRendererProcessor extends AbstractErrorAbsorbingProcessor {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(FieldRendererProcessor.class.getName());
+
+    static final String FIELD_RENDERER_ANNOTATION = "org.kie.workbench.common.forms.adf.rendering.Renderer";
+
+    private String packageName;
+    private List<RendererMeta> fieldTypeRenderers = new ArrayList<>();
+    private List<RendererMeta> fieldDefinitionRenderers = new ArrayList<>();
+
+    private GenerationCompleteCallback callback = null;
+
+    public FieldRendererProcessor() {
+
+    }
+
+    // Constructor for tests only, to prevent code being written to file. The generated code will be sent to the callback
+    FieldRendererProcessor(GenerationCompleteCallback callback) {
+        this();
+        this.callback = callback;
+        LOGGER.info("GenerationCompleteCallback has been provided. Generated source code will not be compiled and hence classes will not be available.");
+    }
+
+    @Override
+    protected boolean processWithExceptions(Set<? extends TypeElement> annotations, RoundEnvironment roundEnvironment) throws Exception {
+
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, "Searching FieldRenderers on project");
+
+        if (roundEnvironment.processingOver()) {
+            return false;
+        }
+
+        //If prior processing threw an error exit
+        if (roundEnvironment.errorRaised()) {
+            return false;
+        }
+
+        packageName = null;
+        fieldTypeRenderers.clear();
+        fieldDefinitionRenderers.clear();
+
+        TypeElement annotation = processingEnv.getElementUtils().getTypeElement(FIELD_RENDERER_ANNOTATION);
+
+        Set<? extends Element> renderers = roundEnvironment.getElementsAnnotatedWith(annotation);
+
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, renderers.size() + " FieldRenderers found on project");
+
+        renderers.forEach(element -> process((TypeElement) element));
+
+        if (!fieldTypeRenderers.isEmpty() || !fieldDefinitionRenderers.isEmpty()) {
+            fieldTypeRenderers.sort(Comparator.comparing(RendererMeta::getKey));
+            fieldDefinitionRenderers.sort(Comparator.comparing(RendererMeta::getKey));
+
+            Map<String, Object> templateContext = new HashMap<>();
+
+            templateContext.put("package", packageName);
+            templateContext.put("generatedByClassName", this.getClass().getName());
+            templateContext.put("fieldTypeRenderers", fieldTypeRenderers);
+            templateContext.put("fieldDefinitionRenderers", fieldDefinitionRenderers);
+
+            StringBuffer code = TemplateWriter.writeTemplate("FieldRendererTypesProvider.ftl", templateContext);
+
+            // If code is successfully created write files, or send generated code to callback.
+            // The callback function is used primarily for testing when we don't necessarily want
+            // the generated code to be stored as a compilable file for javac to process.
+            if (callback == null) {
+                writeCode(packageName, "ModuleFieldRendererTypesProvider", code);
+            } else {
+                callback.generationComplete(code.toString());
+            }
+
+            LOGGER.info("Succesfully Generated sources for [{}] FieldType FieldRenderers and [{}}] FieldDefinition FieldRenderers.", fieldTypeRenderers.size(), fieldDefinitionRenderers.size());
+        }
+
+        return true;
+    }
+
+    private void process(TypeElement rendererElement) {
+        Renderer annotation = rendererElement.getAnnotation(Renderer.class);
+
+        if (annotation != null) {
+            String rendererType = rendererElement.getQualifiedName().toString();
+
+            if (packageName == null) {
+                packageName = rendererType.substring(0, rendererType.lastIndexOf('.'));
+            }
+
+            String fieldDefinitionType = readAnnotationValue(() -> annotation.fieldDefinition().getName());
+
+            if (!fieldDefinitionType.equals(FieldDefinition.class.getName())) {
+                fieldDefinitionRenderers.add(new RendererMeta(fieldDefinitionType, rendererType));
+            } else {
+                fieldTypeRenderers.add(new RendererMeta(readAnnotationValue(() -> annotation.type().getName()), rendererType));
+            }
+        }
+    }
+
+    private String readAnnotationValue(Supplier<String> realValueSupplier) {
+        try {
+            return realValueSupplier.get();
+        } catch (MirroredTypeException exception) {
+            return exception.getTypeMirror().toString();
+        }
+    }
+
+    public static class RendererMeta {
+
+        private String key;
+        private String className;
+
+        RendererMeta(String key, String className) {
+            this.key = key;
+            this.className = className;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/java/org/kie/workbench/common/forms/adf/processors/TemplateWriter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/java/org/kie/workbench/common/forms/adf/processors/TemplateWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.adf.processors;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.util.Map;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.uberfire.annotations.processors.exceptions.GenerationException;
+
+public class TemplateWriter {
+
+    private static final String TEMPLATES_FOLDER = "templates/";
+
+    private TemplateWriter() {
+    }
+
+    public static StringBuffer writeTemplate(final String templateName, final Map<String, Object> context) throws GenerationException {
+
+        // The code used to contain 'new InputStreamReader(this.getClass().getResourceAsStream(templateName))' which for
+        // some reason was causing issues during concurrent invocation of this method (e.g. in parallel Maven build).
+        // The stream returned by 'getResourceAsStream(templateName)' was sometimes already closed (!) and as the
+        // Template class tried to read from the stream it resulted in IOException. Changing the code to
+        // 'getResource(templateName).openStream()' seems to be a sensible workaround
+        try (InputStream templateIs = TemplateWriter.class.getResource(TEMPLATES_FOLDER + templateName).openStream();
+             StringWriter sw = new StringWriter();
+             BufferedWriter bw = new BufferedWriter(sw)) {
+
+            Configuration config = new Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+
+            Template template = new Template("", new InputStreamReader(templateIs), config);
+
+            template.process(context, bw);
+
+            return sw.getBuffer();
+
+        } catch (IOException | TemplateException ioe) {
+            throw new GenerationException(ioe);
+        }
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,2 @@
 org.kie.workbench.common.forms.adf.processors.FormDefinitionsProcessor
+org.kie.workbench.common.forms.adf.processors.FieldRendererProcessor

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/resources/org/kie/workbench/common/forms/adf/processors/templates/FieldRendererTypesProvider.ftl
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/src/main/resources/org/kie/workbench/common/forms/adf/processors/templates/FieldRendererTypesProvider.ftl
@@ -1,0 +1,54 @@
+/*
+* Copyright 2019 Red Hat, Inc. and/or its affiliates.
+*  
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*  
+*    http://www.apache.org/licenses/LICENSE-2.0
+*  
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package ${package};
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.kie.workbench.common.forms.adf.rendering.FieldRendererTypesProvider;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.FieldType;
+
+@Generated("${generatedByClassName}")
+@ApplicationScoped
+public class ModuleFieldRendererTypesProvider implements FieldRendererTypesProvider<FieldRenderer> {
+
+    private Map<Class<? extends FieldType>, Class<? extends FieldRenderer>> fieldTypeRenderers = new HashMap<>();
+    private Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> fieldDefinitionRenderers = new HashMap<>();
+
+    public ModuleFieldRendererTypesProvider() {
+    <#list fieldTypeRenderers as renderer>
+        fieldTypeRenderers.put(${renderer.key}.class, ${renderer.className}.class);
+    </#list>
+    <#list fieldDefinitionRenderers as renderer>
+        fieldDefinitionRenderers.put(${renderer.key}.class, ${renderer.className}.class);
+    </#list>
+    }
+
+    @Override
+    public Map<Class<? extends FieldType>, Class<? extends FieldRenderer>> getFieldTypeRenderers() {
+        return fieldTypeRenderers;
+    }
+
+    @Override
+    public Map<Class<? extends FieldDefinition>, Class<? extends FieldRenderer>> getFieldDefinitionRenderers() {
+        return fieldDefinitionRenderers;
+    }
+}

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorContext.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorContext.java
@@ -16,18 +16,18 @@
 
 package org.kie.workbench.common.forms.editor.client.editor;
 
-import javax.inject.Singleton;
-
-@Singleton
 public class FormEditorContext {
 
-    private FormEditorHelper activeEditorHelper;
+    private static FormEditorHelper activeEditorHelper;
 
-    public void setActiveEditorHelper(FormEditorHelper activeEditorHelper) {
-        this.activeEditorHelper = activeEditorHelper;
+    private FormEditorContext() {
     }
 
-    public FormEditorHelper getActiveEditorHelper() {
+    public static void setActiveEditorHelper(FormEditorHelper activeEditorHelper) {
+        FormEditorContext.activeEditorHelper = activeEditorHelper;
+    }
+
+    public static FormEditorHelper getActiveEditorHelper() {
         return activeEditorHelper;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent;
 import org.kie.workbench.common.forms.editor.model.FormModelerContent;
 import org.kie.workbench.common.forms.editor.service.shared.FormEditorRenderingContext;
@@ -64,12 +65,14 @@ public class FormEditorHelper {
 
     @PostConstruct
     public void init() {
-        Collection<SyncBeanDef<EditorFieldTypesProvider>> providers = IOC.getBeanManager().lookupBeans(EditorFieldTypesProvider.class);
+        final SyncBeanManager beanManager = IOC.getBeanManager();
+        Collection<SyncBeanDef<EditorFieldTypesProvider>> providers = beanManager.lookupBeans(EditorFieldTypesProvider.class);
         providers.stream().map(SyncBeanDef::getInstance)
                 .sorted(Comparator.comparingInt(EditorFieldTypesProvider::getPriority))
                 .forEach((EditorFieldTypesProvider editorProvider) -> {
                     enabledPaletteFieldTypes.addAll(editorProvider.getPaletteFieldTypes());
                     enabledFieldPropertiesFieldTypes.addAll(editorProvider.getFieldPropertiesFieldTypes());
+                    beanManager.destroyBean(editorProvider);
                 });
     }
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorHelper.java
@@ -24,13 +24,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent;
@@ -63,9 +61,17 @@ public class FormEditorHelper {
     protected Collection<FieldType> enabledPaletteFieldTypes = new ArrayList<>();
     protected Collection<FieldType> enabledFieldPropertiesFieldTypes = new ArrayList<>();
 
-    @PostConstruct
-    public void init() {
-        final SyncBeanManager beanManager = IOC.getBeanManager();
+    @Inject
+    public FormEditorHelper(FieldManager fieldManager,
+                            ManagedInstance<EditorFieldLayoutComponent> editorFieldLayoutComponents,
+                            SyncBeanManager beanManager) {
+        this.fieldManager = fieldManager;
+        this.editorFieldLayoutComponents = editorFieldLayoutComponents;
+
+        init(beanManager);
+    }
+
+    private void init(final SyncBeanManager beanManager) {
         Collection<SyncBeanDef<EditorFieldTypesProvider>> providers = beanManager.lookupBeans(EditorFieldTypesProvider.class);
         providers.stream().map(SyncBeanDef::getInstance)
                 .sorted(Comparator.comparingInt(EditorFieldTypesProvider::getPriority))
@@ -74,13 +80,6 @@ public class FormEditorHelper {
                     enabledFieldPropertiesFieldTypes.addAll(editorProvider.getFieldPropertiesFieldTypes());
                     beanManager.destroyBean(editorProvider);
                 });
-    }
-
-    @Inject
-    public FormEditorHelper(FieldManager fieldManager,
-                            ManagedInstance<EditorFieldLayoutComponent> editorFieldLayoutComponents) {
-        this.fieldManager = fieldManager;
-        this.editorFieldLayoutComponents = editorFieldLayoutComponents;
     }
 
     public FormModelerContent getContent() {

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
@@ -602,7 +602,7 @@ public class FormEditorPresenter extends KieEditor<FormModelerContent> {
 
     @PreDestroy
     public void destroy() {
-        if(null != FormEditorContext.getActiveEditorHelper() && FormEditorContext.getActiveEditorHelper().equals(editorHelper)) {
+        if (null != FormEditorContext.getActiveEditorHelper() && FormEditorContext.getActiveEditorHelper().equals(editorHelper)) {
             FormEditorContext.setActiveEditorHelper(null);
         }
         editorFieldLayoutComponents.destroyAll();

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
@@ -106,8 +106,6 @@ public class FormEditorPresenter extends KieEditor<FormModelerContent> {
     @Inject
     protected BusyIndicatorView busyIndicatorView;
     @Inject
-    protected FormEditorContext formEditorContext;
-    @Inject
     protected FormEditorHelper editorHelper;
     protected ManagedInstance<EditorFieldLayoutComponent> editorFieldLayoutComponents;
     @Inject
@@ -183,7 +181,7 @@ public class FormEditorPresenter extends KieEditor<FormModelerContent> {
     }
 
     private void setActiveInstance() {
-        formEditorContext.setActiveEditorHelper(editorHelper);
+        FormEditorContext.setActiveEditorHelper(editorHelper);
 
         initLayoutDragComponentPalette();
 
@@ -604,6 +602,9 @@ public class FormEditorPresenter extends KieEditor<FormModelerContent> {
 
     @PreDestroy
     public void destroy() {
+        if(null != FormEditorContext.getActiveEditorHelper() && FormEditorContext.getActiveEditorHelper().equals(editorHelper)) {
+            FormEditorContext.setActiveEditorHelper(null);
+        }
         editorFieldLayoutComponents.destroyAll();
     }
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenter.java
@@ -602,7 +602,7 @@ public class FormEditorPresenter extends KieEditor<FormModelerContent> {
 
     @PreDestroy
     public void destroy() {
-        if (null != FormEditorContext.getActiveEditorHelper() && FormEditorContext.getActiveEditorHelper().equals(editorHelper)) {
+        if (Objects.equals(FormEditorContext.getActiveEditorHelper(), editorHelper)) {
             FormEditorContext.setActiveEditorHelper(null);
         }
         editorFieldLayoutComponents.destroyAll();

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayerViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayerViewImpl.java
@@ -17,14 +17,15 @@
 package org.kie.workbench.common.forms.editor.client.editor.changes;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Document;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.editor.client.resources.i18n.FormEditorConstants;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKButton;
@@ -53,7 +54,7 @@ public class ChangesNotificationDisplayerViewImpl implements ChangesNotification
     public void init() {
         modal = new BaseModal();
         modal.setTitle(translationService.getTranslation(FormEditorConstants.ChangesNotificationDisplayerTitle));
-        modal.setBody(ElementWrapperWidget.getWidget(this.getElement()));
+        modal.setBody(FormsElementWrapperWidgetUtil.getWidget(this, this.getElement()));
         modal.add(footer);
     }
 
@@ -72,5 +73,11 @@ public class ChangesNotificationDisplayerViewImpl implements ChangesNotification
     @Override
     public void show() {
         modal.show();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        modal.clear();
+        FormsElementWrapperWidgetUtil.clear(this.getElement());
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayerViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/changes/ChangesNotificationDisplayerViewImpl.java
@@ -46,6 +46,9 @@ public class ChangesNotificationDisplayerViewImpl implements ChangesNotification
     private Document document;
 
     @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
+    @Inject
     public ChangesNotificationDisplayerViewImpl(TranslationService translationService) {
         this.translationService = translationService;
     }
@@ -54,7 +57,7 @@ public class ChangesNotificationDisplayerViewImpl implements ChangesNotification
     public void init() {
         modal = new BaseModal();
         modal.setTitle(translationService.getTranslation(FormEditorConstants.ChangesNotificationDisplayerTitle));
-        modal.setBody(FormsElementWrapperWidgetUtil.getWidget(this, this.getElement()));
+        modal.setBody(wrapperWidgetUtil.getWidget(this, this.getElement()));
         modal.add(footer);
     }
 
@@ -78,6 +81,6 @@ public class ChangesNotificationDisplayerViewImpl implements ChangesNotification
     @PreDestroy
     public void destroy() {
         modal.clear();
-        FormsElementWrapperWidgetUtil.clear(this.getElement());
+        wrapperWidgetUtil.clear(this.getElement());
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/errorMessage/ErrorMessageDisplayerViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/errorMessage/ErrorMessageDisplayerViewImpl.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.forms.editor.client.editor.errorMessage;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -26,12 +27,12 @@ import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.Label;
 import org.jboss.errai.common.client.dom.RadioInput;
 import org.jboss.errai.common.client.dom.Span;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.editor.client.resources.i18n.FormEditorConstants;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKButton;
@@ -80,7 +81,7 @@ public class ErrorMessageDisplayerViewImpl implements ErrorMessageDisplayerView,
         modal = new BaseModal();
         modal.setTitle(translationService.getTranslation(FormEditorConstants.ErrorMessageDisplayerViewImplTitle));
         modal.setClosable(false);
-        modal.setBody(ElementWrapperWidget.getWidget(this.getElement()));
+        modal.setBody(FormsElementWrapperWidgetUtil.getWidget(this, this.getElement()));
         modal.add(new ModalFooterOKButton(modal::hide));
         modal.addHideHandler(evt -> presenter.notifyClose());
     }
@@ -139,5 +140,11 @@ public class ErrorMessageDisplayerViewImpl implements ErrorMessageDisplayerView,
     @EventHandler("showMoreAnchor")
     public void onShowMore(ClickEvent event) {
         presenter.notifyShowMorePressed();
+    }
+
+    @PreDestroy
+    public void clear() {
+        modal.clear();
+        FormsElementWrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/errorMessage/ErrorMessageDisplayerViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/errorMessage/ErrorMessageDisplayerViewImpl.java
@@ -72,6 +72,9 @@ public class ErrorMessageDisplayerViewImpl implements ErrorMessageDisplayerView,
     @Inject
     private TranslationService translationService;
 
+    @Inject
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     private Presenter presenter;
 
     private BaseModal modal;
@@ -81,7 +84,7 @@ public class ErrorMessageDisplayerViewImpl implements ErrorMessageDisplayerView,
         modal = new BaseModal();
         modal.setTitle(translationService.getTranslation(FormEditorConstants.ErrorMessageDisplayerViewImplTitle));
         modal.setClosable(false);
-        modal.setBody(FormsElementWrapperWidgetUtil.getWidget(this, this.getElement()));
+        modal.setBody(wrapperWidgetUtil.getWidget(this, this.getElement()));
         modal.add(new ModalFooterOKButton(modal::hide));
         modal.addHideHandler(evt -> presenter.notifyClose());
     }
@@ -145,6 +148,6 @@ public class ErrorMessageDisplayerViewImpl implements ErrorMessageDisplayerView,
     @PreDestroy
     public void clear() {
         modal.clear();
-        FormsElementWrapperWidgetUtil.clear(this);
+        wrapperWidgetUtil.clear(this);
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererViewImpl.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.forms.editor.client.editor.properties;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -27,12 +28,12 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.Modal;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.forms.dynamic.client.DynamicFormRenderer;
+import org.kie.workbench.common.forms.dynamic.client.rendering.util.FormsElementWrapperWidgetUtil;
 import org.kie.workbench.common.forms.editor.client.editor.properties.binding.DataBindingEditor;
 import org.kie.workbench.common.forms.editor.client.resources.i18n.FormEditorConstants;
 import org.kie.workbench.common.forms.editor.service.shared.FormEditorRenderingContext;
@@ -62,6 +63,8 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
     private FieldPropertiesRenderer presenter;
 
     private FieldPropertiesRendererHelper helper;
+
+    private DataBindingEditor dataBindingEditor;
 
     private BaseModal modal;
 
@@ -93,12 +96,13 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
     @Override
     public void render(FieldPropertiesRendererHelper helper,
                        FormEditorRenderingContext renderingContext,
-                       DataBindingEditor bindingEditor) {
+                       DataBindingEditor dataBindingEditor) {
         this.helper = helper;
+        this.dataBindingEditor = dataBindingEditor;
         formRenderer.render(renderingContext);
         initFieldTypeList();
         fieldBinding.clear();
-        fieldBinding.add(ElementWrapperWidget.getWidget(bindingEditor.getElement()));
+        fieldBinding.add(FormsElementWrapperWidgetUtil.getWidget(this, dataBindingEditor.getElement()));
         modal.setTitle(translationService.getTranslation(FormEditorConstants.FieldPropertiesRendererViewImplTitle));
     }
 
@@ -138,5 +142,15 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
     @EventHandler("fieldType")
     public void onTypeChange(ChangeEvent event) {
         presenter.onFieldTypeChange(fieldType.getSelectedValue());
+    }
+
+    @PreDestroy
+    public void clear() {
+        fieldBinding.clear();
+        if(dataBindingEditor != null) {
+            FormsElementWrapperWidgetUtil.clear(this);
+        }
+        formRenderer.unBind();
+        modal.clear();
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererViewImpl.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/properties/FieldPropertiesRendererViewImpl.java
@@ -60,6 +60,8 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
 
     private TranslationService translationService;
 
+    private FormsElementWrapperWidgetUtil wrapperWidgetUtil;
+
     private FieldPropertiesRenderer presenter;
 
     private FieldPropertiesRendererHelper helper;
@@ -70,9 +72,11 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
 
     @Inject
     public FieldPropertiesRendererViewImpl(DynamicFormRenderer formRenderer,
-                                           TranslationService translationService) {
+                                           TranslationService translationService,
+                                           FormsElementWrapperWidgetUtil wrapperWidgetUtil) {
         this.formRenderer = formRenderer;
         this.translationService = translationService;
+        this.wrapperWidgetUtil = wrapperWidgetUtil;
     }
 
     @PostConstruct
@@ -102,7 +106,7 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
         formRenderer.render(renderingContext);
         initFieldTypeList();
         fieldBinding.clear();
-        fieldBinding.add(FormsElementWrapperWidgetUtil.getWidget(this, dataBindingEditor.getElement()));
+        fieldBinding.add(wrapperWidgetUtil.getWidget(this, dataBindingEditor.getElement()));
         modal.setTitle(translationService.getTranslation(FormEditorConstants.FieldPropertiesRendererViewImplTitle));
     }
 
@@ -147,8 +151,8 @@ public class FieldPropertiesRendererViewImpl extends Composite implements FieldP
     @PreDestroy
     public void clear() {
         fieldBinding.clear();
-        if(dataBindingEditor != null) {
-            FormsElementWrapperWidgetUtil.clear(this);
+        if (dataBindingEditor != null) {
+            wrapperWidgetUtil.clear(this);
         }
         formRenderer.unBind();
         modal.clear();

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponent.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/main/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponent.java
@@ -29,7 +29,9 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import org.gwtbootstrap3.client.ui.Modal;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldLayoutComponent;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRendererManager;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
 import org.kie.workbench.common.forms.editor.client.editor.FormEditorContext;
 import org.kie.workbench.common.forms.editor.client.editor.FormEditorHelper;
@@ -45,7 +47,6 @@ import org.uberfire.ext.layout.editor.client.api.HasDragAndDropSettings;
 import org.uberfire.ext.layout.editor.client.api.HasModalConfiguration;
 import org.uberfire.ext.layout.editor.client.api.ModalConfigurationContext;
 import org.uberfire.ext.layout.editor.client.api.RenderingContext;
-import org.uberfire.ext.layout.editor.client.infra.LayoutDragComponentHelper;
 
 @Specializes
 @Dependent
@@ -56,13 +57,9 @@ public class EditorFieldLayoutComponent extends FieldLayoutComponent implements 
 
     protected FieldPropertiesRenderer propertiesRenderer;
 
-    protected LayoutDragComponentHelper layoutDragComponentHelper;
-
     protected Event<FormEditorSyncPaletteEvent> syncPaletteEvent;
 
     protected FieldManager fieldManager;
-
-    protected FormEditorContext formEditorContext;
 
     protected FormEditorHelper editorHelper;
 
@@ -77,15 +74,14 @@ public class EditorFieldLayoutComponent extends FieldLayoutComponent implements 
     private Optional<String> formId = Optional.empty();
 
     @Inject
-    public EditorFieldLayoutComponent(FieldPropertiesRenderer propertiesRenderer,
-                                      LayoutDragComponentHelper layoutDragComponentHelper,
+    public EditorFieldLayoutComponent(FieldRendererManager fieldRendererManager,
+                                      TranslationService translationService,
+                                      FieldPropertiesRenderer propertiesRenderer,
                                       FieldManager fieldManager,
-                                      FormEditorContext formEditorContext,
                                       Event<FormEditorSyncPaletteEvent> syncPaletteEvent) {
+        super(fieldRendererManager, translationService);
         this.propertiesRenderer = propertiesRenderer;
-        this.layoutDragComponentHelper = layoutDragComponentHelper;
         this.fieldManager = fieldManager;
-        this.formEditorContext = formEditorContext;
         this.syncPaletteEvent = syncPaletteEvent;
     }
 
@@ -267,7 +263,7 @@ public class EditorFieldLayoutComponent extends FieldLayoutComponent implements 
             formId = Optional.ofNullable(properties.get(FORM_ID));
         }
 
-        editorHelper = getHelperInstance();
+        editorHelper = FormEditorContext.getActiveEditorHelper();
 
         init(editorHelper.getRenderingContext(),
              editorHelper.getFormField(fieldId.get()));
@@ -277,10 +273,6 @@ public class EditorFieldLayoutComponent extends FieldLayoutComponent implements 
         if (showProperties) {
             propertiesRenderer.render(propertiesRendererHelper);
         }
-    }
-
-    protected FormEditorHelper getHelperInstance() {
-        return formEditorContext.getActiveEditorHelper();
     }
 
     FieldPropertiesRendererHelper getPropertiesRendererHelper() {

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterAbstractTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterAbstractTest.java
@@ -28,6 +28,7 @@ import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuItemBuilder;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.kie.workbench.common.forms.editor.client.editor.changes.ChangesNotificationDisplayer;
@@ -181,6 +182,9 @@ public class FormEditorPresenterAbstractTest {
     @Mock
     protected MenuItem downloadMenuItem;
 
+    @Mock
+    private SyncBeanManager beanManager;
+
     protected TestFieldManager fieldManager;
 
     protected List<Path> assetUsages = new ArrayList<>();
@@ -242,7 +246,7 @@ public class FormEditorPresenterAbstractTest {
         editorServiceCallerMock = new CallerMock<>(formEditorService);
 
         editorHelper = spy(new TestFormEditorHelper(fieldManager,
-                                                    editorFieldLayoutComponents));
+                                                    editorFieldLayoutComponents, beanManager));
 
         when(layoutEditorMock.getLayout()).thenReturn(new LayoutTemplate());
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterAbstractTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/FormEditorPresenterAbstractTest.java
@@ -301,7 +301,6 @@ public class FormEditorPresenterAbstractTest {
                 deletePopUpPresenter = FormEditorPresenterAbstractTest.this.deletePopUpPresenter;
                 renamePopUpPresenter = FormEditorPresenterAbstractTest.this.renamePopUpPresenter;
                 alertsButtonMenuItemBuilder = FormEditorPresenterAbstractTest.this.alertsButtonMenuItemBuilder;
-                formEditorContext = mock(FormEditorContext.class);
                 copyPopUpPresenter = FormEditorPresenterAbstractTest.this.copyPopUpPresenter;
                 promises = FormEditorPresenterAbstractTest.this.promises;
             }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponentTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponentTest.java
@@ -51,7 +51,6 @@ import org.mockito.Mock;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.client.api.ModalConfigurationContext;
 import org.uberfire.ext.layout.editor.client.api.RenderingContext;
-import org.uberfire.ext.layout.editor.client.infra.LayoutDragComponentHelper;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
@@ -90,9 +89,6 @@ public class EditorFieldLayoutComponentTest {
 
     @Mock
     private FormEditorContext formEditorContext;
-
-    @Mock
-    private LayoutDragComponentHelper layoutDragComponentHelper;
 
     @Mock
     private EventSourceMock<FormEditorSyncPaletteEvent> syncPaletteEvent;
@@ -173,21 +169,13 @@ public class EditorFieldLayoutComponentTest {
 
         when(propertiesRenderer.getView()).thenReturn(fieldPropertiesRendererView);
 
-        editorFieldLayoutComponent = spy(new EditorFieldLayoutComponent(propertiesRenderer,
-                                                                        layoutDragComponentHelper,
-                                                                        fieldManager,
-                                                                        formEditorContext,
-                                                                        syncPaletteEvent) {
-            {
-                fieldRendererManager = EditorFieldLayoutComponentTest.this.fieldRendererManager;
-                translationService = EditorFieldLayoutComponentTest.this.translationService;
-            }
+        FormEditorContext.setActiveEditorHelper(formEditorHelper);
 
-            @Override
-            protected FormEditorHelper getHelperInstance() {
-                return formEditorHelper;
-            }
-        });
+        editorFieldLayoutComponent = spy(new EditorFieldLayoutComponent(fieldRendererManager,
+                                                                        translationService,
+                                                                        propertiesRenderer,
+                                                                        fieldManager,
+                                                                        syncPaletteEvent));
 
         editorFieldLayoutComponent.initPropertiesConfig();
         propertiesRendererHelper = spy(editorFieldLayoutComponent.getPropertiesRendererHelper());
@@ -376,8 +364,6 @@ public class EditorFieldLayoutComponentTest {
                                  boolean withConfigContext) {
         FieldDefinition fieldCopy = setupFormEditorHelper();
         ModalConfigurationContext ctx = mock(ModalConfigurationContext.class);
-        
-       
 
         if (bound) {
             when(fieldCopy.getBinding()).thenReturn(BINDING_FIRSTNAME);
@@ -449,20 +435,19 @@ public class EditorFieldLayoutComponentTest {
         assertFalse(editorFieldLayoutComponent.showProperties);
         verify(ctx).configurationCancelled();
     }
-    
+
     @Test
     public void testFieldPartsAdded() {
-        Set<String> parts = Stream.of("p1","p2").collect(Collectors.toSet());
+        Set<String> parts = Stream.of("p1", "p2").collect(Collectors.toSet());
         when(fieldRenderer.getFieldParts()).thenReturn(parts);
         editorFieldLayoutComponent.generateContent(ctx);
         editorFieldLayoutComponent.addComponentParts(ctx.getComponent());
         Set<String> expectedParts = layoutComponent.getParts().stream().map(p -> p.getPartId()).collect(Collectors.toSet());
-        parts = Stream.of("p1","p3").collect(Collectors.toSet());
+        parts = Stream.of("p1", "p3").collect(Collectors.toSet());
         when(fieldRenderer.getFieldParts()).thenReturn(parts);
         editorFieldLayoutComponent.generateContent(ctx);
         editorFieldLayoutComponent.addComponentParts(ctx.getComponent());
         expectedParts = layoutComponent.getParts().stream().map(p -> p.getPartId()).collect(Collectors.toSet());
         assertEquals(parts, expectedParts);
     }
-    
 }

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponentTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/rendering/EditorFieldLayoutComponentTest.java
@@ -26,6 +26,7 @@ import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -136,7 +137,8 @@ public class EditorFieldLayoutComponentTest {
         });
 
         formEditorHelper = spy(new FormEditorHelper(new TestFieldManager(),
-                                                    editorFieldLayoutComponents));
+                                                    editorFieldLayoutComponents,
+                                                    mock(SyncBeanManager.class)));
 
         fieldDefinition = new TextBoxFieldDefinition();
         fieldDefinition.setId(EditorFieldLayoutComponent.FIELD_ID);

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/test/TestFormEditorHelper.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/src/test/java/org/kie/workbench/common/forms/editor/client/editor/test/TestFormEditorHelper.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.kie.workbench.common.forms.editor.client.editor.FormEditorHelper;
 import org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent;
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
@@ -31,9 +32,9 @@ import org.uberfire.commons.data.Pair;
 public class TestFormEditorHelper extends FormEditorHelper {
 
     public TestFormEditorHelper(TestFieldManager fieldManager,
-                                ManagedInstance<EditorFieldLayoutComponent> editorFieldLayoutComponents) {
-        super(fieldManager,
-              editorFieldLayoutComponents);
+                                ManagedInstance<EditorFieldLayoutComponent> editorFieldLayoutComponents,
+                                SyncBeanManager beanManager) {
+        super(fieldManager, editorFieldLayoutComponents, beanManager);
         fieldManager.getAllBasicTypeProviders().stream().forEach((provider) -> {
             enabledPaletteFieldTypes.add(provider.getDefaultField().getFieldType());
             enabledFieldPropertiesFieldTypes.add(provider.getDefaultField().getFieldType());

--- a/kie-wb-common-forms/kie-wb-common-forms-integration-tests/src/test/java/org/kie/workbench/common/forms/integration/tests/formgeneration/FormGenerationIntegrationTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integration-tests/src/test/java/org/kie/workbench/common/forms/integration/tests/formgeneration/FormGenerationIntegrationTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Iterables;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.bpmn2.Definitions;
 import org.guvnor.common.services.backend.util.CommentedOptionFactory;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -93,6 +94,7 @@ import static org.kie.workbench.common.forms.jbpm.model.authoring.document.type.
 import static org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.AbstractBPMNFormGeneratorService.generateNestedFormName;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -178,7 +180,7 @@ public class FormGenerationIntegrationTest {
         formGenerationProcessDefinitions = TestUtils.getDefinitionsFromResources(FormGenerationIntegrationTest.class, DEFINITION_PATH);
 
         formModelerContent = new FormModelerContent();
-        formEditorHelper = new FormEditorHelper(fieldManager, null);
+        formEditorHelper = new FormEditorHelper(fieldManager, null, mock(SyncBeanManager.class));
     }
 
     @Before

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/pom.xml
@@ -92,6 +92,12 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-editor-client</artifactId>
     </dependency>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/rendering/document/DocumentFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/rendering/document/DocumentFieldRenderer.java
@@ -20,13 +20,16 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.jbpm.model.authoring.document.definition.DocumentFieldDefinition;
+import org.kie.workbench.common.forms.jbpm.model.authoring.document.type.DocumentFieldType;
 
 @Dependent
+@Renderer(type = DocumentFieldType.class)
 public class DocumentFieldRenderer extends FieldRenderer<DocumentFieldDefinition, DefaultFormGroup> {
 
     private DocumentFieldRendererView view;
@@ -55,11 +58,6 @@ public class DocumentFieldRenderer extends FieldRenderer<DocumentFieldDefinition
         formGroup.render(view.asWidget(), field);
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return DocumentFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/rendering/documents/DocumentCollectionFieldRenderer.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/src/main/java/org/kie/workbench/common/forms/jbpm/client/rendering/documents/DocumentCollectionFieldRenderer.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import org.jboss.errai.databinding.client.api.Converter;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FormFieldImpl;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
@@ -34,12 +35,14 @@ import org.kie.workbench.common.forms.jbpm.client.rendering.documents.control.Do
 import org.kie.workbench.common.forms.jbpm.client.rendering.util.DocumentSizeHelper;
 import org.kie.workbench.common.forms.jbpm.client.resources.i18n.Constants;
 import org.kie.workbench.common.forms.jbpm.model.authoring.documents.definition.DocumentCollectionFieldDefinition;
+import org.kie.workbench.common.forms.jbpm.model.authoring.documents.type.DocumentCollectionFieldType;
 import org.kie.workbench.common.forms.jbpm.model.document.DocumentData;
 import org.kie.workbench.common.forms.jbpm.model.document.DocumentStatus;
 import org.kie.workbench.common.forms.processing.engine.handling.CustomFieldValidator;
 import org.kie.workbench.common.forms.processing.engine.handling.ValidationResult;
 
 @Dependent
+@Renderer(type = DocumentCollectionFieldType.class)
 public class DocumentCollectionFieldRenderer extends FieldRenderer<DocumentCollectionFieldDefinition, DefaultFormGroup> implements RequiresValueConverter {
 
     private static final Integer MAX_CONTENT_SIZE = 20 * 1024 * 1024;
@@ -65,11 +68,6 @@ public class DocumentCollectionFieldRenderer extends FieldRenderer<DocumentColle
 
     @Override
     public String getName() {
-        return DocumentCollectionFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return DocumentCollectionFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -113,6 +113,12 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-forms-api</artifactId>
     </dependency>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorPicker/ColorPickerFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorPicker/ColorPickerFieldRenderer.java
@@ -19,13 +19,16 @@ package org.kie.workbench.common.stunner.forms.client.fields.colorPicker;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.forms.model.ColorPickerFieldDefinition;
+import org.kie.workbench.common.stunner.forms.model.ColorPickerFieldType;
 
 @Dependent
+@Renderer(type = ColorPickerFieldType.class)
 public class ColorPickerFieldRenderer extends FieldRenderer<ColorPickerFieldDefinition, DefaultFormGroup> {
 
     private ColorPickerWidget colorPicker;
@@ -49,11 +52,6 @@ public class ColorPickerFieldRenderer extends FieldRenderer<ColorPickerFieldDefi
         formGroup.render(colorPicker, field);
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return ColorPickerFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -122,6 +122,12 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-api</artifactId>
     </dependency>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assigneeEditor/AssigneeEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assigneeEditor/AssigneeEditorFieldRenderer.java
@@ -24,6 +24,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FormFieldImpl;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
@@ -34,8 +35,10 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.assigneeEditor.
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.assigneeEditor.widget.AssigneeEditorWidget;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerBPMNConstants;
 import org.kie.workbench.common.stunner.bpmn.forms.model.AssigneeEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.AssigneeEditorFieldType;
 
 @Dependent
+@Renderer(type = AssigneeEditorFieldType.class)
 public class AssigneeEditorFieldRenderer extends FieldRenderer<AssigneeEditorFieldDefinition, AssigneeFormGroup> {
 
     private AssigneeEditorWidget widget;
@@ -62,11 +65,6 @@ public class AssigneeEditorFieldRenderer extends FieldRenderer<AssigneeEditorFie
         formGroup.render(widget.asWidget(), field);
 
         return formGroup;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return AssigneeEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorFieldRenderer.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.assignmentsEdi
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
@@ -26,8 +27,10 @@ import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.BPMNFormsContextUtils;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDefinition;
 import org.kie.workbench.common.stunner.bpmn.forms.model.AssignmentsEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.AssignmentsEditorFieldType;
 
 @Dependent
+@Renderer(type = AssignmentsEditorFieldType.class)
 public class AssignmentsEditorFieldRenderer extends FieldRenderer<AssignmentsEditorFieldDefinition, DefaultFormGroup> {
 
     private AssignmentsEditorWidget assignmentsEditor;
@@ -60,10 +63,5 @@ public class AssignmentsEditorFieldRenderer extends FieldRenderer<AssignmentsEdi
     @Override
     protected void setReadOnly(final boolean readOnly) {
         assignmentsEditor.setReadOnly(readOnly);
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return AssignmentsEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRenderer.java
@@ -22,15 +22,18 @@ import java.util.Optional;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.KeyValueRow;
 import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.cm.RolesEditorFieldType;
 import org.kie.workbench.common.stunner.bpmn.forms.serializer.cm.CaseRoleSerializer;
 
 @Dependent
+@Renderer(type = RolesEditorFieldType.class)
 public class RolesEditorFieldRenderer extends FieldRenderer<RolesEditorFieldDefinition, DefaultFormGroup>
         implements RolesEditorWidgetView.Presenter {
 
@@ -46,11 +49,6 @@ public class RolesEditorFieldRenderer extends FieldRenderer<RolesEditorFieldDefi
 
     @Override
     public String getName() {
-        return RolesEditorFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return RolesEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRenderer.java
@@ -19,9 +19,11 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
 
 @Dependent
+@Renderer(fieldDefinition = ComboBoxFieldDefinition.class)
 public class ComboBoxFieldRenderer
         extends AbstractComboBoxFieldRenderer<ComboBoxFieldDefinition> {
 
@@ -35,15 +37,5 @@ public class ComboBoxFieldRenderer
     @Override
     public String getName() {
         return TYPE_NAME;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return TYPE_NAME;
-    }
-
-    @Override
-    public Class<ComboBoxFieldDefinition> getSupportedFieldDefinition() {
-        return ComboBoxFieldDefinition.class;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRenderer.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeListener;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor.annotation.FixedValues;
@@ -38,6 +39,7 @@ import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
  * Each relatedField can be composed by an hierarchy that is a sequence of sub-fields that should be separated by  a delimiter {@code .} e.g. "general.name"
  */
 @Dependent
+@Renderer(fieldDefinition = ConditionalComboBoxFieldDefinition.class)
 public class ConditionalComboBoxFieldRenderer extends AbstractComboBoxFieldRenderer<ConditionalComboBoxFieldDefinition> {
 
     public static final String TYPE_NAME = ConditionalComboBoxFieldDefinition.FIELD_TYPE.getTypeName();
@@ -140,15 +142,5 @@ public class ConditionalComboBoxFieldRenderer extends AbstractComboBoxFieldRende
     @Override
     public String getName() {
         return TYPE_NAME;
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return TYPE_NAME;
-    }
-
-    @Override
-    public Class<ConditionalComboBoxFieldDefinition> getSupportedFieldDefinition() {
-        return ConditionalComboBoxFieldDefinition.class;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/conditionEditor/ConditionEditorFieldEditorRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/conditionEditor/ConditionEditorFieldEditorRenderer.java
@@ -18,14 +18,17 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.conditionEdito
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionEditorFieldType;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 
+@Renderer(type = ConditionEditorFieldType.class)
 public class ConditionEditorFieldEditorRenderer
         extends FieldRenderer<ConditionEditorFieldDefinition, DefaultFormGroup> {
 
@@ -49,11 +52,6 @@ public class ConditionEditorFieldEditorRenderer
 
     @Override
     public String getName() {
-        return ConditionEditorFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return ConditionEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/ImportsFieldEditorWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/ImportsFieldEditorWidget.java
@@ -28,7 +28,6 @@ import com.google.gwt.user.client.ui.HasValue;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
-import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerFormsClientFieldsConstants;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.importsEditor.popup.ImportsEditor;
@@ -160,12 +159,10 @@ public class ImportsFieldEditorWidget extends Composite implements HasValue<Impo
         return copy;
     }
 
-    @EventHandler("importsButton")
     public void onClickImportsButton(final ClickEvent clickEvent) {
         showImportsEditor();
     }
 
-    @EventHandler("importsTextBox")
     public void onClickImportsTextBox(final ClickEvent clickEvent) {
         showImportsEditor();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/ImportsFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/ImportsFieldRenderer.java
@@ -18,12 +18,15 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.importsEditor;
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ImportsFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ImportsFieldType;
 
+@Renderer(type = ImportsFieldType.class)
 public class ImportsFieldRenderer
         extends FieldRenderer<ImportsFieldDefinition, DefaultFormGroup> {
 
@@ -48,10 +51,5 @@ public class ImportsFieldRenderer
 
     @Override
     protected void setReadOnly(final boolean readOnly) {
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return ImportsFieldDefinition.FIELD_TYPE.getTypeName();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/multipleInstanceVariableEditor/MultipleInstanceVariableFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/multipleInstanceVariableEditor/MultipleInstanceVariableFieldRenderer.java
@@ -18,12 +18,14 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.multipleInstan
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FormFieldImpl;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.MultipleInstanceVariableFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.MultipleInstanceVariableFieldType;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
@@ -32,6 +34,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 
 import static org.kie.workbench.common.stunner.core.client.util.ClientUtils.getSelectedNode;
 
+@Renderer(type = MultipleInstanceVariableFieldType.class)
 public class MultipleInstanceVariableFieldRenderer
         extends FieldRenderer<MultipleInstanceVariableFieldDefinition, DefaultFormGroup> {
 
@@ -59,11 +62,6 @@ public class MultipleInstanceVariableFieldRenderer
 
     @Override
     public String getName() {
-        return MultipleInstanceVariableFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return MultipleInstanceVariableFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/NotificationsEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/NotificationsEditorFieldRenderer.java
@@ -19,13 +19,16 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.notificationsE
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.NotificationsEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.NotificationsEditorFieldType;
 
 @Dependent
+@Renderer(type = NotificationsEditorFieldType.class)
 public class NotificationsEditorFieldRenderer extends FieldRenderer<NotificationsEditorFieldDefinition, DefaultFormGroup> {
 
     private NotificationsEditorWidget notificationsEditorWidget;
@@ -44,11 +47,6 @@ public class NotificationsEditorFieldRenderer extends FieldRenderer<Notification
 
     @Override
     public String getName() {
-        return NotificationsEditorFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return NotificationsEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/ReassignmentsEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/ReassignmentsEditorFieldRenderer.java
@@ -19,13 +19,16 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.reassignmentsE
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ReassignmentsEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ReassignmentsEditorFieldType;
 
 @Dependent
+@Renderer(type = ReassignmentsEditorFieldType.class)
 public class ReassignmentsEditorFieldRenderer extends FieldRenderer<ReassignmentsEditorFieldDefinition, DefaultFormGroup> {
 
     private ReassignmentsEditorWidget reassignmentsEditorWidget;
@@ -44,11 +47,6 @@ public class ReassignmentsEditorFieldRenderer extends FieldRenderer<Reassignment
 
     @Override
     public String getName() {
-        return ReassignmentsEditorFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return ReassignmentsEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeFieldRenderer.java
@@ -18,12 +18,15 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.scriptEditor;
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ScriptTypeFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ScriptTypeFieldType;
 
+@Renderer(type = ScriptTypeFieldType.class)
 public class ScriptTypeFieldRenderer
         extends FieldRenderer<ScriptTypeFieldDefinition, DefaultFormGroup> {
 
@@ -53,10 +56,5 @@ public class ScriptTypeFieldRenderer
     @Override
     protected void setReadOnly(final boolean readOnly) {
         widget.setReadOnly(readOnly);
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return ScriptTypeFieldDefinition.FIELD_TYPE.getTypeName();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeListFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeListFieldRenderer.java
@@ -18,12 +18,15 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.scriptEditor;
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ScriptTypeListFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.ScriptTypeListFieldType;
 
+@Renderer(type = ScriptTypeListFieldType.class)
 public class ScriptTypeListFieldRenderer
         extends FieldRenderer<ScriptTypeListFieldDefinition, DefaultFormGroup> {
 
@@ -52,10 +55,5 @@ public class ScriptTypeListFieldRenderer
     @Override
     protected void setReadOnly(final boolean readOnly) {
         widget.setReadOnly(readOnly);
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return ScriptTypeListFieldDefinition.FIELD_TYPE.getTypeName();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorFieldRenderer.java
@@ -19,13 +19,16 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.serviceEditor;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.GenericServiceTaskEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.GenericServiceTaskEditorFieldType;
 
 @Dependent
+@Renderer(type = GenericServiceTaskEditorFieldType.class)
 public class GenericServiceTaskEditorFieldRenderer extends FieldRenderer<GenericServiceTaskEditorFieldDefinition, DefaultFormGroup> {
 
     private GenericServiceTaskEditorWidget editorWidget;
@@ -44,11 +47,6 @@ public class GenericServiceTaskEditorFieldRenderer extends FieldRenderer<Generic
 
     @Override
     public String getName() {
-        return GenericServiceTaskEditorFieldDefinition.FIELD_TYPE.getTypeName();
-    }
-
-    @Override
-    public String getSupportedCode() {
         return GenericServiceTaskEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldRenderer.java
@@ -18,12 +18,15 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.timerEditor;
 
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.forms.model.TimerSettingsFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.TimerSettingsFieldType;
 
+@Renderer(type = TimerSettingsFieldType.class)
 public class TimerSettingsFieldRenderer
         extends FieldRenderer<TimerSettingsFieldDefinition, DefaultFormGroup> {
 
@@ -51,10 +54,5 @@ public class TimerSettingsFieldRenderer
     @Override
     protected void setReadOnly(final boolean readOnly) {
         widget.setReadOnly(readOnly);
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return TimerSettingsFieldDefinition.FIELD_TYPE.getTypeName();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.def.DefaultFormGroup;
@@ -37,6 +38,7 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.client.util.VariableUtils;
 import org.kie.workbench.common.stunner.bpmn.forms.model.VariablesEditorFieldDefinition;
+import org.kie.workbench.common.stunner.bpmn.forms.model.VariablesEditorFieldType;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Graph;
@@ -47,6 +49,7 @@ import static org.kie.workbench.common.stunner.bpmn.client.util.VariableUtils.Fi
 import static org.kie.workbench.common.stunner.bpmn.client.util.VariableUtils.FindVariableUsagesFlag.CASE_FILE_VARIABLE;
 
 @Dependent
+@Renderer(type = VariablesEditorFieldType.class)
 public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorFieldDefinition, DefaultFormGroup>
         implements VariablesEditorWidgetView.Presenter {
 
@@ -103,11 +106,6 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
     @Override
     protected void setReadOnly(final boolean readOnly) {
         view.setReadOnly(readOnly);
-    }
-
-    @Override
-    public String getSupportedCode() {
-        return VariablesEditorFieldDefinition.FIELD_TYPE.getTypeName();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/cm/roles/RolesEditorFieldRendererTest.java
@@ -81,12 +81,6 @@ public class RolesEditorFieldRendererTest {
     }
 
     @Test
-    public void getSupportedCode() {
-        String code = tested.getSupportedCode();
-        assertThat(code).isEqualTo(RolesEditorFieldDefinition.FIELD_TYPE.getTypeName());
-    }
-
-    @Test
     public void getFormGroup() {
         FormGroup formGroup = tested.getFormGroup(RenderMode.EDIT_MODE);
         verify(view).init(tested);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRendererTest.java
@@ -44,16 +44,4 @@ public class ComboBoxFieldRendererTest {
         Assert.assertEquals(comboBoxFieldRenderer.getName(),
                             ComboBoxFieldType.NAME);
     }
-
-    @Test
-    public void getSupportedCode() throws Exception {
-        Assert.assertEquals(comboBoxFieldRenderer.getSupportedCode(),
-                            ComboBoxFieldType.NAME);
-    }
-
-    @Test
-    public void getSupportedFieldDefinition() throws Exception {
-        Assert.assertEquals(comboBoxFieldRenderer.getSupportedFieldDefinition(),
-                            ComboBoxFieldDefinition.class);
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
@@ -181,16 +181,4 @@ public class ConditionalComboBoxFieldRendererTest {
         Assert.assertEquals(conditionalComboBoxFieldRenderer.getName(),
                             ConditionalComboBoxFieldType.NAME);
     }
-
-    @Test
-    public void getSupportedCode() throws Exception {
-        Assert.assertEquals(conditionalComboBoxFieldRenderer.getSupportedCode(),
-                            ConditionalComboBoxFieldType.NAME);
-    }
-
-    @Test
-    public void getSupportedFieldDefinition() throws Exception {
-        Assert.assertEquals(conditionalComboBoxFieldRenderer.getSupportedFieldDefinition(),
-                            ConditionalComboBoxFieldDefinition.class);
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/conditionEditor/ConditionEditorFieldEditorRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/conditionEditor/ConditionEditorFieldEditorRendererTest.java
@@ -65,12 +65,6 @@ public class ConditionEditorFieldEditorRendererTest {
     }
 
     @Test
-    public void testGetSupportedCode() {
-        assertEquals("ConditionEditorFieldType",
-                     renderer.getSupportedCode());
-    }
-
-    @Test
     public void testSetReadonlyTrue() {
         renderer.setReadOnly(true);
         verify(widget,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/multipleInstanceVariableEditor/MultipleInstanceVariableFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/multipleInstanceVariableEditor/MultipleInstanceVariableFieldRendererTest.java
@@ -98,11 +98,6 @@ public class MultipleInstanceVariableFieldRendererTest {
     }
 
     @Test
-    public void testGetSupportedCode() {
-        assertEquals("MultipleInstanceVariableFieldType", renderer.getSupportedCode());
-    }
-
-    @Test
     public void testSetReadonlyTrue() {
         renderer.setReadOnly(true);
         verify(widget).setReadOnly(true);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/NotificationsEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/NotificationsEditorFieldRendererTest.java
@@ -43,17 +43,11 @@ public class NotificationsEditorFieldRendererTest extends ReflectionUtilsTest {
         notificationsEditorFieldRenderer = spy(new NotificationsEditorFieldRenderer(notificationsEditorWidget));
 
         doCallRealMethod().when(notificationsEditorFieldRenderer).getName();
-        doCallRealMethod().when(notificationsEditorFieldRenderer).getSupportedCode();
         doCallRealMethod().when(notificationsEditorFieldRenderer).getField();
     }
 
     @Test
     public void getNameTest() {
         Assert.assertEquals("NotificationsEditor", notificationsEditorFieldRenderer.getName());
-    }
-
-    @Test
-    public void getSupportedCodeTest() {
-        Assert.assertEquals("NotificationsEditor", notificationsEditorFieldRenderer.getSupportedCode());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/ReassignmentsEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/ReassignmentsEditorFieldRendererTest.java
@@ -42,7 +42,6 @@ public class ReassignmentsEditorFieldRendererTest extends ReflectionUtilsTest {
         reassignmentsEditorFieldRenderer = spy(new ReassignmentsEditorFieldRenderer(reassignmentsEditorWidget));
 
         doCallRealMethod().when(reassignmentsEditorFieldRenderer).getName();
-        doCallRealMethod().when(reassignmentsEditorFieldRenderer).getSupportedCode();
         doCallRealMethod().when(reassignmentsEditorFieldRenderer).getField();
     }
 
@@ -51,8 +50,4 @@ public class ReassignmentsEditorFieldRendererTest extends ReflectionUtilsTest {
         Assert.assertEquals("ReassignmentsEditor", reassignmentsEditorFieldRenderer.getName());
     }
 
-    @Test
-    public void getSupportedCodeTest() {
-        Assert.assertEquals("ReassignmentsEditor", reassignmentsEditorFieldRenderer.getSupportedCode());
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeFieldRendererTest.java
@@ -42,10 +42,4 @@ public class ScriptTypeFieldRendererTest {
         assertEquals("ScriptTypeFieldType",
                      renderer.getName());
     }
-
-    @Test
-    public void testGetSupportedCode() {
-        assertEquals("ScriptTypeFieldType",
-                     renderer.getSupportedCode());
-    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeListFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/scriptEditor/ScriptTypeListFieldRendererTest.java
@@ -46,12 +46,6 @@ public class ScriptTypeListFieldRendererTest {
     }
 
     @Test
-    public void testGetSupportedCode() {
-        assertEquals("ScriptTypeListFieldType",
-                     renderer.getSupportedCode());
-    }
-
-    @Test
     public void testSetReadonlyTrue() {
         renderer.setReadOnly(true);
         verify(widget,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorFieldRendererTest.java
@@ -60,12 +60,6 @@ public class GenericServiceTaskEditorFieldRendererTest extends ReflectionUtilsTe
     }
 
     @Test
-    public void testGetSupportedCode() {
-        assertEquals("GenericServiceTaskEditor",
-                     renderer.getSupportedCode());
-    }
-
-    @Test
     public void testSetReadonlyTrue() {
         renderer.setReadOnly(true);
         verify(widget,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldRendererTest.java
@@ -46,12 +46,6 @@ public class TimerSettingsFieldRendererTest {
     }
 
     @Test
-    public void testGetSupportedCode() {
-        assertEquals("TimerSettingsFieldType",
-                     renderer.getSupportedCode());
-    }
-
-    @Test
     public void testSetReadonlyTrue() {
         renderer.setReadOnly(true);
         verify(widget,


### PR DESCRIPTION
This PR solves some memory leaks on forms engine:
- Improved forms cleanup: layout & forms rendering engine are using both an hybrid aproach mixing GWT Widgets, Errai HTML elements & native HTMLElements. That was forcing us to use ElementWrapperWidget to generate GWT Widgets to wrap the elements. ElementWrapperWidget keeps a reference to the generated GWT Widgets that was not cleared leaving listeners in memory. So we improved the renderer cleanup to remove all the widget references and improved the DOM clean to make sure that all widgets are correctly dettached.
- Improved FieldRenderers lookup: The way FieldRenderer were loaded was generating a somun used instances and  GWT Widgets that were adding listeners.The new mechanism adds a new annotation @Renderer to be added on FieldRenderers and a Annotation Processor to generate a registry of FieldRenderers.

This PR adds a lot of changes on FieldRenderers because I removed some methods and I had to add the new annotation... So I'd like to split the review into parts:

@jesuino could you please take a look at the forms part?
@romartin could you please take a look at the stunner field renderers?
@manstis could you please take a look at the dmn part?
@jstastny-cz I think you'll be the QE in charged of reviewing this...



