### PR TITLE
Fix JavaScript for use in GWTTestCase

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/src/main/resources/org/kie/workbench/common/dmn/webapp/kogito/marshaller/js/MainJs.js
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/src/main/resources/org/kie/workbench/common/dmn/webapp/kogito/marshaller/js/MainJs.js
@@ -22,15 +22,15 @@ MainJs = {
         }
 
         function createConstructor(value) {
-            console.log("Create createConstructor " + value)
-            const parsedJson = JSON.parse(value)
-            const name = parsedJson["name"]
-            const nameSpace = parsedJson["nameSpace"]
-            const typeName = parsedJson["typeName"]
-            console.log("parsedJson " + parsedJson)
-            console.log("name " + name)
-            console.log("nameSpace " + nameSpace)
-            console.log("typeName " + typeName)
+            console.log("Create createConstructor " + value);
+            var parsedJson = JSON.parse(value);
+            var name = parsedJson["name"];
+            var nameSpace = parsedJson["nameSpace"];
+            var typeName = parsedJson["typeName"];
+            console.log("parsedJson " + parsedJson);
+            console.log("name " + name);
+            console.log("nameSpace " + nameSpace);
+            console.log("typeName " + typeName);
             if (nameSpace != null) {
                 if (typeName != null) {
                     window[nameSpace][name] = createFunction(typeName);
@@ -47,31 +47,31 @@ MainJs = {
         }
 
         function hasNameSpace(value) {
-            return JSON.parse(value)["nameSpace"] != null
+            return JSON.parse(value)["nameSpace"] != null;
         }
 
         function hasNotNameSpace(value) {
-            return JSON.parse(value)["nameSpace"] == null
+            return JSON.parse(value)["nameSpace"] == null;
         }
 
         function iterateValueEntry(values) {
             console.log("iterateValueEntry " + values);
-            const baseTypes = values.filter(hasNotNameSpace)
-            const innerTypes = values.filter(hasNameSpace)
-            baseTypes.forEach(createConstructor)
-            innerTypes.forEach(createConstructor)
+            var baseTypes = values.filter(hasNotNameSpace);
+            var innerTypes = values.filter(hasNameSpace);
+            baseTypes.forEach(createConstructor);
+            innerTypes.forEach(createConstructor);
         }
 
         function iterateKeyValueEntry(key, values) {
             console.log("iterateKeyValueEntry " + key + "  " + values);
-            iterateValueEntry(values)
+            iterateValueEntry(values);
         }
 
         console.log('Generating JsInterop constructors.');
 
-        for (const property in constructorsMap) {
+        for (var property in constructorsMap) {
             if (constructorsMap.hasOwnProperty(property)) {
-                iterateKeyValueEntry(property, constructorsMap[property])
+                iterateKeyValueEntry(property, constructorsMap[property]);
             }
         }
     },


### PR DESCRIPTION
This is in preparation for my ongoing work for https://issues.jboss.org/browse/KOGITO-406

When running `GwtTestCase` Unit Tests for the client-side marshaller I get JS compilation issues in `MainJS.js` at runtime when the JS are deployed to `com.gargoylesoftware.htmlunit.WebClient` that is the headless browser engine used for tests. The failures relate to use of `const` (presumably the `WebClient` does not support the JavaScript version introducing `const`). Use of `var` works fine.

I also added missing semi-colons (as IDEA keeps highlighting the file saying they're missing - although this is not true with JavaScript as their use is optional).