### PR TITLE
Fix issue with inheriting junit-vintage-engine transitive dependency

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
@@ -236,6 +236,20 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.optaplanner</groupId>
+          <artifactId>optaplanner-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.optaplanner</groupId>
+          <artifactId>optaplanner-persistence-xstream</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.optaplanner</groupId>
+          <artifactId>optaplanner-persistence-jaxb</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- GWT and GWT Extensions -->


### PR DESCRIPTION
There might be other occurrences...

However I still question why `kie-server-api` should have a dependency on `optaplanner-core`..