### PR TITLE
KOGITO-674: [DMN Designer] Not able to save file with external link

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DMNExternalLinksToExtensionElements.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DMNExternalLinksToExtensionElements.java
@@ -24,6 +24,7 @@ import jsinterop.base.Js;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.api.property.dmn.DMNExternalLink;
 import org.kie.workbench.common.dmn.api.property.dmn.DocumentationLinks;
+import org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.utils.WrapperUtils;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDMNElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDRGElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.kie.JSITAttachment;
@@ -66,7 +67,9 @@ class DMNExternalLinksToExtensionElements {
             final JSITAttachment attachment = new JSITAttachment();
             attachment.setName(link.getDescription());
             attachment.setUrl(link.getUrl());
-            elements.addAny(attachment);
+
+            final JSITAttachment wrappedAttachment = WrapperUtils.getWrappedJSITAttachment(attachment);
+            elements.addAny(wrappedAttachment);
         }
         target.setExtensionElements(elements);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtils.java
@@ -50,6 +50,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JS
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNLabel;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNShape;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNStyle;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.kie.JSITAttachment;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.kie.JSITComponentsWidthsExtension;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.mapper.JSIName;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.mapper.JsUtils;
@@ -159,6 +160,14 @@ public class WrapperUtils {
         JSIDMNShape toReturn = Js.uncheckedCast(JsUtils.getWrappedElement(unwrappedJSIDMNShape));
         JSIName jsiName = JSIDMNShape.getJSIName();
         updateJSIName(jsiName, "dmndi", "DMNShape");
+        JsUtils.setNameOnWrapped(toReturn, jsiName);
+        return toReturn;
+    }
+
+    public static JSITAttachment getWrappedJSITAttachment(JSITAttachment attachment) {
+        JSITAttachment toReturn = Js.uncheckedCast(JsUtils.getWrappedElement(attachment));
+        JSIName jsiName = JSITAttachment.getJSIName();
+        updateJSIName(jsiName, "kie", "attachment");
         JsUtils.setNameOnWrapped(toReturn, jsiName);
         return toReturn;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/src/main/resources/KIE.xsd
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/src/main/resources/KIE.xsd
@@ -22,12 +22,8 @@
   </xs:complexType>
 
   <xs:complexType name="tAttachment">
-    <xs:simpleContent>
-      <xs:extension base="xs:string">
-        <xs:attribute type="xs:anyURI" name="url"/>
-        <xs:attribute type="xs:string" name="name"/>
-      </xs:extension>
-    </xs:simpleContent>
+    <xs:attribute type="xs:anyURI" name="url"/>
+    <xs:attribute type="xs:string" name="name"/>
   </xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
See https://issues.jboss.org/browse/KOGITO-674

`JSITAttachment` needed wrapping for Jsonix to determine it's _type_. I also made a slight change to the `KIE.xsd` as `TAttachment` generated by JAXB had a redundant _value_ property too.