### PR TITLE
JBPM-8450 Stunner - Relax constraint on signal name

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRef.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.property.Valu
 @FieldDefinition(i18nMode = I18nMode.OVERRIDE_I18N_KEY)
 public class SignalRef implements BPMNProperty {
 
-    protected static final String STATIC_EXP = "[a-zA-Z0-9_]+";
+    protected static final String STATIC_EXP = "[a-zA-Z0-9._:\\s]+";
     protected static final String OR_EXP = "|";
     protected static final String EXP_SEPARATOR = "[\\-]";
     protected static final String MVEL_EXP = "[#]{1}[{]{1}[a-zA-Z0-9_]+[}]{1}";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -284,7 +284,7 @@ org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.Interrupt
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.ScopedSignalEventExecutionSet.label=Implementation/Execution
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.label=Signal
 org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.description=The Signal Reference
-org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.helpMessage=The allowed characters for the SignalRef are alphanumeric characters (a-z, A-Z, 0-9) and underscore "_".<br>\
+org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef.helpMessage=The allowed characters for the SignalRef are alphanumeric characters (a-z, A-Z, 0-9), colon ":", underscore "_" and space.<br>\
                                                                                              <br>\
                                                                                              The following expressions are accepted:<br>\
                                                                                              <ul><li>#{var}</li>\

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/event/signal/SignalRefTest.java
@@ -56,6 +56,8 @@ public class SignalRefTest {
     private static final String VALID_COMBINATION_3 = VALID_STATIC_REF + EXP_SEPARATOR + VALID_MVEL_COMPLEX_REF_1;
     private static final String VALID_COMBINATION_4 = VALID_STATIC_REF + EXP_SEPARATOR + VALID_MVEL_COMPLEX_PARAM_REF_1;
 
+    private static final String VALID_EXPRESSION = "Milestone 2: Order shipped";
+
     private static final String INVALID_STATIC_REF = "~`!@#$%^&*()_+=-{}|][:\"';?><,./";
 
     private static final String INVALID_MVEL_REF = "#{~`!@#$%^&*()_+=-{}|][:\"';?><,./}";
@@ -98,6 +100,7 @@ public class SignalRefTest {
         assertValidExpression(VALID_COMBINATION_2);
         assertValidExpression(VALID_COMBINATION_3);
         assertValidExpression(VALID_COMBINATION_4);
+        assertValidExpression(VALID_EXPRESSION);
 
         assertInvalidExpression(INVALID_STATIC_REF);
         assertInvalidExpression(INVALID_MVEL_REF);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxWidgetViewImpl.java
@@ -22,7 +22,6 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -104,12 +103,6 @@ public class ComboBoxWidgetViewImpl extends Composite implements ComboBoxWidgetV
                            false,
                            CUSTOM_PROMPT,
                            ENTER_TYPE_PROMPT);
-        customValueField.addKeyDownHandler((KeyDownEvent event) -> {
-            int iChar = event.getNativeKeyCode();
-            if (iChar == ' ') {
-                event.preventDefault();
-            }
-        });
     }
 
     @Override


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/JBPM-8450

this fix might affect other dropdowns in the stunner, i have checked it and i think it's ok, but it needs to be double checked by QE.