### PR TITLE
KOGITO-418 : Missing structureref type for service task in VSCode BPMN Editor

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>kie-wb-common-bpmn-kogito-runtime</artifactId>
+  <artifactId>kie-wb-common-stunner-bpmn-kogito-runtime</artifactId>
   <packaging>war</packaging>
   <name>Kie Workbench - Common - Stunner - BPMN Definition Set - Kogito Runtime</name>
   <description>Kie Workbench - Common - Stunner - BPMN Definition Set - Kogito Runtime</description>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.kogito.client.editor;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
+import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
+import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
+import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
+import org.kie.workbench.common.stunner.kogito.client.docks.DiagramEditorPreviewAndExplorerDock;
+import org.kie.workbench.common.stunner.kogito.client.docks.DiagramEditorPropertiesDock;
+import org.kie.workbench.common.stunner.kogito.client.editor.event.OnDiagramFocusEvent;
+import org.kie.workbench.common.stunner.kogito.client.menus.BPMNStandaloneEditorMenuSessionItems;
+import org.kie.workbench.common.stunner.kogito.client.service.KogitoClientDiagramService;
+import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
+import org.mockito.Mock;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
+import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
+import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.jgroups.util.Util.assertEquals;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class BPMNDiagramEditorTest {
+
+    private BPMNDiagramEditor editor;
+
+    @Mock
+    private DiagramEditorCore.View view;
+
+    @Mock
+    private FileMenuBuilder fileMenuBuilder;
+
+    @Mock
+    private PlaceManager placeManager;
+
+    @Mock
+    private MultiPageEditorContainerView multiPageEditorContainerView;
+
+    @Mock
+    private EventSourceMock<ChangeTitleWidgetEvent> changeTitleNotificationEvent;
+
+    @Mock
+    private EventSourceMock<NotificationEvent> notificationEvent;
+
+    @Mock
+    private EventSourceMock<OnDiagramFocusEvent> onDiagramFocusEvent;
+
+    @Mock
+    private TextEditorView xmlEditorView;
+
+    @Mock
+    private ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances;
+
+    @Mock
+    private ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances;
+
+    @Mock
+    private BPMNStandaloneEditorMenuSessionItems menuSessionItems;
+
+    @Mock
+    private ErrorPopupPresenter errorPopupPresenter;
+
+    @Mock
+    private DiagramClientErrorHandler diagramClientErrorHandler;
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private DocumentationView documentationView;
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private DiagramEditorPreviewAndExplorerDock diagramPreviewAndExplorerDock;
+
+    @Mock
+    private DiagramEditorPropertiesDock diagramPropertiesDock;
+
+    @Mock
+    private LayoutHelper layoutHelper;
+
+    @Mock
+    private OpenDiagramLayoutExecutor openDiagramLayoutExecutor;
+
+    @Mock
+    private KogitoClientDiagramService diagramServices;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() {
+        editor = new BPMNDiagramEditor(view,
+                                       fileMenuBuilder,
+                                       placeManager,
+                                       multiPageEditorContainerView,
+                                       changeTitleNotificationEvent,
+                                       notificationEvent,
+                                       onDiagramFocusEvent,
+                                       xmlEditorView,
+                                       editorSessionPresenterInstances,
+                                       viewerSessionPresenterInstances,
+                                       menuSessionItems,
+                                       errorPopupPresenter,
+                                       diagramClientErrorHandler,
+                                       translationService,
+                                       documentationView,
+                                       sessionCommandManager,
+                                       diagramPreviewAndExplorerDock,
+                                       diagramPropertiesDock,
+                                       layoutHelper,
+                                       openDiagramLayoutExecutor,
+                                       diagramServices);
+    }
+
+    @Test
+    public void testMenuInitialized() {
+        editor.menuBarInitialized = false;
+        editor.makeMenuBar();
+        assertEquals(editor.menuBarInitialized, true);
+
+        editor.menuBarInitialized = true;
+        editor.makeMenuBar();
+        assertEquals(editor.menuBarInitialized, true);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriter.java
@@ -17,8 +17,6 @@
 package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.properties;
 
 import org.eclipse.bpmn2.Interface;
-import org.eclipse.bpmn2.ItemDefinition;
-import org.eclipse.bpmn2.Message;
 import org.eclipse.bpmn2.Operation;
 import org.eclipse.bpmn2.ServiceTask;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.CustomAttribute;
@@ -53,29 +51,8 @@ public class GenericServiceTaskPropertyWriter extends MultipleInstanceActivityPr
         //2 Interface
         String serviceInterface = value.getServiceInterface();
 
-        //in message
-        final Message inMessage;
-        ItemDefinition itemDefinitionInMsg = bpmn2.createItemDefinition();
-        itemDefinitionInMsg.setId(task.getId() + "_InMessageType");
-        itemDefinitionInMsg.setStructureRef(value.getInMessageStructure());
-        addItemDefinition(itemDefinitionInMsg);
-
-        inMessage = bpmn2.createMessage();
-        inMessage.setId(task.getId() + "_InMessage");
-        inMessage.setItemRef(itemDefinitionInMsg);
-        addRootElement(inMessage);
-
-        //out message
-        final Message outMessage;
-        ItemDefinition itemDefinitionOutMsg = bpmn2.createItemDefinition();
-        itemDefinitionOutMsg.setId(task.getId() + "_OutMessageType");
-        itemDefinitionOutMsg.setStructureRef(value.getOutMessagetructure());
-        addItemDefinition(itemDefinitionOutMsg);
-
-        outMessage = bpmn2.createMessage();
-        outMessage.setId(task.getId() + "_OutMessage");
-        outMessage.setItemRef(itemDefinitionOutMsg);
-        addRootElement(outMessage);
+        //https://issues.jboss.org/browse/KOGITO-418
+        // In/Out Messages should not be written now
 
         //custom attribute
         CustomAttribute.serviceInterface.of(task).set(serviceInterface);
@@ -97,8 +74,6 @@ public class GenericServiceTaskPropertyWriter extends MultipleInstanceActivityPr
         iface.getOperations().add(operation);
         task.setOperationRef(operation);
         addInterfaceDefinition(iface);
-        operation.setInMessageRef(inMessage);
-        operation.setOutMessageRef(outMessage);
     }
 
     public void setAdHocAutostart(boolean autoStart) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriterTest.java
@@ -71,8 +71,8 @@ public class GenericServiceTaskPropertyWriterTest {
         assertEquals("serviceOperation", CustomAttribute.serviceOperation.of(serviceTask).get());
         assertEquals("serviceInterface", CustomAttribute.serviceInterface.of(serviceTask).get());
         assertEquals("serviceOperation", serviceTask.getOperationRef().getName());
-        assertEquals("inMessageStructure", serviceTask.getOperationRef().getInMessageRef().getItemRef().getStructureRef());
-        assertEquals("outMessagetructure", serviceTask.getOperationRef().getOutMessageRef().getItemRef().getStructureRef());
+        //https://issues.jboss.org/browse/KOGITO-418
+        // In/Out Messages should not be written now
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/GenericServiceTaskPropertyReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/GenericServiceTaskPropertyReaderTest.java
@@ -85,8 +85,8 @@ public class GenericServiceTaskPropertyReaderTest {
         assertEquals("Java", task.getServiceImplementation());
         assertEquals("serviceOperation", task.getServiceOperation());
         assertEquals("serviceInterface", task.getServiceInterface());
-        assertEquals("inMessageStructure", task.getInMessageStructure());
-        assertEquals("outMessageStructure", task.getOutMessagetructure());
+        //https://issues.jboss.org/browse/KOGITO-418
+        // In/Out Messages should not be written now
         assertEquals(SLA_DUE_DATE_CDATA, reader.getSLADueDate());
         assertEquals(false, reader.isAsync());
         assertEquals(true, reader.isAdHocAutostart());


### PR DESCRIPTION
Hi @hasys @romartin this is the PR for the change, I moved several folders, wanted to trigger builds to see if any errors. I am waiting for feedback from Maciej, Kris to see if my implementation of using the first Input/Output parameters data type as InMessageType/OutMessageType respectevely